### PR TITLE
[DOCU-3167] Add Amazon Linux 2023 to support page

### DIFF
--- a/app/_data/tables/support/gateway/packages.yml
+++ b/app/_data/tables/support/gateway/packages.yml
@@ -23,6 +23,12 @@ _packages:
     package: true
     arm: false
     fips: false
+  amazonlinux2023: &amazonlinux2023
+    os: Amazon Linux
+    version: 2023
+    package: true
+    arm: false
+    fips: false
   centos7: &centos7
     os: CentOS
     version: 7

--- a/app/_data/tables/support/gateway/versions/33.yml
+++ b/app/_data/tables/support/gateway/versions/33.yml
@@ -34,7 +34,9 @@ distributions:
 
 third-party:
   datastore:
-    - *postgres
+    - <<: *postgres
+      versions:
+        - Amazon Aurora
     - *cassandra
     - *redis
     - *influxdb

--- a/app/_data/tables/support/gateway/versions/33.yml
+++ b/app/_data/tables/support/gateway/versions/33.yml
@@ -1,0 +1,93 @@
+{% include_relative_once _data/tables/support/gateway/packages.yml %}
+{% include_relative_once _data/tables/support/gateway/third-party.yml %}
+{% include_relative_once _data/tables/support/gateway/browsers.yml %}
+
+lts: false
+distributions:
+  - <<: *alpine
+    docker: true
+  - <<: *amazonlinux2
+    docker: true
+    arm: true
+  - <<: *amazonlinux2023
+    docker: true
+    arm: true
+  - *centos7
+  - *debian10
+  - <<: *debian11
+    docker: true
+  - *rhel7
+  - <<: *rhel8
+    docker: true
+    fips: true
+  - <<: *ubuntu1804
+    arm: false
+    docker: false
+  - <<: *ubuntu2004
+    arm: false
+    docker: false
+    fips: true
+  - <<: *ubuntu2204
+    arm: true
+    docker: true
+    fips: true
+
+third-party:
+  datastore:
+    - *postgres
+    - *cassandra
+    - *redis
+    - *influxdb
+    - *kafka
+
+  metrics:
+    - *prometheus
+    - *statsd
+    - *opentelemetry
+    - *zipkin
+
+  vault:
+    - *vaultproject
+    - *aws-sm
+    - *gcp-sm
+
+  identity_provider:
+    - *auth0
+    - *cognito
+    - *connect2id
+    - *curity
+    - *dex
+    - *gluu
+    - *google
+    - *identityserver
+    - *keycloak
+    - *azure-ad
+    - *microsoft-adfs
+    - *microsoft-live-connect
+    - *okta
+    - *onelogin
+    - *openam
+    - *paypal
+    - *pingfederate
+    - *salesforce
+    - *wso2
+    - *yahoo
+
+  service_mesh:
+    - *kongmesh
+    - *istio
+
+  log_provider:
+    - *splunk
+    - *datadog
+    - *loggly
+
+  s3_api:
+    - *s3
+    - *minio
+
+browsers:
+  - *edge
+  - *chrome
+  - *firefox
+  - *safari

--- a/app/_data/tables/support/gateway/versions/33.yml
+++ b/app/_data/tables/support/gateway/versions/33.yml
@@ -36,6 +36,14 @@ third-party:
   datastore:
     - <<: *postgres
       versions:
+        - 15
+        - 14
+        - 13
+        - 12
+        - 11
+        - 10
+        - 9
+        - Amazon RDS
         - Amazon Aurora
     - *cassandra
     - *redis

--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -17,9 +17,51 @@ Kong is licensed under an
 You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
 {% navtabs %}
-{% navtab Package %}
+{% navtab Package (AL2023) %}
+Install {{site.base_gateway}} on Amazon Linux 2023 from the command line.
 
