### PR TITLE
Fix PDF generation with submodules

### DIFF
--- a/.github/workflows/build-docs-pdf.yml
+++ b/.github/workflows/build-docs-pdf.yml
@@ -14,6 +14,8 @@ jobs:
       - run: sudo sysctl -w fs.inotify.max_user_watches=524288
 
       - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       # Configure Ruby to build Jekyll site
       - name: Set up Ruby


### PR DESCRIPTION
### Description

The PDF generation workflow doesn't work due to submodules being added


### Testing instructions

Netlify link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
