### PR TITLE
Plugin k8s examples

### DIFF
--- a/app/_includes/plugins/hub-examples/consumer.html
+++ b/app/_includes/plugins/hub-examples/consumer.html
@@ -40,7 +40,7 @@ Replace `CONSUMER_NAME` with the name of the consumer that this plugin configura
 You can see your available consumers by running `kubectl get KongConsumer`.
 
 To learn more about `KongConsumer` objects, see [Provisioning Consumers and Credentials
-](/kubernetes-ingress-controller/latest/guides/using-consumer-credential-resource/)
+](/kubernetes-ingress-controller/latest/guides/using-consumer-credential-resource/).
 
 <blockquote class="note">
   <strong>Note:</strong> The KongPlugin resource only needs to be defined once

--- a/app/_includes/plugins/hub-examples/consumer.html
+++ b/app/_includes/plugins/hub-examples/consumer.html
@@ -30,20 +30,17 @@ resource:
 
 {% include_cached plugins/hub-examples/kubernetes.html example=hub_example.kubernetes %}
 
-Then, apply it to a [consumer](/gateway/latest/admin-api/#consumer-object) by
-annotating the KongConsumer resource as follows:
+Next, apply the `KongPlugin` resource to an ingress by annotating the `KongConsumer` object as follows:
 
-``` yaml
-apiVersion: configuration.konghq.com/v1
-kind: KongConsumer
-metadata:
-  name: CONSUMER_NAME|CONSUMER_ID
-  annotations:
-    konghq.com/plugins: {{ hub_example.plugin_name }}-example
-    kubernetes.io/ingress.class: kong
-  ```
+```yaml
+kubectl annotate KongConsumer CONSUMER_NAME konghq.com/plugins={{ hub_example.kubernetes.plugin_name }}-example
+```
 
-Replace `CONSUMER_NAME|CONSUMER_ID` with the `id` or `name` of the consumer that this plugin configuration will target.
+Replace `CONSUMER_NAME` with the name of the consumer that this plugin configuration will target.
+You can see your available consumers by running `kubectl get KongConsumer`.
+
+To learn more about `KongConsumer` objects, see [Provisioning Consumers and Credentials
+](/kubernetes-ingress-controller/latest/guides/using-consumer-credential-resource/)
 
 <blockquote class="note">
   <strong>Note:</strong> The KongPlugin resource only needs to be defined once

--- a/app/_includes/plugins/hub-examples/kubernetes.html
+++ b/app/_includes/plugins/hub-examples/kubernetes.html
@@ -1,10 +1,12 @@
 ```yaml
+echo "
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
 metadata:
   name: {{ include.example.plugin_name }}-example
+plugin: {{ include.example.plugin_name }}
 config:
   {%- for line in include.example.example_config %}
   {{ line }}{%- endfor %}
-plugin: {{ include.example.plugin_name }}
+" | kubectl apply -f -
 ```

--- a/app/_includes/plugins/hub-examples/route.html
+++ b/app/_includes/plugins/hub-examples/route.html
@@ -24,31 +24,14 @@ resource:
 
 {% include_cached plugins/hub-examples/kubernetes.html example=hub_example.kubernetes %}
 
-Then, apply it to an ingress ([route or routes](/gateway/latest/admin-api/#route-object))
-by annotating the ingress as follows:
+Next, apply the `KongPlugin` resource to an ingress by annotating the `ingress` as follows:
 
-``` yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ROUTE_NAME|ROUTE_ID
-  annotations:
-    kubernetes.io/ingress.class: kong
-    konghq.com/plugins: {{ hub_example.plugin_name }}-example
-spec:
-  rules:
-  - host: examplehostname.com
-    http:
-      paths:
-      - path: /bar
-        backend:
-          service:
-            name: echo
-            port:
-              number: 80
-  ```
+```yaml
+kubectl annotate ingress INGRESS_NAME konghq.com/plugins={{ hub_example.kubernetes.plugin_name }}-example
+```
 
-Replace `ROUTE_NAME|ROUTE_ID` with the `id` or `name` of the route that this plugin configuration will target.
+Replace `INGRESS_NAME` with the name of the ingress that this plugin configuration will target.
+You can see your available ingresses by running `kubectl get ingress`.
 
 <blockquote class="note">
   <strong>Note:</strong> The KongPlugin resource only needs to be defined once

--- a/app/_includes/plugins/hub-examples/service.html
+++ b/app/_includes/plugins/hub-examples/service.html
@@ -24,30 +24,14 @@ resource:
 
 {% include_cached plugins/hub-examples/kubernetes.html example=hub_example.kubernetes %}
 
-Next, apply the KongPlugin resource to a
-[service](/gateway/latest/admin-api/#service-object) by annotating the
-service as follows:
+Next, apply the `KongPlugin` resource to an ingress by annotating the `service` as follows:
 
 ```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: SERVICE_NAME|SERVICE_ID
-  labels:
-    app: SERVICE_NAME|SERVICE_ID
-  annotations:
-    konghq.com/plugins: {{ hub_example.plugin_name }}-example
-spec:
-  ports:
-  - port: 80
-    targetPort: 80
-    protocol: TCP
-    name: SERVICE_NAME|SERVICE_ID
-  selector:
-    app: SERVICE_NAME|SERVICE_ID
-  ```
+kubectl annotate service SERVICE_NAME konghq.com/plugins={{ hub_example.kubernetes.plugin_name }}-example
+```
 
-Replace `SERVICE_NAME|SERVICE_ID` with the `id` or `name` of the service that this plugin configuration will target.
+Replace `SERVICE_NAME` with the name of the service that this plugin configuration will target.
+You can see your available ingresses by running `kubectl get service`.
 
 <blockquote class="note">
   <strong>Note:</strong> The KongPlugin resource only needs to be defined once


### PR DESCRIPTION
### Description

Fix plugin hub examples for k8s configuration

### Testing instructions

Netlify link: I tested key-auth for service/route and rate-limiting for consumer


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
