### PR TITLE
Plugin hub: Fix protocols table

### DIFF
--- a/app/hub/plugins/compatibility/index.md
+++ b/app/hub/plugins/compatibility/index.md
@@ -135,7 +135,7 @@ data plane roles. Kong provides and hosts the control plane and a database with
         <td style="text-align: center">N/A</td>
         <td style="text-align: center">N/A</td>
       {% else %}
-        {% assign protocols = extn.schema.protocols %}
+      {% assign protocols = extn.schema.protocols.elements.one_of %}
         <td style="text-align: center"> 
           {% if protocols contains "http" %}
             <i class="fa fa-check"></i>


### PR DESCRIPTION
### Description

Plugin protocol table is broken, not reading the right values from the schemas. Fixing that.

![Screenshot 2023-05-22 at 1 59 05 PM](https://github.com/Kong/docs.konghq.com/assets/54370747/71a12620-d706-40f3-a0c8-f5ad878ba56e)

### Testing instructions

Netlify link: https://deploy-preview-5616--kongdocs.netlify.app/hub/plugins/compatibility/#protocols


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

