### PR TITLE
Hub breadcrumbs

### DIFF
--- a/app/_hub/kong-inc/oas-validation/_metadata.yml
+++ b/app/_hub/kong-inc/oas-validation/_metadata.yml
@@ -6,6 +6,8 @@ plus: true
 enterprise: true
 konnect: true
 network_config_opts: Self-managed traditional, DB-less, and hybrid
+categories:
+  - traffic-control
 notes: --
 publisher: Kong Inc.
 desc: Validate HTTP requests and responses based on an OpenAPI 3.0 or Swagger API Specification

--- a/app/_plugins/generators/plugin_single_source/pages/base.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/base.rb
@@ -87,6 +87,7 @@ module PluginSingleSource
       def category_url
         categories = @release.metadata['categories']
         return nil if categories.nil?
+
         "/hub/?category=#{categories.first}"
       end
 
@@ -98,6 +99,7 @@ module PluginSingleSource
 
         cat = @site_categories.detect { |category| category['slug'] == categories.first }
         return categories[0] if cat.nil?
+
         cat['name']
       end
 

--- a/app/_plugins/generators/plugin_single_source/pages/base.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/base.rb
@@ -78,10 +78,15 @@ module PluginSingleSource
 
       def breadcrumbs
         [
-          { text: @release.metadata['categories'] },
+          { text: @release.metadata['categories'], url: category_url(@release.metadata['categories']) },
           { text: @release.metadata['name'], url: permalink.split('/').tap(&:pop).join('/').concat('/') },
           { text: breadcrumb_title, url: permalink }
         ]
+      end
+
+      def category_url(categories)
+        return nil if categories.nil?
+        "/hub/?category=#{categories.first}"
       end
 
       def layout

--- a/app/_plugins/generators/plugin_single_source/pages/base.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/base.rb
@@ -78,15 +78,27 @@ module PluginSingleSource
 
       def breadcrumbs
         [
-          { text: @release.metadata['categories'], url: category_url(@release.metadata['categories']) },
+          { text: category_title, url: category_url },
           { text: @release.metadata['name'], url: permalink.split('/').tap(&:pop).join('/').concat('/') },
           { text: breadcrumb_title, url: permalink }
         ]
       end
 
-      def category_url(categories)
+      def category_url
+        categories = @release.metadata['categories']
         return nil if categories.nil?
         "/hub/?category=#{categories.first}"
+      end
+
+      def category_title
+        categories = @release.metadata['categories']
+        return nil if categories.nil? # This happens when the plugin is not categorized
+
+        @site_categories ||= @site.config['extensions']['categories']
+
+        cat = @site_categories.detect { |category| category['slug'] == categories.first }
+        return categories[0] if cat.nil?
+        cat['name']
       end
 
       def layout

--- a/app/_plugins/generators/plugin_single_source/pages/overview.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/overview.rb
@@ -37,7 +37,7 @@ module PluginSingleSource
 
       def breadcrumbs
         [
-          { text: @release.metadata['categories'], url: category_url(@release.metadata['categories']) },
+          { text: category_title, url: category_url },
           { text: breadcrumb_title, url: permalink }
         ]
       end

--- a/app/_plugins/generators/plugin_single_source/pages/overview.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/overview.rb
@@ -37,7 +37,7 @@ module PluginSingleSource
 
       def breadcrumbs
         [
-          { text: @release.metadata['categories'] },
+          { text: @release.metadata['categories'], url: category_url(@release.metadata['categories']) },
           { text: breadcrumb_title, url: permalink }
         ]
       end


### PR DESCRIPTION
### Description

Make the Plugin Hub category breadcrumbs use the nice title rather than `analytics-monitoring` etc

![CleanShot 2023-05-16 at 12 29 14](https://github.com/Kong/docs.konghq.com/assets/59130/ef3a090f-1a6f-4608-b6a7-2ae652b97cb8)

![CleanShot 2023-05-16 at 12 29 22](https://github.com/Kong/docs.konghq.com/assets/59130/e3a24ed0-9668-468e-927a-5f8a1572f90b)

I couldn't see where to add tests - let me know where to add them. Feel free to refactor if there's a better way to achieve this too.

### Testing instructions

Netlify link: /hub/kong-inc/datadog/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

