### PR TITLE
Fix external links hook.

### DIFF
--- a/app/_plugins/hooks/external_links.rb
+++ b/app/_plugins/hooks/external_links.rb
@@ -5,7 +5,7 @@ require 'nokogiri'
 module Jekyll
   Jekyll::Hooks.register :pages, :post_render do |page|
     # Only process pages. This prevents _redirects being output with a HTML doctype
-    next unless page.instance_of?(Jekyll::Page)
+    next unless page.is_a?(Jekyll::Page)
 
     has_changes = false
     doc = ::Nokogiri::HTML(page.output)


### PR DESCRIPTION
### Description

The hook was skipping single source pages because of the `instance_of?` check.

`#instance_of?` returns true only if the object is an instance of the exact class.

`#is_a?` returns true only if the object is an instance of the class or one of its subclasses.

Production
<img width="898" alt="Screenshot 2023-05-31 at 10 12 14" src="https://github.com/Kong/docs.konghq.com/assets/715229/a283c7be-e0dc-4639-b083-d2fe3b601c38">

After the Changes
<img width="1259" alt="Screenshot 2023-05-31 at 10 11 52" src="https://github.com/Kong/docs.konghq.com/assets/715229/2d023f05-d488-43f9-bb14-47f2207e2a30">


### Testing instructions

Netlify link: https://deploy-preview-5646--kongdocs.netlify.app/gateway/latest/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

