### PR TITLE
Add Helm instructions when enabling KIC debug endpoint

### DIFF
--- a/app/_src/kubernetes-ingress-controller/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/troubleshooting.md
@@ -243,7 +243,7 @@ approaches to isolate issues:
   purposes, run `curl https://get.konghq.com/quickstart | bash -s -- -D`.
 
   Once this image is running, run `curl http://localhost:8001/config @last_bad.json`
-  to try applying the configuration and see any errors
+  to try applying the configuration and see any errors.
   
 ## Inspecting network traffic with a tcpdump sidecar
 

--- a/app/_src/kubernetes-ingress-controller/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/troubleshooting.md
@@ -204,6 +204,16 @@ temporary file. To use the diagnostic mode:
 1. Set the `--dump-config` flag (or `CONTROLLER_DUMP_CONFIG` environment
    variable) to `true`. Optionally set the `--dump-sensitive-config` flag to
    `true` to include un-redacted TLS certificate keys and credentials.
+
+   If you're deploying with the Helm chart, add the following to your
+   `values.yaml` file:
+
+   ```yaml
+   ingressController:
+    env:
+      dump_config: "true"
+      dump_sensitive_config: "true"
+    ```
 1. (Optional) Make a change to a Kubernetes resource that you know will
    reproduce the issue. If you are unsure what change caused the issue
    originally, you can omit this step.
@@ -229,7 +239,12 @@ approaches to isolate issues:
   and responses (passing `--verbose 2` to decK will show all requests) and
    add debug Kong Lua code when controller requests result in an
   unhandled error (500 response).
+- To run a DB-less {{ site.base_gateway }} instance with Docker for testing
+  purposes, run `curl https://get.konghq.com/quickstart | bash -s -- -D`.
 
+  Once this image is running, run `curl http://localhost:8001/config @last_bad.json`
+  to try applying the configuration and see any errors
+  
 ## Inspecting network traffic with a tcpdump sidecar
 
 Inspecting network traffic allows you to review traffic between the ingress


### PR DESCRIPTION
### Description

I couldn't work out how to enable the debug endpoint with Helm

### Testing instructions

Netlify link: /kubernetes-ingress-controller/latest/troubleshooting/#dumping-generated-kong-configuration

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)