### PR TITLE
Timeout support for dynamic log levels

### DIFF
--- a/app/_src/gateway/production/logging/update-log-level-dynamically.md
+++ b/app/_src/gateway/production/logging/update-log-level-dynamically.md
@@ -9,7 +9,7 @@ You can change the log level of {{site.base_gateway}} dynamically, without resta
 The log level change is propagated to all NGINX worker nodes, including the newly spawned workers.
 
 {:.important}
-> Be careful when changing the log level of a node to `debug` in a production environment, because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level such as `notice`, **or** specify a `timeout` as a request querystring parameter when issuing a request to modify the log level. To ensure stability, the `timeout` for all dynamically set log levels is 60 seconds **by default**.
+> Changing the log level to `debug` in a production environment can rapidly fill up the disk. After debug logging, switch back to a higher level like `notice` or use a `timeout` parameter in the request query string. **The default timeout for dynamically set log levels is 60 seconds**.
 
 
 ## View current log level

--- a/app/_src/gateway/production/logging/update-log-level-dynamically.md
+++ b/app/_src/gateway/production/logging/update-log-level-dynamically.md
@@ -9,19 +9,19 @@ You can change the log level of {{site.base_gateway}} dynamically, without resta
 The log level change is propagated to all NGINX worker nodes, including the newly spawned workers.
 
 {:.important}
-> Be careful when changing the log level of a node to `debug` in a production environment, because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level such as `notice`.
+> Be careful when changing the log level of a node to `debug` in a production environment, because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level such as `notice`, **or** specify a `timeout` as a request querystring parameter when issuing a request to modify the log level. To ensure stability, the `timeout` for all dynamically set log levels is 60 seconds **by default**.
 
 
 ## View current log level
 
-To view the log level of an individual node, issue a `GET` request passing the desired `node` as a path parameter: 
+To view the log level of an individual node, issue a `GET` request passing the desired `node` as a path parameter:
 
 ```bash
 curl --request GET \
-  --url http://localhost:8001/debug/node/log-level/ 
+  --url http://localhost:8001/debug/node/log-level/
 ```
 
-If you have the appropriate permissions, this request returns information about your current log level: 
+If you have the appropriate permissions, this request returns information about your current log level:
 
 ```json
 {
@@ -30,18 +30,18 @@ If you have the appropriate permissions, this request returns information about 
 ```
 
 {:.note}
-> It is currently not possible to change the log level of the data plane or DB-less nodes. 
+> It is currently not possible to change the log level of the data plane or DB-less nodes.
 
 ## Modify the log level for an individual {{site.base_gateway}} node
 
-To change the log level of an individual node, issue a `PUT` request passing the desired `node` and [`log-level`](/gateway/{{page.kong_version}}/production/logging/log-reference/) as path parameters: 
+To change the log level of an individual node, issue a `PUT` request passing the desired `node` and [`log-level`](/gateway/{{page.kong_version}}/production/logging/log-reference/) as path parameters:
 
 ```bash
 curl --request PUT \
-  --url http://localhost:8001/debug/node/log-level/notice 
+  --url http://localhost:8001/debug/node/log-level/notice
 ```
 
-If you have the appropriate permissions and the request is successful, you receive a `200` response code and the following response body: 
+If you have the appropriate permissions and the request is successful, you receive a `200` response code and the following response body:
 
 ```json
 {
@@ -51,7 +51,7 @@ If you have the appropriate permissions and the request is successful, you recei
 
 ## Change the log level of the {{site.base_gateway}} cluster
 
-To change the log level of every node in your cluster, issue a `PUT` request with the desired [`log-level`](/gateway/{{page.kong_version}}/production/logging/log-reference/) specified as a path parameter: 
+To change the log level of every node in your cluster, issue a `PUT` request with the desired [`log-level`](/gateway/{{page.kong_version}}/production/logging/log-reference/) specified as a path parameter:
 
 ```bash
 curl --request PUT \

--- a/app/_src/gateway/production/logging/update-log-level-dynamically.md
+++ b/app/_src/gateway/production/logging/update-log-level-dynamically.md
@@ -8,7 +8,7 @@ You can change the log level of {{site.base_gateway}} dynamically, without resta
 
 The log level change is propagated to all NGINX worker nodes, including the newly spawned workers.
 
-{:.important}
+{:.note}
 > Changing the log level to `debug` in a production environment can rapidly fill up the disk. After debug logging, switch back to a higher level like `notice` or use a `timeout` parameter in the request query string. **The default timeout for dynamically set log levels is 60 seconds**.
 
 


### PR DESCRIPTION
### Description

Timeout support for dynamic log levels
 
KAG-5
DOCU-2903


### Testing instructions

Netlify link: https://deploy-preview-5550--kongdocs.netlify.app/gateway/latest/production/logging/update-log-level-dynamically/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

