### PR TITLE
docs:  remove the excess "#"

### DIFF
--- a/app/_src/gateway/admin-api/index.md
+++ b/app/_src/gateway/admin-api/index.md
@@ -2650,7 +2650,7 @@ See POST and PATCH responses.
 
 ##### Delete Route
 
-<div class="endpoint delete indent">{{ prefix }}/routes/{route name or id}</div>#
+<div class="endpoint delete indent">{{ prefix }}/routes/{route name or id}</div>
 
 {:.indent}
 Attributes | Description


### PR DESCRIPTION
### Description

remove the excess "#" in  admin-api 
![image](https://github.com/Kong/docs.konghq.com/assets/20812895/95692ea0-1de8-487e-84d0-6e2c3d9d2dec)

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

