### PR TITLE
Bring removal & deprecation reminders to top of changelog

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -11,6 +11,12 @@ no_version: true
 
 ### Breaking changes and deprecations
 
+* **Alpine deprecation reminder:** Kong has announced our intent to remove support for Alpine images and packages later this year. 
+These images and packages are still available in 3.3. We will stop building Alpine images and packages in Kong Gateway 3.4.
+
+* **Cassandra deprecation and removal reminder:** Using Cassandra as a backend database for Kong Gateway is deprecated. 
+It is planned for removal with {{site.base_gateway}} 3.4.
+
 #### Core
 
 * The `traditional_compat` router mode has been made more compatible with the
@@ -64,14 +70,6 @@ instead of the previous 1 (trace all requests).
   This plugin now uses queues for internal buffering. 
   The standard queue parameter set is available to control queuing behavior.
   [#10753](https://github.com/Kong/kong/pull/10753)
-
-#### Reminders 
-
-* **Alpine deprecation reminder:** Kong has announced our intent to remove support for Alpine images and packages later this year. 
-These images and packages are still available in 3.3. We will stop building Alpine images and packages in Kong Gateway 3.4.
-
-* **Cassandra deprecation and removal reminder:** Using Cassandra as a backend database for Kong Gateway is deprecated. 
-It is planned for removal with {{site.base_gateway}} 3.4.
 
 ### Features
 


### PR DESCRIPTION
### Description

Reminders were a bit buried in their own section. Pulling up in the changelog per request from Tom.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

