### PR TITLE
Increase timeout for flaky test

### DIFF
--- a/tests/seo.test.js
+++ b/tests/seo.test.js
@@ -49,7 +49,7 @@ describe("Canonical links", () => {
       await expect($("head link[rel='canonical']").attr("href")).toBe(
         `https://docs.konghq.com${t.href}`
       );
-    }, 7000);
+    }, 15000);
   });
 });
 


### PR DESCRIPTION
### Description

GH Actions runners are underpowered. Increase the test timeout time (like we did in #4801)

### Testing instructions

Netlify link: N/A


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)