### PR TITLE
[DOCU-2925] HTTPie cleanout

### DIFF
--- a/app/_hub/kong-inc/mocking/_index.md
+++ b/app/_hub/kong-inc/mocking/_index.md
@@ -295,14 +295,10 @@ IP address or URL for {{site.base_gateway}}.
 }
 ```
 
-### Step 2. Create the stock service {#create-stock-service}
+### Create the stock service {#create-stock-service}
 
 This example creates a service named `Stock-Service`.
 
-Command:
-
-{% navtabs %}
-{% navtab cURL %}
 
 ```bash
 curl -i -X POST http://<admin-hostname>:8001/services \
@@ -310,19 +306,9 @@ curl -i -X POST http://<admin-hostname>:8001/services \
   --data url='http://httpbin.org/anything'
 ```
 
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http :8001/services name=Stock-Service url='http://httpbin.org/anything'
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
 Response:
 
-```
+```json
 HTTP/1.1 201 Created
 Access-Control-Allow-Credentials: true
 Access-Control-Allow-Origin: http://localhost:8002
@@ -356,28 +342,15 @@ vary: Origin
 }
 ```
 
-### Step 3. Create the get stock quote route {#create-stock-quote-route}
+### Create the get stock quote route {#create-stock-quote-route}
 
 This example creates a route named `getStockQuote` on the service named `Stock-Service`.
-
-{% navtabs %}
-{% navtab cURL %}
 
 ```bash
 curl -X POST http://localhost:8001/services/Stock-Service/routes \
     --data "name=getStockQuote" \
     --data paths="/stock/historical"
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f :8001/services/Stock-Service/routes name='getStockQuote' paths="/stock/historical"
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Response:
 
@@ -426,14 +399,9 @@ vary: Origin
 }
 ```
 
-### Step 4. Enable the Mocking plugin {#enable-mock-plugin}
+### Enable the Mocking plugin {#enable-mock-plugin}
 
 This example enables the Mocking plugin on the `getStockQuote` route.
-
-Command:
-
-{% navtabs %}
-{% navtab cURL %}
 
 ```bash
 curl -X POST http://<admin-hostname>:8001/routes/getStockQuote/plugins \
@@ -474,28 +442,6 @@ In Kong Manager, you can copy and paste the contents of the spec directly into
 the `Config.Api Specification` text field.
 
 ![Kong Manager Config API Spec Text Field](/assets/images/docs/dev-portal/km-config-api-spec-txt-fld.png)
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f :8001/routes/getStockQuote/plugins name=mocking config.api_specification_filename=stock-0.1.json
-```
-
-Optional configuration for random simulated delay using default maximum and minimum delays:
-
-```bash
-http -f :8001/routes/getStockQuote/plugins name=mocking config.api_specification_filename=stock-0.1.json config.random_delay=true
-```
-
-Specify the path to your spec file if you are using `config.api_specification`:
-
-```bash
-http -f localhost:8001/routes/mocking/plugins name=mocking config.api_specification=@../stock-0.1.json
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Response (random delay not enabled):
 
@@ -581,31 +527,16 @@ vary: Origin
 }
 ```
 
-### Step 5. Enable the CORS plugin {#enable-cors-plugin}
+### Enable the CORS plugin {#enable-cors-plugin}
 
 Cross-origin resource sharing (CORS) is disabled by default for security reasons. To test the mock response
 from the Dev Portal, enable the [CORS plugin](/hub/kong-inc/cors/) on the `getStockQuote` route.
-
-Command:
-
-{% navtabs %}
-{% navtab cURL %}
 
 ```bash
 curl -X POST http://<admin-hostname>:8001/routes/getStockQuote/plugins \
     --data "name=cors"  \
     --data "config.origins=*"
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f :8001/routes/getStockQuote/plugins name=cors config.origins=*
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Response:
 
@@ -663,7 +594,7 @@ vary: Origin
 }
 ```
 
