### PR TITLE
Add plugin aliases

### DIFF
--- a/app/_assets/javascripts/plugin-hub.js
+++ b/app/_assets/javascripts/plugin-hub.js
@@ -63,8 +63,17 @@ $(document).ready(function () {
       showCard = showCard && passesFilters(card, selectedCompatibility);
 
       if (searchQuery !== '') {
-        var cardTitle = $(card).find('.plugin-card--meta__name')[0].innerText.toLowerCase();
-        showCard = showCard && cardTitle.includes(searchQuery);
+        var meta = $(card).find('.plugin-card--meta__name')[0];
+
+        var searchStrings = $(meta).data("search").split(", "); // Search aliases
+        searchStrings.push(meta.innerText.toLowerCase()) // Card title
+
+        var searchMatches = false;
+        searchStrings.forEach(function(value){
+          searchMatches = searchMatches || value.includes(searchQuery)
+        });
+
+        showCard = showCard && searchMatches;
       }
       $(card).toggle(showCard);
     });

--- a/app/_hub/kong-inc/openid-connect/_metadata.yml
+++ b/app/_hub/kong-inc/openid-connect/_metadata.yml
@@ -1,4 +1,7 @@
 name: OpenID Connect
+search_aliases:
+  - oidc
+  - oauth2
 dbless_compatible: 'yes'
 free: false
 plus: true

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -27,7 +27,7 @@
   <a href="{{ extn.url | remove: 'index.html' }}" title="{{ extn.name }}: {{ extn.desc }}">
     <div class="plugin-card--content">
       <div class="plugin-card--meta">
-        <div class="plugin-card--meta__name">
+        <div class="plugin-card--meta__name" data-search="{{ extn.search_aliases | join: ', ' }}">
           <img src="{{ extn.extn_icon }}" alt="{{ extn.name }} icon" />
           <p>{{ extn.name }}</p>
         </div>


### PR DESCRIPTION
### Description

Add the ability to specify aliases for plugins e.g. `oidc` for `OpenID Connect`

### Testing instructions

Netlify link: /hub/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

