### PR TITLE
Fix kong mesh images

### DIFF
--- a/app/_plugins/generators/kuma_to_kong_mesh.rb
+++ b/app/_plugins/generators/kuma_to_kong_mesh.rb
@@ -33,7 +33,7 @@ module KumaToKongMesh
       # Links can be wrapped with " (html) or ( and ) (markdown)
       page.content = page
                      .content
-                     .gsub(%r{([("]/.*)kuma(?!(?:-cp|-dp|ctl))([^\s]*)([)"])}, '\1kong-mesh\2\3')
+                     .gsub(%r{([("]/(?!assets/).*)kuma(?!(?:-cp|-dp|ctl))([^\s]*)([)"])}, '\1kong-mesh\2\3')
                      .gsub('kong-mesh.io', 'kuma.io')
     end
 

--- a/spec/app/_plugins/generators/kuma_to_kong_mesh_spec.rb
+++ b/spec/app/_plugins/generators/kuma_to_kong_mesh_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe KumaToKongMesh::Generator do
           expect(page.content).to include('/mesh/{{ page.kong_version }}/generated/cmd/kuma-dp/kuma-dp_run')
           expect(page.content).to include('/mesh/{{ page.kong_version }}/generated/cmd/kumactl/kumactl_apply')
         end
+
+        context 'assets' do
+          it 'does not replace `kuma` in assets' do
+            expect(page.content).to include('<img src="/assets/images/docs/0.4.0/kuma_dp1.jpeg"')
+            expect(page.content).to include('<img src="/assets/images/docs/0.4.0/kuma_dp2.png"')
+            expect(page.content).to include('<img src="/assets/images/docs/0.4.0/kuma_dp3.png"')
+            expect(page.content).to include('<img src="/assets/images/docs/1.1.2/kuma_dp4.png"')
+          end
+        end
       end
 
       context 'transforms specific links' do

--- a/spec/fixtures/app/kuma-to-kong-mesh.md
+++ b/spec/fixtures/app/kuma-to-kong-mesh.md
@@ -25,6 +25,16 @@ The word "Kuma" means "bear" in Japanese (クマ).
 [kuma-dp run](/docs/{{ page.version }}/generated/cmd/kuma-dp/kuma-dp_run)
 [kumactl apply](/docs/{{ page.version }}/generated/cmd/kumactl/kumactl_apply)
 
+
+#### Dashboards
+
+<center>
+<img src="/assets/images/docs/0.4.0/kuma_dp1.jpeg" alt="Kuma Dataplane dashboard" style="width: 600px; padding-top: 20px; padding-bottom: 10px;"/>
+<img src="/assets/images/docs/0.4.0/kuma_dp2.png" alt="Kuma Dataplane dashboard" style="width: 600px; padding-top: 20px; padding-bottom: 10px;"/>
+<img src="/assets/images/docs/0.4.0/kuma_dp3.png" alt="Kuma Dataplane dashboard" style="width: 600px; padding-top: 20px; padding-bottom: 10px;"/>
+<img src="/assets/images/docs/1.1.2/kuma_dp4.png" alt="Kuma Dataplane dashboard" style="width: 600px; padding-top: 20px; padding-bottom: 10px;"/>
+</center>
+
 ## Exact links transforms
 
 [Install Kuma](/install/)


### PR DESCRIPTION
### Description

What did you change and why?

Prevent the generator to replace kuma with kong-mesh on links that start with `/assets/`.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

