### PR TITLE
Fix k8s config example

### DIFF
--- a/app/_includes/plugins/hub-examples/global.html
+++ b/app/_includes/plugins/hub-examples/global.html
@@ -35,7 +35,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: kong
   labels:
-    global: \"true\"
+    global: "true"
 config:
   {%- for line in hub_example.kubernetes.example_config %}
   {{ line }}{%- endfor %}

--- a/app/_plugins/drops/plugins/examples/yaml.rb
+++ b/app/_plugins/drops/plugins/examples/yaml.rb
@@ -10,7 +10,7 @@ module Jekyll
           FIELD = {
             'consumer' => 'consumer: CONSUMER_NAME|CONSUMER_ID',
             'global' => nil,
-            'route' => 'route: ROUTE_NAME',
+            'route' => 'route: ROUTE_NAME|ROUTE_ID',
             'service' => 'service: SERVICE_NAME|SERVICE_ID'
           }.freeze
 


### PR DESCRIPTION
### Description

`"true"` should not be escaped in the global k8s example

### Testing instructions

Netlify link: /hub/kong-inc/opentelemetry/configuration/examples/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)