### PR TITLE
kic: add k8s events reference

### DIFF
--- a/app/_data/docs_nav_kic_2.10.x.yml
+++ b/app/_data/docs_nav_kic_2.10.x.yml
@@ -1,0 +1,163 @@
+product: kubernetes-ingress-controller
+release: 2.10.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /kubernetes-ingress-controller/
+    absolute_url: true
+    items:
+      - text: FAQ
+        url: /faq
+      - text: Version Support Policy
+        url: /support-policy
+      - text: Stages of Software Availability
+        url: /availability-stages
+      - text: Changelog
+        url: https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md
+        absolute_url: true
+        target_blank: true
+
+  - title: Concepts
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    items:
+      - text: Architecture
+        url: /concepts/design
+      - text: Custom Resources
+        url: /concepts/custom-resources
+      - text: Deployment Methods
+        url: /concepts/deployment
+      - text: Kong for Kubernetes with Kong Enterprise
+        url: /concepts/k4k8s-with-kong-enterprise
+      - text: High-Availability and Scaling
+        url: /concepts/ha-and-scaling
+      - text: Resource Classes
+        url: /concepts/ingress-classes
+      - text: Security
+        url: /concepts/security
+      - text: Ingress Resource API Versions
+        url: /concepts/ingress-versions
+      - text: Gateway API
+        url: /concepts/gateway-api
+  - title: Deployment
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /deployment/overview
+    items:
+      - text: Kong Ingress on Minikube
+        url: /deployment/minikube
+      - text: Kong for Kubernetes
+        url: /deployment/k4k8s
+      - text: Kong for Kubernetes Enterprise
+        url: /deployment/k4k8s-enterprise
+      - text: Kong for Kubernetes with Kong Enterprise
+        url: /deployment/kong-enterprise
+      - text: Kong Ingress on AKS
+        url: /deployment/aks
+      - text: Kong Ingress on EKS
+        url: /deployment/eks
+      - text: Kong Ingress on GKE
+        url: /deployment/gke
+      - text: Admission Webhook
+        url: /deployment/admission-webhook
+      - text: Installing Gateway APIs
+        url: /deployment/install-gateway-apis
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    url: /guides/overview
+    items:
+      - text: Getting Started with KIC
+        url: /guides/getting-started
+      - text: Upgrading from previous versions
+        url: /guides/upgrade
+      - text: Upgrading to Kong 3.x
+        url: /guides/upgrade-kong-3x
+      - text: Getting Started using Istio
+        url: /guides/getting-started-istio
+      - text: Using Custom Resources
+        items:
+          - text: Using the KongPlugin Resource
+            url: /guides/using-kongplugin-resource
+          - text: Using the KongIngress Resource
+            url: /guides/using-kongingress-resource
+          - text: Using KongConsumer and KongCredential Resources
+            url: /guides/using-consumer-credential-resource
+          - text: Using the TCPIngress Resource
+            url: /guides/using-tcpingress
+          - text: Using the UDPIngress Resource
+            url: /guides/using-udpingress
+      - text: Using the ACL and JWT Plugins
+        url: /guides/configure-acl-plugin
+      - text: Using cert-manager with Kong
+        url: /guides/cert-manager
+      - text: Allowing Multiple Authentication Methods
+        url: /guides/allowing-multiple-authentication-methods
+      - text: Configuring a Fallback Service
+        url: /guides/configuring-fallback-service
+      - text: Using an External Service
+        url: /guides/using-external-service
+      - text: Configuring HTTPS Redirects for Services
+        url: /guides/configuring-https-redirect
+      - text: Using Redis for Rate Limiting
+        url: /guides/redis-rate-limiting
+      - text: Integrate KIC with Prometheus/Grafana
+        url: /guides/prometheus-grafana
+      - text: Configuring Circuit-Breaker and Health-Checking
+        url: /guides/configuring-health-checks
+      - text: Setting up a Custom Plugin
+        url: /guides/setting-up-custom-plugins
+      - text: Setting up Upstream mTLS
+        url: /guides/upstream-mtls
+      - text: Exposing a TCP/UDP/gRPC Service
+        items:
+        - text: Exposing a TCP Service
+          url: /guides/using-tcpingress
+          generate: false # Generated in the CustomResources section above
+        - text: Exposing a UDP Service
+          url: /guides/using-udpingress
+          generate: false # Generated in the CustomResources section above
+        - text: Exposing a gRPC service
+          url: /guides/using-ingress-with-grpc
+      - text: Using the mTLS Auth Plugin
+        url: /guides/using-mtls-auth-plugin
+      - text: Configuring Custom Entities
+        url: /guides/configuring-custom-entities
+      - text: Using the OpenID Connect Plugin
+        url: /guides/using-oidc-plugin
+      - text: Rewriting Hosts and Paths
+        url: /guides/using-rewrites
+      - text: Preserving Client IP Address
+        url: /guides/preserve-client-ip
+      - text: Using Kong with Knative
+        url: /guides/using-kong-with-knative
+      - text: Using Multiple Backend Services
+        url: /guides/using-multiple-backends
+      - text: Using Gateway Discovery
+        url: /guides/using-gateway-discovery
+      - text: Routing by Header
+        url: /guides/routing-by-header/
+  - title: References
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    items:
+      - text: KIC Annotations
+        url: /references/annotations
+      - text: CLI Arguments
+        url: /references/cli-arguments
+      - text: Custom Resource Definitions
+        url: /references/custom-resources
+        src: references/custom-resources-2.9.x
+      - text: Plugin Compatibility
+        url: /references/plugin-compatibility
+      - text: Version Compatibility
+        url: /references/version-compatibility
+      - text: Supported Kong Router Flavors
+        url: /references/supported-router-flavors
+      - title: Troubleshooting
+        url: /troubleshooting
+      - text: Kubernetes Events
+        url: /references/kubernetes-events
+      - text: Prometheus Metrics
+        url: /references/prometheus
+      - text: Feature Gates
+        url: /references/feature-gates
+      - text: Supported Gateway API Features
+        url: /references/gateway-api-support

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -325,6 +325,9 @@
 - release: "2.9.x"
   version: "2.9.3"
   edition: "kubernetes-ingress-controller"
