### PR TITLE
[DOCU-3225] Add AWS Graviton support to OS support table

### DIFF
--- a/app/_data/tables/support/gateway/packages.yml
+++ b/app/_data/tables/support/gateway/packages.yml
@@ -19,7 +19,7 @@ _packages:
     package: true
     arm: false
     fips: false
-    graviton: true
+    graviton: false
   amazonlinux2022: &amazonlinux2022
     os: Amazon Linux
     version: 2022
@@ -110,18 +110,18 @@ _packages:
     package: true
     arm: false
     fips: false
-    graviton: true
+    graviton: false
   ubuntu2004: &ubuntu2004
     os: Ubuntu
     version: 20.04
     package: true
     arm: false
     fips: false
-    graviton: true
+    graviton: false
   ubuntu2204: &ubuntu2204
     os: Ubuntu
     version: 22.04
     package: true
     arm: false
     fips: false
-    graviton: true
+    graviton: false

--- a/app/_data/tables/support/gateway/packages.yml
+++ b/app/_data/tables/support/gateway/packages.yml
@@ -5,105 +5,123 @@ _packages:
     package: true
     arm: false
     fips: false
+    graviton: false
   amazonlinux1: &amazonlinux1
     os: Amazon Linux
     version: 1
     package: true
     arm: false
     fips: false
+    graviton: false
   amazonlinux2: &amazonlinux2
     os: Amazon Linux
     version: 2
     package: true
     arm: false
     fips: false
+    graviton: true
   amazonlinux2022: &amazonlinux2022
     os: Amazon Linux
     version: 2022
     package: true
     arm: false
     fips: false
+    graviton: false
   centos7: &centos7
     os: CentOS
     version: 7
     package: true
     arm: false
     fips: false
+    graviton: false
   centos8: &centos8
     os: CentOS
     version: 8
     package: true
     arm: false
     fips: false
+    graviton: false
   debian8: &debian8
     os: Debian
     version: 8
     package: true
     arm: false
     fips: false
+    graviton: false
   debian9: &debian9
     os: Debian
     version: 9
     package: true
     arm: false
     fips: false
+    graviton: false
   debian10: &debian10
     os: Debian
     version: 10
     package: true
     arm: false
     fips: false
+    graviton: false
   debian11: &debian11
     os: Debian
     version: 11
     package: true
     arm: false
     fips: false
+    graviton: false
   debian-stable: &debian-stable
     os: Debian
     version: stable
     package: true
     arm: false
     fips: false
+    graviton: false
   rhel7: &rhel7
     os: RHEL
     version: 7.x
     package: true
     arm: false
     fips: false
+    graviton: false
   rhel8: &rhel8
     os: RHEL
     version: 8.x
     package: true
     arm: false
     fips: false
+    graviton: false
   rhel9: &rhel9
     os: RHEL
     version: 9.x
     package: true
     arm: false
     fips: false
+    graviton: false
   ubuntu1604: &ubuntu1604
     os: Ubuntu
     version: 16.04
     package: true
     arm: false
     fips: false
+    graviton: false
   ubuntu1804: &ubuntu1804
     os: Ubuntu
     version: 18.04
     package: true
     arm: false
     fips: false
+    graviton: true
   ubuntu2004: &ubuntu2004
     os: Ubuntu
     version: 20.04
     package: true
     arm: false
     fips: false
+    graviton: true
   ubuntu2204: &ubuntu2204
     os: Ubuntu
     version: 22.04
     package: true
     arm: false
     fips: false
+    graviton: true

--- a/app/_data/tables/support/gateway/versions/32.yml
+++ b/app/_data/tables/support/gateway/versions/32.yml
@@ -7,12 +7,15 @@ distributions:
   - <<: *alpine
     docker: true
     arm: true
+    graviton: true
   - <<: *amazonlinux2
     docker: true
     arm: true
+    graviton: true
   - <<: *amazonlinux2022
     docker: true
     arm: true
+    graviton: true
   - *debian10
   - <<: *debian11
     docker: true
@@ -29,6 +32,7 @@ distributions:
     fips: true
   - <<: *ubuntu2204
     arm: true
+    graviton: true
     docker: true
     fips: true
 

--- a/app/_data/tables/support/gateway/versions/33.yml
+++ b/app/_data/tables/support/gateway/versions/33.yml
@@ -7,12 +7,15 @@ distributions:
   - <<: *alpine
     docker: true
     arm: true
+    graviton: true
   - <<: *amazonlinux2
     docker: true
     arm: true
+    graviton: true
   - <<: *amazonlinux2022
     docker: true
     arm: true
+    graviton: true
   - *debian10
   - <<: *debian11
     docker: true
@@ -29,6 +32,7 @@ distributions:
     fips: true
   - <<: *ubuntu2204
     arm: true
+    graviton: true
     docker: true
     fips: true
 

--- a/app/_includes/gateway-support.html
+++ b/app/_includes/gateway-support.html
@@ -9,6 +9,7 @@ Kong Gateway {{ include.version }} supports the following deployment targets unt
       <th>Artifacts</th>
       <th>ARM support</th>
       <th>FIPS compliant</th>
+      <th>AWS Graviton support</th>
       <th>EOL</th>
     </tr>
   </thead>
@@ -27,6 +28,7 @@ Kong Gateway {{ include.version }} supports the following deployment targets unt
         </td>
         <td>{{ d.arm | to_check }}</td>
         <td>{{ d.fips | to_check }}</td>
+        <td>{{ d.graviton | to_check }}</td>
         <td>
           {% if d.eol %}
             {{ d.eol }}

--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -16,6 +16,9 @@ Kong is licensed under an
 
 You can install {{site.base_gateway}} by downloading an installation package or using our yum repository.
 
+{:.note}
+> **Note:** {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
+
 {% navtabs %}
 {% navtab Package %}
 

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -22,6 +22,9 @@ Kong is licensed under an
 
 ## Installation
 
+{:.note}
+> **Note:** {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
+
 The quickest way to get started with {{ site.base_gateway }} is using our install script:
 
 {% navtabs_ee codeblock %}
@@ -67,10 +70,8 @@ Once {{ site.base_gateway }} is running, you may want to do the following:
 You can install {{site.base_gateway}} by downloading an installation package or using our APT repository.
 
 {:.note .no-icon}
-> We currently package {{ site.base_gateway }} for Ubuntu Bionic and Focal.
-> If you are using a different release, replace `$(lsb_release -sc)` with `focal` in the commands below.
-> <br /><br />
-> To check your release name run `lsb_release -sc`.
+> * We currently package {{ site.base_gateway }} for Ubuntu Bionic and Focal. If you are using a different release, replace `$(lsb_release -sc)` with `focal` in the commands below. To check your release name run `lsb_release -sc`.
+> * {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
 
 {% navtabs %}
 {% navtab Package %}


### PR DESCRIPTION
### Description

What did you change and why?
- I added notes about AWS Graviton support to the Ubuntu and Amazon Linux install pages
- I also added a new column to the support table that shows which OSes support AWS Graviton processors
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-3225

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
- /gateway/latest/support-policy/#supported-versions
- /gateway/latest/install/linux/amazon-linux/
- /gateway/latest/install/linux/ubuntu/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

