### PR TITLE
add concept page for kic using expression router

### DIFF
--- a/app/_data/docs_nav_kic_2.10.x.yml
+++ b/app/_data/docs_nav_kic_2.10.x.yml
@@ -39,6 +39,8 @@ items:
         url: /concepts/ingress-versions
       - text: Gateway API
         url: /concepts/gateway-api
+      - text: Expression Based Router
+        url: /concepts/expression-based-router
   - title: Deployment
     icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
     url: /deployment/overview

--- a/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
@@ -1,0 +1,120 @@
+---
+title: Using Expression Based Router
+alpha: true
+---
+
+This page introduces how could {{site.kic_product_name}} use expression router, and its supported 
+features and limitations in current version.
+
+[Expression based router](gateway-expression-router) is introduced in {{site.base_gateway}} 3.0 and
+later. Compared to the traditional router, expression router have higher performance and allows more
+precise priority specification. 
+
+{{site.kic_product_name}} supports expression based router in exprerimental maturity since 2.10. By 
+using expression based router, {{site.kic_product_name}} can reduce most of generated routes with 
+regular expression match on path, thus improve the performance of the router. 
+
+## Deployment
+
+To use KIC with Kong running expression router, you need {{site.kic_product_name}} with version 2.10
+or higher, and {{site.base_gateway}} with version 3.0 or higher. We need to configure environment 
+variables in container of {{site.kic_product_name}} and {{site.base_gateway}} to enable expression 
+router:
+
+For {{site.kic_product_name}}, we need to enable `ExpressionRoutes` feature gate and `CombinedRoutes`
+feature gate to enable {{site.kic_product_name}} to translate kubernetes resources to expression based
+Kong routes. (`CombinedRoutes` is enabled by default) For {{site.base_gateway}}, we need to configure 
+`KONG_ROUTER_FLAVOR` to `expressions` to use expression based router of {{site.base_gateway}}.
+
+You could use the following `values.yaml` to install {{site.kic_product_name}} using expression router
+by helm:
+
+```yaml
+image:
+  repository: kong
+  tag: "3.3" # 3.0 and newer
+
+env:
+  database: "off"
+  router_flavor: "expressions" # set KONG_ROUTER_FLAVOR to "expressions"
+
+ingressController:
+  enabled: true
+  image:
+    repository: kong/kubernetes-ingress-controller
+    tag: "2.10" # 2.10 and newer
+  env:
+    feature_gates: "ExpressionRoutes=true" # enable "ExpressionRoutes" feature gate
+```
+
+then use helm to install kong :
+
+```bash
+  helm upgrade --install controller kong/kong -n kong --create-namespace -f values.yaml
+```
+
+## Supported Resources
+
+Currently {{site.kic_product_name}} supports the following kubernetes resources when translating to
+expression based routes is enabled:
+
+- `Ingress` [networking.k8s.io/v1.Ingress](ingress)
+- `HTTPRoute` in gateway APIs ([gateway.networking.k8s.io/v1beta1.HTTPRoute](gateway-api-httproute))
+- `GRPCRoute` in gateway APIs ([gateway.networking.k8s.io/v1alpha2.GRPCRoute](gateway-api-grpcroute))
+
+## Limitations and Unsupported Features
+
+In the current versions of {{site.kic_product_name}} and {{site.base_gateway}}, some features and
+kubernetes resources supported with traditional routers are not supported if expression router is
+enabled.
+
+### Unsupported Kubernetes Resources
+
+The following kubernetes resources are not supported when expression router is enabled:
+
+- `knative.Service` ([serving.knative.dev/v1.Service](knative-service))
+- `TCPIngress` ([configuration.konghq.com/v1beta1.TCPIngress](crd-tcpingress))
+- `UDPIngress` ([configuration.konghq.com/v1beta1/UDPIngress](crd-udpingress))
+- `TCPRoute` ([gateway.networking.k8s.io/v1alpha2.TCPRoute](gateway-api-tcproute))
+- `TLSRoute` ([gateway.networking.k8s.io/v1alpha2.TLSRoute](gateway-api-tlsroute))
+- `UDPRoute` ([gateway.networking.k8s.io/v1alpha2.UDPRoute](gateway-api-udproute))
+
+### Unsupport Methods of Overriding Routes
+
+Because kubernetes objects could not fully express specification of Kong configurations, {{site.kic_product_name}}
+provides methods to override services, routes, plugins, consumers and other objects in Kong configurations
+after translating from kubernetes objects. The methods include overriding by `KongIngress` resource and annotations
+of resources. When expression router is enabled, some of the methods of overriding routes in kong configurations 
+after translating are not supported.
+
+Overriding routes in kong configurations by `KongIngress` is not supported when expression routes is enabled. The 
+`route` fields of `KongIngress` resources will be ignored when {{site.kic_product_name}} translate kubernetes resources
+to expression based routes.
+
+Overriding `Ingress` with annotations `konghq.com/path_handling` and `konghq.com/regex_priority` is not supported because
+the `path_handling` and `regex_priority` fields are not supported in routes of kong configurations when {{site.base_gateway}}
+is running expression based router.
+
+For `HTTPRoute` and `GRPCRoute`, annotations `konghq.com/path_handling` and `konghq.com/regex_priority` are not supported
+for the same reason. Besides this, annotations `konghq.com/host_aliases`, `konghq.com/methods` and `konghq.com/headers` to
+override hosts, methods and headers are not supported.
+
+### Other Unsupported Features and Breaking Changes
+
+- HTTPS redirect is not supported by expression router of {{site.base_gateway}} yet. 
+- Current translator assigns the same priority to all translated routes, so the chosen route when multiple routes matches
+  the request may be different with the result in using traditional router.
+- The standard of regular expressions changed to regex in rust in expression based router instead of PCRE2 in the traditional
+  router, so previously valid regex may become invalid if changed to expression based router. For example, non-escape
+  character after `\` like `\/`, `\j` becomes invalid in regex of expression based router.
+
+[gateway-expression-router]:/gateway/latest/key-concepts/routes/expressions/
+[ingress]:https://kubernetes.io/docs/concepts/services-networking/ingress/
+[gateway-api-httproute]:https://gateway-api.sigs.k8s.io/api-types/httproute/
+[gateway-api-grpcroute]:https://gateway-api.sigs.k8s.io/api-types/grpcroute/
+[gateway-api-tcproute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
+[gateway-api-tlsroute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute
+[gateway-api-udproute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.UDPRoute
+[crd-tcpingress]:/kubernetes-ingress-controller/{{page.version}}/refereces/custom-resources/#tcpingress
+[crd-tcpingress]:/kubernetes-ingress-controller/{{page.version}}/refereces/custom-resources/#udpingress
+[knative-service]:https://knative.dev/docs/serving/reference/serving-api/#serving.knative.dev/v1.Service

--- a/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
@@ -3,110 +3,81 @@ title: Using Expression Based Router
 alpha: true
 ---
 
-This page introduces how could {{site.kic_product_name}} use expression router, and its supported 
-features and limitations in current version.
+The [expression-based routers](gateway-expression-router), introduced in {{site.base_gateway}} 3.0, have higher performance and allow more precise priority specification than the traditional router. By using the expression-based router, {{site.kic_product_name}} can reduce most of generated routes with regular expression match on path, and therefore improve the performance of the router. 
 
-[Expression based router](gateway-expression-router) is introduced in {{site.base_gateway}} 3.0 and
-later. Compared to the traditional router, expression router have higher performance and allows more
-precise priority specification. 
+This page explains how {{site.kic_product_name}} can use the expression-based router, and the supported features and limitations of the current version.
 
-{{site.kic_product_name}} supports expression based router in exprerimental maturity since 2.10. By 
-using expression based router, {{site.kic_product_name}} can reduce most of generated routes with 
-regular expression match on path, thus improve the performance of the router. 
+## Install {{site.kic_product_name}} with a {{site.base_gateway}} expression-based router
 
-## Deployment
+To install {{site.kic_product_name}} with a {{site.base_gateway}} expression-based router, you must configure environment variables in the container of {{site.kic_product_name}} and {{site.base_gateway}}.
 
-To use KIC with Kong running expression router, you need {{site.kic_product_name}} with version 2.10
-or higher, and {{site.base_gateway}} with version 3.0 or higher. We need to configure environment 
-variables in container of {{site.kic_product_name}} and {{site.base_gateway}} to enable expression 
-router:
+### Prerequistes
 
-For {{site.kic_product_name}}, we need to enable `ExpressionRoutes` feature gate and `CombinedRoutes`
-feature gate to enable {{site.kic_product_name}} to translate kubernetes resources to expression based
-Kong routes. (`CombinedRoutes` is enabled by default) For {{site.base_gateway}}, we need to configure 
-`KONG_ROUTER_FLAVOR` to `expressions` to use expression based router of {{site.base_gateway}}.
+* {{site.kic_product_name}} 2.10.x or later
+* {{site.base_gateway}} 3.0.x or later
 
-You could use the following `values.yaml` to install {{site.kic_product_name}} using expression router
-by helm:
+### Instructions
+
+For {{site.kic_product_name}}, you must enable `ExpressionRoutes` and `CombinedRoutes` (enabled by default) so {{site.kic_product_name}} can translate Kubernetes resources to expression-based
+{{site.base_gateway}} routes. For {{site.base_gateway}}, you must configure `KONG_ROUTER_FLAVOR` for `expressions` to use expression-based router.
+
+You can use the following `values.yaml` to install {{site.kic_product_name}} using the expression-based router by helm:
 
 ```yaml
 image:
   repository: kong