-### Step 6. Test the mock response {#testing123}
+### Test the mock response {#testing123}
 
 Test the mocked response from within the Dev Portal Service,
 [Insomnia](https://insomnia.rest/download), or from the command line.
@@ -700,23 +631,10 @@ Test the mock response from within the Insomnia spec using the **Try it out** fe
 
 #### Command line test
 
-{% navtabs %}
-{% navtab cURL %}
-
 ```bash
 curl -X GET "http://<admin-hostname>:8000/stock/historical?tickers=AAPL" \
   -H "accept: application/json"
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http :8000/stock/historical?tickers=AAPL accept:application/json
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 The response matches the mocked response from within the spec:
 
@@ -756,7 +674,7 @@ vary: Origin
 }
 ```
 
-### Step 7. Disable the Mocking plugin and update the Service URL {#post-test}
+### Disable the Mocking plugin and update the Service URL {#post-test}
 
 When your API mock testing is completed, disable the Mocking plugin and update the service
 URL.
@@ -766,24 +684,11 @@ or by using a command. You can copy and paste the plugin ID from within Kong Man
 
 ![Copy Plugin ID](/assets/images/docs/dev-portal/km-copy-plugin-id.png)
 
-{% navtabs %}
-{% navtab cURL %}
-
 ```
 curl -X PATCH http://localhost:8001/plugins/<plugin-id>  -i \
     --data "name=mocking"  \
     --data "enabled=false"
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```
-http PATCH :8001/plugins/<plugin-id> enabled=false -f
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Response:
 

--- a/app/_src/deck/guides/defaults-v2.md
+++ b/app/_src/deck/guides/defaults-v2.md
@@ -398,18 +398,9 @@ For the most accurate default values for your version of {{site.base_gateway}}, 
 [`/schemas`](/gateway/latest/admin-api/#retrieve-entity-schema) endpoint. For example, you can check the schema for `targets` and look for any value that
 has defined defaults:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i -X GET http://localhost:8001/schemas/targets
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http :8001/schemas/targets
-```
-{% endnavtab %}
-{% endnavtabs %}
 
 ## See also
 * [Deduplicate plugin configuration](/deck/{{page.kong_version}}/guides/deduplicate-plugin-configuration/)

--- a/app/_src/gateway/admin-api/developers/reference.md
+++ b/app/_src/gateway/admin-api/developers/reference.md
@@ -96,11 +96,11 @@ Attribute                     | Description
 Example request:
 
 ```sh
-http POST :8001/developers \
-  email=example@example.com \
-  meta="{\"full_name\":\"Wally\"}" \
-  password=mypass \
-  id=62d17e63-0628-43a3-b936-97b8dcbd366f
+curl -i -X POST http://localhost:8001/developers \
+  --data email=example@example.com \
+  --data meta="{\"full_name\":\"Wally\"}" \
+  --data password=mypass \
+  --data id=62d17e63-0628-43a3-b936-97b8dcbd366f
 ```
 
 **Response**
@@ -141,7 +141,9 @@ Attribute                     | Description
 
 Example request:
 ```sh
-http POST :8001/developers/invite emails:='["example@example.com", "example2@example.com"]'
+curl -i -X POST http://localhost:8001/developers/invite \
+  --data "emails[]=example@example.com" \
+  --data "emails[]=example2@example.com"
 ```
 
 **Response**
@@ -948,9 +950,9 @@ Plugin configuration fields | Any configuration parameters for the plugin that y
 Example request:
 
 ```sh
-http POST :8001/developers/example@example.com/plugins \
-  name=proxy-cache \
-  config.strategy=memory
+curl -i -X POST http://localhost:8001/developers/example@example.com/plugins \
+  --data name=proxy-cache \
+  --data config.strategy=memory
 ```
 
 **Response**
@@ -1244,7 +1246,7 @@ Plugin configuration fields | Any authentication credentials for the plugin that
 
 Example request for creating a `key-auth` credential:
 ```sh
-http POST :8001/developers/91a1fb59-d90f-4f07-b609-4c2a1e3d847e/credentials/key-auth
+curl -i -X POST http://localhost:8001/developers/91a1fb59-d90f-4f07-b609-4c2a1e3d847e/credentials/key-auth
 ```
 
 **Response**
@@ -1445,7 +1447,9 @@ Attribute                    | Description
 Example request for creating an `oauth2` credential:
 
 ```sh
-http POST :8001/developers/5f60930a-ad12-4303-ac5a-59d121ad4942/applications/5ff48aaf-3951-4c99-a636-3b682081705c/credentials/oauth2 client_id=myclient client_secret=mysecret
+curl -i -X POST http://localhost:8001/developers/5f60930a-ad12-4303-ac5a-59d121ad4942/applications/5ff48aaf-3951-4c99-a636-3b682081705c/credentials/oauth2 \ 
+  --data client_id=myclient \
+  --data client_secret=mysecret
 ```
 
 **Response**

--- a/app/_src/gateway/install/helm-quickstart.md
+++ b/app/_src/gateway/install/helm-quickstart.md
@@ -325,18 +325,7 @@ For local deployments, Kong Manager is locally accessible at `https://kong.127-0
 
 You can configure Kong via the Admin API with [decK](https://docs.konghq.com/deck/latest/), [Insomnia](https://docs.insomnia.rest/insomnia/get-started), HTTPie, or cURL, at `https://kong.127-0-0-1.nip.io/api`:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
     curl --silent --insecure -X GET https://kong.127-0-0-1.nip.io/api -H 'kong-admin-token:kong'
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-    http --verify=no get https://kong.127-0-0-1.nip.io/api kong-admin-token:kong
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Teardown 
 

--- a/app/_src/gateway/install/kubernetes/helm-quickstart.md
+++ b/app/_src/gateway/install/kubernetes/helm-quickstart.md
@@ -335,18 +335,8 @@ For local deployments, Kong Manager is locally accessible at `https://kong.127-0
 
 You can configure Kong via the Admin API with [decK](https://docs.konghq.com/deck/latest/), [Insomnia](https://docs.insomnia.rest/insomnia/get-started), HTTPie, or cURL, at `https://kong.127-0-0-1.nip.io/api`:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
     curl --silent --insecure -X GET https://kong.127-0-0-1.nip.io/api -H 'kong-admin-token:kong'
 
-{% endnavtab %}
-{% navtab HTTPie %}
-
-    http --verify=no get https://kong.127-0-0-1.nip.io/api kong-admin-token:kong
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Teardown 
 

--- a/app/_src/gateway/kong-enterprise/audit-log.md
+++ b/app/_src/gateway/kong-enterprise/audit-log.md
@@ -42,7 +42,7 @@ For example, consider a query to the Admin API to the `/status`
 endpoint:
 
 ```sh
-http :8001/status
+curl -i -X GET http://localhost:8001/status
 ```
 
 You get the following response:
@@ -87,7 +87,7 @@ The above interaction with the Admin API generates a correlating entry in
 the audit log table. Querying the audit log via the Admin API returns the details of the previous interaction:
 
 ```sh
-http :8001/audit/requests
+curl -i -X GET http://localhost:8001/audit/requests
 ```
 
 {% if_version lte:3.1.x %}
@@ -318,7 +318,7 @@ Database update audit logs are also associated with Admin API request unique
 IDs. Consider the following request to create a consumer:
 
 ```sh
-http :8001/consumers username=bob
+curl -i -X POST http://localhost:8001/consumers username=bob
 ```
 
 Response:
@@ -346,7 +346,7 @@ Note the presence of the `payload` field, recorded when the request body is
 present:
 
 ```sh
-http :8001/audit/requests
+curl -i -X GET http://localhost:8001/audit/requests
 ```
 
 ```sh
@@ -382,7 +382,7 @@ Additionally, audit logs are generated to track the creation of the
 database entity:
 
 ```sh
-http :8001/audit/objects
+curl -i -X GET http://localhost:8001/audit/objects
 ```
 
 Response:

--- a/app/_src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/app/_src/gateway/kong-enterprise/consumer-groups/index.md
@@ -35,23 +35,10 @@ For all possible requests, see the
 
 1. Create a consumer group named `Gold`:
 
-{% capture create_consumer_group %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
-  --data name=Gold
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http POST :8001/consumer_groups name=Gold
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ create_consumer_group | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
+    --data name=Gold
+    ```
 
     Response:
 
@@ -66,23 +53,10 @@ http POST :8001/consumer_groups name=Gold
 
 1. Create a consumer, `Amal`:
 
-{% capture create_consumer %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X POST http://{HOSTNAME}:8001/consumers \
-  --data username=Amal
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http POST :8001/consumers username=Amal
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ create_consumer | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X POST http://{HOSTNAME}:8001/consumers \
+    --data username=Amal
+    ```
 
     Response:
 
@@ -100,23 +74,10 @@ http POST :8001/consumers username=Amal
 
 1. Add `Amal` to the `Gold` consumer group:
 
-{% capture add_consumer %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X POST http://{HOSTNAME}:8001/consumer_groups/Gold/consumers \
-  --data consumer=Amal
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http POST :8001/consumer_groups/Gold/consumers consumer=Amal
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ add_consumer | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X POST http://{HOSTNAME}:8001/consumer_groups/Gold/consumers \
+    --data consumer=Amal
+    ```
 
     Response:
 
@@ -146,36 +107,16 @@ http POST :8001/consumer_groups/Gold/consumers consumer=Amal
 setting the rate limit to five requests (`config.limit`) for every
 30 seconds (`config.window_size`):
 
-{% capture add_plugin %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X POST http://{HOSTNAME}:8001/plugins/  \
-  --data name=rate-limiting-advanced \
-  --data config.limit=5 \
-  --data config.window_size=30 \
-  --data config.window_type=sliding \
-  --data config.retry_after_jitter_max=0 \
-  --data config.enforce_consumer_groups=true \
-  --data config.consumer_groups=Gold
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http -f :8001/plugins/  \
-  name=rate-limiting-advanced \
-  config.limit=5 \
-  config.window_size=30 \
-  config.window_type=sliding \
-  config.retry_after_jitter_max=0 \
-  config.enforce_consumer_groups=true \
-  config.consumer_groups=Gold
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ add_plugin | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X POST http://{HOSTNAME}:8001/plugins/  \
+    --data name=rate-limiting-advanced \
+    --data config.limit=5 \
+    --data config.window_size=30 \
+    --data config.window_type=sliding \
+    --data config.retry_after_jitter_max=0 \
+    --data config.enforce_consumer_groups=true \
+    --data config.consumer_groups=Gold
+    ```
 
     For consumer groups, the following parameters are required:
     * `config.enforce_consumer_groups=true`: enables consumer groups for this plugin.
@@ -192,28 +133,12 @@ http -f :8001/plugins/  \
 the rate limiting configuration for the `Gold` consumer group only, setting
 the limit to ten requests for every ten seconds:
 
-{% capture override %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X PUT http://{HOSTNAME}:8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced \
-  --data config.limit=10 \
-  --data config.window_size=10 \
-  --data config.retry_after_jitter_max=1
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http PUT :8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced \
-  config.limit=10 \
-  config.window_size=10 \
-  config.retry_after_jitter_max=1
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ override | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X PUT http://{HOSTNAME}:8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced \
+    --data config.limit=10 \
+    --data config.window_size=10 \
+    --data config.retry_after_jitter_max=1
+    ```
 
     Response:
 
@@ -235,22 +160,9 @@ http PUT :8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced \
 
 1. Check that it worked by looking at the `Gold` consumer group object:
 
-{% capture check_group1 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X GET http://{HOSTNAME}:8001/consumer_groups/Gold
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http :8001/consumer_groups/Gold
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ check_group1 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X GET http://{HOSTNAME}:8001/consumer_groups/Gold
+    ```
 
     Notice the `plugins` object in the response, along with the parameters that you
     just set for the Rate Limiting Advanced plugin:
@@ -302,7 +214,9 @@ You can remove a consumer from a group by accessing `/consumers` or
 
 1. Check the `Gold` consumer group for the consumer name:
 
-{{ check_group1 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X GET http://{HOSTNAME}:8001/consumer_groups/Gold
+    ```
 
     Response:
 
@@ -329,22 +243,9 @@ You can remove a consumer from a group by accessing `/consumers` or
 1. Using the username or ID of the consumer (`Amal` in this example),
 remove the consumer from the group:
 
-{% capture delete_consumer1 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Gold/consumers/Amal
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http DELETE :8001/consumer_groups/Gold/consumers/Amal
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ delete_consumer1 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Gold/consumers/Amal
+    ```
 
     If successful, you receive the following response:
     ```
@@ -353,7 +254,9 @@ http DELETE :8001/consumer_groups/Gold/consumers/Amal
 
 1. To verify, check the consumer group configuration again:
 
-{{ check_group1 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X GET http://{HOSTNAME}:8001/consumer_groups/Gold
+    ```
 
     Response, with no consumers assigned:
 
@@ -376,22 +279,9 @@ You can remove a consumer from a group by accessing `/consumers` or
 1. If you know the consumer name and not the consumer group name,
 you can look up the group through the consumer:
 
-{% capture check_group2 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X GET http://{HOSTNAME}:8001/consumers/Amal/consumer_groups
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http :8001/consumers/Amal/consumer_groups
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ check_group2 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X GET http://{HOSTNAME}:8001/consumers/Amal/consumer_groups
+    ```
 
     Response:
 
@@ -411,22 +301,9 @@ http :8001/consumers/Amal/consumer_groups
 1. Using the username or ID of the group (`Gold` in this example),
 remove the consumer from the group:
 
-{% capture delete_consumer2 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X DELETE http://{HOSTNAME}:8001/consumers/Amal/consumer_groups/Gold
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http DELETE :8001/consumers/Amal/consumer_groups/Gold
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ delete_consumer2 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X DELETE http://{HOSTNAME}:8001/consumers/Amal/consumer_groups/Gold
+    ```
 
     If successful, you receive the following response:
     ```
@@ -435,7 +312,9 @@ http DELETE :8001/consumers/Amal/consumer_groups/Gold
 
 1. To verify, check the consumer object configuration:
 
-{{ check_group1 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X GET http://{HOSTNAME}:8001/consumer_groups/Gold
+    ```
 
     Response, with no consumers assigned:
 
@@ -458,22 +337,9 @@ With this method, the consumers in the group aren't deleted and are still in the
 
 1. Delete the consumer group configuration using the following request:
 
-{% capture delete_consumer_group_config %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http DELETE :8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ delete_consumer_group_config | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced
+    ```
 
     If successful, you receive see the following response:
     ```
@@ -482,7 +348,9 @@ http DELETE :8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced
     
 1. To verify, check the consumer object configuration:
 
-{{ check_group1 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X GET http://{HOSTNAME}:8001/consumer_groups/Gold
+    ```
 
     Response, without a `plugins` object:
 
@@ -498,7 +366,6 @@ http DELETE :8001/consumer_groups/Gold/overrides/plugins/rate-limiting-advanced
     ```
 
 
-
 ## Delete consumer group
 
 If you don't need a consumer group anymore, you can delete it. This removes
@@ -507,22 +374,9 @@ the group are not deleted.
 
 1. Delete a consumer group using the following request:
 
-{% capture delete_consumer2 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Gold
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http DELETE :8001/consumer_groups/Gold
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ delete_consumer2 | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Gold
+    ```
 
     If successful, you receive see the following response:
     ```
@@ -531,22 +385,9 @@ http DELETE :8001/consumer_groups/Gold
 
 1. Check the list of consumer groups to verify that the `Gold` group is gone:
 
-{% capture check_all_groups %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X GET http://{HOSTNAME}:8001/consumer_groups
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http :8001/consumer_groups
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ check_all_groups | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X GET http://{HOSTNAME}:8001/consumer_groups
+    ```
 
     Response:
     ```json
@@ -558,22 +399,9 @@ http :8001/consumer_groups
 
 1. Check a consumer that was in the group to make sure it still exists:
 
-{% capture check_consumer %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X GET http://{HOSTNAME}:8001/consumers/Amal
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http :8001/consumers/Amal
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ check_consumer | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X GET http://{HOSTNAME}:8001/consumers/Amal
+    ```
 
     An `HTTP/1.1 200 OK` response means the consumer exists.
 
@@ -585,74 +413,31 @@ You can perform many `/consumer_groups` operations in bulk.
 1. Assuming you deleted the group `Gold` in the previous section, create it again,
 along with another group named `Speedsters`:
 
-{% capture create_consumer_group2 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
-  --data name=Gold
+    ```bash
+    curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
+    --data name=Gold
 
-curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
-  --data name=Speedsters
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http POST :8001/consumer_groups name=Gold
-
-http POST :8001/consumer_groups name=Speedsters
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ create_consumer_group2 | indent | replace: " </code>", "</code>" }}
+    curl -i -X POST http://{HOSTNAME}:8001/consumer_groups \
+    --data name=Speedsters
+    ```
 
 1. Create two consumers, `BarryAllen` and `WallyWest`:
 
-{% capture create_two_consumers %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X POST http://{HOSTNAME}:8001/consumers \
-  --data username=BarryAllen
+    ```bash
+    curl -i -X POST http://{HOSTNAME}:8001/consumers \
+    --data username=BarryAllen
 
-curl -i -X POST http://{HOSTNAME}:8001/consumers \
-  --data username=WallyWest
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http POST :8001/consumers username=BarryAllen
-
-http POST :8001/consumers username=WallyWest
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ create_two_consumers | indent | replace: " </code>", "</code>" }}
+    curl -i -X POST http://{HOSTNAME}:8001/consumers \
+    --data username=WallyWest
+    ```
 
 1. Add both consumers to the `Speedsters` group:
-{% capture add_two_consumers %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X POST http://{HOSTNAME}:8001/consumer_groups/Speedsters/consumers \
-  --data consumer=BarryAllen \
-  --data consumer=WallyWest
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http POST :8001/consumer_groups/Speedsters/consumers \
-  consumer:='["BarryAllen", "WallyWest"]'
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
 
-{{ add_two_consumers | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X POST http://{HOSTNAME}:8001/consumer_groups/Speedsters/consumers \
+    --data consumer=BarryAllen \
+    --data consumer=WallyWest
+    ```
 
     {{site.base_gateway}} validates the provided list of consumers before assigning
     them to the consumer group. To pass validation, consumers must exist and must
@@ -694,22 +479,9 @@ if you need to cycle the group for a new batch of users.
 
     For example, delete all consumers from the `Speedsters` group:
 
-{% capture delete_all_consumers %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Speedsters/consumers
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http DELETE :8001/consumer_groups/Speedsters/consumers
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ delete_all_consumers | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X DELETE http://{HOSTNAME}:8001/consumer_groups/Speedsters/consumers
+    ```
 
     Response:
     ```
@@ -724,25 +496,11 @@ http DELETE :8001/consumer_groups/Speedsters/consumers
 
     Add `BarryAllen` to two groups, `Gold` and `Speedsters`:
 
-{% capture add_consumer_many_groups %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X POST http://{HOSTNAME}:8001/consumers/BarryAllen/consumer_groups \
-  --data group=Gold \
-  --data group=Speedsters
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http POST :8001/consumers/BarryAllen/consumer_groups \
-  group:='["Gold", "Speedsters"]'
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ add_consumer_many_groups | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X POST http://{HOSTNAME}:8001/consumers/BarryAllen/consumer_groups \
+    --data group=Gold \
+    --data group=Speedsters
+    ```
 
     The response should look something like this:
 
@@ -776,22 +534,9 @@ http POST :8001/consumers/BarryAllen/consumer_groups \
 
 1. Finally, you can also remove a consumer from all groups:
 
-{% capture add_consumer_many_groups %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-```bash
-curl -i -X DELETE http://{HOSTNAME}:8001/consumers/BarryAllen/consumer_groups
-```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http DELETE :8001/consumers/BarryAllen/consumer_groups
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-{{ add_consumer_many_groups | indent | replace: " </code>", "</code>" }}
+    ```bash
+    curl -i -X DELETE http://{HOSTNAME}:8001/consumers/BarryAllen/consumer_groups
+    ```
 
     Response:
     ```

--- a/app/_src/gateway/kong-enterprise/dev-portal/applications/enable-key-auth-plugin.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/applications/enable-key-auth-plugin.md
@@ -82,19 +82,10 @@ Scroll to view all of the available examples.
 
 ### Make a request with the key as a query string parameter
 
-{% navtabs codeblock %}
-{% navtab cURL %}
+
 ```bash
 curl -X POST {proxy}/{route}?apikey={CLIENT_ID}
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http {proxy}/{route}?apikey={CLIENT_ID}
-```
-{% endnavtab %}
-{% endnavtabs %}
-
 Response (will be the same for all valid requests regardless of key location):
 
 ```bash
@@ -104,34 +95,17 @@ HTTP/1.1 200 OK
 
 ### Make a request with the key in a header
 
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```bash
 curl -X POST {proxy}/{route} \
 --header "apikey: {CLIENT_ID}"
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http {proxy}/{route} apikey:{CLIENT_ID}
-```
-{% endnavtab %}
-{% endnavtabs %}
 
 ### Make a request with the key in the body
 
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```bash
 curl -X POST {proxy}/{route} \
 --data "apikey:={CLIENT_ID}"
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http {proxy}/{route} apikey={CLIENT_ID}
-```
-{% endnavtab %}
-{% endnavtabs %}
 
-**Note:** The `key_in_body` parameter must be set to `true`.
+{:.note}
+> **Note:** The `key_in_body` parameter must be set to `true`.

--- a/app/_src/gateway/kong-enterprise/dev-portal/authentication/azure-oidc-config.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/authentication/azure-oidc-config.md
@@ -12,7 +12,7 @@ for use with the Kong OIDC and Portal Application Registration plugins.
   and strategy (`kong-oauth2` or `external-oauth2`). See
   [Configure the Authorization Provider Strategy](/gateway/{{page.kong_version}}/kong-enterprise/dev-portal/applications/auth-provider-strategy/) for the Portal Application Registration plugin.
 
-## Create an Application in Azure
+## Create an application in Azure
 
 1. Within Azure, go to the **App registrations** service and register a new application.
 
@@ -22,162 +22,77 @@ for use with the Kong OIDC and Portal Application Registration plugins.
 3. Under **Manifest**, update `accessTokenAcceptedVersion=2` (default is null).
    The JSON for your application should look similar to this example:
 
-## Create a Service in Kong
-
-{% navtabs %}
-{% navtab Using cURL %}
+## Create a service in Kong
 
 ```bash
 curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure \
   --data 'url=https://httpbin.org/anything'
 ```
 
-{% endnavtab %}
-{% navtab Using HTTPie %}
-
-```bash
-http PUT :8001/services/httpbin-service-azure \
-  url=https://httpbin.org/anything
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-## Create a Route in Kong
-
-{% navtabs %}
-{% navtab Using cURL %}
+## Create a route in Kong
 
 ```bash
 curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
   --data 'paths=/httpbin-azure'
 ```
-{% endnavtab %}
-{% navtab Using HTTPie %}
 
-```bash
-http -f PUT :8001/services/httpbin-service-azure/routes/httpbin-route-azure \
-  paths=/httpbin-azure
-```
-
-{% endnavtab %}
-{% endnavtabs %}
-
-## Map the OIDC and Application Registration Plugins to the Service
+## Map the OIDC and Application Registration plugins to the service
 
 Map the OpenID Connect and Application Registration plugins to the **Service**.
 The plugins must be applied to a Service to work properly.
 
-### Step 1: Configure the OIDC plugin for the Service
+1. Configure the OIDC plugin for the service:
+
+    ```bash
+    curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+      --data name=openid-connect \
+      --data config.issuer="https://login.microsoftonline.com/<your_tenant_id>/v2.0" \
+      --data config.display_errors="true" \
+      --data config.client_id="<your_client_id>" \
+      --data config.client_secret="<your_client_secret>" \
+      --data config.redirect_uri="https://example.com/api" \
+      --data config.consumer_claim=aud \
+      --data config.scopes="openid" \
+      --data config.scopes="YOUR_CLIENT_ID/.default" \
+      --data config.verify_parameters="false"
+    ```
+
+    For more information, see [OIDC plugin](/hub/kong-inc/openid-connect/).
 
 
-{% navtabs %}
-{% navtab Using cURL %}
+2. Configure the Application Registration plugin for the service:
 
- ```bash
-curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
-  --data name=openid-connect \
-  --data config.issuer="https://login.microsoftonline.com/<your_tenant_id>/v2.0" \
-  --data config.display_errors="true" \
-  --data config.client_id="<your_client_id>" \
-  --data config.client_secret="<your_client_secret>" \
-  --data config.redirect_uri="https://example.com/api" \
-  --data config.consumer_claim=aud \
-  --data config.scopes="openid" \
-  --data config.scopes="YOUR_CLIENT_ID/.default" \
-  --data config.verify_parameters="false"
-```
+    ```bash
+    curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+      --data "name=application-registration"  \
+      --data "config.auto_approve=true" \
+      --data "config.description=Uses consumer claim with various values (sub, aud, etc.) as registration id to support different flows and use cases." \
+      --data "config.display_name=For Azure" \
+      --data "config.show_issuer=true"
+    ```
 
-{% endnavtab %}
-{% navtab Using HTTPie %}
-
-```bash
-http -f :8001/services/httpbin-service-azure/plugins \
-  name=openid-connect \
-  config.issuer=https://login.microsoftonline.com/<your_tenant_id>/v2.0 \
-  config.display_errors=true \
-  config.client_id=<your_client_id> \
-  config.client_secret="<your_client_secret>" \
-  config.redirect_uri="https://example.com/api" \
-  config.consumer_claim=aud \
-  config.scopes=openid \
-  config.scopes=<your_client_id>/.default \
-  config.verify_parameters=false
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-For more information, see [OIDC plugin](/hub/kong-inc/openid-connect/).
-
-
-### Step 2: Configure the Application Registration plugin for the Service
-
-{% navtabs %}
-{% navtab Using cURL %}
-
-```bash
-curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
-  --data "name=application-registration"  \
-  --data "config.auto_approve=true" \
-  --data "config.description=Uses consumer claim with various values (sub, aud, etc.) as registration id to support different flows and use cases." \
-  --data "config.display_name=For Azure" \
-  --data "config.show_issuer=true"
-```
-
-{% endnavtab %}
-{% navtab Using HTTPie %}
-
-```bash
-http -f :8001/services/httpbin-service-azure/plugins \
-  name=application-registration \
-  config.auto_approve=true \
-  config.display_name="For Azure" \
-  config.description="Uses consumer claim with various values (sub, aud, etc.) as registration id to support different flows and use cases." \
-  config.show_issuer=true
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-### Step 3: Get an access token from Azure
-
-Get an access token using the Client Credential workflow and convert the token
+3. Get an access token from Azure using the Client Credential workflow and convert the token
 into a JSON Web Token (JWT). Replace the placeholder values with your values for
 `<your_tenant_id>`, `<your_client_id>`,`<your_client_secret>`, and
 `<admin-hostname>`.
 
-Get an access token from Azure:
+    ```bash
+    curl -X POST https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token \
+      --data scope="<your_client_id>/.default" \
+      --data grant_type="client_credentials" \
+      --data client_id="<your_client_id>" \
+      --data client_secret="<your_client_secret>" \
+    ```
 
-{% navtabs %}
-{% navtab Using cURL %}
+4. Convert an access token into a JWT token:
 
-```bash
-curl -X POST https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token \
-  --data scope="<your_client_id>/.default" \
-  --data grant_type="client_credentials" \
-  --data client_id="<your_client_id>" \
-  --data client_secret="<your_client_secret>" \
-```
+    1. Paste the access token obtained from the previous step into
+    [JWT](https://jwt.io).
 
-{% endnavtab %}
-{% navtab Using HTTPie %}
-
-```bash
-https -f POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
-  scope=<your_client_id>/.default \
-  grant_type=client_credentials \
-  -a <your_client_id>:<your_client_secret>
-```   
-{% endnavtab %}
-{% endnavtabs %}
-
-### Step 4: Convert an access token into a JWT token
-
-1. Paste the access token obtained from the previous step into
-[JWT](https://jwt.io).
-
-1. Click **Share JWT** to copy the value for the
-[aud (audience)](https://tools.ietf.org/html/rfc7519#section-4.1.3) claim to
-your clipboard. You will use the `aud` value as your **Reference ID** in the
-next procedure.
+    2. Click **Share JWT** to copy the value for the
+    [aud (audience)](https://tools.ietf.org/html/rfc7519#section-4.1.3) claim to
+    your clipboard. You will use the `aud` value as your **Reference ID** in the
+    next procedure.
 
 ## Create an Application in Kong
 
@@ -203,63 +118,31 @@ next procedure.
 Follow these instructions to test your client credentials or authorization code
 flows with your Azure AD implementation.
 
-### Test Client Credentials Flow
+1. Get a token:
 
-#### Step 1: Get a token
+    ```bash
+    curl -X POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
+    --data scope="<your_client_id>/.default" \
+    --data grant_type="client_credentials" \
+    --data client_id="<your_client_id>" \
+    --data client_secret="<your_client_secret>"
+    ```
 
-{% navtabs %}
-{% navtab Using cURL %}
+2. Use the token in an authorization header to retrieve the data:
 
-```bash
-curl -X POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
---data scope="<your_client_id>/.default" \
---data grant_type="client_credentials" \
---data client_id="<your_client_id>" \
---data client_secret="<your_client_secret>"
-```
+    ```bash
+    curl --header 'Authorization: bearer <token_from_above>' '<admin-hostname>:8000/httpbin-azure'
+    ``` 
 
-{% endnavtab %}
-{% navtab Using HTTPie %}
+    Replace `<token_from_above>` with the bearer token you generated in the previous step.
 
-```bash
-https -f POST "https://login.microsoftonline.com/<your_tenant_id>/oauth2/v2.0/token" \
-  scope=<your_client_id>/.default \
-  grant_type=client_credentials \
-  -a <your_client_id>:<your_client_secret> \
-  --verify NO
-```
-{% endnavtab %}
-{% endnavtabs %}
+3. Test the authorization code flow. In your browser, go to `http://<admin-hostname>:8000/httpbin-azure`.
 
-#### Step 2: Use the token in an authorization header to retrieve the data
-
-{% navtabs %}
-{% navtab Using cURL %}
-
-```bash
-curl --header 'Authorization: bearer <token_from_above>' '<admin-hostname>:8000/httpbin-azure'
-```
-
-{% endnavtab %}
-{% navtab Using HTTPie %}
-
-```bash
-http :8000/httpbin-azure Authorization:'bearer <token_from_above>'
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-   Replace `<token_from_above>` with the bearer token you generated in the previous step.
-
-### Test Authorization Code Flow
-
-In your browser, go to `http://<admin-hostname>:8000/httpbin-azure`.
-
-You should be guided through a log in process within Azure and then the results
-delivered in your browser.
+    You should be guided through a login process within Azure with the results
+    delivered in your browser.
 
 ## Troubleshoot
 
 If you encounter any issues, review your data plane logs. Because you
-enabled `display_errors=true` on the OpenID Connect Plugin, you will receive
+enabled `display_errors=true` on the OpenID Connect plugin, you will receive
 more verbose error messages that can help pinpoint any issues.

--- a/app/_src/gateway/kong-enterprise/event-hooks/index.md
+++ b/app/_src/gateway/kong-enterprise/event-hooks/index.md
@@ -16,35 +16,21 @@ To create a webhook event hook:
 2. Select **Copy to clipboard** next to **Your unique URL**.
 3. Create a webhook event hook on the `consumers` event (Kong entity the event hook will listen to for events),
    on the `crud` source (action that triggers logging), and the URL you copied from step 2 using the following HTTP request:
-{% capture the_code %}
-{% navtabs codeblock %}
-{% navtab cURL %}
 
-<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/event-hooks \
--d source=crud \
--d event=consumers \
--d handler=webhook \
--d config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
+    ```sh
+    curl -i -X POST http://{HOSTNAME}:8001/event-hooks \
+      -d source=crud \
+      -d event=consumers \
+      -d handler=webhook \
+      -d config.url={WEBHOOK_URL}
+    ```
 
-{% endnavtab %}
-{% navtab HTTPie %}
-
-<div class="copy-code-snippet"><pre><code>http -f :8001/event-hooks \
-source=crud \
-event=consumers \
-handler=webhook \
-config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
-
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-{{ the_code | indent }}
 
 4. Navigate to the URL from step 2. You should see a POST request, of type `ping`, notifying our webhook endpoint
    about the creation of this webhook.
 5. In Kong Manager or Kong Admin API, add a consumer from any workspace.
 
-{% capture the_code2 %}
+{% capture the_code %}
 {% navtabs %}
 {% navtab Kong Manager %}
 
@@ -60,28 +46,19 @@ config.url=<div contenteditable="true">{WEBHOOK_URL}</div></code></pre></div>
 
 Create a consumer, Ada Lovelace, by making the following HTTP request to your instance of the Kong Admin API:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
-<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/consumers \
--d username="Ada Lovelace"</code></pre></div>
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-<div class="copy-code-snippet"><pre><code>http -f :8001/consumers \
-username="Ada Lovelace"</code></pre><div>
+```
+curl -i -X POST http://{HOSTNAME}:8001/consumers \
+  -d username="Ada Lovelace"
+```
 
 {% endnavtab %}
 {% endnavtabs %}
 
-{% endnavtab %}
-{% endnavtabs %}
 {% endcapture %}
-{{ the_code2 | indent }}
+{{ the_code | indent }}
 
-6. Check the URL from the [https://webhook.site](https://webhook.site) page.
-   You should see an entry with data for the new consumer in its payload.
+1. Check the URL from the [https://webhook.site](https://webhook.site) page.
+    You should see an entry with data for the new consumer in its payload.
 
     ```json
     {
@@ -115,38 +92,21 @@ To create a custom webhook event hook:
 2. Activate incoming webhooks in the settings for your new app.
 3. Select to **Add New Webhook to Workspace**, select the channel where you wish to receive notices, and select **Allow**.
 4. Copy the **Webhook URL**, for example `https://hooks.slack.com/services/foo/bar/baz`.
-5. Create a webhook event hook on the `admins` event (Kong entity the event hook will listen to for events),
-   and the `crud` source (action that triggers logging), and format the payload as, {% raw %}"Admin account \`{{ entity.username }}\` {{ operation }}d; e-mail address set to \`{{ entity.email }}\`"{% endraw %}, using the following HTTP request:
+5. Create a webhook event hook on the `admins` event (Kong entity the event hook will listen to for events)
+   and the `crud` source (action that triggers logging). 
+   
+   Format the payload as `{% raw %}"Admin account \`{{ entity.username }}\` {{ operation }}d; e-mail address set to \`{{ entity.email }}\`"{% endraw %}`, using the following HTTP request:
 
-{% capture the_code3 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-
-<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/event-hooks \
--d source=crud \
--d event=admins \
--d handler=webhook-custom \
--d config.method=POST \
--d config.url=<div contenteditable="true">{WEBHOOK_URL}</div> \
--d config.headers.content-type="application/json" \
--d config.payload.text={% raw %}"Admin account \`{{ entity.username }}\` {{ operation}}d; email address set to \`{{ entity.email }}\`"{% endraw %}</code></pre></div>
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-<div class="copy-code-snippet"><pre><code>http -f :8001/event-hooks \
-source=crud \
-event=admins \
-handler=webhook-custom \
-config.method=POST \
-config.url=<div contenteditable="true">{WEBHOOK_URL}</div> \
-config.headers.content-type="application/json" \
-config.payload.text={% raw %}"Admin account \`{{ entity.username }}\` {{ operation}}d; email address set to \`{{ entity.email }}\`"{% endraw %}</code></pre></div>
-
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-{{ the_code3 | indent }}
+    ```sh
+    curl -i -X POST http://{HOSTNAME}:8001/event-hooks \
+      -d source=crud \
+      -d event=admins \
+      -d handler=webhook-custom \
+      -d config.method=POST \
+      -d config.url={WEBHOOK_URL} \
+      -d config.headers.content-type="application/json" \
+      -d config.payload.text={% raw %}"Admin account \`{{ entity.username }}\` {{ operation}}d; email address set to \`{{ entity.email }}\`"{% endraw %}
+    ```
 
 6. Turn on RBAC.
 
@@ -178,24 +138,12 @@ Create an admin, Arya Stark, by making the following HTTP request to your instan
 > **Note:** Replace `{KONG_ADMIN_PASSWORD`} with your `kong_admin` password. This is the initial
   `KONG_PASSWORD` you used when you ran migrations during installation.
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
-<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/admins \
+```sh
+curl -i -X POST http://{HOSTNAME}:8001/admins \
 -d username="Arya Stark" \
 -d email=arya@gameofthrones.com \
--H Kong-Admin-Token:{KONG_ADMIN_PASSWORD}</code></pre></div>
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-<div class="copy-code-snippet"><pre><code>http -f :8001/admins \
-username="Arya Stark" \
-email=arya@gameofthrones.com \
-Kong-Admin-Token={KONG_ADMIN_PASSWORD}</code></pre><div>
-
-{% endnavtab %}
-{% endnavtabs %}
+-H Kong-Admin-Token:{KONG_ADMIN_PASSWORD}
+```
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -214,31 +162,16 @@ To create a log event hook:
 1. Create a log event hook on the `consumers` event (Kong entity the event hook will listen to for events)
   and on the `crud` source (action that triggers logging) using the following HTTP request:
 
-{% capture the_code5 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-
-<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/event-hooks \
--d source=crud \
--d event=consumers \
--d handler=log</code></pre></div>
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-<div class="copy-code-snippet"><pre><code>http -f :8001/event-hooks \
-source=crud \
-event=consumers \
-handler=log</code></pre></div>
-
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-{{ the_code5 | indent }}
+    ```sh
+    curl -i -X POST http://{HOSTNAME}:8001/event-hooks \
+      -d source=crud \
+      -d event=consumers \
+      -d handler=log
+    ```
 
 2. In Kong Manager or Kong Admin API, add a consumer from any workspace.
 
-{% capture the_code6 %}
+{% capture the_code3 %}
 {% navtabs %}
 {% navtab Kong Manager %}
 
@@ -254,25 +187,15 @@ handler=log</code></pre></div>
 
 Create a consumer, Elizabeth Bennet, by making the following HTTP request to your instance of the Kong Admin API:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
-<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/consumers \
--d username="Elizabeth Bennet"</code></pre></div>
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-<div class="copy-code-snippet"><pre><code>http -f :8001/consumers \
-username="Elizabeth Bennet"</code></pre><div>
-
-{% endnavtab %}
-{% endnavtabs %}
+```sh
+curl -i -X POST http://{HOSTNAME}:8001/consumers \
+-d username="Elizabeth Bennet"
+```
 
 {% endnavtab %}
 {% endnavtabs %}
 {% endcapture %}
-{{ the_code6 | indent }}
+{{ the_code3 | indent }}
 
 3. You should see an entry with data for the new consumer in the payload in Kong's error log,
    which is typically accessible at `/usr/local/kong/logs/error.log`.
@@ -319,33 +242,17 @@ To create a lambda event hook:
 2. Create a lambda event hook on the `consumers` event (Kong entity the event hook will listen to for events)
   and on the `crud` source (action that triggers logging) using the following HTTP request:
 
-{% capture the_code7 %}
-{% navtabs codeblock %}
-{% navtab cURL %}
-
-<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/event-hooks \
--d source=crud \
--d event=consumers \
--d handler=lambda \
--F config.functions='return function (data, event, source, pid) local user = data.entity.username error("Event hook on consumer " .. user .. "")end'</code></pre></div>
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-<div class="copy-code-snippet"><pre><code>http -f :8001/event-hooks \
-source=crud \
-event=consumers \
-handler=lambda \
-config.functions[]=@~/lambda.lua</code></pre></div>
-
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-{{ the_code7 | indent }}
+    ```sh
+    curl -i -X POST http://{HOSTNAME}:8001/event-hooks \
+      -d source=crud \
+      -d event=consumers \
+      -d handler=lambda \
+      -F config.functions='return function (data, event, source, pid) local user = data.entity.username error("Event hook on consumer " .. user .. "")end'
+    ```
 
 3. In Kong Manager or Kong Admin API, add a consumer to any workspace.
 
-{% capture the_code8 %}
+{% capture the_code4 %}
 {% navtabs %}
 {% navtab Kong Manager %}
 
@@ -361,25 +268,15 @@ config.functions[]=@~/lambda.lua</code></pre></div>
 
 Create a consumer, Lois Lane, by making the following HTTP request to your instance of the Kong Admin API:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
-<div class="copy-code-snippet"><pre><code>curl -i -X POST http://<div contenteditable="true">{HOSTNAME}</div>:8001/consumers \
--d username="Lois Lane"</code></pre></div>
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-<div class="copy-code-snippet"><pre><code>http -f :8001/consumers \
-username="Lois Lane"</code></pre></div>
-
-{% endnavtab %}
-{% endnavtabs %}
+```sh
+curl -i -X POST http://{HOSTNAME}:8001/consumers \
+  -d username="Lois Lane"
+```
 
 {% endnavtab %}
 {% endnavtabs %}
 {% endcapture %}
-{{ the_code8 | indent }}
+{{ the_code4 | indent }}
 
 3. You should see an entry "Event hook on consumer Lois Lane" in Kong's error log,
    which is typically accessible at `/usr/local/kong/logs/error.log`.

--- a/app/_src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/app/_src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -22,9 +22,6 @@ authentication method.
 Call the Admin API on port `8001` and enable the
 `rate-limiting` plugin, configuring it to run before `key-auth`:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i -X POST http://<admin-hostname>:8001/plugins \
   --data name=rate-limiting \
@@ -33,22 +30,9 @@ curl -i -X POST http://<admin-hostname>:8001/plugins \
   --data config.limit_by=ip \
   --data ordering.before.access=key-auth
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http -f post :8001/plugins \
-  name=rate-limiting \
-  config.minute=5 \
-  config.policy=local \
-  config.limit_by=ip \
-  ordering.before.access=key-auth
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 {% endnavtab %}
-{% navtab  Kubernetes %}
+{% navtab Kubernetes %}
 ```yaml
 apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin
@@ -175,27 +159,14 @@ plugin, you can change the order of the authentication plugin
 Call the Admin API on port `8001` and enable the
 `basic-auth` plugin, configuring it to run after `request-transformer`:
 
-<!-- codeblock tabs -->
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```sh
 curl -i -X POST http://<admin-hostname>:8001/plugins \
   --data name=basic-auth \
   --data ordering.after.access=request-transformer
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```sh
-http -f post :8001/plugins \
-  name=basic-auth \
-  ordering.after.access=request-transformer
-```
-{% endnavtab %}
-{% endnavtabs %}
-<!-- end codeblock tabs -->
 
 {% endnavtab %}
-{% navtab  Kubernetes %}
+{% navtab Kubernetes %}
 ```yaml
 apiVersion: configuration.konghq.com/v1
 kind: KongClusterPlugin

--- a/app/_src/gateway/kong-enterprise/secrets-management/advanced-usage.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/advanced-usage.md
@@ -43,28 +43,12 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 
 Create a Vault entity:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
 ```bash
 curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault-1  \
   --data name=env \
   --data description='ENV vault for secrets' \
   --data config.prefix=SECRET_
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT :8001/vaults/my-env-vault-1 \
-  name=env \
-  description="ENV vault for secrets" \
-  config.prefix=SECRET_
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -55,27 +55,12 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtabs %}
 {% navtab Admin API %}
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
 ```bash
 curl -i -X PUT http://HOSTNAME:8001/vaults/my-aws-sm-vault  \
   --data name=aws \
   --data description="Storing secrets in AWS Secrets Manager" \
   --data config.region="us-east-1"
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT :8001/vaults/my-aws-sm-vault name="aws" \
-  description="Storing secrets in AWS Secrets Manager" \
-  config.region="us-east-1"
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/env.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/env.md
@@ -45,26 +45,11 @@ This allows you to reference the secrets separately:
 {% navtabs %}
 {% navtab Admin API %}
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
 ```bash
 curl -i -X PUT http://HOSTNAME:8001/vaults/my-env-vault \
   --data name=env \
   --data description="Store secrets in environment variables"
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT :8001/vaults/my-env-vault \
-  name="env" \
-  description="Store secrets in environment variables"
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
@@ -79,28 +79,12 @@ that encapsulates the provider and the GCP project ID:
 {% navtabs %}
 {% navtab Admin API %}
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
 ```bash
 curl -i -X PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
   --data name=gcp \
   --data description="Storing secrets in GCP Secrets Manager" \
   --data config.project_id="my_project_id"
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT http://HOSTNAME:8001/vaults/my-gcp-sm-vault \
-  name="gcp" \
-  description="Storing secrets in GCP Secrets Manager" \
-  config.project_id="my_project_id"
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -44,9 +44,6 @@ The Vault entity can only be used once the database is initialized. Secrets for 
 {% navtabs %}
 {% navtab Admin API %}
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
 ```bash
 curl -i -X PUT http://HOSTNAME:8001/vaults/my-hashicorp-vault \
   --data name="hcv" \
@@ -58,24 +55,6 @@ curl -i -X PUT http://HOSTNAME:8001/vaults/my-hashicorp-vault \
   --data config.kv="v2" \
   --data config.token="<mytoken>"
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT :8001/vaults/my-hashicorp-vault \
-  name="hcv" \
-  description="Storing secrets in HashiCorp Vault" \
-  config.protocol="https" \
-  config.host="localhost" \
-  config.port="8200" \
-  config.mount="secret" \
-  config.kv="v2" \
-  config.token="<mytoken>"
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 

--- a/app/_src/gateway/kong-enterprise/workspaces/index.md
+++ b/app/_src/gateway/kong-enterprise/workspaces/index.md
@@ -55,8 +55,12 @@ other, the only difference being that it's created by Kong, at migration time.
 In a fresh {{site.base_gateway}} install, submit the
 following request:
 
+```sh
+curl -i -X GET http://localhost:8001/workspaces
 ```
-http GET :8001/workspaces
+
+Response:
+```json
 {
   "total": 1,
   "data": [
@@ -72,110 +76,114 @@ http GET :8001/workspaces
 ## Creating a workspace
 
 A more interesting example would be segmenting entities by teams; for the sake of
-example, let's say they are teamA, teamB, and teamC.
+example, let's say they are teamA and teamB.
 
 Each of these teams has its own set of entities—say, upstream services and
 routes—and want to segregate their configurations and traffic; they can
 achieve that with workspaces.
 
-```
-http POST :8001/workspaces name=teamA
-{
-    "created_at": 1528843468000,
-    "id": "735af96e-206f-43f7-88f0-b930d5fd4b7e",
-    "name": "teamA"
-}
-```
 
-```
-http POST :8001/workspaces name=teamB
-{
-  "name": "teamB",
-  "created_at": 1529628574000,
-  "id": "a25728ac-6036-497c-82ee-524d4c22fcae"
-}
-```
+1. Create teamA:
 
-```
-http POST :8001/workspaces name=teamC
-{
-  "name": "teamC",
-  "created_at": 1529628622000,
-  "id": "34b28f10-e1ec-4dad-9ac0-74780baee182"
-}
-```
+    ```sh
+    curl -i -X POST http://localhost:8001/workspaces \
+      --data name=teamA
+    ```
 
-At this point, if we list workspaces, we will get a total of 4—remember,
-Kong provisions a "default" workspace and, on top of that, we created other
-3.
-
-```
-{
-  "data": [
+    Response:
+    ```json
     {
-      "created_at": 1529627841000,
-      "id": "a43fc3f9-98e4-43b0-b703-c3b1004980d5",
-      "name": "default"
-    },
-    {
-      "created_at": 1529628818000,
-      "id": "5ed1c043-78cc-4fe2-924e-40b17ecd97bc",
-      "name": "teamA"
-    },
-    {
-      "created_at": 1529628574000,
-      "id": "a25728ac-6036-497c-82ee-524d4c22fcae",
-      "name": "teamB"
-    },
-    {
-      "created_at": 1529628622000,
-      "id": "34b28f10-e1ec-4dad-9ac0-74780baee182",
-      "name": "teamC"
+        "created_at": 1528843468000,
+        "id": "735af96e-206f-43f7-88f0-b930d5fd4b7e",
+        "name": "teamA"
     }
-  ]
-  "total": 4,
-}
+    ```
 
-```
+1. Create teamB:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/workspaces \
+      --data name=teamB
+    ```
+
+    Response:
+    ```json
+    {
+      "name": "teamB",
+      "created_at": 1529628574000,
+      "id": "a25728ac-6036-497c-82ee-524d4c22fcae"
+    }
+    ```
+
+1. At this point, if you list workspaces, you get a total of three: 
+the default workspace and the two team workspaces.
+
+    ```json
+    {
+      "data": [
+        {
+          "created_at": 1529627841000,
+          "id": "a43fc3f9-98e4-43b0-b703-c3b1004980d5",
+          "name": "default"
+        },
+        {
+          "created_at": 1529628818000,
+          "id": "5ed1c043-78cc-4fe2-924e-40b17ecd97bc",
+          "name": "teamA"
+        },
+        {
+          "created_at": 1529628574000,
+          "id": "a25728ac-6036-497c-82ee-524d4c22fcae",
+          "name": "teamB"
+        }
+      ]
+      "total": 3,
+    }
+
+    ```
 
 ## Entities in different workspaces can have the same name!
 
 Different teams—belonging to different workspaces—are allowed to give any
-name to their entities. To provide an example of that, let's say that Teams A, B,
-and C want a particular consumer named `guest`—a different consumer for each
+name to their entities. To provide an example of that, let's say that Teams A and
+B want a particular consumer named `guest`—a different consumer for each
 team, sharing the same username.
 
-```
-http :8001/teamA/consumers username=guest
-{
-    "created_at": 1529703386000,
-    "id": "2e230275-2a4a-41fd-b06b-bae37008aed2",
-    "type": 0,
-    "username": "guest"
-}
-```
+1. Create a consumer named `guest` in teamA:
 
-```
-http :8001/teamB/consumers username=guest
-{
-    "created_at": 1529703390000,
-    "id": "8533e404-8d56-4481-a919-0ee35b8a768c",
-    "type": 0,
-    "username": "guest"
-}
-```
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/consumers \
+      --data username=guest
+    ```
 
-```
-http :8001/teamC/consumers username=guest
-{
-    "created_at": 1529703393000,
-    "id": "5fb180b0-0cd0-42e1-8d75-ce42a54b2909",
-    "type": 0,
-    "username": "guest"
-}
-```
+    Response:
+    ```json
+    {
+        "created_at": 1529703386000,
+        "id": "2e230275-2a4a-41fd-b06b-bae37008aed2",
+        "type": 0,
+        "username": "guest"
+    }
+    ```
 
-With this, Teams A, B, and C will have the freedom to operate their `guest`
+
+1. Create a consumer named `guest` in teamB:
+    ```sh
+    curl -i -X POST http://localhost:8001/teamB/consumers \
+      --data username=guest
+    ```
+
+    Response:
+    ```json
+    {
+        "created_at": 1529703390000,
+        "id": "8533e404-8d56-4481-a919-0ee35b8a768c",
+        "type": 0,
+        "username": "guest"
+    }
+    ```
+
+With this, Teams A and B will have the freedom to operate their `guest`
 consumer independently, choosing authentication plugins or doing any other
 operation that is allowed in the non-workspaced Kong world.
 

--- a/app/_src/gateway/licenses/examples.md
+++ b/app/_src/gateway/licenses/examples.md
@@ -28,7 +28,7 @@ in some other way, the new license will not apply.
 Submit the following request:
 
 ```bash
-http GET :8001/licenses
+curl -i -X GET http://localhost:8001/licenses
 ```
 
 {% navtabs codeblock %}
@@ -63,7 +63,7 @@ http GET :8001/licenses
 Using the ID of the license, submit the following request:
 
 ```bash
-http GET :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f
+curl -i -X GET http://localhost:8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f
 ```
 
 ```json
@@ -82,8 +82,8 @@ http GET :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f
 To generate an ID automatically, submit a `POST` request directly to `/licenses`:
 
 ```bash
-http POST :8001/licenses \
-  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
+curl -i -X POST http://localhost:8001/licenses \
+  --data payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
 
 Response:
@@ -102,7 +102,7 @@ To create a license with a custom ID, submit a `PUT` request to
 `/licenses/<uuid>`:
 
 ```bash
-http PUT :8001/licenses/e8201120-4ee3-43ca-9e92-3fed08b1a15d \
+curl -i -X PUT http://localhost:8001/licenses/e8201120-4ee3-43ca-9e92-3fed08b1a15d \
   payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
 
@@ -116,7 +116,8 @@ Response:
 }
 ```
 
-**Note**: If the provided ID exists, the request will perform
+{:.note}
+> **Note**: If the provided ID exists, the request will perform
           an update to the license for the given ID instead of creating a new
           `license` entity.
 
@@ -125,7 +126,7 @@ Response:
 To update a license, submit a `PATCH` request to an existing license ID:
 
 ```bash
-http PATCH :8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f \
+curl -i -X PATCH http://localhost:8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f \
   payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-21","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb","version":"1"}}'
 ```
 
@@ -144,7 +145,7 @@ Response:
 To generate a report, submit a `GET` request directly to `/license/report`:
 
 ```bash
-http GET :8001/license/report
+curl -i -X GET http://localhost:8001/license/report
 ```
 
 {% navtabs codeblock %}

--- a/app/_src/gateway/production/access-control/enable-rbac.md
+++ b/app/_src/gateway/production/access-control/enable-rbac.md
@@ -24,7 +24,7 @@ To sum up, workspaces and RBAC are complementary: workspaces provide segmentatio
 Admin API entities, while RBAC provides access control.
 
 {:.note}
-> **Note:** The example responses in this guide are often partial excerpts 
+> **Note:** The example responses in this guide are often excerpts of full responses,
 focusing on the most relevant part of the response, as the full response can be very long.
 
 ## Bootstrapping the first RBAC user
@@ -40,7 +40,7 @@ with RBAC enabled.
 If you chose this option, skip to [Enforcing RBAC](#enforcing-rbac).
 
 {{site.base_gateway}} ships with a set of default RBAC roles: `super-admin`,
-the `admin`, and `read-only`, which the task of creating a Super Admin user easy:
+the `admin`, and `read-only`, which makes the task of creating a super admin user easy:
 
 1. Create the RBAC user, named `super-admin`:
 
@@ -93,15 +93,15 @@ the `admin`, and `read-only`, which the task of creating a Super Admin user easy
 
 ## Enforcing RBAC
 
-As the `super-admin` user has just been created, the Kong admin may now
-restart Kong with RBAC enforced:
+With the `super-admin` user created, the Kong admin can now restart 
+{{site.base_gateway}} with RBAC enforced:
 
 ```
 KONG_ENFORCE_RBAC=on kong restart
 ```
 
 This is one of the possible ways of enforcing RBAC and restarting
-Kong. Another possibility is editing the Kong configuration file and
+Kong. Another options is editing the {{site.base_gateway}} configuration file and
 restarting.
 
 Before moving on, note that this guide uses the super admin user, but you 
@@ -198,7 +198,7 @@ one workspace for each and one admin for each.
     }
     ```
 
-1. With this, both of the teams have one admin and each admin can only be seen
+1. Both of the teams now have one admin and each admin can only be seen
 in their corresponding workspace. To verify, run:
 
     ```sh
@@ -251,7 +251,7 @@ The super admin is now done creating RBAC admin users for each team. The next
 task is to create admin roles that will effectively grant permissions to admin
 users.
 
-The admin role must have access to all of the Admin API, restricted to their
+The admin role must have access to all of the Admin API, restricted to its
 workspace.
 
 1. Set up the admin role, paying close attention to the request parameters:
@@ -335,7 +335,7 @@ workspace.
     }
     ```
 
-1. With these steps, Team A's admin user is now able to manage their team. To
+1. Team A's admin user is now able to manage their team. To
 validate that, let's try to list RBAC users in Team B using Team A's admin
 user token:
 
@@ -351,7 +351,7 @@ user token:
     }
     ```
 
-1. Now try to list RBAC users in Team A's workspace:
+1. Now try listing RBAC users in Team A's workspace:
 
     ```sh
     curl -i -X GET http://localhost:8001/teamA/rbac/users \
@@ -388,9 +388,9 @@ step is to create team users, such as engineers that are part of Team A or B.
 Let's go ahead and do that, using Admin A's user token.
 
 Before regular users can be created, a role needs to be available for them.
-This role needs to have permissions to all of Admin API endpoints, except
-RBAC and workspaces. Regular users don't need access to these endpoints in general
-and if they do, the admin can grant them.
+This role needs to have permissions to all of the Admin API endpoints, except
+RBAC and workspaces. Regular users don't need access to these endpoints,
+and if they do, the admin can grant them individually.
 
 ### Create the users role
 
@@ -496,10 +496,10 @@ and if they do, the admin can grant them.
 
 {:.important}
 > **Important**: As explained in the [Wildcards in Permissions](#wildcards-in-permissions)
-section, the meaning of `*` is not the expected generic globbing one might
-be used to. As such, `/rbac/*` or `/workspaces/*` do not match all of the
+section, the meaning of `*` is not the same as generic globbing.
+ As such, `/rbac/*` or `/workspaces/*` do not match all of the
 RBAC and Workspaces endpoints. For example, to cover all of the RBAC API,
-one would have to define permissions for the following endpoints:
+you would have to define permissions for the following endpoints:
 >
 > - `/rbac/*`
 > - `/rbac/*/*`
@@ -710,14 +710,14 @@ can be allowed or disallowed access in a role.
 
 RBAC is [enforced](#enforcing-rbac) with the `enforce_rbac`
 configuration directive, or with its `KONG_ENFORCE_RBAC` environment variable
-counterpart. Such directive is an enum, with 4 possible values:
+counterpart. The directive is an enum, with the following possible values:
 
 - `on`: Applies endpoint-levelaccess control
 - `entity`: Applies **only** Entity-level access control
 - `both`: Applies **both Endpoint and Entity level access control**
 - `off`: disables RBAC enforcement
 
-If set to `entity` or `both`, Kong will enforce entity-level
+If set to `entity` or `both`, Kong enforces entity-level
 access control. However, as with endpoint-level access control, permissions
 must be bootstrapped before enforcement is enabled.
 
@@ -864,7 +864,7 @@ the two entities over Kong's admin API.
 
 Let's assume that Admin A [enabled entity-level enforcement](#enforcing-rbac) as well.
 Note that as `qux` has **no endpoint-level permissions**. If both endpoint and
-entity-level enforcement is enabled, `qux` won't  be able to read their entities, as
+entity-level enforcement is enabled, `qux` won't be able to read their entities, as
 endpoint-level validation comes before entity-level.
 
 1. As `qux`, try listing all RBAC users:

--- a/app/_src/gateway/production/access-control/enable-rbac.md
+++ b/app/_src/gateway/production/access-control/enable-rbac.md
@@ -827,7 +827,7 @@ to use entity-level RBAC.
         "read"
       ]
     }
-
+    ```
 
 1. Add the user `qux` to `qux-role`:
 

--- a/app/_src/gateway/production/access-control/enable-rbac.md
+++ b/app/_src/gateway/production/access-control/enable-rbac.md
@@ -23,6 +23,10 @@ access control over their Workspace, which is possible with RBAC.
 To sum up, workspaces and RBAC are complementary: workspaces provide segmentation of
 Admin API entities, while RBAC provides access control.
 
+{:.note}
+> **Note:** The example responses in this guide are often partial excerpts 
+focusing on the most relevant part of the response, as the full response can be very long.
+
 ## Bootstrapping the first RBAC user
 
 The first RBAC user is called the super admin.
@@ -307,29 +311,27 @@ workspace.
       -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
     ```
 
-    Response:
+    Response: 
+
     ```json
     {
       "roles": [
-        {
-          "comment": "Default user role generated for adminA",
-          "created_at": 1531014784000,
-          "id": "e2941b41-92a4-4f49-be89-f1a452bdecd0",
-          "name": "adminA"
-        },
-        {
-          "created_at": 1531016728000,
-          "id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
-          "name": "admin"
-        }
+          {
+              "created_at": 1685551877,
+              "id": "42809ada-650c-4575-b0a0-d464a64ffb70",
+              "name": "admin",
+              "ws_id": "9dc7adbb-9b64-4121-bf76-653cf5871bc2"
+          }
       ],
       "user": {
-        "created_at": 1531014784000,
-        "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
-        "name": "adminA",
-        "enabled": true,
-        "user_token": "n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG"
-      }
+          "comment": "null",
+          "created_at": 1685552809,
+          "enabled": true,
+          "id": "bca4e390-fbbf-4a46-b55d-f4642efc14bb",
+          "name": "adminA",
+          "user_token": "$2b$09$oLyKTIDuKriPZ.SD5wYtxeMclGYNDn4udJkQG0NGx/Aq3j9j/tWsa",
+          "user_token_ident": "0ebb5"
+            }
     }
     ```
 
@@ -1062,8 +1064,6 @@ Response:
   "id": "6ee76f74-3c96-46a9-ae48-72df0717d244"
 }
 ```
-
----
 
 [workspaces-examples]: /gateway/{{page.kong_version}}/kong-enterprise/workspaces
 [getting-started-guide]: /gateway/{{page.kong_version}}/get-started/

--- a/app/_src/gateway/production/access-control/enable-rbac.md
+++ b/app/_src/gateway/production/access-control/enable-rbac.md
@@ -105,7 +105,7 @@ KONG_ENFORCE_RBAC=on kong restart
 ```
 
 This is one of the possible ways of enforcing RBAC and restarting
-Kong. Another options is editing the {{site.base_gateway}} configuration file and
+Kong. Another option is editing the {{site.base_gateway}} configuration file and
 restarting.
 
 Before moving on, note that this guide uses the super admin user, but you 

--- a/app/_src/gateway/production/access-control/enable-rbac.md
+++ b/app/_src/gateway/production/access-control/enable-rbac.md
@@ -46,8 +46,9 @@ the `admin`, and `read-only`, which makes the task of creating a super admin use
 
     ```sh
     curl -i -X POST http://localhost:8001/rbac/users \
-      -H Kong-Admin-Token:secureadmintoken \
-      --data name=super-admin
+      -H 'Kong-Admin-Token:secureadmintoken' \
+      --data name=super-admin \
+      --data user_token=exampletoken
     ```
 
     Response:
@@ -56,7 +57,8 @@ the `admin`, and `read-only`, which makes the task of creating a super admin use
       "user_token": "M8J5A88xKXa7FNKsMbgLMjkm6zI2anOY",
       "id": "da80838d-49f8-40f6-b673-6fff3e2c305b",
       "enabled": true,
-      "created_at": 1531009435000,
+      "created_at": 1531009435,
+      "updated_at": 1531009435,
       "name": "super-admin"
     }
     ```
@@ -76,13 +78,15 @@ the `admin`, and `read-only`, which makes the task of creating a super admin use
       "roles": [
         {
           "comment": "Full access to all endpoints, across all workspaces",
-          "created_at": 1531009724000,
+          "created_at": 1531009724,
+          "updated_at": 1531009724,
           "name": "super-admin",
           "id": "b924ac91-e83f-4136-a5a4-4a7ff92594a8"
         }
       ],
       "user": {
-        "created_at": 1531009858000,
+        "created_at": 1531009435,
+        "updated_at": 1531009724,
         "id": "e6897cc0-0c34-4a9c-9f0b-cc65b4f04d68",
         "name": "super-admin",
         "enabled": true,
@@ -134,7 +138,8 @@ one workspace for each and one admin for each.
     ```json
     {
       "name": "teamA",
-      "created_at": 1531014100000,
+      "created_at": 1531014100,
+      "updated_at": 1531014100,
       "id": "1412f3a6-4d9b-4b9d-964e-60d8d63a9d46"
     }
     ```
@@ -151,7 +156,8 @@ one workspace for each and one admin for each.
     ```json
     {
       "name": "teamB",
-      "created_at": 1531014143000,
+      "created_at": 1531014143,
+      "updated_at": 1531014143,
       "id": "7dee8c56-c6db-4125-b87a-b508baa33c66"
     }
     ```
@@ -173,7 +179,8 @@ one workspace for each and one admin for each.
       "user_token": "qv1VLIpl8kHj7lC1QOKwRdCMXanqEDii",
       "id": "4d315ff9-8c1a-4844-9ea2-21b16204a154",
       "enabled": true,
-      "created_at": 1531015165000,
+      "created_at": 1531015165,
+      "updated_at": 1531015165,
       "name": "adminA"
     }
     ```
@@ -193,7 +200,8 @@ one workspace for each and one admin for each.
       "user_token": "IX5vHVgYqM40tLcctdmzRtHyfxB4ToYv",
       "id": "49641fc0-8c9d-4507-bc7a-2acac8f2903a",
       "enabled": true,
-      "created_at": 1531015221000,
+      "created_at": 1531015221,
+      "updated_at": 1531015221,
       "name": "adminB"
     }
     ```
@@ -207,12 +215,14 @@ in their corresponding workspace. To verify, run:
     ```
 
     Response:
+
     ```json
     {
       "total": 1,
       "data": [
         {
-          "created_at": 1531014784000,
+          "created_at": 1531014784,
+          "updated_at": 1531014784,
           "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
           "name": "adminA",
           "enabled": true,
@@ -230,12 +240,14 @@ in their corresponding workspace. To verify, run:
     ```
 
     Response:
+
     ```json
     {
       "total": 1,
       "data": [
         {
-          "created_at": 1531014805000,
+          "created_at": 1531014805,
+          "updated_at": 1531014805,
           "id": "3a829408-c1ee-4764-8222-2d280a5de441",
           "name": "adminB",
           "enabled": true,
@@ -265,7 +277,8 @@ workspace.
     Response:
     ```json
     {
-      "created_at": 1531016728000,
+      "created_at": 1531016728,
+      "updated_at": 1531016728,
       "id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
       "name": "admin"
     }
@@ -288,7 +301,8 @@ workspace.
       "data": [
         {
           "endpoint": "*",
-          "created_at": 1531017322000,
+          "created_at": 1531017322,
+          "updated_at": 1531017322,
           "role_id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
           "actions": [
             "delete",
@@ -318,6 +332,7 @@ workspace.
       "roles": [
           {
               "created_at": 1685551877,
+              "updated_at": 1531014805,
               "id": "42809ada-650c-4575-b0a0-d464a64ffb70",
               "name": "admin",
               "ws_id": "9dc7adbb-9b64-4121-bf76-653cf5871bc2"
@@ -326,6 +341,7 @@ workspace.
       "user": {
           "comment": "null",
           "created_at": 1685552809,
+          "updated_at": 1531014805,
           "enabled": true,
           "id": "bca4e390-fbbf-4a46-b55d-f4642efc14bb",
           "name": "adminA",
@@ -364,7 +380,8 @@ user token:
       "total": 1,
       "data": [
         {
-          "created_at": 1531014784000,
+          "created_at": 1531014784,
+          "updated_at": 1531014784,
           "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
           "name": "adminA",
           "enabled": true,
@@ -405,7 +422,8 @@ and if they do, the admin can grant them individually.
     Response:
     ```json
     {
-      "created_at": 1531020346000,
+      "created_at": 1531020346,
+      "updated_at": 1531020346,
       "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
       "name": "users"
     }
@@ -425,7 +443,8 @@ and if they do, the admin can grant them individually.
     ```json
     {
       "endpoint": "*",
-      "created_at": 1531020573000,
+      "created_at": 1531020573,
+      "udpated_at": 1531020573,
       "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
       "actions": [
         "delete",
@@ -454,7 +473,8 @@ and if they do, the admin can grant them individually.
     ```json
     {
       "endpoint": "/rbac/*",
-      "created_at": 1531020744000,
+      "created_at": 1531020744,
+      "updated_at": 1531020744,
       "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
       "actions": [
         "delete",
@@ -481,7 +501,8 @@ and if they do, the admin can grant them individually.
     ```json
     {
       "endpoint": "/workspaces/*",
-      "created_at": 1531020778000,
+      "created_at": 1531020778,
+      "updated_at": 1531020778,
       "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
       "actions": [
         "delete",
@@ -525,7 +546,8 @@ access to Kong.
     Response:
     ```json
     {
-      "created_at": 1531019797000,
+      "created_at": 1531019797,
+      "updated_at": 1531019797,
       "id": "0b4111da-2827-4767-8651-a327f7a559e9",
       "name": "foogineer",
       "enabled": true,
@@ -547,18 +569,21 @@ access to Kong.
       "roles": [
         {
           "comment": "Default user role generated for foogineer",
-          "created_at": 1531019797000,
+          "created_at": 1531019797,
+          "updated_at": 1531019797,
           "id": "125c4212-b882-432d-a323-9cbe38b1d0df",
           "name": "foogineer"
         },
         {
-          "created_at": 1531020346000,
+          "created_at": 1531020346,
+          "updated_at": 1531020346,
           "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
           "name": "users"
         }
       ],
       "user": {
-        "created_at": 1531019797000,
+        "created_at": 1531019797,
+        "updated_at": 1531019797,
         "id": "0b4111da-2827-4767-8651-a327f7a559e9",
         "name": "foogineer",
         "enabled": true,
@@ -579,7 +604,8 @@ access to Kong.
     Response:
     ```json
     {
-      "created_at": 1531019797000,
+      "created_at": 1531019797,
+      "updated_at": 1531019797,
       "id": "e8926efa-11b4-43a3-9a28-767c05d8e9d8",
       "name": "bargineer",
       "enabled": true,
@@ -601,18 +627,21 @@ access to Kong.
       "roles": [
         {
           "comment": "Default user role generated for bargineer",
-          "created_at": 1531019797000,
+          "created_at": 1531019797,
+          "updated_at": 1531019797,
           "id": "125c4212-b882-432d-a323-9cbe38b1d0df",
           "name": "bargineer"
         },
         {
-          "created_at": 1531020346000,
+          "created_at": 1531020346,
+          "updated_at": 1531020346,
           "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
           "name": "users"
         }
       ],
       "user": {
-        "created_at": 1531019797000,
+        "created_at": 1531019797,
+        "updated_at": 1531019797,
         "id": "e8926efa-11b4-43a3-9a28-767c05d8e9d8",
         "name": "bargineer",
         "enabled": true,
@@ -652,7 +681,8 @@ confines of their Team A workspace. Let's validate this.
     Response:
     ```json
     {
-      "created_at": 1531021732000,
+      "created_at": 1531021732,
+      "updated_at": 1531021732,
       "config": {
         "key_in_body": false,
         "run_on_preflight": true,
@@ -681,7 +711,8 @@ confines of their Team A workspace. Let's validate this.
       "total": 1,
       "data": [
         {
-          "created_at": 1531021732000,
+          "created_at": 1531021732,
+          "updated_at": 1531021732,
           "config": {
             "key_in_body": false,
             "run_on_preflight": true,
@@ -742,7 +773,8 @@ to use entity-level RBAC.
     ```json
     {
       "name": "qux-role",
-      "created_at": 1531065975000,
+      "created_at": 1531065975,
+      "updated_at": 1531065975,
       "id": "ffe93269-7993-4308-965e-0286d0bc87b9"
     }
     ```
@@ -762,7 +794,8 @@ to use entity-level RBAC.
     Response:
     ```json
     {
-      "created_at": 1531066684000,
+      "created_at": 1531066684,
+      "updated_at": 1531066684,
       "role_id": "ffe93269-7993-4308-965e-0286d0bc87b9",
       "entity_id": "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43",
       "negative": false,
@@ -784,7 +817,8 @@ to use entity-level RBAC.
     Response:
     ```json
     {
-      "created_at": 1531066684000,
+      "created_at": 1531066684,
+      "updated_at": 1531066684,
       "role_id": "ffe93269-7993-4308-965e-0286d0bc87b9",
       "entity_id": "d25afc46-dc59-48b2-b04f-d3ebe19f6d4b",
       "negative": false,
@@ -809,18 +843,21 @@ to use entity-level RBAC.
       "roles": [
         {
           "comment": "Default user role generated for qux",
-          "created_at": 1531065373000,
+          "created_at": 1531065373,
+          "updated_at": 1531065373,
           "name": "qux",
           "id": "31614171-4174-42b4-9fae-43c9ce14830f"
         },
         {
-          "created_at": 1531065975000,
+          "created_at": 1531065975,
+          "updated_at": 1531065975,
           "name": "qux-role",
           "id": "ffe93269-7993-4308-965e-0286d0bc87b9"
         }
       ],
       "user": {
-        "created_at": 1531065373000,
+        "created_at": 1531065373,
+        "created_at": 1531065373,
         "id": "4d87bf78-5824-4756-b0d0-ceaa9bd9b2d5",
         "name": "qux",
         "enabled": true,
@@ -893,6 +930,7 @@ endpoint-level validation comes before entity-level.
     {
       "host": "httpbin.org",
       "created_at": 1531066074,
+      "updated_at": 1531066074,
       "connect_timeout": 60000,
       "id": "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43",
       "protocol": "http",
@@ -962,9 +1000,9 @@ Response:
   "data": [
     {
       "created_at": 1531066253,
+      "updated_at": 1531066253,
       "id": "d25afc46-dc59-48b2-b04f-d3ebe19f6d4b",
       "hosts": null,
-      "updated_at": 1531066253,
       "preserve_host": false,
       "regex_priority": 0,
       "service": {
@@ -1002,7 +1040,8 @@ Response:
   "total": 2,
   "data": [
     {
-      "created_at": 1531070344000,
+      "created_at": 1531070344,
+      "updated_at": 1531070344,
       "config": {
         "key_in_body": false,
         "run_on_preflight": true,
@@ -1045,11 +1084,11 @@ Response:
 ```json
 {
   "created_at": 1531070828,
+  "updated_at": 1531070828,
   "strip_path": false,
   "hosts": null,
   "preserve_host": false,
   "regex_priority": 0,
-  "updated_at": 1531070828,
   "paths": [
     "/anything"
   ],

--- a/app/_src/gateway/production/access-control/enable-rbac.md
+++ b/app/_src/gateway/production/access-control/enable-rbac.md
@@ -379,7 +379,7 @@ a similar set up, with an admin role and an admin user, both restricted to the
 team's workspace.
 
 The super admin's job is now done. 
-Individual team admins are now able to set up their teams users and entities!
+Individual team admins are now able to set up their team's users and entities!
 
 ## Team admins create regular users
 

--- a/app/_src/gateway/production/access-control/enable-rbac.md
+++ b/app/_src/gateway/production/access-control/enable-rbac.md
@@ -9,269 +9,422 @@ use case demonstrates how **RBAC with workspaces** can be coupled
 to achieve a flexible organization of teams and users in complex
 hierarchies. 
 
-## Use Case
+## Use case
 
 For the sake of example, let's say a given company has a {{site.base_gateway}}
-cluster to be shared with 3 teams: teamA, teamB, and teamC. While the Kong
-cluster are shared among these teams, they want to be able to segment
+cluster to be shared with two teams: teamA and teamB. While the Kong
+clusters are shared among these teams, they want to be able to segment
 their entities in such a way that management of entities in one team doesn't
 disrupt operation in some other team. As shown in the
 [Workspaces Page][workspaces-examples], such a use case is possible
 with workspaces. On top of workspaces, though, each team wants to enforce
-access control over their Workspace, which is possible with RBAC. **To sum up,
-Workspaces and RBAC are complementary: Workspaces provide segmentation of
-Admin API entities, while RBAC provides access control**.
+access control over their Workspace, which is possible with RBAC. 
 
-## Bootstrapping the first RBAC user—the Super Admin
+To sum up, workspaces and RBAC are complementary: workspaces provide segmentation of
+Admin API entities, while RBAC provides access control.
 
-**Note:** It is possible to create the first Super Admin at the time
-of migration as described in the [Getting Started Guide][getting-started-guide].
+## Bootstrapping the first RBAC user
+
+The first RBAC user is called the super admin.
+
+Kong recommends that you create a super admin
+user before actually enforcing RBAC and restarting {{site.base_gateway}} 
+with RBAC enabled.
+
+{:.note}
+> It's possible to create the first super admin at installation time.
 If you chose this option, skip to [Enforcing RBAC](#enforcing-rbac).
 
-Before anything, we will assume the Kong Admin—or, more interestingly,
-the KongOps Engineer—in charge of operating Kong, will create a Super Admin
-user, before actually enforcing RBAC and restarting Kong with RBAC enabled.
+{{site.base_gateway}} ships with a set of default RBAC roles: `super-admin`,
+the `admin`, and `read-only`, which the task of creating a Super Admin user easy:
 
-As Kong ships with a handy set of default RBAC Roles—the `super-admin`,
-the `admin`, and `read-only`—the task of creating a Super Admin user is
-quite easy:
+1. Create the RBAC user, named `super-admin`:
 
-Create the RBAC user, named `super-admin`:
+    ```sh
+    curl -i -X POST http://localhost:8001/rbac/users \
+      -H Kong-Admin-Token:secureadmintoken \
+      --data name=super-admin
+    ```
 
-```
-http :8001/rbac/users name=super-admin
-{
-  "user_token": "M8J5A88xKXa7FNKsMbgLMjkm6zI2anOY",
-  "id": "da80838d-49f8-40f6-b673-6fff3e2c305b",
-  "enabled": true,
-  "created_at": 1531009435000,
-  "name": "super-admin"
-}
-```
-
-As the `super-admin` user name coincides with an existing `super-admin`
-role, it gets automatically added to the `super-admin` role—which can be
-confirmed with the following command:
-
-```
-http :8001/rbac/users/super-admin/roles
-{
-  "roles": [
+    Response:
+    ```json
     {
-      "comment": "Full access to all endpoints, across all workspaces",
-      "created_at": 1531009724000,
-      "name": "super-admin",
-      "id": "b924ac91-e83f-4136-a5a4-4a7ff92594a8"
+      "user_token": "M8J5A88xKXa7FNKsMbgLMjkm6zI2anOY",
+      "id": "da80838d-49f8-40f6-b673-6fff3e2c305b",
+      "enabled": true,
+      "created_at": 1531009435000,
+      "name": "super-admin"
     }
-  ],
-  "user": {
-    "created_at": 1531009858000,
-    "id": "e6897cc0-0c34-4a9c-9f0b-cc65b4f04d68",
-    "name": "super-admin",
-    "enabled": true,
-    "user_token": "vajeOlkybsn0q0VD9qw9B3nHYOErgY7b8"
-  }
-}
+    ```
 
-```
+    As the `super-admin` username coincides with an existing `super-admin`
+    role, it gets automatically added to the `super-admin` role. 
+
+1. Confirm using the following command:
+
+    ```sh
+    curl -i -X GET http://localhost:8001/rbac/users/super-admin/roles
+    ```
+
+    Response:
+    ```json
+    {
+      "roles": [
+        {
+          "comment": "Full access to all endpoints, across all workspaces",
+          "created_at": 1531009724000,
+          "name": "super-admin",
+          "id": "b924ac91-e83f-4136-a5a4-4a7ff92594a8"
+        }
+      ],
+      "user": {
+        "created_at": 1531009858000,
+        "id": "e6897cc0-0c34-4a9c-9f0b-cc65b4f04d68",
+        "name": "super-admin",
+        "enabled": true,
+        "user_token": "vajeOlkybsn0q0VD9qw9B3nHYOErgY7b8"
+      }
+    }
+    ```
 
 ## Enforcing RBAC
 
-As the `super-admin` user has just been created, the Kong Admin may now
-restart Kong with RBAC enforced, with, e.g.:
+As the `super-admin` user has just been created, the Kong admin may now
+restart Kong with RBAC enforced:
 
 ```
 KONG_ENFORCE_RBAC=on kong restart
 ```
 
-**NOTE**: This is one of the possible ways of enforcing RBAC and restarting
-Kong; another possibility is editing the Kong configuration file and
+This is one of the possible ways of enforcing RBAC and restarting
+Kong. Another possibility is editing the Kong configuration file and
 restarting.
 
-Before we move on, note that we will be using the Super Admin user, but we
-could, in fact, be moving without RBAC enabled, and having our Kong Admin do
-all the job of setting up the RBAC hierarchy. We want, however, to stress the
-fact that RBAC is powerful enough to allow a flexible separation of tasks. To
-summarize:
+Before moving on, note that this guide uses the super admin user, but you 
+could move on without RBAC enabled, and have the Kong admin set up the whole RBAC hierarchy. 
 
-- **Kong Admin**: this user has physical access to Kong infrastructure; her
+However, we want to stress the fact that RBAC is powerful enough to allow a flexible separation of tasks.
+To summarize:
+
+- **Kong admin**: This user has physical access to Kong infrastructure. Their
 task is to bootstrap the Kong cluster as well as its configuration, including
-initial RBAC users;
-- **RBAC Super Admin**: created by the Kong Admin, has the role of managing
-RBAC users, roles, etc; this could all be done by the **Kong Admin**, but let's
-give him a break.
+initial RBAC users.
+- **RBAC super admin**: Created by the Kong admin, has the role of managing
+RBAC users, roles, and permissions. While this could all be done by the Kong admin, 
+we recommend separating the responsibility for better security.
 
-## Super Admin creates the teams Workspaces
+## Super admin creates the team workspaces
 
-The Super Admin will now set up our 3 teams: teamA, teamB, and teamC, creating
-one workspace for each, one admin for each. Enough talking.
+The super admin now sets up two teams: teamA and teamB, creating
+one workspace for each and one admin for each.
 
-Creating workspaces for each team—this overlaps a bit with
-[Workspaces Examples][workspaces-examples], yes, but it will make our
-exploration of RBAC + Workspaces easier:
+1. Create the workspace for `teamA`:
 
-**Team A**:
+    ```sh
+    curl -i -X POST http://localhost:8001/workspaces \
+      --data name=teamA \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
 
-```
-http :8001/workspaces name=teamA Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "name": "teamA",
-  "created_at": 1531014100000,
-  "id": "1412f3a6-4d9b-4b9d-964e-60d8d63a9d46"
-}
-
-```
-
-**Team B**:
-
-```
-http :8001/workspaces name=teamB Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "name": "teamB",
-  "created_at": 1531014143000,
-  "id": "7dee8c56-c6db-4125-b87a-b508baa33c66"
-}
-```
-
-**Team C**:
-
-```
-http :8001/workspaces name=teamC Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "name": "teamC",
-  "created_at": 1531014171000,
-  "id": "542c8662-17cc-49eb-af50-6eb14f3b2e8a"
-}
-```
-
-**NOTE**: this is the RBAC Super Admin creating workspaces—note his
-token being passed in through the `Kong-Admin-Token` HTTP header.
-
-## Super Admin Creates one Admin for each Team
-
-**Team A**:
-
-```
-http :8001/teamA/rbac/users name=adminA Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "user_token": "qv1VLIpl8kHj7lC1QOKwRdCMXanqEDii",
-  "id": "4d315ff9-8c1a-4844-9ea2-21b16204a154",
-  "enabled": true,
-  "created_at": 1531015165000,
-  "name": "adminA"
-}
-```
-
-**Team B**:
-
-```
-http :8001/teamB/rbac/users name=adminB Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "user_token": "IX5vHVgYqM40tLcctdmzRtHyfxB4ToYv",
-  "id": "49641fc0-8c9d-4507-bc7a-2acac8f2903a",
-  "enabled": true,
-  "created_at": 1531015221000,
-  "name": "adminB"
-}
-```
-
-**Team C**:
-
-```
-http :8001/teamC/rbac/users name=adminC Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "user_token": "w2f7tsuUW4BerXocZIMRQHE84nK2ZAo7",
-  "id": "74643f69-8852-49f9-b363-21971bac4f52",
-  "enabled": true,
-  "created_at": 1531015304000,
-  "name": "teamC"
-}
-```
-
-With this, all of the teams have one admin and each admin can only be seen
-in his corresponding workspace. To verify:
-
-```
-http :8001/teamA/rbac/users Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "total": 1,
-  "data": [
+    Response:
+    ```json
     {
-      "created_at": 1531014784000,
-      "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
-      "name": "adminA",
-      "enabled": true,
-      "user_token": "n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG"
+      "name": "teamA",
+      "created_at": 1531014100000,
+      "id": "1412f3a6-4d9b-4b9d-964e-60d8d63a9d46"
     }
-  ]
-}
-```
+    ```
 
-Similarly, workspaces teamB and teamC only show their respective admins:
+1. Create the workspace for `teamB`:
 
-```
-http :8001/teamB/rbac/users Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "total": 1,
-  "data": [
+    ```sh
+    curl -i -X POST http://localhost:8001/workspaces \
+      --data name=teamB \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
+
+    Response:
+    ```json
     {
-      "created_at": 1531014805000,
-      "id": "3a829408-c1ee-4764-8222-2d280a5de441",
-      "name": "adminB",
-      "enabled": true,
-      "user_token": "C8b6kTTN10JFyU63ORjmCQwVbvK4maeq"
+      "name": "teamB",
+      "created_at": 1531014143000,
+      "id": "7dee8c56-c6db-4125-b87a-b508baa33c66"
     }
-  ]
-}
-```
+    ```
 
-```
-http :8001/teamC/rbac/users Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "total": 1,
-  "data": [
+## Super admin creates one admin for each team
+
+1. Create an admin for `teamA`:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/users \
+      --data name=adminA \
+      --data user_token=exampletokenA \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
+
+    Response:
+    ```json
     {
-      "created_at": 1531014813000,
-      "id": "84d43cdb-5274-4b74-ad22-615e50f005e3",
-      "name": "adminC",
+      "user_token": "qv1VLIpl8kHj7lC1QOKwRdCMXanqEDii",
+      "id": "4d315ff9-8c1a-4844-9ea2-21b16204a154",
       "enabled": true,
-      "user_token": "zN5Nj8U1MiGR7vVQKvl8odaGBDI6mjgY"
+      "created_at": 1531015165000,
+      "name": "adminA"
     }
-  ]
-}
-```
+    ```
 
-## Super Admin Creates Admin Roles for Teams
+1. Create an admin for `teamB`:
 
-Super Admin is now done creating RBAC Admin users for each team; his next
+    ```sh
+    curl -i -X POST http://localhost:8001/teamB/rbac/users \
+      --data name=adminB \
+      --data user_token=exampletokenB \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
+
+    Response:
+    ```json
+    {
+      "user_token": "IX5vHVgYqM40tLcctdmzRtHyfxB4ToYv",
+      "id": "49641fc0-8c9d-4507-bc7a-2acac8f2903a",
+      "enabled": true,
+      "created_at": 1531015221000,
+      "name": "adminB"
+    }
+    ```
+
+1. With this, both of the teams have one admin and each admin can only be seen
+in their corresponding workspace. To verify, run:
+
+    ```sh
+    curl -i -X GET http://localhost:8001/teamA/rbac/users \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
+
+    Response:
+    ```json
+    {
+      "total": 1,
+      "data": [
+        {
+          "created_at": 1531014784000,
+          "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
+          "name": "adminA",
+          "enabled": true,
+          "user_token": "n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG"
+        }
+      ]
+    }
+    ```
+
+    Similarly, workspace `teamB` only shows its own admin:
+
+    ```sh
+    curl -i -X GET http://localhost:8001/teamB/rbac/users \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
+
+    Response:
+    ```json
+    {
+      "total": 1,
+      "data": [
+        {
+          "created_at": 1531014805000,
+          "id": "3a829408-c1ee-4764-8222-2d280a5de441",
+          "name": "adminB",
+          "enabled": true,
+          "user_token": "C8b6kTTN10JFyU63ORjmCQwVbvK4maeq"
+        }
+      ]
+    }
+    ```
+
+## Super admin creates admin roles for teams
+
+The super admin is now done creating RBAC admin users for each team. The next
 task is to create admin roles that will effectively grant permissions to admin
 users.
 
-The admin role must have access to all of the Admin API, restricted to his
+The admin role must have access to all of the Admin API, restricted to their
 workspace.
 
-Setting up the Admin role—pay close attention to the request parameters:
+1. Set up the admin role, paying close attention to the request parameters:
 
-```
-http :8001/teamA/rbac/roles/ name=admin Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "created_at": 1531016728000,
-  "id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
-  "name": "admin"
-}
-```
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles/ \
+      --data name=admin \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
 
-Creating role endpoint permissions:
+    Response:
+    ```json
+    {
+      "created_at": 1531016728000,
+      "id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
+      "name": "admin"
+    }
+    ```
 
-```
-http :8001/teamA/rbac/roles/admin/endpoints/ endpoint=* workspace=teamA actions=* Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "total": 1,
-  "data": [
+1. Create role endpoint permissions:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles/admin/endpoints/ \
+      --data 'endpoint=*' \
+      --data 'workspace=teamA' \
+      --data 'actions=*' \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
+
+    Response:
+    ```json
+    {
+      "total": 1,
+      "data": [
+        {
+          "endpoint": "*",
+          "created_at": 1531017322000,
+          "role_id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
+          "actions": [
+            "delete",
+            "create",
+            "update",
+            "read"
+          ],
+          "negative": false,
+          "workspace": "teamA"
+        }
+      ]
+    }
+    ```
+
+1. Add the `adminA` user to the admin role in their workspace:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/users/adminA/roles/ \
+      --data roles=admin \
+      -H 'Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8'
+    ```
+
+    Response:
+    ```json
+    {
+      "roles": [
+        {
+          "comment": "Default user role generated for adminA",
+          "created_at": 1531014784000,
+          "id": "e2941b41-92a4-4f49-be89-f1a452bdecd0",
+          "name": "adminA"
+        },
+        {
+          "created_at": 1531016728000,
+          "id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
+          "name": "admin"
+        }
+      ],
+      "user": {
+        "created_at": 1531014784000,
+        "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
+        "name": "adminA",
+        "enabled": true,
+        "user_token": "n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG"
+      }
+    }
+    ```
+
+1. With these steps, Team A's admin user is now able to manage their team. To
+validate that, let's try to list RBAC users in Team B using Team A's admin
+user token:
+
+    ```sh
+    curl -i -X GET http://localhost:8001/teamB/rbac/users \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Notice that you can't access the endpoint:
+    ```json
+    {
+      "message": "Invalid RBAC credentials"
+    }
+    ```
+
+1. Now try to list RBAC users in Team A's workspace:
+
+    ```sh
+    curl -i -X GET http://localhost:8001/teamA/rbac/users \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Response:
+    ```json
+    {
+      "total": 1,
+      "data": [
+        {
+          "created_at": 1531014784000,
+          "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
+          "name": "adminA",
+          "enabled": true,
+          "user_token": "n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG"
+        }
+      ]
+    }
+    ```
+
+If the same procedure is repeated for Team B, they will end up with
+a similar set up, with an admin role and an admin user, both restricted to the
+team's workspace.
+
+The super admin's job is now done. 
+Individual team admins are now able to set up their teams users and entities!
+
+## Team admins create regular users
+
+From this point on, team admins are able to drive the process. The next
+step is to create team users, such as engineers that are part of Team A or B. 
+Let's go ahead and do that, using Admin A's user token.
+
+Before regular users can be created, a role needs to be available for them.
+This role needs to have permissions to all of Admin API endpoints, except
+RBAC and workspaces. Regular users don't need access to these endpoints in general
+and if they do, the admin can grant them.
+
+### Create the users role
+
+1. As a team admin, create the regular `users` role:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles/ \
+      --data name=users \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Response:
+    ```json
+    {
+      "created_at": 1531020346000,
+      "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
+      "name": "users"
+    }
+    ```
+
+1. Create a permission for all of the Admin API, which requires a positive permission on `\*`:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles/users/endpoints/ \
+      --data 'endpoint=*' \
+      --data 'workspace=teamA' \
+      --data 'actions=*' \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Response:
+    ```json
     {
       "endpoint": "*",
-      "created_at": 1531017322000,
-      "role_id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
+      "created_at": 1531020573000,
+      "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
       "actions": [
         "delete",
         "create",
@@ -281,340 +434,221 @@ http :8001/teamA/rbac/roles/admin/endpoints/ endpoint=* workspace=teamA actions=
       "negative": false,
       "workspace": "teamA"
     }
-  ]
-}
-```
+    ```
 
-Next logical step is to add the adminA user—admin of Team A—to the Admin
-role in his workspace:
+1. Then, filter out RBAC and workspaces with negative permissions:
 
-```
-http :8001/teamA/rbac/users/adminA/roles/ roles=admin Kong-Admin-Token:vajeOlkbsn0q0VD9qw9B3nHYOErgY7b8
-{
-  "roles": [
+    Filter out RBAC endpoints:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles/users/endpoints/ \
+      --data 'endpoint=/rbac/*' \
+      --data 'workspace=teamA' \
+      --data 'actions=*' \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Response:
+    ```json
     {
-      "comment": "Default user role generated for adminA",
-      "created_at": 1531014784000,
-      "id": "e2941b41-92a4-4f49-be89-f1a452bdecd0",
-      "name": "adminA"
-    },
-    {
-      "created_at": 1531016728000,
-      "id": "d40e61ab-8dad-4ef2-a48b-d11379f7b8d1",
-      "name": "admin"
+      "endpoint": "/rbac/*",
+      "created_at": 1531020744000,
+      "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
+      "actions": [
+        "delete",
+        "create",
+        "update",
+        "read"
+      ],
+      "negative": true,
+      "workspace": "teamA"
     }
-  ],
-  "user": {
-    "created_at": 1531014784000,
-    "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
-    "name": "adminA",
-    "enabled": true,
-    "user_token": "n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG"
-  }
-}
-```
+    ```
 
-Note the admin role in the list above.
+    Filter out workspaces endpoints:
 
-With these steps, Team A's admin user is now able to manage his team. To
-validate that, let's try to list RBAC users in Team B using Team A's admin
-user token—and see that we are not allowed to do so:
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles/users/endpoints/ \
+      --data 'endpoint=/workspaces/*' \
+      --data 'workspace=teamA' \
+      --data 'actions=*' \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
 
-```
-http :8001/teamB/rbac/users Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "message": "Invalid RBAC credentials"
-}
-```
-
-Said admin is, however, allowed to list RBAC users in Team A's workspace:
-
-```
-http :8001/teamA/rbac/users Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "total": 1,
-  "data": [
+    Response:
+    ```json
     {
-      "created_at": 1531014784000,
-      "id": "1faaacd1-709f-4762-8c3e-79f268ec8faf",
-      "name": "adminA",
-      "enabled": true,
-      "user_token": "n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG"
+      "endpoint": "/workspaces/*",
+      "created_at": 1531020778000,
+      "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
+      "actions": [
+        "delete",
+        "create",
+        "update",
+        "read"
+      ],
+      "negative": true,
+      "workspace": "teamA"
     }
-  ]
-}
-```
+    ```
 
-If the same procedure is repeated for Team B and Team C, they will end up with
-a similar set up, with an admin role and an admin user, both restricted to the
-team's workspace.
-
-And so Super Admin ends his participation; individual team admins are now able
-to set up his teams users and entities!
-
-## Team Admins Create Team Regular Users
-
-From this point on, team admins are able to drive the process; the next logical
-step is for Team users to be created; such team users could be, for example,
-engineers that are part of Team A (or B or C). Let's go ahead and do that,
-using Admin A's user token.
-
-Before regular users can be created, a role needs to be available for them.
-Such a role needs to have permissions to all of Admin API endpoints, except
-RBAC and Workspaces—regular users will not need access to these in general
-and, if they do, the Admin can grant them.
-
-**Creating the regular users role**:
-
-```
-http :8001/teamA/rbac/roles/ name=users Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "created_at": 1531020346000,
-  "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
-  "name": "users"
-}
-```
-
-**Creating permissions in the regular users role**:
-
-First, permission to all of Admin API—positive permission on \*:
-
-```
-http :8001/teamA/rbac/roles/users/endpoints/ endpoint=* workspace=teamA actions=* Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "endpoint": "*",
-  "created_at": 1531020573000,
-  "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
-  "actions": [
-    "delete",
-    "create",
-    "update",
-    "read"
-  ],
-  "negative": false,
-  "workspace": "teamA"
-}
-```
-
-Then, filter out RBAC and workspaces with negative permissions:
-
-```
-http :8001/teamA/rbac/roles/users/endpoints/ endpoint=/rbac/* workspace=teamA actions=* Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "endpoint": "/rbac/*",
-  "created_at": 1531020744000,
-  "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
-  "actions": [
-    "delete",
-    "create",
-    "update",
-    "read"
-  ],
-  "negative": true,
-  "workspace": "teamA"
-}
-```
-
-```
-http :8001/teamA/rbac/roles/users/endpoints/ endpoint=/workspaces/* workspace=teamA actions=* Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "endpoint": "/workspaces/*",
-  "created_at": 1531020778000,
-  "role_id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
-  "actions": [
-    "delete",
-    "create",
-    "update",
-    "read"
-  ],
-  "negative": true,
-  "workspace": "teamA"
-}
-```
-
-**IMPORTANT**: as explained in the [Wildcards in Permissions](#wildcards-in-permissions)
+{:.important}
+> **Important**: As explained in the [Wildcards in Permissions](#wildcards-in-permissions)
 section, the meaning of `*` is not the expected generic globbing one might
 be used to. As such, `/rbac/*` or `/workspaces/*` do not match all of the
 RBAC and Workspaces endpoints. For example, to cover all of the RBAC API,
 one would have to define permissions for the following endpoints:
+>
+> - `/rbac/*`
+> - `/rbac/*/*`
+> - `/rbac/*/*/*`
+> - `/rbac/*/*/*/*`
+> - `/rbac/*/*/*/*/*`
 
-- `/rbac/*`
-- `/rbac/*/*`
-- `/rbac/*/*/*`
-- `/rbac/*/*/*/*`
-- `/rbac/*/*/*/*/*`
+### Add members to a team
 
-Team A just got 3 new members: foogineer, bargineer, and bazgineer. Admin A
-will welcome them to the team by creating RBAC users for them and giving them
-access to Kong!
+Team A just got two new members: `foogineer` and `bargineer`. Admin A
+welcomes them to the team by creating RBAC users for them and giving them
+access to Kong.
 
-Create foogineer:
+1. Create `foogineer`:
 
-```
-http :8001/teamA/rbac/users name=foogineer Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "created_at": 1531019797000,
-  "id": "0b4111da-2827-4767-8651-a327f7a559e9",
-  "name": "foogineer",
-  "enabled": true,
-  "user_token": "dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI"
-}
-```
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/users \
+      --data name=foogineer \
+      --data user_token=exampletokenfoo \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
 
-Add foogineer to the `users` role:
-
-```
-http :8001/teamA/rbac/users/foogineer/roles roles=users Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "roles": [
+    Response:
+    ```json
     {
-      "comment": "Default user role generated for foogineer",
       "created_at": 1531019797000,
-      "id": "125c4212-b882-432d-a323-9cbe38b1d0df",
-      "name": "foogineer"
-    },
-    {
-      "created_at": 1531020346000,
-      "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
-      "name": "users"
+      "id": "0b4111da-2827-4767-8651-a327f7a559e9",
+      "name": "foogineer",
+      "enabled": true,
+      "user_token": "dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI"
     }
-  ],
-  "user": {
-    "created_at": 1531019797000,
-    "id": "0b4111da-2827-4767-8651-a327f7a559e9",
-    "name": "foogineer",
-    "enabled": true,
-    "user_token": "dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI"
-  }
-}
-```
+    ```
 
-Create bargineer:
+1. Add `foogineer` to the `users` role:
 
-```
-http :8001/teamA/rbac/users name=bargineer Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "created_at": 1531019837000,
-  "id": "25dfa68e-32e8-48d8-815f-6fedfd2fb4a6",
-  "name": "bargineer",
-  "enabled": true,
-  "user_token": "eZj3WUc46wO3zEJbLP3Y4VGvNaUgGlyv"
-}
-```
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/users/foogineer/roles \
+      --data roles=users \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
 
-Add bargineer to the `users` role:
-
-```
-http :8001/teamA/rbac/users/bargineer/roles roles=users Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "roles": [
+    Response:
+    ```json
     {
-      "comment": "Default user role generated for bargineer",
-      "created_at": 1531019837000,
-      "id": "3edb00c2-9ae1-423d-ac81-bec702c29e37",
-      "name": "bargineer"
-    },
-    {
-      "created_at": 1531020346000,
-      "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
-      "name": "users"
+      "roles": [
+        {
+          "comment": "Default user role generated for foogineer",
+          "created_at": 1531019797000,
+          "id": "125c4212-b882-432d-a323-9cbe38b1d0df",
+          "name": "foogineer"
+        },
+        {
+          "created_at": 1531020346000,
+          "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
+          "name": "users"
+        }
+      ],
+      "user": {
+        "created_at": 1531019797000,
+        "id": "0b4111da-2827-4767-8651-a327f7a559e9",
+        "name": "foogineer",
+        "enabled": true,
+        "user_token": "dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI"
+      }
     }
-  ],
-  "user": {
-    "created_at": 1531019837000,
-    "id": "25dfa68e-32e8-48d8-815f-6fedfd2fb4a6",
-    "name": "bargineer",
-    "enabled": true,
-    "user_token": "eZj3WUc46wO3zEJbLP3Y4VGvNaUgGlyv"
-  }
-}
-```
+    ```
 
-Create bazgineer:
+1. Create `bargineer`:
 
-```
-http :8001/teamA/rbac/users name=bazgineer Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "created_at": 1531019937000,
-  "id": "ea7207d7-0d69-427b-b288-ce696b7f4690",
-  "name": "bazgineer",
-  "enabled": true,
-  "user_token": "r8NhaT213Zm8o1woQF4ZyQyCVjFRgGp3"
-}
-```
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/users \
+      --data name=bargineer \
+      --data user_token=exampletokenbar \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
 
-Add bazgineer to the `users` role:
-
-```
-http :8001/teamA/rbac/users/bazgineer/roles roles=users Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "roles": [
+    Response:
+    ```json
     {
-      "comment": "Default user role generated for bazgineer",
-      "created_at": 1531019937000,
-      "id": "fa409bb6-c86c-45d2-8a6b-ac8e71de2cc9",
-      "name": "bazgineer"
-    },
-    {
-      "created_at": 1531020346000,
-      "name": "users",
-      "id": "9846b92c-6820-4741-ac31-425b3d6abc5b"
+      "created_at": 1531019797000,
+      "id": "e8926efa-11b4-43a3-9a28-767c05d8e9d8",
+      "name": "bargineer",
+      "enabled": true,
+      "user_token": "dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI"
     }
-  ],
-  "user": {
-    "created_at": 1531019937000,
-    "id": "ea7207d7-0d69-427b-b288-ce696b7f4690",
-    "name": "bazgineer",
-    "enabled": true,
-    "user_token": "r8NhaT213Zm8o1woQF4ZyQyCVjFRgGp3"
-  }
-}
-```
+    ```
 
-## Regular Team Users use their tokens
+1. Add `bargineer` to the `users` role:
 
-foogineer, bargineer, and bazgineer all have gotten their RBAC user tokens
-from their Team A admin, and are now allowed to explore Kong—within the
-confines of their Team A workspace. Let's validate they can in fact do anything
-they wish, except over RBAC and Workspaces.
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/users/foogineer/roles \
+      --data roles=users \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
 
-Try listing Workspaces:
+    Response:
+    ```json
+    {
+      "roles": [
+        {
+          "comment": "Default user role generated for bargineer",
+          "created_at": 1531019797000,
+          "id": "125c4212-b882-432d-a323-9cbe38b1d0df",
+          "name": "bargineer"
+        },
+        {
+          "created_at": 1531020346000,
+          "id": "9846b92c-6820-4741-ac31-425b3d6abc5b",
+          "name": "users"
+        }
+      ],
+      "user": {
+        "created_at": 1531019797000,
+        "id": "e8926efa-11b4-43a3-9a28-767c05d8e9d8",
+        "name": "bargineer",
+        "enabled": true,
+        "user_token": "dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI"
+      }
+    }
+    ```
 
-```
-http :8001/teamA/workspaces/ Kong-Admin-Token:dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI
-{
-  "message": "foogineer, you do not have permissions to read this resource"
-}
-```
+## Regular team users use their tokens
 
-Enable some plugin—e.g., key-auth:
+`foogineer` and `bargineer` have gotten their RBAC user tokens
+from their Team A admin, and are now allowed to explore {{site.base_gateway}} within the
+confines of their Team A workspace. Let's validate this.
 
-```
-http :8001/teamA/plugins name=key-auth Kong-Admin-Token:dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI
-{
-  "created_at": 1531021732000,
-  "config": {
-    "key_in_body": false,
-    "run_on_preflight": true,
-    "anonymous": "",
-    "hide_credentials": false,
-    "key_names": [
-      "apikey"
-    ]
-  },
-  "id": "cdc85ef0-804b-4f92-aafd-3ff58512e445",
-  "enabled": true,
-  "name": "key-auth"
-}
-```
+1. As `foogineer`, try listing workspaces:
 
-List currently enabled plugins:
+    ```sh
+    curl -i -X GET http://localhost:8001/teamA/workspaces/ \
+      -H 'Kong-Admin-Token:dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI'
+    ```
 
-```
-http :8001/teamA/plugins Kong-Admin-Token:dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI
-{
-  "total": 1,
-  "data": [
+    Respone:
+    ```json
+    {
+      "message": "foogineer, you do not have permissions to read this resource"
+    }
+    ```
+
+1. Enable some plugin, for example `key-auth`:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/plugins \
+      --data name=key-auth \
+      -H 'Kong-Admin-Token:dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI'
+    ```
+
+    Response:
+    ```json
     {
       "created_at": 1531021732000,
       "config": {
@@ -627,66 +661,233 @@ http :8001/teamA/plugins Kong-Admin-Token:dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI
         ]
       },
       "id": "cdc85ef0-804b-4f92-aafd-3ff58512e445",
-      "name": "key-auth",
-      "enabled": true
+      "enabled": true,
+      "name": "key-auth"
     }
-  ]
-}
-```
+    ```
 
-This ends our use case tutorial; it demonstrates the power of RBAC and
-workspaces with a real-world scenario. Following, we will approach **Entity-Level
-RBAC**, an extension of our powerful access control to entity-level granularity.
+1. List currently enabled plugins:
 
-## Entity-Level RBAC: a Primer
+    ```sh
+    curl -i -X GET http://localhost:8001/teamA/plugins \
+      -H 'Kong-Admin-Token:dNeYvYAwvjOJdoReVJZXF8vLBXQioKkI'
+    ```
 
-{{site.base_gateway}}'s new RBAC implementation goes one step further in permissions
-granularity: in addition to "endpoint" permissions, it supports entity-level
+    Response:
+    ```json
+    {
+      "total": 1,
+      "data": [
+        {
+          "created_at": 1531021732000,
+          "config": {
+            "key_in_body": false,
+            "run_on_preflight": true,
+            "anonymous": "",
+            "hide_credentials": false,
+            "key_names": [
+              "apikey"
+            ]
+          },
+          "id": "cdc85ef0-804b-4f92-aafd-3ff58512e445",
+          "name": "key-auth",
+          "enabled": true
+        }
+      ]
+    }
+    ```
+
+This ends the use case tutorial, which demonstrates the power of RBAC and
+workspaces with a real-world scenario.
+
+## Entity-level RBAC
+
+In addition to endpoint permissions, RBAC in {{site.base_gateway}} supports entity-level
 permissions, meaning that particular entities, identified by their unique ID,
 can be allowed or disallowed access in a role.
 
-Refreshing our minds, RBAC is [enforced](#enforcing-rbac) with the `enforce_rbac`
-configuration directive—or with its `KONG_ENFORCE_RBAC` environment variable
+RBAC is [enforced](#enforcing-rbac) with the `enforce_rbac`
+configuration directive, or with its `KONG_ENFORCE_RBAC` environment variable
 counterpart. Such directive is an enum, with 4 possible values:
 
-- `on`: similarly to the previous RBAC implementation, applies Endpoint-level
-access control
-- `entity`: applies **only** Entity-level access control
-- `both`: applies **both Endpoint and Entity level access control**
+- `on`: Applies endpoint-levelaccess control
+- `entity`: Applies **only** Entity-level access control
+- `both`: Applies **both Endpoint and Entity level access control**
 - `off`: disables RBAC enforcement
 
-If one sets it to either `entity` or `both`, Kong will enforce entity-level
+If set to `entity` or `both`, Kong will enforce entity-level
 access control. However, as with endpoint-level access control, permissions
 must be bootstrapped before enforcement is enabled.
 
-### Creating Entity-Level Permissions
+### Creating entity-level permissions
 
-Team A just got one new, temporary, team member: qux. Admin A, the admin of
-Team A, has already created his qux RBAC user; he needs, however, to limit
-access that qux has over entities in Team A workspace, giving him read access
-to only a couple of entities—say, a Service and a Route. For that, he will
-use Entity-Level RBAC.
+Team A just got one new, temporary, team member: `qux`. Admin A, the admin of
+Team A, has already created the `qux` RBAC user. 
 
-**Admin A creates a role for the temporary user qux**:
+Next, the admin needs to limit the access that `qux` has over entities in the Team A workspace, 
+giving the user read access to only a couple of entities. For that, the admin needs
+to use entity-level RBAC.
 
-```
-http :8001/teamA/rbac/roles name=qux-role Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "name": "qux-role",
-  "created_at": 1531065975000,
-  "id": "ffe93269-7993-4308-965e-0286d0bc87b9"
-}
-```
+1. As Admin A, create a role for the temporary user `qux`:
 
-We will assume the following entities exist:
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles \
+      --data name=qux-role \
+      -H Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
+    ```
 
-A service:
+    Response:
+    ```json
+    {
+      "name": "qux-role",
+      "created_at": 1531065975000,
+      "id": "ffe93269-7993-4308-965e-0286d0bc87b9"
+    }
+    ```
 
-```
-http :8001/teamA/services Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "next": null,
-  "data": [
+1. Grant the user read access to two entities: a service and a route. Reference each entity by its ID:
+
+    For example, using `service1` with the ID `3ed24101-19a7-4a0b-a10f-2f47bcd4ff43` and `route1` with the ID `d25afc46-dc59-48b2-b04f-d3ebe19f6d4b`:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles/admin/entities \
+      --data entity_id=3ed24101-19a7-4a0b-a10f-2f47bcd4ff43 \
+      --data entity_type=services \
+      --data actions=read \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Response:
+    ```json
+    {
+      "created_at": 1531066684000,
+      "role_id": "ffe93269-7993-4308-965e-0286d0bc87b9",
+      "entity_id": "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43",
+      "negative": false,
+      "entity_type": "services",
+      "actions": [
+        "read"
+      ]
+    }
+    ```
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/roles/qux-role/entities \
+      --data entity_id=d25afc46-dc59-48b2-b04f-d3ebe19f6d4b \
+      --data entity_type=routes \
+      --data actions=read \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Response:
+    ```json
+    {
+      "created_at": 1531066684000,
+      "role_id": "ffe93269-7993-4308-965e-0286d0bc87b9",
+      "entity_id": "d25afc46-dc59-48b2-b04f-d3ebe19f6d4b",
+      "negative": false,
+      "entity_type": "routes",
+      "actions": [
+        "read"
+      ]
+    }
+
+
+1. Add the user `qux` to `qux-role`:
+
+    ```sh
+    curl -i -X POST http://localhost:8001/teamA/rbac/users/qux/roles \
+      --data roles=qux-role \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Response:
+    ```json
+    {
+      "roles": [
+        {
+          "comment": "Default user role generated for qux",
+          "created_at": 1531065373000,
+          "name": "qux",
+          "id": "31614171-4174-42b4-9fae-43c9ce14830f"
+        },
+        {
+          "created_at": 1531065975000,
+          "name": "qux-role",
+          "id": "ffe93269-7993-4308-965e-0286d0bc87b9"
+        }
+      ],
+      "user": {
+        "created_at": 1531065373000,
+        "id": "4d87bf78-5824-4756-b0d0-ceaa9bd9b2d5",
+        "name": "qux",
+        "enabled": true,
+        "user_token": "sUnv6uBehM91amYRNWESsgX3HzqoBnR5"
+      }
+    }
+    ```
+
+1. Check that the correct permissions are listed for `qux`:
+
+    ```sh
+    curl -i -X GET http://localhost:8001/teamA/rbac/users/qux/permissions \
+      -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
+    ```
+
+    Response:
+    ```json
+    {
+      "entities": {
+        "d25afc46-dc59-48b2-b04f-d3ebe19f6d4b": {
+          "actions": [
+            "read"
+          ],
+          "negative": false
+        },
+        "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43": {
+          "actions": [
+            "read"
+          ],
+          "negative": false
+        }
+      },
+      "endpoints": {}
+    }
+    ```
+    
+    `qux` should have two entity permissions and no endpoint permissions.
+
+Admin A is done setting up `qux`, and `qux `can now use their user token to read
+the two entities over Kong's admin API.
+
+Let's assume that Admin A [enabled entity-level enforcement](#enforcing-rbac) as well.
+Note that as `qux` has **no endpoint-level permissions**. If both endpoint and
+entity-level enforcement is enabled, `qux` won't  be able to read their entities, as
+endpoint-level validation comes before entity-level.
+
+1. As `qux`, try listing all RBAC users:
+
+    ```sh
+    curl -i -X GET http://localhost:8001/teamA/rbac/users/ \
+      -H Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
+    ```
+
+    Response:
+    ```json
+    {
+      "message": "qux, you do not have permissions to read this resource"
+    }
+    ```
+
+1. As `qux`, try to access `service1`:
+
+    ```
+    curl -i -X GET http://localhost:8001/teamA/services/service1 \
+      -H Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
+    ```
+
+    Response:
+    ```json
     {
       "host": "httpbin.org",
       "created_at": 1531066074,
@@ -701,248 +902,59 @@ http :8001/teamA/services Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
       "retries": 5,
       "write_timeout": 60000
     }
-  ]
-}
-```
+    ```
 
-and a Route to that Service:
+## Wildcards in permissions
 
-```
-http :8001/teamA/routes Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "next": null,
-  "data": [
-    {
-      "created_at": 1531066253,
-      "id": "d25afc46-dc59-48b2-b04f-d3ebe19f6d4b",
-      "hosts": null,
-      "updated_at": 1531066253,
-      "preserve_host": false,
-      "regex_priority": 0,
-      "service": {
-        "id": "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43"
-      },
-      "paths": [
-        "/anything"
-      ],
-      "methods": null,
-      "strip_path": false,
-      "protocols": [
-        "http",
-        "https"
-      ]
-    }
-  ]
-}
-```
+RBAC supports the use of wildcards (`*`) in many aspects of permissions.
 
-**Admin A creates entity permissions in qux-role**:
+### Creating endpoint permissions
 
-Add service1—whose ID is 3ed24101-19a7-4a0b-a10f-2f47bcd4ff43:
-
-```
-http :8001/teamA/rbac/roles/qux-role/entities entity_id=3ed24101-19a7-4a0b-a10f-2f47bcd4ff43 actions=read Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "created_at": 1531066684000,
-  "role_id": "ffe93269-7993-4308-965e-0286d0bc87b9",
-  "entity_id": "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43",
-  "negative": false,
-  "entity_type": "services",
-  "actions": [
-    "read"
-  ]
-}
-```
-
-Add the route—whose ID is d25afc46-dc59-48b2-b04f-d3ebe19f6d4b:
-
-```
-http :8001/teamA/rbac/roles/qux-role/entities entity_id=d25afc46-dc59-48b2-b04f-d3ebe19f6d4b actions=read Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "created_at": 1531066728000,
-  "role_id": "ffe93269-7993-4308-965e-0286d0bc87b9",
-  "entity_id": "d25afc46-dc59-48b2-b04f-d3ebe19f6d4b",
-  "negative": false,
-  "entity_type": "routes",
-  "actions": [
-    "read"
-  ]
-}
-```
-
-**Admin A adds qux to his role**:
-
-```
-http :8001/teamA/rbac/users/qux/roles roles=qux-role Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "roles": [
-    {
-      "comment": "Default user role generated for qux",
-      "created_at": 1531065373000,
-      "name": "qux",
-      "id": "31614171-4174-42b4-9fae-43c9ce14830f"
-    },
-    {
-      "created_at": 1531065975000,
-      "name": "qux-role",
-      "id": "ffe93269-7993-4308-965e-0286d0bc87b9"
-    }
-  ],
-  "user": {
-    "created_at": 1531065373000,
-    "id": "4d87bf78-5824-4756-b0d0-ceaa9bd9b2d5",
-    "name": "qux",
-    "enabled": true,
-    "user_token": "sUnv6uBehM91amYRNWESsgX3HzqoBnR5"
-  }
-}
-```
-
-Checking permissions appear listed:
-
-```
-http :8001/teamA/rbac/users/qux/permissions Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG
-{
-  "entities": {
-    "d25afc46-dc59-48b2-b04f-d3ebe19f6d4b": {
-      "actions": [
-        "read"
-      ],
-      "negative": false
-    },
-    "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43": {
-      "actions": [
-        "read"
-      ],
-      "negative": false
-    }
-  },
-  "endpoints": {}
-}
-```
-
-That is, 2 entities permissions and no endpoint permissions.
-
-Admin A is done setting up qux, and qux can now use his user token to read
-his two entities over Kong's admin API.
-
-We will assume that Admin A [enabled entity-level enforcement](#enforcing-rbac).
-Note that as qux has **no endpoint-level permissions**, if both endpoint and
-entity-level enforcement is enabled, he will not be able to read his entities -
-endpoint-level validation comes before entity-level.
-
-**qux tries listing all RBAC users**
-
-```
-http :8001/teamA/rbac/users/ Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
-{
-  "message": "qux, you do not have permissions to read this resource"
-}
-```
-
-**qux tries listing all Workspaces**
-
-```
-http :8001/teamA/rbac/workspaces/ Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
-{
-  "message": "qux, you do not have permissions to read this resource"
-}
-```
-
-**qux tries to access service1**
-
-```
-http :8001/teamA/services/service1 Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
-{
-  "host": "httpbin.org",
-  "created_at": 1531066074,
-  "connect_timeout": 60000,
-  "id": "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43",
-  "protocol": "http",
-  "name": "service1",
-  "read_timeout": 60000,
-  "port": 80,
-  "path": null,
-  "updated_at": 1531066074,
-  "retries": 5,
-  "write_timeout": 60000
-}
-```
-
-Similarly, he can access his Route:
-
-```
-http :8001/teamA/routes/3ed24101-19a7-4a0b-a10f-2f47bcd4ff43 Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
-{
-  "created_at": 1531066253,
-  "strip_path": false,
-  "hosts": null,
-  "preserve_host": false,
-  "regex_priority": 0,
-  "updated_at": 1531066253,
-  "paths": [
-    "/anything"
-  ],
-  "service": {
-    "id": "3ed24101-19a7-4a0b-a10f-2f47bcd4ff43"
-  },
-  "methods": null,
-  "protocols": [
-    "http",
-    "https"
-  ],
-  "id": "d25afc46-dc59-48b2-b04f-d3ebe19f6d4b"
-}
-```
-
-## Closing Remarks
-
-We will end this chapter with a few closing remarks.
-
-### Wildcards in Permissions
-
-RBAC supports the use of wildcards—represented by the `*` character—in many
-aspects of permissions:
-
-**Creating endpoint permissions—`/rbac/roles/:role/endpoints`**
-
-To create an endpoint permission, one must pass the parameters below, all of
-which can be replaced by a * character:
+To create an endpoint permission via `/rbac/roles/:role/endpoints`, 
+you must pass the parameters below, all of which can be replaced by a `*` character:
 
 - `endpoint`: `*` matches **any endpoint**
 - `workspace`: `*` matches **any workspace**
 - `actions`: `*` evaluates to **all actions—read, update, create, delete**
 
 **Special case**: `endpoint`, in addition to a single `*`, also accepts `*`
-within the endpoint itself, replacing a URL segment between `/`; for example,
+within the endpoint itself, replacing a URL segment between `/`. For example,
 all of the following are valid endpoints:
 
-- `/rbac/*`: where `*` replaces any possible segment—e.g., `/rbac/users`,
-`/rbac/roles`, etc
-- `/services/*/plugins`: `*` matches any Service name or ID
+- `/rbac/*`: where `*` replaces any possible segment, for example `/rbac/users` 
+and `/rbac/roles`
+- `/services/*/plugins`: `*` matches any service name or ID
 
-Note, however, that `*` **is not** a generic, shell-like, glob pattern.
+{:.note}
+> **Note** `*` **is not** a generic, shell-like, glob pattern.
 
 If `workspace` is omitted, it defaults to the current request's workspace. For
 example, a role-endpoint permission created with `/teamA/roles/admin/endpoints`
 is scoped to workspace `teamA`.
 
-**Creating entity permissions—`/rbac/roles/:role/entities`**
+### Creating entity permissions
 
-Similarly, for entity permissions, the following parameters accept a `*`
-character:
+For entity permissions created via `/rbac/roles/:role/entities`,
+the following parameter accepts a `*` character:
 
 - `entity_id`: `*` matches **any entity ID**
 
-### Entities Concealing in Entity-Level RBAC
+## Entities nested in entity-level RBAC
 
-With Entity-Level RBAC enabled, endpoints that list all entities of a
-particular collection will only list entities that the user has access to;
-in the example above, if user qux listed all Routes, he would only get as
-response the entities he has access to—even though there could be more:
+With entity-level RBAC enabled, endpoints that list all entities of a
+particular collection will only list entities that the user has access to.
 
+In the example above, if user `qux` listed all routes, they would only get 
+the entities they have access to in the response, even though there 
+could be more in the workspace:
+
+```sh
+curl -i -X GET http://localhost:8001/teamA/routes \
+  -H 'Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5'
 ```
-http :8001/teamA/routes Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
+
+Response:
+```json
 {
   "next": null,
   "data": [
@@ -970,14 +982,20 @@ http :8001/teamA/routes Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
 }
 ```
 
-Some Kong endpoints carry a `total` field in responses; with Entity-Level RBAC
+Some Kong endpoints carry a `total` field in responses. With entity-level RBAC
 enabled, the global count of entities is displayed, but only entities the user
-has access to are themselves shown; for example, if Team A has a number of
-plugins configured, but qux only has access to one of them, the following
-would be the expected output for a GET request to `/teamA/plugins`:
+has access to are themselves shown. 
 
+For example, if Team A has a number of plugins configured, but `qux` only has access to one of them, 
+the following would be the expected output for a GET request to `/teamA/plugins`:
+
+```sh
+curl -i -X GET http://localhost:8001/teamA/plugins \
+  -H 'Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5'
 ```
-http :8001/teamA/plugins Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
+
+Response:
+```json
 {
   "total": 2,
   "data": [
@@ -1000,17 +1018,29 @@ http :8001/teamA/plugins Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
 }
 ```
 
-Notice the `total` field is 2, but qux only got one entity in the response.
+Notice the `total` field is 2, but `qux` only got one entity in the response.
 
-### Creating Entities in Entity-Level RBAC
+### Creating entities in entity-level RBAC
 
 As entity-level RBAC provides access control to individual existing entities,
-it does not apply to creation of new entities; for that, endpoint-level
-permissions must be configured and enforced. For example, if endpoint-level
-permissions are not enforced, qux will be able to create new entities:
+it does not apply to creation of new entities. For that, endpoint-level
+permissions must be configured and enforced. 
 
+For example, if endpoint-level
+permissions are not enforced, `qux` will be able to create new entities, and
+will automatically have permissions to perform any actions to entities 
+they create:
+
+```sh
+curl -i -X POST http://localhost:8001/teamA/routes \
+  --data paths[]=/anything \
+  --data service.id=3ed24101-19a7-4a0b-a10f-2f47bcd4ff43 \
+  --data strip_path=false \
+  -H 'Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5'
 ```
-http :8001/teamA/routes paths[]=/anything service.id=3ed24101-19a7-4a0b-a10f-2f47bcd4ff43 strip_path=false Kong-Admin-Token:sUnv6uBehM91amYRNWESsgX3HzqoBnR5
+
+Response:
+```json
 {
   "created_at": 1531070828,
   "strip_path": false,
@@ -1032,9 +1062,6 @@ http :8001/teamA/routes paths[]=/anything service.id=3ed24101-19a7-4a0b-a10f-2f4
   "id": "6ee76f74-3c96-46a9-ae48-72df0717d244"
 }
 ```
-
-and qux will automatically have permissions to perform any actions to entities
-he created.
 
 ---
 

--- a/app/_src/gateway/production/access-control/register-admin-api.md
+++ b/app/_src/gateway/production/access-control/register-admin-api.md
@@ -3,13 +3,11 @@ title: Admins Examples
 badge: enterprise
 ---
 
-## How to Invite and Register an Admin
+Invite and register an admin using the Admin API. Can be used for automation.
 
-### Introduction
+## Prerequisites
 
-Can be used for automation
-
-### Prerequisites
+Set up the following environment variables:
 
 ```bash
 export USERNAME=<username>
@@ -19,7 +17,7 @@ export HOST=<admin_api_host>
 export TOKEN=Kong-Admin-Token:<super_admin_token>
 ```
 
-for example:
+For example:
 ```bash
 export USERNAME=drogon
 export EMAIL=test@test.com
@@ -28,30 +26,41 @@ export HOST=127.0.0.1:8001
 export ADMIN_TOKEN=Kong-Admin-Token:hunter2
 ```
 
-May benefit from HTTPie and jq.
+You may benefit from HTTPie and jq.
 
-## Step 1
+## Invite an admin
+
 Extract and store the token from the registration URL, either by manually creating an environment variable or by echoing and piping with `jq`:
 
-#### Manual method example:
+{% navtabs %}
+{% navtab Manual method example %}
 
 1. Send a request to the registration URL
 ```bash
-http $HOST/$WORKSPACE/admins/$USERNAME?generate_register_url=true $TOKEN
+curl -i -X hhttp://localhost:8001/$WORKSPACE/admins/$USERNAME?generate_register_url=true \
+  -H Kong-Admin-Token:$TOKEN
 ```
 
 2. Copy the response and export as an environment variable, for example:
 ```bash
 export REGISTER_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NDUwNjc0NjUsImlkIjoiM2IyNzY3MzEtNjIxZC00ZjA3LTk3YTQtZjU1NTg0NmJkZjJjIn0.gujRDi2pX_E7u2zuhYBWD4MoPFKe3axMAq-AUcORg2g
 ```
+{% endnavtab %}
+{% navtab Programmatic method (requires jq) %}
 
-#### Programmatic method (requires `jq`):
 ```bash
-REGISTER_TOKEN=$(http $HOST/$WORKSPACE/admins/$USERNAME?generate_register_url=true $TOKEN | jq .token -r)
+REGISTER_TOKEN=$(curl -i -X http://localhost:8001/$WORKSPACE/admins/$USERNAME?generate_register_url=true -H Kong-Admin-Token:$TOKEN | jq .token -r)
 ```
 
-## Step 2
+{% endnavtab %}
+{% endnavtabs %}
+
+## Register the admin
 
 ```bash
-http $HOST/$WORKSPACE/admins/register token=$REGISTER_TOKEN username=$USERNAME email=$EMAIL password="<new_password>"
+curl -i -X http://localhost:8001/$WORKSPACE/admins/register \
+  --data token=$REGISTER_TOKEN \
+  --data username=$USERNAME \
+  --data email=$EMAIL \
+  --data password="<new_password>"
 ```

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -61,13 +61,13 @@ verify that `database` is set to `off`.
 
 Command:
 
-```
-http :8001/
+```sh
+curl -i -X GET http://localhost:8001
 ```
 
 Sample response:
 
-```
+```json
 HTTP/1.1 200 OK
 Access-Control-Allow-Origin: *
 Connection: keep-alive
@@ -92,13 +92,13 @@ services, or entities of any kind.
 
 Command:
 
-```
-http :8001/routes
+```sh
+curl -i -X GET http://localhost:8001/routes
 ```
 
 Sample response:
 
-```
+```json
 HTTP/1.1 200 OK
 Access-Control-Allow-Origin: *
 Connection: keep-alive
@@ -231,10 +231,11 @@ kong start -c kong.conf
 
 You can also load a declarative configuration file into a running
 Kong node with the Admin API, using the `/config` endpoint. The
-following example loads `kong.yml` using HTTPie:
+following example loads `kong.yml`:
 
-```
-http :8001/config config=@kong.yml
+```sh
+curl -i -X GET http://localhost:8001/config \
+  --data config=@kong.yml
 ```
 
 {:.important}

--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
@@ -589,18 +589,11 @@ provides:
 
 To check whether the CP and DP nodes you just brought up are connected, run the
 following on a control plane:
-{% navtabs %}
-{% navtab Using cURL %}
+
 ```bash
 curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
 ```
-{% endnavtab %}
-{% navtab Using HTTPie %}
-```bash
-http :8001/clustering/data-planes
-```
-{% endnavtab %}
-{% endnavtabs %}
+
 The output shows all of the connected data plane instances in the cluster:
 
 ```json

--- a/app/_src/gateway/reference/key-management.md
+++ b/app/_src/gateway/reference/key-management.md
@@ -57,24 +57,10 @@ Both formats carry the same base information, such as the public or private key 
 
 Create a Key Set:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
 ```bash
 curl -i -X PUT http://HOSTNAME:8001/key-sets  \
-  --data name=my-set \
+  --data name=my-set
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT :8001/key-sets \
-  name=my-set \
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 
@@ -90,9 +76,6 @@ Result:
 
 Create a key and associate it with the Key Set:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
 ```bash
 curl -i -X POST http://HOSTNAME:8001/keys  \
   --data name=my-first-jwk \
@@ -100,20 +83,6 @@ curl -i -X POST http://HOSTNAME:8001/keys  \
   --data kid=42 \
   --data set.name=my-set
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT :8001/keys \
-  name=my-first-jwk \
-  jwk='{"kty":"RSA","kid":"42","use":"enc","n":"pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w","e":"AQAB","d":"ksDmucdMJXkFGZxiomNHnroOZxe8AmDLDGO1vhs-POa5PZM7mtUPonxwjVmthmpbZzla-kg55OFfO7YcXhg-Hm2OWTKwm73_rLh3JavaHjvBqsVKuorX3V3RYkSro6HyYIzFJ1Ek7sLxbjDRcDOj4ievSX0oN9l-JZhaDYlPlci5uJsoqro_YrE0PRRWVhtGynd-_aWgQv1YzkfZuMD-hJtDi1Im2humOWxA4eZrFs9eG-whXcOvaSwO4sSGbS99ecQZHM2TcdXeAs1PvjVgQ_dKnZlGN3lTWoWfQP55Z7Tgt8Nf1q4ZAKd-NlMe-7iqCFfsnFwXjSiaOa2CRGZn-Q","p":"4A5nU4ahEww7B65yuzmGeCUUi8ikWzv1C81pSyUKvKzu8CX41hp9J6oRaLGesKImYiuVQK47FhZ--wwfpRwHvSxtNU9qXb8ewo-BvadyO1eVrIk4tNV543QlSe7pQAoJGkxCia5rfznAE3InKF4JvIlchyqs0RQ8wx7lULqwnn0","q":"ven83GM6SfrmO-TBHbjTk6JhP_3CMsIvmSdo4KrbQNvp4vHO3w1_0zJ3URkmkYGhz2tgPlfd7v1l2I6QkIh4Bumdj6FyFZEBpxjE4MpfdNVcNINvVj87cLyTRmIcaGxmfylY7QErP8GFA-k4UoH_eQmGKGK44TRzYj5hZYGWIC8","dp":"lmmU_AG5SGxBhJqb8wxfNXDPJjf__i92BgJT2Vp4pskBbr5PGoyV0HbfUQVMnw977RONEurkR6O6gxZUeCclGt4kQlGZ-m0_XSWx13v9t9DIbheAtgVJ2mQyVDvK4m7aRYlEceFh0PsX8vYDS5o1txgPwb3oXkPTtrmbAGMUBpE","dq":"mxRTU3QDyR2EnCv0Nl0TCF90oliJGAHR9HJmBe__EjuCBbwHfcT8OG3hWOv8vpzokQPRl5cQt3NckzX3fs6xlJN4Ai2Hh2zduKFVQ2p-AF2p6Yfahscjtq-GY9cB85NxLy2IXCC0PF--Sq9LOrTE9QV988SJy_yUrAjcZ5MmECk","qi":"ldHXIrEmMZVaNwGzDF9WG8sHj2mOZmQpw9yrjLK9hAsmsNr5LTyqWAqJIYZSwPTYWhY4nu2O0EY9G9uYiqewXfCKw_UngrJt8Xwfq1Zruz0YY869zPN4GiE9-9rzdZB33RBw8kIOquY3MK74FMwCihYx_LiU2YTHkaoJ3ncvtvg"}' \
-  kid=42 \
-  set.name=my-set
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 
@@ -140,25 +109,11 @@ Result:
 
 
 Create a Key Set:
-  
-{% navtabs codeblock %}
-{% navtab cURL %}
 
 ```bash
 curl -i -X PUT http://HOSTNAME:8001/key-sets  \
-  --data name=my-other-set \
+  --data name=my-other-set
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT :8001/key-sets \
-  name=my-other-set \
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 
@@ -174,33 +129,14 @@ Result:
 
 Create a PEM-encoded key and associate it with the Key Set:
 
-{% navtabs codeblock %}
-{% navtab cURL %}
-
 ```bash
 curl -i -X POST http://HOSTNAME:8001/keys  \
   --data name=my-first-pem-key \
-  --data pem.private_key=@path/to/private_key.pem
-  --data pem.public_key=@path/to/public_key.pem
+  --data pem.private_key=@path/to/private_key.pem \
+  --data pem.public_key=@path/to/public_key.pem \
   --data kid=23 \
   --data set.name=my-other-set
 ```
-
-{% endnavtab %}
-{% navtab HTTPie %}
-
-```bash
-http -f PUT :8001/keys \
-  name=my-first-jwk \
-  kid=23 \
-  set.name=my-other-set \
-  pem.private_key=@path/to/private_key.pem \
-  pem.public_key=@path/to/public_key.pem \
-  -f
-```
-
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 


### PR DESCRIPTION
### Description

Cleaning out HTTPie from our docs, as its an extra tool that someone would need to install. This causes a problem for customers.

* Converting any httpie examples into curl
* For curl/httpie navtabs, removing the tabs and leaving curl only
* Cleaned up and tested the ["Enable RBAC"](https://docs.konghq.com/gateway/latest/production/access-control/enable-rbac/) doc. It became apparent that this needed doing as I couldn't just convert inaccurate commands from httpie to curl, I had to make sure they were real. This doc has also commonly been a source of bug reports in the past, and we've just never gotten to it.

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1685430807824339

https://konghq.atlassian.net/browse/DOCU-2925
https://konghq.atlassian.net/browse/DOCU-288


### Testing instructions

Netlify link: Lots of pages, but here are the main ones:

* https://deploy-preview-5652--kongdocs.netlify.app/gateway/latest/production/access-control/enable-rbac/ - big page update, needs the most review.

Removed/converted HTTPie:
* https://deploy-preview-5652--kongdocs.netlify.app/gateway/latest/kong-enterprise/workspaces/
* https://deploy-preview-5652--kongdocs.netlify.app/gateway/latest/kong-enterprise/consumer-groups/
* https://deploy-preview-5652--kongdocs.netlify.app/gateway/latest/kong-enterprise/event-hooks/
* https://deploy-preview-5652--kongdocs.netlify.app/gateway/latest/kong-enterprise/plugin-ordering/get-started/
* https://deploy-preview-5652--kongdocs.netlify.app/gateway/latest/production/access-control/register-admin-api/
* https://deploy-preview-5652--kongdocs.netlify.app/gateway/latest/reference/key-management/



### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

