### PR TITLE
[DOCU-3229] Tech partner badges for third-party plugins

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -596,4 +596,7 @@ jQuery(function () {
   $(".badge.konnect").append(
     '<div class="tooltip"><span class="tooltiptext">Available in the Kong Konnect app</span></div>'
   );
+  $(".badge.techpartner").append(
+    '<div class="tooltip"><span class="tooltiptext">Verified Kong technical partner</span></div>'
+  );
 });

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -40,6 +40,12 @@
     }
   }
 
+  &.techpartner::after {
+    content: "TECH PARTNER";
+    color: #008871;
+    background: #E8F8F5;
+  }
+
   &.enterprise::after {
     content: "ENTERPRISE";
     color: @steel-700;

--- a/app/_hub/imperva/imp-appsec-connector/_metadata.yml
+++ b/app/_hub/imperva/imp-appsec-connector/_metadata.yml
@@ -34,6 +34,7 @@ description: |
   kept under the control of the application owner.
 
 enterprise: true
+techpartner: true
 # (required) extended description.
 # Use YAML pipe notation for extended entries.
 # EXAMPLE long text format (do not use this entry)

--- a/app/_hub/moesif/kong-plugin-moesif/_metadata.yml
+++ b/app/_hub/moesif/kong-plugin-moesif/_metadata.yml
@@ -11,7 +11,7 @@ categories:
 
 type: plugin
 
-desc: Powerful API analytics and tools to activate, understand, and monetize customers.
+desc: Powerful API analytics and tools to activate, understand, and monetize customers
 
 description: |
   This plugin logs API traffic to [Moesif API Analytics](https://www.moesif.com?language=kong-api-gateway&utm_medium=docs&utm_campaign=partners&utm_source=kong), which enables you to:
@@ -36,6 +36,7 @@ privacy_policy_url: https://www.moesif.com/privacy?utm_medium=docs&utm_campaign=
 terms_of_service_url: https://www.moesif.com/terms?utm_medium=docs&utm_campaign=partners&utm_source=kong
 
 enterprise: true
+techpartner: true
 
 kong_version_compatibility: # required
   community_edition: # optional

--- a/app/_hub/okta/okta/_metadata.yml
+++ b/app/_hub/okta/okta/_metadata.yml
@@ -7,8 +7,9 @@ categories:
 type: integration
 
 enterprise: true
+techpartner: true
 
-desc: Integrate Okta's API Access Management (OAuth as a Service) with Kong API Gateway.
+desc: Integrate Okta's API Access Management (OAuth as a Service) with Kong API Gateway
 
 description: |
   [This integration guide](https://github.com/tom-smith-okta/okta-api-center/tree/master/gateways/kong){:target="_blank"}{:rel="noopener noreferrer"} describes how to integrate Okta's API Access Management (OAuth as a Service) with Kong API Gateway.

--- a/app/_hub/salt/salt/_metadata.yml
+++ b/app/_hub/salt/salt/_metadata.yml
@@ -42,6 +42,7 @@ description: |
   # (Optional) Link to your online TOS.
 
 enterprise: true
+techpartner: true
 
 kong_version_compatibility:
   community_edition:

--- a/app/_hub/wallarm/wallarm/_metadata.yml
+++ b/app/_hub/wallarm/wallarm/_metadata.yml
@@ -48,6 +48,7 @@ description: |
 terms_of_service_url: https://www.wallarm.com/terms-of-service
 
 enterprise: true
+techpartner: true
 
 kong_version_compatibility:
   community_edition:

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -37,6 +37,7 @@
         {% endif %}
         {% if include.enterprise %}<a href="https://konghq.com/pricing" target="_blank" class="badge enterprise" aria-label="available with enterprise subscription"></a>{% endif %}
         {% if include.oss %}<a href="https://konghq.com/pricing" target="_blank" class="badge oss" aria-label="open-source only"></a>{% endif %}
+        {% if include.techpartner %}<a href="https://konghq.com/partners" target="_blank" class="badge techpartner" aria-label="Verified Kong technical partner"></a>{% endif %}
         </div>
       </div>
     </div>

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -11,6 +11,9 @@
 {%- if badges.enterprise? -%}
   {%- assign css_classes =  css_classes | append: " enterprise" -%}
 {%- endif -%}
+{%- if badges.techpartner? -%}
+  {%- assign css_classes =  css_classes | append: " techpartner" -%}
+{%- endif -%}
 {%- unless extn.enterprise -%}
   {%- assign css_classes = css_classes | append: " open-source" -%}
 {%- endunless -%}
@@ -40,6 +43,9 @@
           {% endif %}
           {% if badges.enterprise? %}
             <span class="badge enterprise"></span>
+          {% endif %}
+          {% if badges.techpartner? %}
+            <span class="badge techpartner"></span>
           {% endif %}
         </div>
         <div class="plugin-card--meta__description">{{ extn.desc }}</div>

--- a/app/_includes/plugins/badges.html
+++ b/app/_includes/plugins/badges.html
@@ -7,6 +7,9 @@
 {% if include.badges.enterprise? %}
   <a href="https://konghq.com/pricing" target="_blank" class="badge enterprise" aria-label="available with enterprise subscription"> </a>
 {% endif %}
+{% if include.badges.techpartner? %}
+  <a href="https://konghq.com/partners" target="_blank" class="badge techpartner" aria-label="Verified Kong technical partner"> </a>
+{% endif %}
 {% if include.oss %}
   <a href="https://konghq.com/pricing" target="_blank" class="badge oss" aria-label="open-source only"> </a>
 {% endif %}

--- a/app/_layouts/plugins/show.html
+++ b/app/_layouts/plugins/show.html
@@ -24,6 +24,7 @@ type: plugin
                       plus=page.plus
                       enterprise=page.enterprise
                       konnect=page.konnect
+                      techpartner=page.techpartner
                       extn_publisher=page.extn_publisher
                       extn_versions=extn_versions
                       extn_data=page.extn_data

--- a/app/_plugins/drops/plugins/badges.rb
+++ b/app/_plugins/drops/plugins/badges.rb
@@ -23,8 +23,12 @@ module Jekyll
           !!@metadata['enterprise'] && !!!@metadata['free']
         end
 
+        def techpartner?
+          !!@metadata['techpartner'] && @publisher != KONG_INC
+        end
+
         def hash
-          "publisher:#{@publisher}-plus:#{plus?}-konnect:#{konnect?}-enterprise:#{enterprise?}"
+          "publisher:#{@publisher}-plus:#{plus?}-konnect:#{konnect?}-enterprise:#{enterprise?}-techpartner:#{techpartner?}"
         end
       end
     end

--- a/app/_plugins/drops/plugins/badges.rb
+++ b/app/_plugins/drops/plugins/badges.rb
@@ -28,7 +28,11 @@ module Jekyll
         end
 
         def hash
-          "publisher:#{@publisher}-plus:#{plus?}-konnect:#{konnect?}-enterprise:#{enterprise?}-techpartner:#{techpartner?}"
+          "publisher:#{@publisher}-" \
+            "plus:#{plus?}-" \
+            "konnect:#{konnect?}-" \
+            "enterprise:#{enterprise?}-" \
+            "techpartner:#{techpartner?}"
         end
       end
     end


### PR DESCRIPTION
### Description

Added a tech partner badge to the following plugins:
- Moesif
- Wallarm
- Imperva
- Salt
- Okta

https://konghq.atlassian.net/browse/DOCU-3229

### Testing instructions

Netlify link: https://deploy-preview-5596--kongdocs.netlify.app/hub/?support=third-party


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

