### PR TITLE
Update deprecation notice for Cassandra

### DIFF
--- a/app/_includes/md/enterprise/cassandra-deprecation.md
+++ b/app/_includes/md/enterprise/cassandra-deprecation.md
@@ -9,7 +9,7 @@ because support for Cassandra is [deprecated and planned to be removed](/gateway
 > **Deprecation warning:** Cassandra as a backend database for {{site.base_gateway}}
 is deprecated. Support for Cassandra will be removed in a future release.
 > <br>
-> Our target for Cassandra removal is the {{site.base_gateway}} 4.0 release.
+> Our target for Cassandra removal is the {{site.base_gateway}} 3.4 release.
 Starting with the {{site.base_gateway}} 3.0 release, some new features might
 not be supported with Cassandra.
 

--- a/app/_src/deck/faqs.md
+++ b/app/_src/deck/faqs.md
@@ -87,7 +87,7 @@ upgrading to decK 1.12 to take advantage of the new `--konnect` CLI flags.
 
 {:.important}
 > Cassandra as a backend database for {{site.base_gateway}}
-is deprecated with 2.7.0.0 and will be removed in a future Gateway version.
+is deprecated with 2.7.0.0 and will be removed in version 3.4.0.0.
 
 You can use decK with Kong backed by Cassandra.
 However, if you observe errors during a sync process, you will have to

--- a/app/gateway/2.7.x/install-and-run/upgrade-oss.md
+++ b/app/gateway/2.7.x/install-and-run/upgrade-oss.md
@@ -132,7 +132,7 @@ database in the final expected state for Kong 2.7.x).
 
 {:.warning .no-icon}
 > **Deprecation notice:**
-> Cassandra as a backend database for Kong Gateway is deprecated. This means the feature will eventually be removed. Our target for Cassandra removal is the Kong Gateway 4.0 release, and some new features might not be supported with Cassandra in the Kong Gateway 3.0 release.
+> Cassandra as a backend database for Kong Gateway is deprecated. This means the feature will eventually be removed. Our target for Cassandra removal is the Kong Gateway 3.4 release, and some new features might not be supported with Cassandra in the Kong Gateway 3.0 release.
 
 Due to internal changes, the table schemas used by Kong 2.7.x on Cassandra
 are incompatible with those used by Kong 2.1.x (or lower). Migrating using the usual commands

--- a/app/gateway/2.8.x/install-and-run/upgrade-oss.md
+++ b/app/gateway/2.8.x/install-and-run/upgrade-oss.md
@@ -173,7 +173,7 @@ database in the final expected state for Kong 2.8.x).
 
 {:.warning .no-icon}
 > **Deprecation notice:**
-> Cassandra as a backend database for Kong Gateway is deprecated. This means the feature will eventually be removed. Our target for Cassandra removal is the Kong Gateway 4.0 release, and some new features might not be supported with Cassandra in the Kong Gateway 3.0 release.
+> Cassandra as a backend database for Kong Gateway is deprecated. This means the feature will eventually be removed. Our target for Cassandra removal is the Kong Gateway 3.4 release, and some new features might not be supported with Cassandra in the Kong Gateway 3.0 release.
 
 Due to internal changes, the table schemas used by Kong 2.8.x on Cassandra
 are incompatible with those used by Kong 2.1.x (or lower). Migrating using the usual commands

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -3671,7 +3671,7 @@ To access old Kong Immunity documentation, see the
 * Cassandra as a backend database for Kong Gateway
 is deprecated with this release and will be removed in a future version.
 
-  The target for Cassandra removal is the Kong Gateway 4.0 release.
+  The target for Cassandra removal is the Kong Gateway 3.4 release.
   Starting with the Kong Gateway 3.0 release, some new features might
   not be supported with Cassandra. Our intent is to provide our users with ample
   time and alternatives for satisfying the use cases that they have been able to


### PR DESCRIPTION
### Description

Cassandra support will be removed in 3.4

### Testing instructions

Netlify link: https://deploy-preview-5630--kongdocs.netlify.app/

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


