### PR TITLE
fix(zipkin): properly describe the meaning of `sample_ratio`

### DIFF
--- a/app/_hub/kong-inc/zipkin/_index.md
+++ b/app/_hub/kong-inc/zipkin/_index.md
@@ -36,7 +36,7 @@ The `http_endpoint` configuration variable must contain the full uri including s
 
 The plugin does *request sampling*. For each request which triggers the plugin, a random number between 0 and 1 is chosen.
 
-If the number is greater than the configured `sample_ratio`, then a trace with several spans will be generated. If `sample_ratio` is set to 1, then all requests will generate a trace (this might be very noisy).
+If the number is smaller than the configured `sample_ratio`, then a trace with several spans will be generated. If `sample_ratio` is set to 1, then all requests will generate a trace (this might be very noisy).
 
 For each request that gets traced, the following spans are produced:
 


### PR DESCRIPTION
### Description

The previous description reverses the meaning of `sample_ratio`. The correct one should be smaller than the configured `sample_ratio`.


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