-  tag: "3.3" # 3.0 and newer
+  tag: "3.3" # 3.0 or later
 
 env:
   database: "off"
-  router_flavor: "expressions" # set KONG_ROUTER_FLAVOR to "expressions"
+  router_flavor: "expressions" # sets KONG_ROUTER_FLAVOR to "expressions"
 
 ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "2.10" # 2.10 and newer
+    tag: "2.10" # 2.10 or later
   env:
-    feature_gates: "ExpressionRoutes=true" # enable "ExpressionRoutes" feature gate
+    feature_gates: "ExpressionRoutes=true" # enables the "ExpressionRoutes" feature gate
 ```
 
-then use helm to install kong :
+Then, use Helm to install {{site.base_gateway}}:
 
 ```bash
   helm upgrade --install controller kong/kong -n kong --create-namespace -f values.yaml
 ```
 
-## Supported Resources
+## Kubernetes resource support
 
-Currently {{site.kic_product_name}} supports the following kubernetes resources when translating to
-expression based routes is enabled:
+The following table displays which Kubernetes resources are supported when translating to expression-based routes is enabled in {{site.kic_product_name}}:
 
-- `Ingress` [networking.k8s.io/v1.Ingress](ingress)
-- `HTTPRoute` in gateway APIs ([gateway.networking.k8s.io/v1beta1.HTTPRoute](gateway-api-httproute))
-- `GRPCRoute` in gateway APIs ([gateway.networking.k8s.io/v1alpha2.GRPCRoute](gateway-api-grpcroute))
+| Kubernetes resource | Supported? |
+| ------------------- | ---------- |
+| [`Ingress`](ingress) | ✅ &nbsp; |
+| [`HTTPRoute`](gateway-api-httproute) | ✅ &nbsp; |
+| [`GRPCRoute` in gateway APIs](gateway-api-grpcroute) | ✅ &nbsp; |
+| [`knative.Service`](knative-service) | ❌ &nbsp; |
+| [`TCPIngress`](crd-tcpingress) | ❌ &nbsp; |
+| [`UDPIngress`](crd-udpingress) | ❌ &nbsp; |
+| [`TCPRoute`](gateway-api-tcproute) | ❌ &nbsp; |
+| [`TLSRoute`](gateway-api-tlsroute) | ❌ &nbsp; |
+| [`UDPRoute`](gateway-api-udproute) | ❌ &nbsp; |
 
-## Limitations and Unsupported Features
+## Unsupport methods of overriding routes
 
-In the current versions of {{site.kic_product_name}} and {{site.base_gateway}}, some features and
-kubernetes resources supported with traditional routers are not supported if expression router is
-enabled.
+Because Kubernetes objects can't fully express {{site.base_gateway}} configuration specifications, {{site.kic_product_name}} provides methods to override services, routes, plugins, consumers, and other objects in {{site.base_gateway}} configurations after translating from Kubernetes objects. These methods include overriding using the `KongIngress` resource and annotations
+of resources. When the expression-based router is enabled, some of the methods of overriding routes in {{site.base_gateway}} configurations after translating are not supported:
 
-### Unsupported Kubernetes Resources
+* You can't override routes in {{site.base_gateway}} configurations using `KongIngress` isn't supported when expression routes is enabled. The `route` fields of `KongIngress` resources will be ignored when {{site.kic_product_name}} translate Kubernetes resources to expression based routes.
+* You can't override `Ingress` with the `konghq.com/path_handling` and `konghq.com/regex_priority` annotations because the `path_handling` and `regex_priority` fields are not supported in {{site.base_gateway}} route configurations when {{site.base_gateway}} is running expression-based router.
+* For `HTTPRoute` and `GRPCRoute`, the `konghq.com/path_handling` and `konghq.com/regex_priority` annotations aren't supported for the same reason. Besides this, the `konghq.com/host_aliases`, `konghq.com/methods`, and `konghq.com/headers` annotations can't be used to override hosts, methods, and headers.
 
-The following kubernetes resources are not supported when expression router is enabled:
+### Other unsupported features and breaking changes
 
-- `knative.Service` ([serving.knative.dev/v1.Service](knative-service))
-- `TCPIngress` ([configuration.konghq.com/v1beta1.TCPIngress](crd-tcpingress))
-- `UDPIngress` ([configuration.konghq.com/v1beta1/UDPIngress](crd-udpingress))
-- `TCPRoute` ([gateway.networking.k8s.io/v1alpha2.TCPRoute](gateway-api-tcproute))
-- `TLSRoute` ([gateway.networking.k8s.io/v1alpha2.TLSRoute](gateway-api-tlsroute))
-- `UDPRoute` ([gateway.networking.k8s.io/v1alpha2.UDPRoute](gateway-api-udproute))
-
-### Unsupport Methods of Overriding Routes
-
-Because kubernetes objects could not fully express specification of Kong configurations, {{site.kic_product_name}}
-provides methods to override services, routes, plugins, consumers and other objects in Kong configurations
-after translating from kubernetes objects. The methods include overriding by `KongIngress` resource and annotations
-of resources. When expression router is enabled, some of the methods of overriding routes in kong configurations 
-after translating are not supported.
-
-Overriding routes in kong configurations by `KongIngress` is not supported when expression routes is enabled. The 
-`route` fields of `KongIngress` resources will be ignored when {{site.kic_product_name}} translate kubernetes resources
-to expression based routes.
-
-Overriding `Ingress` with annotations `konghq.com/path_handling` and `konghq.com/regex_priority` is not supported because
-the `path_handling` and `regex_priority` fields are not supported in routes of kong configurations when {{site.base_gateway}}
-is running expression based router.
-
-For `HTTPRoute` and `GRPCRoute`, annotations `konghq.com/path_handling` and `konghq.com/regex_priority` are not supported
-for the same reason. Besides this, annotations `konghq.com/host_aliases`, `konghq.com/methods` and `konghq.com/headers` to
-override hosts, methods and headers are not supported.
-
-### Other Unsupported Features and Breaking Changes
-
-- HTTPS redirect is not supported by expression router of {{site.base_gateway}} yet. 
-- Current translator assigns the same priority to all translated routes, so the chosen route when multiple routes matches
-  the request may be different with the result in using traditional router.
-- The standard of regular expressions changed to regex in rust in expression based router instead of PCRE2 in the traditional
-  router, so previously valid regex may become invalid if changed to expression based router. For example, non-escape
-  character after `\` like `\/`, `\j` becomes invalid in regex of expression based router.
+- HTTPS redirect isn't supported by the {{site.base_gateway}} expression-based router yet. 
+- The current translator assigns the same priority to all translated routes. When there are multiple route that match the request, the chosen route may be different than if you were using a traditional router.
+- The standard of regular expressions changed to regex in Rust for the expression-based router (instead of PCRE2 in the traditional
+  router), so previously valid regex may become invalid if you enable the expression-based router. For example, a non-escape character after `\` like `\/`, `\j` becomes invalid in the regex of the expression-based router.
 
 [gateway-expression-router]:/gateway/latest/key-concepts/routes/expressions/
 [ingress]:https://kubernetes.io/docs/concepts/services-networking/ingress/

--- a/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
@@ -3,7 +3,7 @@ title: Using Expression Based Router
 alpha: true
 ---
 
-The [expression-based routers](gateway-expression-router), introduced in {{site.base_gateway}} 3.0, have higher performance and allow more precise priority specification than the traditional router. By using the expression-based router, {{site.kic_product_name}} can reduce most of generated routes with regular expression match on path, and therefore improve the performance of the router. 
+The [expression-based routers][gateway-expression-router], introduced in {{site.base_gateway}} 3.0, have higher performance and allow more precise priority specification than the traditional router. By using the expression-based router, {{site.kic_product_name}} can reduce most of generated routes with regular expression match on path, and therefore improve the performance of the router. 
 
 This page explains how {{site.kic_product_name}} can use the expression-based router, and the supported features and limitations of the current version.
 
@@ -86,6 +86,6 @@ of resources. When the expression-based router is enabled, some of the methods o
 [gateway-api-tcproute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
 [gateway-api-tlsroute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute
 [gateway-api-udproute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.UDPRoute
-[crd-tcpingress]:/kubernetes-ingress-controller/{{page.version}}/references/custom-resources/#tcpingress
-[crd-udpingress]:/kubernetes-ingress-controller/{{page.version}}/references/custom-resources/#udpingress
+[crd-tcpingress]:/kubernetes-ingress-controller/{{page.release}}/references/custom-resources/#tcpingress/kubernetes-ingress-controller/latest/references/custom-resources/#tcpingress
+[crd-udpingress]:/kubernetes-ingress-controller/{{page.release}}/references/custom-resources/#udpingress
 [knative-service]:https://knative.dev/docs/serving/reference/serving-api/#serving.knative.dev/v1.Service

--- a/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
@@ -53,15 +53,15 @@ The following table displays which Kubernetes resources are supported when trans
 
 | Kubernetes resource | Supported? |
 | ------------------- | ---------- |
-| [`Ingress`](ingress) | ✅ &nbsp; |
-| [`HTTPRoute`](gateway-api-httproute) | ✅ &nbsp; |
-| [`GRPCRoute` in gateway APIs](gateway-api-grpcroute) | ✅ &nbsp; |
-| [`knative.Service`](knative-service) | ❌ &nbsp; |
-| [`TCPIngress`](crd-tcpingress) | ❌ &nbsp; |
-| [`UDPIngress`](crd-udpingress) | ❌ &nbsp; |
-| [`TCPRoute`](gateway-api-tcproute) | ❌ &nbsp; |
-| [`TLSRoute`](gateway-api-tlsroute) | ❌ &nbsp; |
-| [`UDPRoute`](gateway-api-udproute) | ❌ &nbsp; |
+| [`Ingress`][ingress] | ✅ &nbsp; |
+| [`HTTPRoute`][gateway-api-httproute] | ✅ &nbsp; |
+| [`GRPCRoute` in gateway APIs][gateway-api-grpcroute] | ✅ &nbsp; |
+| [`knative.Service`][knative-service] | ❌ &nbsp; |
+| [`TCPIngress`][crd-tcpingress] | ❌ &nbsp; |
+| [`UDPIngress`][crd-udpingress] | ❌ &nbsp; |
+| [`TCPRoute`][gateway-api-tcproute] | ❌ &nbsp; |
+| [`TLSRoute`][gateway-api-tlsroute] | ❌ &nbsp; |
+| [`UDPRoute`][gateway-api-udproute] | ❌ &nbsp; |
 
 ## Unsupported methods of overriding routes
 

--- a/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/expression-based-router.md
@@ -63,13 +63,13 @@ The following table displays which Kubernetes resources are supported when trans
 | [`TLSRoute`](gateway-api-tlsroute) | ❌ &nbsp; |
 | [`UDPRoute`](gateway-api-udproute) | ❌ &nbsp; |
 
-## Unsupport methods of overriding routes
+## Unsupported methods of overriding routes
 
 Because Kubernetes objects can't fully express {{site.base_gateway}} configuration specifications, {{site.kic_product_name}} provides methods to override services, routes, plugins, consumers, and other objects in {{site.base_gateway}} configurations after translating from Kubernetes objects. These methods include overriding using the `KongIngress` resource and annotations
 of resources. When the expression-based router is enabled, some of the methods of overriding routes in {{site.base_gateway}} configurations after translating are not supported:
 
-* You can't override routes in {{site.base_gateway}} configurations using `KongIngress` isn't supported when expression routes is enabled. The `route` fields of `KongIngress` resources will be ignored when {{site.kic_product_name}} translate Kubernetes resources to expression based routes.
-* You can't override `Ingress` with the `konghq.com/path_handling` and `konghq.com/regex_priority` annotations because the `path_handling` and `regex_priority` fields are not supported in {{site.base_gateway}} route configurations when {{site.base_gateway}} is running expression-based router.
+* Overriding routes in {{site.base_gateway}} configurations using `KongIngress` isn't supported when expression routes is enabled. The `route` fields of `KongIngress` resources will be ignored when {{site.kic_product_name}} translates Kubernetes resources to expression based routes.
+* You can't override `Ingress` with the `konghq.com/path_handling` and `konghq.com/regex_priority` annotations because the `path_handling` and `regex_priority` fields are not supported in {{site.base_gateway}} route configurations when {{site.base_gateway}} is running the `expressions` router.
 * For `HTTPRoute` and `GRPCRoute`, the `konghq.com/path_handling` and `konghq.com/regex_priority` annotations aren't supported for the same reason. Besides this, the `konghq.com/host_aliases`, `konghq.com/methods`, and `konghq.com/headers` annotations can't be used to override hosts, methods, and headers.
 
 ### Other unsupported features and breaking changes
@@ -86,6 +86,6 @@ of resources. When the expression-based router is enabled, some of the methods o
 [gateway-api-tcproute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute
 [gateway-api-tlsroute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute
 [gateway-api-udproute]:https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.UDPRoute
-[crd-tcpingress]:/kubernetes-ingress-controller/{{page.version}}/refereces/custom-resources/#tcpingress
-[crd-tcpingress]:/kubernetes-ingress-controller/{{page.version}}/refereces/custom-resources/#udpingress
+[crd-tcpingress]:/kubernetes-ingress-controller/{{page.version}}/references/custom-resources/#tcpingress
+[crd-udpingress]:/kubernetes-ingress-controller/{{page.version}}/references/custom-resources/#udpingress
 [knative-service]:https://knative.dev/docs/serving/reference/serving-api/#serving.knative.dev/v1.Service


### PR DESCRIPTION
### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

Add a guide page to introduce how to use expression based router in KIC. fixes https://github.com/Kong/kubernetes-ingress-controller/issues/4077.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

