### PR TITLE
Set correct value for cookie_same_site

### DIFF
--- a/app/_src/gateway/install/helm-quickstart.md
+++ b/app/_src/gateway/install/helm-quickstart.md
@@ -143,8 +143,8 @@ Configuring {{site.base_gateway}} requires a namespace and configuration secrets
        {% if_version gte:3.2.x %}
 
        kubectl create secret generic kong-config-secret -n kong \
-           --from-literal=portal_session_conf='{"storage":"kong","secret":"super_secret_salt_string","cookie_name":"portal_session","cookie_same_site":"off","cookie_secure":false}' \
-           --from-literal=admin_gui_session_conf='{"storage":"kong","secret":"super_secret_salt_string","cookie_name":"admin_session","cookie_same_site":"off","cookie_secure":false}' \
+           --from-literal=portal_session_conf='{"storage":"kong","secret":"super_secret_salt_string","cookie_name":"portal_session","cookie_same_site":"Lax","cookie_secure":false}' \
+           --from-literal=admin_gui_session_conf='{"storage":"kong","secret":"super_secret_salt_string","cookie_name":"admin_session","cookie_same_site":"Lax","cookie_secure":false}' \
            --from-literal=pg_host="enterprise-postgresql.kong.svc.cluster.local" \
            --from-literal=kong_admin_password=kong \
            --from-literal=password=kong

--- a/app/_src/gateway/install/kubernetes/helm-quickstart.md
+++ b/app/_src/gateway/install/kubernetes/helm-quickstart.md
@@ -153,8 +153,8 @@ Configuring {{site.base_gateway}} requires a namespace and configuration secrets
        {% if_version gte:3.2.x %}
 
        kubectl create secret generic kong-config-secret -n kong \
-           --from-literal=portal_session_conf='{"storage":"kong","secret":"super_secret_salt_string","cookie_name":"portal_session","cookie_same_site":"off","cookie_secure":false}' \
-           --from-literal=admin_gui_session_conf='{"storage":"kong","secret":"super_secret_salt_string","cookie_name":"admin_session","cookie_same_site":"off","cookie_secure":false}' \
+           --from-literal=portal_session_conf='{"storage":"kong","secret":"super_secret_salt_string","cookie_name":"portal_session","cookie_same_site":"Lax","cookie_secure":false}' \
+           --from-literal=admin_gui_session_conf='{"storage":"kong","secret":"super_secret_salt_string","cookie_name":"admin_session","cookie_same_site":"Lax","cookie_secure":false}' \
            --from-literal=pg_host="enterprise-postgresql.kong.svc.cluster.local" \
            --from-literal=kong_admin_password=kong \
            --from-literal=password=kong

--- a/app/_src/gateway/install/kubernetes/helm.md
+++ b/app/_src/gateway/install/kubernetes/helm.md
@@ -85,7 +85,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     {% endif_version %}
     {% if_version gte:3.2.x %}
     ```bash
-    echo '{"cookie_name":"admin_session","cookie_same_site":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
+    echo '{"cookie_name":"admin_session","cookie_same_site":"Lax","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf
     ```
     {% endif_version %}
 
@@ -105,14 +105,14 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     {% endif_version %}
     {% if_version gte:3.2.x %}
     ```bash
-    echo '{"cookie_name":"portal_session","cookie_same_site":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_same_site":"Lax","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
     Or, if you have different subdomains for the `portal_api_url` and `portal_gui_host`, set the `cookie_domain`
     and `cookie_same_site` properties as follows:
 
     ```
-    echo '{"cookie_name":"portal_session","cookie_same_site":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_same_site":"Lax","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
     {% endif_version %}
 

--- a/app/_src/gateway/kong-enterprise/dev-portal/authentication/basic-auth.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/authentication/basic-auth.md
@@ -50,7 +50,7 @@ Or, if you have different subdomains for the `portal_api_url` and `portal_gui_ho
 and `cookie_same_site` properties as follows:
 
 ```
