### PR TITLE
kic: Gateway Discovery only works with DB-less deployments of Kong

### DIFF
--- a/app/_src/kubernetes-ingress-controller/concepts/deployment.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/deployment.md
@@ -322,6 +322,9 @@ Kubernetes Service which is backed by [Kong Admin API][admin] endpoints.
 This Service endpoints can be then discovered by {{site.kic_product_name}}
 through Kubernetes EndpointSlice watch.
 
+{:.important}
+> Gateway Discovery is only supported with DB-less deployments of Kong.
+
 The overview of this type of deployment can be found on the figure below:
 
 ![Gateway Discovery overview](/assets/images/docs/kubernetes-ingress-controller/gateway-discovery-diagram.png "Gateway Discovery overview")


### PR DESCRIPTION
### Description

Closes: https://github.com/Kong/kubernetes-ingress-controller/issues/4001

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