+- release: "2.10.x"
+  version: "2.10.0"
+  edition: "kubernetes-ingress-controller"
 - edition: mesh
   version: 1.2.6
   release: 1.2.x
@@ -396,4 +399,3 @@
   version: preview
   release: dev
   branch: master
-

--- a/app/_src/kubernetes-ingress-controller/references/kubernetes-events.md
+++ b/app/_src/kubernetes-ingress-controller/references/kubernetes-events.md
@@ -1,0 +1,46 @@
+---
+title: Kubernetes Events
+---
+
+Kubernetes API allows creating events to notify users about changes in the cluster. Events are treated as informative,
+best-effort, supplemental data which might be helpful in debugging issues. Some of the built-in events users might be
+familiar with are `CrashLoopBackOff`, `ImagePullBackOff`, `FailedScheduling`, etc.
+Every event has a set of fields defined in the [Event](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/#Event) 
+API object schema. The most relevant of those in the context of {{site.kic_product_name}} are:
+
+- **Reason** - a short, machine-friendly string that describes the reason for emitting an event, can be treated 
+  as a category (e.g. `KongConfigurationTranslationFailed`, `KongConfigurationApplyFailed`, etc.).
+- **Message** - a human-readable description of the event with a detailed explanation of what happened (e.g. 
+  `invalid methods: cannot set 'methods' when 'protocols' is 'grpc' or 'grpcs'`).
+- **Type** - a string that describes the type of the event (e.g. `Warning`, `Normal`, etc.).
+- **InvolvedObject** - a reference to the object(s) that the event is about (e.g. `Ingress`, `KongPlugin`, etc.).
+
+## Emitted Events
+
+All the events that are emitted by {{site.kic_product_name}} are listed in the table below.
+
+| Reason                               | Type       | Meaning                                                                                                                                                                         | Involved objects                                                                                                                                                                                                                                            |
+|--------------------------------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `KongConfigurationTranslationFailed` | ⚠️ Warning | During the translation of Kubernetes resources into a Kong state, a conflict was detected. The involved object(s) were skipped to unblock building the Kong state without them. | Any of the supported resources (e.g. `Ingress`, `KongPlugin`, `HTTPRoute`, etc.)                                                                                                                                                                            |
+| `KongConfigurationApplyFailed`       | ⚠️ Warning | A Kong state built from Kubernetes resources was rejected by the {{site.base_gateway}} Admin API. The update of the configuration was not effective.                            | In the case of a failure caused by a specific object - any of the supported resources (e.g. `Ingress`, `KongPlugin`, `HTTPRoute`, etc.). When a specific causing object couldn't be identified, the event is attached to the {{site.kic_product_name}} Pod. |
+| `KongConfigurationSucceeded`         | ℹ️ Normal  | A Kong state built from Kubernetes resources was successfully applied to the {{site.base_gateway}} Admin API.                                                                   | {{site.kic_product_name}} Pod.                                                                                                                                                                                                                              |
+
+## Inspecting Events
+
+Although {{site.kic_product_name}} provides Prometheus metrics to monitor the current state of the configuration translation and application 
+processes (`ingress_controller_translation_count`, `ingress_controller_configuration_push_count`, 
+see [Prometheus Metrics][prometheus] for details), it's recommended to use the events to get more information
+about the root cause of the issue when the metrics indicate that something went wrong.
+
+Events can be inspected using the `kubectl get events` command. Their `reason` field might be used to filter a specific
+kind of events (e.g. `KongConfigurationApplyFailed`).
+
+The output of the command will look similar to this:
+
+```shell
+kubectl get events --field-selector='reason=KongConfigurationApplyFailed'
+LAST SEEN   TYPE       REASON                                 OBJECT                             MESSAGE
+1m          Warning    KongConfigurationApplyFailed           KongPlugin/my-plugin               Plugin schema validation failed: invalid value "foo" for field "config"
+```
+
+[prometheus]: /kubernetes-ingress-controller/latest/references/prometheus

--- a/app/_src/kubernetes-ingress-controller/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/troubleshooting.md
@@ -365,7 +365,6 @@ metadata:
     konghq.com/protocols: grpcs
     kubernetes.io/ingress.class: kong
   name: httpbin
-  uid: 3dcd75e9-c076-46a0-8cd3-3cc62f081920
 spec:
   rules:
   - http:
@@ -418,24 +417,19 @@ the number of times the problem occurred, and when it occurred:
 apiVersion: v1
 kind: Event
 count: 1
-eventTime: null
 firstTimestamp: "2023-02-21T22:42:48Z"
 involvedObject:
   apiVersion: networking.k8s.io/v1
   kind: Ingress
   name: httpbin
   namespace: default
-  uid: 3dcd75e9-c076-46a0-8cd3-3cc62f081920
 kind: Event
 lastTimestamp: "2023-02-21T22:42:48Z"
 message: 'invalid methods: cannot set ''methods'' when ''protocols'' is ''grpc''
   or ''grpcs'''
 metadata:
-  creationTimestamp: "2023-02-21T22:42:48Z"
   name: httpbin.1745f83aefeb8dde
   namespace: default
-  resourceVersion: "861"
-  uid: ab78a0fa-ebe7-4d86-a465-a4e7d636ccff
 reason: KongConfigurationApplyFailed
 reportingComponent: ""
 reportingInstance: ""


### PR DESCRIPTION
### Description

Adds a `Kubernetes Events` reference page describing the events emitted by Kong Ingress Controller. Also adds a 2.10.x navigation for KIC.

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4042.

### Testing instructions

https://deploy-preview-5644--kongdocs.netlify.app/kubernetes-ingress-controller/latest/references/kubernetes-events/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

