### PR TITLE
Support page updates for 3.3

### DIFF
--- a/app/_data/tables/support/gateway/versions/33.yml
+++ b/app/_data/tables/support/gateway/versions/33.yml
@@ -1,0 +1,104 @@
+{% include_relative_once _data/tables/support/gateway/packages.yml %}
+{% include_relative_once _data/tables/support/gateway/third-party.yml %}
+{% include_relative_once _data/tables/support/gateway/browsers.yml %}
+
+lts: false
+distributions:
+  - <<: *alpine
+    docker: true
+    arm: true
+  - <<: *amazonlinux2
+    docker: true
+    arm: true
+  - <<: *amazonlinux2022
+    docker: true
+    arm: true
+  - *centos7
+  - *debian10
+  - <<: *debian11
+    docker: true
+  - *rhel7
+  - <<: *rhel8
+    docker: true
+    fips: true
+  - <<: *ubuntu1804
+    arm: false
+    docker: false
+  - <<: *ubuntu2004
+    arm: false
+    docker: false
+    fips: true
+  - <<: *ubuntu2204
+    arm: true
+    docker: true
+    fips: true
+
+third-party:
+  datastore:
+    - <<: *postgres
+      versions:
+        - 15
+        - 14
+        - 13
+        - 12
+        - 11
+        - 10
+        - 9
+        - Amazon RDS
+        - Amazon Aurora
+    - *cassandra
+    - *redis
+    - *influxdb
+    - *kafka
+
+  metrics:
+    - *prometheus
+    - *statsd
+    - *opentelemetry
+    - *zipkin
+
+  vault:
+    - *vaultproject
+    - *aws-sm
+    - *gcp-sm
+
+  identity_provider:
+    - *auth0
+    - *cognito
+    - *connect2id
+    - *curity
+    - *dex
+    - *gluu
+    - *google
+    - *identityserver
+    - *keycloak
+    - *azure-ad
+    - *microsoft-adfs
+    - *microsoft-live-connect
+    - *okta
+    - *onelogin
+    - *openam
+    - *paypal
+    - *pingfederate
+    - *salesforce
+    - *wso2
+    - *yahoo
+
+  service_mesh:
+    - *kongmesh
+    - *istio
+
+  log_provider:
+    - *splunk
+    - *datadog
+    - *loggly
+
+  s3_api:
+    - *s3
+    - *minio
+
+browsers:
+  - *edge
+  - *chrome
+  - *firefox
+  - *safari

--- a/app/_src/gateway/support/browser.md
+++ b/app/_src/gateway/support/browser.md
@@ -8,6 +8,9 @@ breadcrumb: Browser
 Kong supports N-1 versions of Edge, Chrome, Firefox and Safari on desktop plus any extended support versions.
 
 {% navtabs %}
+  {% navtab 3.3 %}
+    {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.33 %}
+  {% endnavtab %}
   {% navtab 3.2 %}
     {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.32 %}
   {% endnavtab %}

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -46,7 +46,7 @@ Kong supports the following versions of {{site.ee_product_name}}:
 
 {% navtabs %}
   {% navtab 3.3 %}
-    {% include_cached gateway-support.html version="3.2" data=site.data.tables.support.gateway.versions.33 eol="May 2024" %}
+    {% include_cached gateway-support.html version="3.3" data=site.data.tables.support.gateway.versions.33 eol="May 2024" %}
   {% endnavtab %}
   {% navtab 3.2 %}
     {% include_cached gateway-support.html version="3.2" data=site.data.tables.support.gateway.versions.32 eol="February 2024" %}

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -45,6 +45,9 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 Kong supports the following versions of {{site.ee_product_name}}: 
 
 {% navtabs %}
+  {% navtab 3.3 %}
+    {% include_cached gateway-support.html version="3.2" data=site.data.tables.support.gateway.versions.33 eol="May 2024" %}
+  {% endnavtab %}
   {% navtab 3.2 %}
     {% include_cached gateway-support.html version="3.2" data=site.data.tables.support.gateway.versions.32 eol="February 2024" %}
   {% endnavtab %}

--- a/app/_src/gateway/support/third-party.md
+++ b/app/_src/gateway/support/third-party.md
@@ -11,6 +11,9 @@ Kong aims to support the last 2 versions of any third party tool, plus the curre
 > Some third party tools below do not have a version number. These tools are managed services and Kong provides compatibility with the currently released version
 
 {% navtabs %}
+  {% navtab 3.3 %}
+    {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.33 %}
+  {% endnavtab %}
   {% navtab 3.2 %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.32 %}
   {% endnavtab %}


### PR DESCRIPTION
### Description

Adding 3.3 tabs for all of the support pages + Amazon RDS support.

### Testing instructions
 
Netlify link: https://deploy-preview-5569--kongdocs.netlify.app/gateway/latest/support/third-party/
https://deploy-preview-5569--kongdocs.netlify.app/gateway/latest/support/browser/
https://deploy-preview-5569--kongdocs.netlify.app/gateway/latest/support-policy/

Make sure all the support pages have 3.3 tabs and that Amazon RDS appears on the Postgres tile.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

