### PR TITLE
Fix indentation filter

### DIFF
--- a/app/_plugins/filters/indent_filter.rb
+++ b/app/_plugins/filters/indent_filter.rb
@@ -2,7 +2,11 @@
 
 module IndentFilter
   def indent(input)
-    input.gsub(/\n/, "\n    ")
+    input
+      .gsub("\n</code>", '</code>')
+      .split("\n")
+      .map { |l| l.prepend('   ') }
+      .join("\n")
   end
 end
 


### PR DESCRIPTION
### Description

[Jira ticket](https://konghq.atlassian.net/browse/DOCU-3208)

What did you change and why?
 
It prepends 4 spaces to every line

It also fixes an edge case regarding code snippets being part of the content to be indented. Previously, it was adding an extra newline to the code snippet. This is the same fix we added to Kuma, see https://github.com/kumahq/kuma-website/pull/1117


### Testing instructions

[Netlify link](https://deploy-preview-5540--kongdocs.netlify.app/mesh/latest/production/secure-deployment/api-server-auth/#signing-key-rotation). Verify that the tabs under `Signing key rotation` section are rendered correctly.


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

