### PR TITLE
Plugin Hub: post-release fixes

### DIFF
--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -334,6 +334,16 @@ table {
   .docs-sidebar {
     top: 75px;
     height: ~"calc(100vh - 75px)";
+
+    .accordion-item.plugin-hub {
+      img {
+        background: gray;
+      }
+
+      @media (min-width: 801px) {
+        display: none;
+      }
+    }
   }
 
   .page-content-container {

--- a/app/_hub/kong-inc/serverless-functions/_changelog.md
+++ b/app/_hub/kong-inc/serverless-functions/_changelog.md
@@ -1,0 +1,15 @@
+## Changelog
+
+**{{site.base_gateway}} 3.0**
+
+* The deprecated `config.functions` parameter has been removed from the plugin.
+Use `config.access` instead.
+* The pre-function plugin changed priority from `+inf` to `1000000`.
+
+**{{site.base_gateway}} 2.3**
+
+* Introduced sandboxing, which is enabled by default.
+Only the Kong PDK, OpenResty `ngx` APIs, and Lua standard libraries are allowed.
+To change the default setting, see the Kong [configuration property reference](/gateway/latest/reference/configuration/#untrusted_lua).
+
+  This change was also introduced into previous releases through patch versions: 1.5.0.9, 2.1.4.3, and 2.2.1.0.

--- a/app/_hub/kong-inc/serverless-functions/_index.md
+++ b/app/_hub/kong-inc/serverless-functions/_index.md
@@ -1,0 +1,201 @@
+## Usage
+
+{% navtabs %}
+{% navtab With a database %}
+
+1. Create a service on Kong:
+
+    ```bash
+    curl -i -X  POST http://localhost:8001/services/ \
+      --data "name=plugin-testing" \
+      --data "url=http://httpbin.org/headers"
+    ```
+
+2. Add a route to the service:
+
+    ```bash
+    curl -i -X  POST http://localhost:8001/services/plugin-testing/routes \
+      --data "paths[]=/test"
+    ```
+
+1. Create a file named `custom-auth.lua` with the following content:
+
+    ```lua
+      -- Get list of request headers
+      local custom_auth = kong.request.get_header("x-custom-auth")
+
+      -- Terminate request early if our custom authentication header
+      -- does not exist
+      if not custom_auth then
+        return kong.response.exit(401, "Invalid Credentials")
+      end
+
+      -- Remove custom authentication header from request
+      kong.service.request.clear_header('x-custom-auth')
+    ```
+
+4. Ensure the file contents:
+
+    ```bash
+    cat custom-auth.lua
+    ```
+
+5. Apply our Lua code using the `pre-function` plugin using cURL file upload:
+
+    ```bash
+    curl -i -X POST http://localhost:8001/services/plugin-testing/plugins \
+        -F "name=pre-function" \
+        -F "config.access[1]=@custom-auth.lua" \
+        -F "config.access[2]=kong.log.err('Hi there Access!')" \
+        -F "config.header_filter[1]=kong.log.err('Hi there Header_Filter!')" \
+        -F "config.body_filter[1]=kong.log.err('Hi there Body_Filter!')" \
+        -F "config.log[1]=kong.log.err('Hi there Log!')"
+    ```
+
+    Response:
+    ```
+    HTTP/1.1 201 Created
+    ...
+    ```
+
+6. Test that our Lua code will terminate the request when no header is passed:
+
+    ```bash
+    curl -i -X GET http://localhost:8000/test
+
+    HTTP/1.1 401 Unauthorized
+    ...
+    "Invalid Credentials"
+    ```
+    In the logs, there will be the following messages:
+    ```
+    [pre-function] Hi there Header_Filter!
+    [pre-function] Hi there Body_Filter!
+    [pre-function] Hi there Body_Filter!
+    [pre-function] Hi there Log!
+    ```
+    The "Access" message is missing because the first function in that phase does
+    an early exit, throwing the 401. Hence the subsequent functions are not executed.
+
+7. Test the Lua code we just applied by making a valid request:
+
+    ```bash
+    curl -i -X GET http://localhost:8000/test \
+      --header "x-custom-auth: demo"
+
+    HTTP/1.1 200 OK
+    ...
+    ```
+    Now the logs will also have the "Access" message.
+
+{% endnavtab %}
+{% navtab Without a database %}
+
+1. Create the service, route, and associated plugin in the declarative config file:
+
+    ``` yaml
+    services:
+    - name: plugin-testing
+      url: http://httpbin.org/headers
+
+    routes:
+    - service: plugin-testing
+      paths: [ "/test" ]
+
+    plugins:
+    - name: pre-function
+      config:
+        access:
+        - |2
+            -- Get list of request headers
+            local custom_auth = kong.request.get_header("x-custom-auth")
+
+            -- Terminate request early if the custom authentication header
+            -- does not exist
+            if not custom_auth then
+              return kong.response.exit(401, "Invalid Credentials")
+            end
+
+            -- Remove custom authentication header from request
+            kong.service.request.clear_header('x-custom-auth')
+        - kong.log.err('Hi there Access!')
+        header_filter:
+        - kong.log.err('Hi there Header_Filter!')
+        body_filter:
+        - kong.log.err('Hi there Body_Filter!')
+        log:
+        - kong.log.err('Hi there Log!')
+    ```
+
+2. Test that the Lua code will terminate the request when no header is passed:
+
+    ```bash
+    curl -i -X GET http://localhost:8000/test
+
+    HTTP/1.1 401 Unauthorized
+    ...
+    "Invalid Credentials"
+    ```
+    The following messages will be in the logs:
+    ```
+    [pre-function] Hi there Header_Filter!
+    [pre-function] Hi there Body_Filter!
+    [pre-function] Hi there Body_Filter!
+    [pre-function] Hi there Log!
+    ```
+    The "Access" message is missing because the first function in that phase does
+    an early exit, throwing the 401. Hence the subsequent functions are not executed.
+
+3. Test the Lua code we just applied by making a valid request:
+
+    ```bash
+    curl -i -X GET http://localhost:8000/test \
+      --header "x-custom-auth: demo"
+
+    HTTP/1.1 200 OK
+    ...
+    ```
+    Now the logs will also have the "Access" message.
+
+{% endnavtab %}
+{% endnavtabs %}
+
+This is just a small demonstration of the power these plugins grant. You were
+able to dynamically inject Lua code into the plugin phases to dynamically
+terminate, or transform the request without creating a custom plugin or
+reloading / redeploying Kong.
+
+In summary, serverless functions give you the full capabilities of a custom plugin
+without requiring redeploying or restarting Kong.
+
+## Sandboxing
+
+The provided Lua environment is sandboxed.
+
+{% include /md/plugins-hub/sandbox.md %}
+
+## Upvalues
+
+You can return a function to run on each request,
+allowing for upvalues to keep state in between requests:
+
+```lua
+-- this runs once on the first request
+local count = 0
+
+return function()
+  -- this runs on each request
+  count = count + 1
+  ngx.log(ngx.ERR, "hello world: ", count)
+end
+```
+
+## Minifying Lua
+
+Since we send our code over in a string format, it is advisable to use either
+curl file upload `@file.lua` (see demonstration) or to minify your Lua code
+using a [minifier][lua-minifier].
+
+
+[service-url]: https://getkong.org/docs/latest/admin-api/#service-object
+[lua-minifier]: https://mothereff.in/lua-minifier

--- a/app/_hub/kong-inc/serverless-functions/_metadata.yml
+++ b/app/_hub/kong-inc/serverless-functions/_metadata.yml
@@ -1,0 +1,29 @@
+name: Serverless Functions
+publisher: Kong Inc.
+desc: Dynamically run Lua code from Kong
+description: |
+  Dynamically run Lua code from Kong.
+
+  The Serverless Functions plugin comes as two separate plugins. Each one runs with a
+  different priority in the plugin chain.
+
+  - `pre-function`
+    - Runs before other plugins run during each phase. The `pre-function` plugin can be applied to individual services, routes, or globally.
+  - `post-function`
+    - Runs after other plugins in each phase. The `post-function` plugin can be applied to individual services, routes, or globally.
+
+  {:.important}
+  > **Warning:** The pre-function and post-function serverless plugin
+    allows anyone who can enable the plugin to execute arbitrary code.
+    If your organization has security concerns about this, disable the plugin
+    in your `kong.conf` file.
+
+type: plugin
+categories:
+  - serverless
+free: true
+enterprise: true
+konnect_examples: false
+dbless_compatible: partially
+dbless_explanation: |
+  The functions will be executed, but if the configured functions attempt to write to the database, the writes will fail.

--- a/app/_hub/kong-inc/serverless-functions/_metadata.yml
+++ b/app/_hub/kong-inc/serverless-functions/_metadata.yml
@@ -27,3 +27,5 @@ konnect_examples: false
 dbless_compatible: partially
 dbless_explanation: |
   The functions will be executed, but if the configured functions attempt to write to the database, the writes will fail.
+
+reference_param_name: pre-function OR post-function

--- a/app/_hub/kong-inc/serverless-functions/versions.yml
+++ b/app/_hub/kong-inc/serverless-functions/versions.yml
@@ -1,0 +1,13 @@
+strategy: gateway
+releases:
+  minimum_version: '2.1.x'
+
+overrides:
+  2.8.x: 2.1.0
+  2.7.x: 2.1.0
+  2.6.x: 2.1.0
+  2.5.x: 2.1.0
+  2.4.x: 2.1.0
+  2.3.x: 2.1.0
+  2.2.x: 2.1.0
+  2.1.x: 2.1.0

--- a/app/_hub/salt/salt/_metadata.yml
+++ b/app/_hub/salt/salt/_metadata.yml
@@ -56,3 +56,5 @@ kong_version_compatibility:
     compatible:
       - 0.35-x
       - 0.34-x
+
+reference_param_name: salt-agent

--- a/app/_includes/plugins/schema.html
+++ b/app/_includes/plugins/schema.html
@@ -10,7 +10,10 @@
       <span class="required"><strong>required</strong></span>
     </div>
     <div class="field-description-and-children">
-      <p class="field-description">The name of the plugin, in this case <code>{{ page.extn_slug }}</code>.</p>
+      {% capture plugin_name %}
+        {%- if page.reference_param_name != nil -%}{{ page.reference_param_name }}{%- else -%}{{ page.extn_slug }}{%- endif -%}
+      {% endcapture %}
+      <p class="field-description">The name of the plugin, in this case <code>{{ plugin_name }}</code>.</p>
     </div>
   </li>
 

--- a/app/_includes/plugins/schemas/field.html
+++ b/app/_includes/plugins/schemas/field.html
@@ -34,13 +34,15 @@
     {% endif %}
 
     {% unless include.field.default == nil %}
-      <span class="default">
-        {% if include.field.type == 'array' or include.field.type == 'set' %}
-          <strong>default: </strong><code>{{ include.field.default | join: ", " }}</code>
-        {% else %}
-          <strong>default: </strong><code>{{ include.field.default }}</code>
-        {% endif %}
-      </span>
+      {% unless include.field.default == empty %}
+        <span class="default">
+          {% if include.field.type == 'array' or include.field.type == 'set' %}
+            <strong>default: </strong><code>{{ include.field.default | join: ", " }}</code>
+          {% else %}
+            <strong>default: </strong><code>{{ include.field.default }}</code>
+          {% endif %}
+        </span>
+      {% endunless %}
     {% endunless %}
 
     {% if include.field.match %}

--- a/app/_includes/plugins/sidebar.html
+++ b/app/_includes/plugins/sidebar.html
@@ -3,6 +3,22 @@
 
   <ul class="accordion-container">
     <input id="accordion-opened" type="text" />
+
+    <li class="accordion-item plugin-hub">
+      <input id="accordion-0" type="checkbox" />
+      <label for="accordion-0">
+        <img src="/assets/images/icons/documentation/hub/icn-breadcrumbs.svg" alt="Plugin Hub">
+        <a
+          href="/hub/"
+          class="accordion-link"
+          role="menuitem"
+          tabindex="0"
+        >
+          Plugin Hub
+        </a>
+      </label>
+    </li>
+
     {% for item in include.sidenav.nav_items %}
       {% include_cached accordion_item.html item=item id=forloop.index %}
     {% endfor %}

--- a/app/_plugins/generators/plugin_single_source/plugin/examples/kong.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/examples/kong.rb
@@ -7,11 +7,21 @@ module PluginSingleSource
         EXAMPLES_PATH = 'app/_src/.repos/kong-plugins/examples'
 
         def file_path
-          @file_path ||= File.join(EXAMPLES_PATH, @name, "_#{release_version}.yaml")
+          @file_path ||= File.join(EXAMPLES_PATH, plugin_folder, "_#{release_version}.yaml")
         end
 
         def release_version
           @version.split('.').first(2).join('.').concat('.x')
+        end
+
+        private
+
+        def plugin_folder
+          if @name == 'serverless-functions'
+            'pre-function'
+          else
+            @name
+          end
         end
       end
     end

--- a/app/_plugins/generators/plugin_single_source/plugin/schemas/kong.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/schemas/kong.rb
@@ -11,13 +11,23 @@ module PluginSingleSource
         def file_path
           @file_path ||= File.join(
             SCHEMAS_PATH,
-            plugin_name,
+            plugin_folder,
             "#{release_version}.json"
           )
         end
 
         def release_version
           version.split('.').first(2).join('.').concat('.x')
+        end
+
+        private
+
+        def plugin_folder
+          if plugin_name == 'serverless-functions'
+            'pre-function'
+          else
+            plugin_name
+          end
         end
       end
     end

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/examples/kong_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/examples/kong_spec.rb
@@ -1,9 +1,21 @@
 RSpec.describe PluginSingleSource::Plugin::Examples::Kong do
+  let(:name) { 'acme' }
+  let(:vendor) { 'kong-inc' }
+  let(:version) { '3.1.1' }
+
   describe '#file_path' do
-    subject { described_class.new(name: 'acme', vendor: 'kong-inc', version: '3.1.1') }
+    subject { described_class.new(name:, vendor:, version:) }
 
     it 'returns the path to the corresponding example file' do
       expect(subject.file_path).to eq('app/_src/.repos/kong-plugins/examples/acme/_3.1.x.yaml')
+    end
+
+    context 'special case - serverless-functions' do
+      let(:name) { 'serverless-functions' }
+
+      it 'returns the path to pre-function\'s example' do
+        expect(subject.file_path).to eq('app/_src/.repos/kong-plugins/examples/pre-function/_3.1.x.yaml')
+      end
     end
   end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/schemas/kong_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/schemas/kong_spec.rb
@@ -83,4 +83,18 @@ RSpec.describe PluginSingleSource::Plugin::Schemas::Kong do
       ])
     end
   end
+
+  describe '#file_path' do
+    it 'returns the path to the corresponding schema file' do
+      expect(subject.file_path).to eq('app/_src/.repos/kong-plugins/schemas/acme/3.1.x.json')
+    end
+
+    context 'special case - serverless-functions' do
+      let(:plugin_name) { 'serverless-functions' }
+
+      it 'returns the path to pre-function\'s schema' do
+        expect(subject.file_path).to eq('app/_src/.repos/kong-plugins/schemas/pre-function/3.1.x.json')
+      end
+    end
+  end
 end

--- a/spec/templates/plugins/configuration_spec.rb
+++ b/spec/templates/plugins/configuration_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Plugin page' do
     expect(name).to have_css('h4', text: 'name')
     expect(name).to have_css('strong', text: 'string')
     expect(name).to have_css('.required', text: 'required')
-    expect(name).to have_css('.field-description', text: 'The name of the plugin, in this case unbundled-plugin.')
+    expect(name).to have_css('.field-description', text: 'The name of the plugin, in this case unbundled-plugin.', normalize_ws: true)
 
     service = fields.find('> .field:nth-of-type(2)')
     expect(service).to have_css('h4', text: 'service.name or service.id')


### PR DESCRIPTION
### Description

What did you change and why?

* Add missing descriptions to schemas
* Bring back `serverless-functions` plugins
* Fix an issue that rendered empty default values for some fields
* Add a link to `/hub/` on mobile to the sidenav


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