-portal_session_conf={ "cookie_name":"portal_session","secret":"<CHANGE_THIS>","storage":"kong","cookie_secure":false,"cookie_domain":"<.your_subdomain.com>","cookie_same_site":"off"  }
+portal_session_conf={ "cookie_name":"portal_session","secret":"<CHANGE_THIS>","storage":"kong","cookie_secure":false,"cookie_domain":"<.your_subdomain.com>","cookie_same_site":"Lax"  }
 ```
 {% endif_version %}
 

--- a/app/_src/gateway/kong-enterprise/dev-portal/authentication/sessions.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/authentication/sessions.md
@@ -148,7 +148,7 @@ The dev portal `portal_gui_host` and the dev
 portal api `portal_api_url` must share a domain or subdomain. The following
 example assumes subdomains of `portal.xyz.com` and `portalapi.xyz.com`.
 Set a subdomain such as ``"cookie_domain": ".xyz.com"`` and set
-`cookie_same_site` to `off`.
+`cookie_same_site` to `Lax`.
 
 ```
 portal_auth = basic-auth
@@ -159,7 +159,7 @@ portal_session_conf = {
     "secret":"super-secret"
     "cookie_secure":false
     "rolling_timeout":31557600,
-    "cookie_same_site":"off"
+    "cookie_same_site":"Lax"
 }
 ```
 {% endif_version %}

--- a/app/_src/gateway/kong-manager/auth/basic.md
+++ b/app/_src/gateway/kong-manager/auth/basic.md
@@ -31,7 +31,7 @@ or a user that has `/admins` and `/rbac` read and write access.
     * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
     {% endif_version %}
     {% if_version gte:3.2.x %}
-    * If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `off`.
+    * If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `Lax`.
     {% endif_version %}
     
     Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/kong-manager/auth/sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/kong-manager/auth/sessions/#example-configurations).

--- a/app/_src/gateway/kong-manager/auth/index.md
+++ b/app/_src/gateway/kong-manager/auth/index.md
@@ -42,7 +42,7 @@ The **Sessions plugin** (configured with `admin_gui_session_conf`) requires a se
 * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
 {% endif_version %}
 {% if_version gte:3.2.x %}
-* If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `off`.
+* If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `Lax`.
 {% endif_version %}
 
 Learn more about these properties in

--- a/app/_src/gateway/kong-manager/auth/ldap/configure.md
+++ b/app/_src/gateway/kong-manager/auth/ldap/configure.md
@@ -55,7 +55,7 @@ The **Sessions plugin** (configured with `admin_gui_session_conf`) requires a se
 * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
 {% endif_version %}
 {% if_version gte:3.2.x %}
-* If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `off`.
+* If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `Lax`.
 {% endif_version %}
 
 Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/kong-manager/auth/sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/kong-manager/auth/sessions/#example-configurations).

--- a/app/_src/gateway/kong-manager/auth/ldap/service-directory-mapping.md
+++ b/app/_src/gateway/kong-manager/auth/ldap/service-directory-mapping.md
@@ -47,7 +47,7 @@ Configure service directory mapping to use your LDAP directory for authenticatio
     * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
     {% endif_version %}
     {% if_version gte:3.2.x %}
-    * If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `off`.
+    * If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `Lax`.
     {% endif_version %}
     
     Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/kong-manager/auth/sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/kong-manager/auth/sessions/#example-configurations).

--- a/app/_src/gateway/kong-manager/auth/oidc/configure.md
+++ b/app/_src/gateway/kong-manager/auth/oidc/configure.md
@@ -49,7 +49,7 @@ The **Sessions plugin** (configured with `admin_gui_session_conf`) requires a se
 * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
 {% endif_version %}
 {% if_version gte:3.2.x %}
-* If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `off`.
+* If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `Lax`.
 {% endif_version %}
 
 Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/kong-manager/auth//sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/kong-manager/auth/sessions/#example-configurations).

--- a/app/_src/gateway/production/access-control/start-securely.md
+++ b/app/_src/gateway/production/access-control/start-securely.md
@@ -49,7 +49,7 @@ This plugin (configured with `admin_gui_session_conf`) requires a secret and is 
 * If using different domains for the Admin API and Kong Manager, `cookie_samesite` must be set to `off`.
 {% endif_version %}
 {% if_version gte:3.2.x %}
-* If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `off`.
+* If using different domains for the Admin API and Kong Manager, `cookie_same_site` must be set to `Lax`.
 {% endif_version %}
 
 Learn more about these properties in [Session Security in Kong Manager](/gateway/{{page.kong_version}}/kong-manager/auth/sessions/#session-security), and see [example configurations](/gateway/{{page.kong_version}}/kong-manager/auth/sessions#example-configurations).

--- a/app/_src/gateway/production/networking/dns-considerations.md
+++ b/app/_src/gateway/production/networking/dns-considerations.md
@@ -182,16 +182,35 @@ settings (`admin_gui_auth_conf`).
   its API. For example, if you use `api.admin.kong.example` and
   `manager.admin.kong.example` for the Admin API and Kong Manager,
   `cookie_domain` should be `admin.kong.example`.
-- {% if_version lte:3.1.x %}`cookie_samesite`{% endif_version %}
-  {% if_version gte:3.2.x %}`cookie_same_site`{% endif_version %}
-  should typically be left at its default, `strict`. `none`
-  is not necessary if you have your DNS records and `cookie_domain` set
-  following the examples in this document. `off` is only needed if the GUI and
-  API are on entirely separate hostnames, e.g. `admin.kong.example` for the API
-  and `manager.example.com` for Kong Manager. This configuration is not
-  recommended because `off` opens a vector for cross-site request forgery
-  attacks. It may be needed in some development or testing environments, but
-  should not be used in production.
+
+{% if_version lte:3.1.x %}
+- `cookie_samesite` should typically be left at 
+  its default, `strict`. 
+   - `none` is not necessary if you have your DNS records and 
+    `cookie_domain` set following the examples in this document. 
+   - `off` is only needed if the GUI and
+    API are on entirely separate hostnames, e.g. `admin.kong.example` for the API
+    and `manager.example.com` for Kong Manager. This configuration is not
+    recommended because `off` opens a vector for cross-site request forgery
+    attacks. It may be needed in some development or testing environments, but
+    should not be used in production.
+{% endif_version %} 
+
+{% if_version gte:3.2.x %}
+- `cookie_same_site` should typically be left at its default, `Strict`.
+  
+    - `None` is 
+    not necessary if you have your DNS records and 
+    `cookie_domain` set following the examples in this document.
+
+    - `Lax` is only needed if the GUI and
+    API are on entirely separate hostnames, e.g. `admin.kong.example` for the API
+    and `manager.example.com` for Kong Manager. This configuration is not
+    recommended because `Lax` opens a vector for cross-site request forgery
+    attacks. It may be needed in some development or testing environments, but
+    should not be used in production.
+{% endif_version %}
+
 - `cookie_secure` controls whether cookies can be sent over unsecured
   (plaintext HTTP) requests. By default, it is set to `true`, which does not
   permit sending the cookie over unsecured connections. This setting should

--- a/app/_src/gateway/upgrade-v2.md
+++ b/app/_src/gateway/upgrade-v2.md
@@ -208,6 +208,9 @@ from session configuration to avoid unpredictable behavior.
 
 #### Session plugin
 
+The following parameters and the values that they accept have changed. 
+For details on the new accepted values, see the [Seesion plugin](/hub/kong-inc/session/) documentation.
+
 Old parameter name | New parameter name
 -------------------|--------------------
 `cookie_lifetime` | `rolling_timeout`
@@ -219,6 +222,9 @@ Old parameter name | New parameter name
   
 
 #### SAML plugin
+
+The following parameters and the values that they accept have changed. 
+For details on the new accepted values, see the [SAML plugin](/hub/kong-inc/saml/) documentation.
 
 Old parameter name | New parameter name
 -------------------|--------------------
@@ -237,6 +243,9 @@ Old parameter name | New parameter name
 `session_compressor` | Removed, no replacement parameter. 
 
 #### OpenID Connect plugin
+
+The following parameters and the values that they accept have changed. 
+For details on the new accepted values, see the [OpenID Connect plugin](/hub/kong-inc/openid-connect/) documentation.
 
 Old parameter name | New parameter name
 -------------------|--------------------


### PR DESCRIPTION
### Description

There is no such thing as `cookie_same_site=off`. The old value `off` now maps to `Lax`: https://github.com/Kong/kong/blob/d8391aee22b56144ed3496ab7bbeaf0efb327d07/kong/plugins/session/schema.lua#L141

Follow-up to https://github.com/Kong/docs.konghq.com/pull/5620 updating everything else.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

