### PR TITLE
Fix konnect compatibility table

### DIFF
--- a/app/hub/plugins/compatibility/index.md
+++ b/app/hub/plugins/compatibility/index.md
@@ -99,11 +99,6 @@ data plane roles. Kong provides and hosts the control plane and a database with
 
 {% endfor %}
 
-### Deployment
-
-[Deployment plugins](/hub/#deployment) are not bundled with any version of {{site.base_gateway}} or {{site.konnect_short_name}}, and are
-simply tools to help you deploy {{ site.base_gateway }} in various environments.
-
 ## Protocols
 
 {{site.base_gateway}} and {{site.konnect_short_name}} plugins are compatible with the following protocols:

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -37,8 +37,10 @@ access to a subset of plugins:
 
 If you're looking for supported network protocols and entity scopes, see [Plugin Compatibility](/hub/plugins/compatibility/) on the Plugin Hub.
 
+{% assign hub = site.data.ssg_hub %}
+{% assign kong_extns = hub | where: "extn_publisher", "kong-inc" %}
 {% assign categories = site.extensions.categories %}
-{% assign kong_extns = site.data.ssg_hub | where: "extn_publisher", "kong-inc" %}
+{% assign plugins = site.data.ssg_hub | where: "extn_publisher", "kong-inc" %}
 
 {% for category in categories %}
 <h3 id="{{ category.slug }}">
@@ -55,42 +57,42 @@ If you're looking for supported network protocols and entity scopes, see [Plugin
       <th style="text-align: left; width: 35%">Notes</th>
   </thead>
   <tbody>
-    {% assign plugins_for_category = kong_extns | where_exp: "plugin", "plugin.metadata.categories contains category.slug" %}
+    {% assign plugins_for_category = kong_extns | where_exp: "plugin", "plugin.categories contains category.slug" %}
     {% for plugin in plugins_for_category %}
       <tr>
         <td>
           <a href="{{plugin.url}}">{{ plugin.name }}</a>
         </td>
         <td style="text-align: center">
-          {% if plugin.metadata.free == true %}
+          {% if plugin.free == true %}
             <i class="fa fa-check"></i>
-          {% elsif plugin.metadata.free == false %}
+          {% elsif plugin.free == false %}
             <i class="fa fa-times"></i>
           {% endif %}
         </td>
         <td style="text-align: center">
-          {% if plugin.metadata.plus == true %}
+          {% if plugin.plus == true %}
             <i class="fa fa-check"></i>
-          {% elsif plugin.metadata.plus == false %}
+          {% elsif plugin.plus == false %}
             <i class="fa fa-times"></i>
           {% endif %}
         </td>
         <td style="text-align: center">
-          {% if plugin.metadata.enterprise == true %}
+          {% if plugin.enterprise == true %}
             <i class="fa fa-check"></i>
-          {% elsif plugin.metadata.enterprise == false %}
+          {% elsif plugin.enterprise == false %}
             <i class="fa fa-times"></i>
           {% endif %}
         </td>
-         <td style="text-align: center">
-          {% if plugin.metadata.konnect == true %}
+        <td style="text-align: center">
+          {% if plugin.konnect == true %}
             <i class="fa fa-check"></i>
-          {% elsif plugin.metadata.konnect == false %}
+          {% elsif plugin.konnect == false %}
             <i class="fa fa-times"></i>
           {% endif %}
         </td>
         <td>
-          {{ plugin.metadata.notes }}
+          {{ plugin.notes }}
         </td>
       </tr>
     {% endfor %}
@@ -98,8 +100,3 @@ If you're looking for supported network protocols and entity scopes, see [Plugin
 </table>
 
 {% endfor %}
-
-### Deployment
-
-[Deployment plugins](/hub/#deployment) are not bundled with any version of {{site.konnect_short_name}}, and are
-simply tools to help you deploy {{site.base_gateway}} in various environments.


### PR DESCRIPTION
### Description

Fixes https://github.com/Kong/docs.konghq.com/issues/5606.

Also removing the "Deployment" section/heading, as it no longer exists on the Plugin Hub.

### Testing instructions

Netlify link: https://deploy-preview-5607--kongdocs.netlify.app/konnect/compatibility/#plugin-compatibility

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

