### PR TITLE
Typo. Fix for #5145.

### DIFF
--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
@@ -139,7 +139,7 @@ In case the control plane stops working, the data plane will keep serving reques
 cached configurations. It does so while constantly trying to reestablish communication
 with the control plane.
 
-This means that the data plane nodes can be stopped even for extended periods
+This means that the control plane nodes can be stopped even for extended periods
 of time, and the data plane will still proxy traffic normally. Data plane
 nodes can be restarted while in disconnected mode, and will load the last
 configuration in the cache to start working. When the control plane is brought


### PR DESCRIPTION
### Description

This is a fix for issue #5145 where it was mentioned we wrote data plane when we meant control plane in the Fault Tolerance section.

### Testing instructions

N/A

### Checklist 

- [Y] Review label added <!-- (see below) -->
- [Y] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
