### PR TITLE
Fix referenceable fields.

### DIFF
--- a/app/_plugins/drops/plugins/schema.rb
+++ b/app/_plugins/drops/plugins/schema.rb
@@ -37,7 +37,7 @@ module Jekyll
         end
 
         def referenceable
-          @schema['referenceable']
+          @schema['referenceable'] || @schema.dig('elements', 'referenceable')
         end
 
         def description

--- a/spec/app/_plugins/drops/plugins/schema_field_spec.rb
+++ b/spec/app/_plugins/drops/plugins/schema_field_spec.rb
@@ -55,4 +55,29 @@ RSpec.describe Jekyll::Drops::Plugins::SchemaField do
       expect(subject.fields).to all(be_an(described_class))
     end
   end
+
+  describe '#referenceable' do
+    context 'when the field is referenceable' do
+      let(:name) { 'token' }
+      let(:parent) { 'vault' }
+      let(:field_schema) { { "referenceable" => true, "type" => "string" } }
+
+      it { expect(subject.referenceable).to eq(true) }
+    end
+
+    context 'when the field is of type array and its elements are referenceable' do
+      let(:name) { 'body' }
+      let(:parent) { 'rename' }
+      let(:field_schema) do
+        {
+          "default" => [],
+          "type" => "array",
+          "elements" => { "type" => "string", "referenceable" => true },
+          "description" => "List of parameters..."
+        }
+      end
+
+      it { expect(subject.referenceable).to eq(true) }
+    end
+  end
 end


### PR DESCRIPTION
### Description

Looks like the way to specify whether a field is `referenceable` differs a bit.
We have fields that have the property `referenceable`, e.g. acme:
```
{
  "token": {
    "referenceable": true,
    "type": "string"
  }
},
```
See https://github.com/fabianrbz/kong-plugins-docs-toolkit/blob/main/schemas/acme/3.2.x.json#L269-L274

Other fields, mostly of type `array` mark their elements as referenceable, e.g. request-transformer-advanced:
```
{
  "body": {
    "default": [

    ],
    "type": "array",
    "elements": {
      "type": "string",
      "referenceable": true
    },
    "description": "List of parameter `name:value` pairs. Rename the parameter name if and only if content-type is\none of the following: [`application/json`, `multipart/form-data`, `application/x-www-form-urlencoded`]; and parameter is present."
  }
},
```
See https://github.com/fabianrbz/kong-plugins-docs-toolkit/blob/main/schemas/request-transformer-advanced/3.2.x.json#L78-L88

In both cases, we should display them as `referenceable`.

Fixes https://github.com/Kong/docs.konghq.com/issues/5626

### Testing instructions

Netlify link: https://deploy-preview-5638--kongdocs.netlify.app/hub/kong-inc/request-transformer-advanced/configuration/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

