### PR TITLE
adjusted defaults based on latest values for plugin

### DIFF
--- a/app/_hub/moesif/kong-plugin-moesif/schemas/_index.json
+++ b/app/_hub/moesif/kong-plugin-moesif/schemas/_index.json
@@ -70,7 +70,7 @@
           {
             "keepalive": {
               "type": "number",
-              "default": 1000,
+              "default": 5000,
               "description": "Value in milliseconds that defines for how long an idle connection will live before being closed."
             }
           },
@@ -168,7 +168,7 @@
           {
             "event_queue_size": {
               "type": "number",
-              "default": 5000,
+              "default": 1000,
               "description": "Maximum number of events to hold in the queue before sending to Moesif. In case of network issues where the plugin is unable to connect or send an event to Moesif, skips adding new events to the queue to prevent memory overflow."
             }
           },
@@ -182,7 +182,7 @@
           {
             "max_callback_time_spent": {
               "type": "number",
-              "default": 2000,
+              "default": 750,
               "description": "Limits the amount of time in milliseconds to send events to Moesif per worker cycle."
             }
           },


### PR DESCRIPTION
### Description

What did you change and why?
Some of our default values changed for our latest plugin config. I've adjusted those values in the docs now.
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