-Install {{site.base_gateway}} on Amazon Linux from the command line.
+1. Download the Kong package:
+
+{% capture download_package %}
+{% navtabs_ee codeblock %}
+{% navtab Kong Gateway %}
+```bash
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.aws.amd64.rpm "{{ site.links.download }}/gateway-3.x-amazonlinux-2023/Packages/k/kong-enterprise-edition-{{page.versions.ee}}.aws.amd64.rpm"
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+curl -Lo kong-{{page.versions.ce}}.aws.amd64.rpm "{{ site.links.download }}/gateway-3.x-amazonlinux-2023/Packages/k/kong-{{page.versions.ce}}.aws.amd64.rpm"
+```
+{% endnavtab %}
+{% endnavtabs_ee %}
+{% endcapture %}
+
+{{ download_package | indent | replace: " </code>", "</code>" }}
+
+2. Install the package:
+
+{% capture install_package %}
+{% navtabs_ee codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo yum install kong-enterprise-edition-{{page.versions.ee}}.aws.amd64.rpm
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo yum install kong-{{page.versions.ce}}.aws.amd64.rpm
+```
+{% endnavtab %}
+{% endnavtabs_ee %}
+{% endcapture %}
+
+{{ install_package | indent | replace: " </code>", "</code>" }}
+
+{% endnavtab %}
+{% navtab Package (Amazon Linux 2) %}
+
+Install {{site.base_gateway}} on Amazon Linux 2 from the command line.
 
 1. Download the Kong package:
 

--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -102,7 +102,36 @@ sudo yum install kong-{{page.versions.ce}}.aws.amd64.rpm
 {{ install_package | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
-{% navtab YUM repository %}
+{% navtab YUM repository (AL2023) %}
+
+Install the YUM repository from the command line.
+
+1. Download the Kong APT repository:
+    ```bash
+    curl https://download.konghq.com/gateway-3.x-amazonlinux-2023/config.repo | sudo tee /etc/yum.repos.d/kong.repo
+    ```
+
+2. Install Kong:
+
+{% capture install_from_repo %}
+{% navtabs_ee codeblock %}
+{% navtab Kong Gateway %}
+```bash
+sudo yum install kong-enterprise-edition-{{page.versions.ee}}
+```
+{% endnavtab %}
+{% navtab Kong Gateway (OSS) %}
+```bash
+sudo yum install kong-{{page.versions.ce}}
+```
+{% endnavtab %}
+{% endnavtabs_ee %}
+{% endcapture %}
+
+{{ install_from_repo | indent | replace: " </code>", "</code>" }}
+
+{% endnavtab %}
+{% navtab YUM repository (Amazon Linux 2) %}
 
 Install the YUM repository from the command line.
 

--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -16,9 +16,6 @@ Kong is licensed under an
 
 You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
-{:.note}
-> **Note:** {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
-
 {% navtabs %}
 {% navtab Package (AL2023) %}
 Install {{site.base_gateway}} on Amazon Linux 2023 from the command line.

--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -16,6 +16,9 @@ Kong is licensed under an
 
 You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
+{:.note}
+> **Note:** {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
+
 {% navtabs %}
 {% navtab Package (AL2023) %}
 Install {{site.base_gateway}} on Amazon Linux 2023 from the command line.

--- a/app/_src/gateway/install/linux/rhel.md
+++ b/app/_src/gateway/install/linux/rhel.md
@@ -16,9 +16,6 @@ Kong is licensed under an
 
 You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
-{:.note}
-> **Note:** {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
-
 {% navtabs %}
 {% navtab Package %}
 

--- a/app/_src/gateway/install/linux/rhel.md
+++ b/app/_src/gateway/install/linux/rhel.md
@@ -16,6 +16,9 @@ Kong is licensed under an
 
 You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
+{:.note}
+> **Note:** {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
+
 {% navtabs %}
 {% navtab Package %}
 

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -67,10 +67,8 @@ Once {{ site.base_gateway }} is running, you may want to do the following:
 You can install {{site.base_gateway}} by downloading an installation package or using our APT repository.
 
 {:.note .no-icon}
-> We currently package {{ site.base_gateway }} for Ubuntu Bionic and Focal.
-> If you are using a different release, replace `$(lsb_release -sc)` with `focal` in the commands below.
-> <br /><br />
-> To check your release name run `lsb_release -sc`.
+> * We currently package {{ site.base_gateway }} for Ubuntu Bionic and Focal. If you are using a different release, replace `$(lsb_release -sc)` with `focal` in the commands below. To check your release name run `lsb_release -sc`.
+> * {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
 
 {% navtabs %}
 {% navtab Package %}

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -67,8 +67,7 @@ Once {{ site.base_gateway }} is running, you may want to do the following:
 You can install {{site.base_gateway}} by downloading an installation package or using our APT repository.
 
 {:.note .no-icon}
-> * We currently package {{ site.base_gateway }} for Ubuntu Bionic and Focal. If you are using a different release, replace `$(lsb_release -sc)` with `focal` in the commands below. To check your release name run `lsb_release -sc`.
-> * {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
+> We currently package {{ site.base_gateway }} for Ubuntu Bionic and Focal. If you are using a different release, replace `$(lsb_release -sc)` with `focal` in the commands below. To check your release name run `lsb_release -sc`.
 
 {% navtabs %}
 {% navtab Package %}

--- a/app/_src/gateway/support/browser.md
+++ b/app/_src/gateway/support/browser.md
@@ -8,6 +8,9 @@ breadcrumb: Browser
 Kong supports N-1 versions of Edge, Chrome, Firefox and Safari on desktop plus any extended support versions.
 
 {% navtabs %}
+  {% navtab 3.3 %}
+    {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.33 %}
+  {% endnavtab %}
   {% navtab 3.2 %}
     {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.32 %}
   {% endnavtab %}

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -45,6 +45,9 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 Kong supports the following versions of {{site.ee_product_name}}: 
 
 {% navtabs %}
+  {% navtab 3.3 %}
+    {% include_cached gateway-support.html version="3.3" data=site.data.tables.support.gateway.versions.33 eol="February 2024" %}
+  {% endnavtab %}
   {% navtab 3.2 %}
     {% include_cached gateway-support.html version="3.2" data=site.data.tables.support.gateway.versions.32 eol="February 2024" %}
   {% endnavtab %}

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -46,7 +46,7 @@ Kong supports the following versions of {{site.ee_product_name}}:
 
 {% navtabs %}
   {% navtab 3.3 %}
-    {% include_cached gateway-support.html version="3.3" data=site.data.tables.support.gateway.versions.33 eol="February 2024" %}
+    {% include_cached gateway-support.html version="3.3" data=site.data.tables.support.gateway.versions.33 eol="May 2024" %}
   {% endnavtab %}
   {% navtab 3.2 %}
     {% include_cached gateway-support.html version="3.2" data=site.data.tables.support.gateway.versions.32 eol="February 2024" %}

--- a/app/_src/gateway/support/third-party.md
+++ b/app/_src/gateway/support/third-party.md
@@ -11,6 +11,9 @@ Kong aims to support the last 2 versions of any third party tool, plus the curre
 > Some third party tools below do not have a version number. These tools are managed services and Kong provides compatibility with the currently released version
 
 {% navtabs %}
+  {% navtab 3.3 %}
+    {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.33 %}
+  {% endnavtab %}
   {% navtab 3.2 %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.32 %}
   {% endnavtab %}


### PR DESCRIPTION
### Description

What did you change and why?
- I added Amazon Linux 2023 to the 3.3 supported versions page
- I added the new Linux 2023 tab to the Amazon Linux install page
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-3167

### Testing instructions

Netlify link: 
- https://deploy-preview-5536--kongdocs.netlify.app/gateway/latest/install/linux/amazon-linux/
- https://deploy-preview-5536--kongdocs.netlify.app/gateway/latest/support-policy/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

