### PR TITLE
kic: add FAQ section for 2.10+ for EndpointSlices

### DIFF
--- a/app/_src/kubernetes-ingress-controller/faq.md
+++ b/app/_src/kubernetes-ingress-controller/faq.md
@@ -2,16 +2,24 @@
 title: FAQs
 ---
 
-### Why endpoints and not services?
+{% if_version lte: 2.9.x %}
+### Why `Endpoint`s and not `Service`s?
 
-The {{site.kic_product_name}} does not use
-[Services][k8s-service] to route traffic
-to the pods. Instead, it uses the Endpoints API
-to bypass [kube-proxy][kube-proxy]
-to allow Kong features like session affinity and
-custom load balancing algorithms.
-It also removes overhead
-such as conntrack entries for iptables DNAT.
+The {{site.kic_product_name}} does not use [Services][k8s-service] to route traffic to the pods.
+Instead, it uses the [`Endpoints`][k8s-endpoints] API to bypass
+[kube-proxy][kube-proxy] to allow Kong features like session affinity and custom
+load balancing algorithms.
+It also removes overhead such as conntrack entries for iptables DNAT.
+{% endif_version %}
+{% if_version gte: 2.10.x %}
+### Why `EndpointSlice`s and not `Service`s?
+
+The {{site.kic_product_name}} does not use [Services][k8s-service] to route traffic to the pods.
+Instead, it uses the [`EndpointSlice`][k8s-endpointslices] API
+(which is available since Kubernetes v1.21) to bypass [kube-proxy][kube-proxy]
+to allow Kong features like session affinity and custom load balancing algorithms.
+It also removes overhead such as conntrack entries for iptables DNAT.
+{% endif_version %}
 
 ### Is it possible to create consumers using the Admin API?
 
@@ -23,3 +31,5 @@ won't be deleted by the Ingress Controller.
 
 [k8s-service]: https://kubernetes.io/docs/concepts/services-networking/service
 [kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy
+[k8s-endpointslices]: https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/
+[k8s-endpoints]: https://kubernetes.io/docs/concepts/services-networking/service/#endpoints


### PR DESCRIPTION
### Description

KIC 2.10 moves from using `Endpoint`s to `EndpointSlice`s.

This PR adds a FAQ section for that. Due to version dependent logic this can be merged to `main` before 2.10 is released.

Closes #5578

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

