### PR TITLE
Fix trailing / on URLs with fragments

### DIFF
--- a/app/_plugins/drops/sidenav.rb
+++ b/app/_plugins/drops/sidenav.rb
@@ -47,7 +47,10 @@ module Jekyll
       private
 
       def standardize_url(url)
-        url.prepend('/').concat('/').gsub(%r{/+}, '/')
+        # Make sure that we add the trailing / before any URL fragment
+        parts = url.split('#')
+        parts[0] = parts[0].prepend('/').concat('/').gsub(%r{/+}, '/')
+        parts.join('#')
       end
     end
 

--- a/spec/app/_plugins/drops/plugins/sidenav_menu_item_spec.rb
+++ b/spec/app/_plugins/drops/plugins/sidenav_menu_item_spec.rb
@@ -33,5 +33,18 @@ RSpec.describe Jekyll::Drops::SidenavMenuItem do
         expect(subject.url).to eq('/gateway/3.2.x/kong-enterprise/dev-portal/workspaces/')
       end
     end
+
+    context 'when the URL contains a fragment' do
+      let(:item) do
+        {
+         'text' => 'Health Routes',
+         'url' => 'admin-api#health-routes'
+        }
+      end
+
+      it 'adds the trailing slash before the fragment' do
+        expect(subject.url).to eq('/gateway/3.2.x/admin-api/#health-routes')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description

Fix sidebar URLs that contain a URL fragment


### Testing instructions

Netlify link: Check the admin API URLs

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)