### PR TITLE
Rename Kubernetes Ingress Controller to Kong Ingress Controller

### DIFF
--- a/app/_data/docs_nav_kic_1.0.x.yml
+++ b/app/_data/docs_nav_kic_1.0.x.yml
@@ -1,4 +1,4 @@
-- title: Kubernetes Ingress Controller
+- title: Kong Ingress Controller
   icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
   url: /kubernetes-ingress-controller/1.0.x/
   absolute_url: true

--- a/app/_data/docs_nav_kic_1.1.x.yml
+++ b/app/_data/docs_nav_kic_1.1.x.yml
@@ -1,4 +1,4 @@
-- title: Kubernetes Ingress Controller
+- title: Kong Ingress Controller
   icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
   url: /kubernetes-ingress-controller/1.1.x/
   absolute_url: true

--- a/app/_data/landing_page.yml
+++ b/app/_data/landing_page.yml
@@ -57,7 +57,7 @@ features:
             icon: /assets/images/icons/icn-doc.svg
             url: /hub/
 
-      - name: Kubernetes Ingress Controller
+      - name: Kong Ingress Controller
         description: Implement authentication, transformations, and other functionalities across Kubernetes clusters with zero downtime.
         icon: /assets/images/landing-page/kubernetes.svg
         links:

--- a/app/_data/tables/features/gateway.yml
+++ b/app/_data/tables/features/gateway.yml
@@ -17,7 +17,7 @@ features:
         tooltip: Drive a GitOps flow of API design and execution
         oss: true
         enterprise: true
-      - name: Kubernetes Ingress Controller
+      - name: Kong Ingress Controller
         tooltip: Deploy APIs to Kubernetes in a native fashion
         oss: true
         enterprise: true

--- a/app/_hub/imperva/imp-appsec-connector/_index.md
+++ b/app/_hub/imperva/imp-appsec-connector/_index.md
@@ -4,7 +4,7 @@ The plugin sends a copy of API call requests/responses to the Imperva API receiv
 ## How to install
 
 {:.note}
-> If you are using Kong's [Kubernetes Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for Kubernetes Ingress](/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/).
+> If you are using [Kong's Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for the Kong Ingress Controller](/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/).
 
 The `.rock` file is a self-contained package that can be installed locally or from a remote server.
 

--- a/app/_hub/imperva/imp-appsec-connector/_index.md
+++ b/app/_hub/imperva/imp-appsec-connector/_index.md
@@ -4,7 +4,7 @@ The plugin sends a copy of API call requests/responses to the Imperva API receiv
 ## How to install
 
 {:.note}
-> If you are using [Kong's Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for the Kong Ingress Controller](/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/).
+> If you are using Kong's [Kubernetes ingress controllerr](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for the Kong Ingress Controller](/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/).
 
 The `.rock` file is a self-contained package that can be installed locally or from a remote server.
 

--- a/app/_hub/imperva/imp-appsec-connector/_index.md
+++ b/app/_hub/imperva/imp-appsec-connector/_index.md
@@ -4,7 +4,7 @@ The plugin sends a copy of API call requests/responses to the Imperva API receiv
 ## How to install
 
 {:.note}
-> If you are using Kong's [Kubernetes ingress controllerr](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for the Kong Ingress Controller](/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/).
+> If you are using Kong's [Kubernetes ingress controller](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for the Kong Ingress Controller](/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/).
 
 The `.rock` file is a self-contained package that can be installed locally or from a remote server.
 

--- a/app/_hub/moesif/kong-plugin-moesif/_index.md
+++ b/app/_hub/moesif/kong-plugin-moesif/_index.md
@@ -10,7 +10,7 @@ Moesif natively supports REST, GraphQL, Web3, SOAP, JSON-RPC, and more.
 
 ## How to install
 
-> If you are using [Kong's Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for the Kong Ingress Controller](https://www.moesif.com/docs/server-integration/kubernetes-ingress-controller/).
+> If you are using Kong's [Kubernetes ingress controller](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for the Kong Ingress Controller](https://www.moesif.com/docs/server-integration/kubernetes-ingress-controller/).
 
 The `.rock` file is a self-contained package that can be installed locally or from a remote server.
 

--- a/app/_hub/moesif/kong-plugin-moesif/_index.md
+++ b/app/_hub/moesif/kong-plugin-moesif/_index.md
@@ -10,7 +10,7 @@ Moesif natively supports REST, GraphQL, Web3, SOAP, JSON-RPC, and more.
 
 ## How to install
 
-> If you are using Kong's [Kubernetes Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for Kubernetes Ingress](https://www.moesif.com/docs/server-integration/kong-ingress-controller/).
+> If you are using [Kong's Ingress Controller](https://github.com/Kong/kubernetes-ingress-controller), the installation is slightly different. Review the [docs for the Kong Ingress Controller](https://www.moesif.com/docs/server-integration/kubernetes-ingress-controller/).
 
 The `.rock` file is a self-contained package that can be installed locally or from a remote server.
 

--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -38,7 +38,7 @@
           <a href="/deck/latest/" {% if include.edition == 'deck' %}class="active"{% endif %}>decK</a>
         </li>
         <li role="menuitem" tabindex="-1" {% if include.edition == 'kubernetes-ingress-controller' %} class="active"{% endif %}" >
-          <a href="/kubernetes-ingress-controller/latest/" {% if include.edition == 'kubernetes-ingress-controller' %}class="active"{% endif %}>Kubernetes Ingress Controller</a>
+          <a href="/kubernetes-ingress-controller/latest/" {% if include.edition == 'kubernetes-ingress-controller' %}class="active"{% endif %}>Kong Ingress Controller</a>
         </li>
         <li>
           <a href="https://docs.insomnia.rest/" target="_blank">Insomnia</a>

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -59,7 +59,7 @@
                 <a href="/deck/latest/" class="navbar-item navbar-item-docs">decK</a>
               </li>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">
-                <a href="/kubernetes-ingress-controller/latest/" class="navbar-item navbar-item-docs">Kubernetes Ingress
+                <a href="/kubernetes-ingress-controller/latest/" class="navbar-item navbar-item-docs">Kong Ingress
                   Controller</a>
               </li>
               <li role="menuitem" class="docs-dropdown-li" tabindex="-1">

--- a/app/_src/gateway/install/helm-quickstart.md
+++ b/app/_src/gateway/install/helm-quickstart.md
@@ -429,4 +429,4 @@ To remove {{site.base_gateway}} from your system, follow these instructions:
 
 ## Next Steps
 
-See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.
+See the [{{site.kic_product_name}} docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.

--- a/app/_src/gateway/install/kubernetes/deployment-options.md
+++ b/app/_src/gateway/install/kubernetes/deployment-options.md
@@ -9,8 +9,8 @@ configuration to route and control traffic.
 
 The [kong-gateway][enterprise-download] proxy image supports DB-less
 operation and is recommended for all deployments.
-* [DB-less installation with the Kong Ingress Controller][k4k8s-enterprise-install]
-* [Database-backed installation with or without the Kong Ingress Controller](/gateway/{{page.kong_version}}/install/kubernetes/helm-quickstart/)
+* [DB-less installation with the {{site.kic_product_name}}][k4k8s-enterprise-install]
+* [Database-backed installation with or without the {{site.kic_product_name}}](/gateway/{{page.kong_version}}/install/kubernetes/helm-quickstart/)
 
 ### Migrating to 2.1.x and up
 

--- a/app/_src/gateway/install/kubernetes/helm-quickstart.md
+++ b/app/_src/gateway/install/kubernetes/helm-quickstart.md
@@ -440,4 +440,4 @@ To remove {{site.base_gateway}} from your system, follow these instructions:
 
 ## Next Steps
 
-See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.
+See the [{{site.kic_product_name}} docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.

--- a/app/_src/gateway/install/kubernetes/helm.md
+++ b/app/_src/gateway/install/kubernetes/helm.md
@@ -215,4 +215,4 @@ Note that the Enterprise deployment includes a Postgres sub-chart provided by Bi
 
 ## Next steps
 
-See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.
+See the [{{site.kic_product_name}} docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.

--- a/app/_src/gateway/install/kubernetes/kubectl.md
+++ b/app/_src/gateway/install/kubernetes/kubectl.md
@@ -162,4 +162,4 @@ oc get service kong-proxy -n kong
 
 ## Next steps
 
-See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.
+See the [{{site.kic_product_name}} docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.

--- a/app/_src/gateway/install/kubernetes/openshift.md
+++ b/app/_src/gateway/install/kubernetes/openshift.md
@@ -197,4 +197,4 @@ Note that this deployment includes a Postgres sub-chart provided by Bitnami. You
 
 ## Next steps
 
-See the [Kong Ingress Controller docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.
+See the [{{site.kic_product_name}} docs](/kubernetes-ingress-controller/) for  how-to guides, reference guides, and more.

--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
@@ -53,7 +53,7 @@ You can run {{site.base_gateway}} in hybrid mode on any platform where
 ### Kubernetes Support and Additional Documentation
 
 [{{site.base_gateway}} on Kubernetes](/gateway/{{page.kong_version}}/install/kubernetes/helm-quickstart)
-fully supports hybrid mode deployments, with or without the Kong Ingress Controller.
+fully supports hybrid mode deployments, with or without the {{site.kic_product_name}}.
 
 For the full Kubernetes hybrid mode documentation, see
 [hybrid mode](https://github.com/Kong/charts/blob/main/charts/kong/README.md#hybrid-mode)

--- a/app/_src/gateway/production/deployment-topologies/index.md
+++ b/app/_src/gateway/production/deployment-topologies/index.md
@@ -61,7 +61,7 @@ You can enable [DB-less mode](/gateway/{{page.kong_version}}/production/deployme
 
 When running in DB-less mode, configuration is provided to {{ site.base_gateway }} using a second file. This file contains your configuration in YAML or JSON format using Kong's declarative configuration syntax.
 
-DB-less mode is also used by the Kong Ingress Controller, where the Kubernetes API server uses Kong's `/config` endpoint to update the running configuration in memory any time a change is made.
+DB-less mode is also used by the {{site.kic_product_name}}, where the Kubernetes API server uses Kong's `/config` endpoint to update the running configuration in memory any time a change is made.
 
 The combination of DB-less mode and declarative configuration has a number
 of benefits:

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -132,6 +132,6 @@ readinessProbe:
 
 For more information on Kong and related topics, check out the following resources:
 
-* [Kong Admin API Documentation](https://docs.konghq.com/gateway/latest/admin-api/)
-* [Get Started with Kong Ingress Controller](https://docs.konghq.com/kubernetes-ingress-controller/latest/deployment/)
+* [Kong Admin API Documentation](/gateway/latest/admin-api/)
+* [Get Started with Kong Ingress Controller](/kubernetes-ingress-controller/latest/deployment/overview/)
 * [Kong Helm Chart](https://github.com/Kong/charts/tree/main/charts/kong)

--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -133,5 +133,5 @@ readinessProbe:
 For more information on Kong and related topics, check out the following resources:
 
 * [Kong Admin API Documentation](/gateway/latest/admin-api/)
-* [Get Started with Kong Ingress Controller](/kubernetes-ingress-controller/latest/deployment/overview/)
+* [Get Started with {{site.kic_product_name}}](/kubernetes-ingress-controller/latest/deployment/overview/)
 * [Kong Helm Chart](https://github.com/Kong/charts/tree/main/charts/kong)

--- a/app/_src/gateway/support-policy.md
+++ b/app/_src/gateway/support-policy.md
@@ -51,7 +51,7 @@ Support includes:
 * Assistance with upgrades to later versions of the Kong software
 * Access to bug-fix releases and/or workarounds based on the below Bug Fix Guidelines
 
-**<sup>*</sup>** 24 month support applies starting with {{site.ee_product_name}} 2.1.3.x. For prior releases, support remains at 12 months from the first minor version release. Support for the Kubernetes Ingress Controller and Kong Mesh remain at 12 months. The 24 month support applies to {{site.ee_product_name}} standard releases.
+**<sup>*</sup>** 24 month support applies starting with {{site.ee_product_name}} 2.1.3.x. For prior releases, support remains at 12 months from the first minor version release. Support for the {{site.kic_product_name}} and {{site.mesh_product_name}} remain at 12 months. The 24 month support applies to {{site.ee_product_name}} standard releases.
 
 ## Sunset support
 After the product hits the end of the support period, Kong will provide limited support to help the customer upgrade to a fully supported version of {{site.ee_product_name}} for up to an additional 12 month sunset period. Kong will not provide patches for software covered by this sunset period. If there is an issue that requires a patch during this period, the customer will need to upgrade to a newer {{site.ee_product_name}} version covered by 24 month active support.

--- a/app/_src/kubernetes-ingress-controller/concepts/deployment.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Deployment
+title: Kong Ingress Controller Deployment
 ---
 
 The {{site.kic_product_name}} is designed to be deployed in a variety of ways

--- a/app/_src/kubernetes-ingress-controller/concepts/deployment.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/deployment.md
@@ -213,7 +213,7 @@ loss of functionality.
 
 #### Without a database
 
-In DB-less deployments, Kong's Ingress controller runs
+In DB-less deployments, Kong's Kubernetes ingress controller runs
 alongside and dynamically configures
 Kong as per the changes it receives from the Kubernetes API server.
 
@@ -362,7 +362,7 @@ by {{site.kic_product_name}} for configuring local Kong Gateways. It enables usi
 to inspect the configuration of your Kong instances in a **read-only** mode, track [Analytics][konnect-analytics],
 and more.
 
-For installation steps, please see the [Kong Ingress Controller for Kubernetes Association][konnect-kic] page.
+For installation steps, please see the [{{site.kic_product_name}} for Kubernetes Association][konnect-kic] page.
 
 ![KIC {{site.konnect_short_name}} overview](/assets/images/docs/kubernetes-ingress-controller/kic-konnect-diagram.png "KIC {{site.konnect_short_name}} overview")
 

--- a/app/_src/kubernetes-ingress-controller/concepts/design.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/design.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Design
+title: Kong Ingress Controller Design
 ---
 
 ## Overview

--- a/app/_src/kubernetes-ingress-controller/concepts/ingress-classes.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/ingress-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller and Ingress Class
+title: Kong Ingress Controller and Ingress Class
 ---
 
 ## Introduction
@@ -130,5 +130,5 @@ referenced by other resources that do.
 
 [class-annotation]:/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations/#kubernetesioingressclass
 [knative-class]:/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kong-with-knative/#ingress-class
-[knative-override]:https://knative.tips/networking/ingress-override/
+[knative-override]:https://knative.dev/docs/serving/services/ingress-class/
 [ingress-class-name]:https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

--- a/app/_src/kubernetes-ingress-controller/concepts/ingress-versions.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/ingress-versions.md
@@ -169,5 +169,5 @@ v1beta1 Ingresses.
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
 [deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io
+[ingress-class-api]: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/
 [rfc-2606]:https://datatracker.ietf.org/doc/html/rfc2606

--- a/app/_src/kubernetes-ingress-controller/guides/getting-started-istio.md
+++ b/app/_src/kubernetes-ingress-controller/guides/getting-started-istio.md
@@ -1,5 +1,5 @@
 ---
-title: Running the Kubernetes Ingress Controller with Istio
+title: Running the Kong Ingress Controller with Istio
 ---
 
 This guide walks you through deploying {{site.base_gateway}} with {{site.kic_product_name}}

--- a/app/_src/kubernetes-ingress-controller/guides/getting-started.md
+++ b/app/_src/kubernetes-ingress-controller/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Kubernetes Ingress Controller
+title: Getting started with the Kong Ingress Controller
 content_type: tutorial
 ---
 
@@ -235,5 +235,5 @@ Pod Information:
 * The [External Services Guide](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-external-service/) explains how to proxy services outside of your Kubernetes cluster.
 {% if_version gte:2.4.x %}
 * [Gateway API](https://gateway-api.sigs.k8s.io/) is a set of resources for
-configuring networking in Kubernetes. The Kubernetes Ingress Controller supports Gateway API by default. To learn how to use Gateway API supported by the Kubernetes Ingress Controller, see [Using Gateway API](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-gateway-api/).
+configuring networking in Kubernetes. The {{site.kic_product_name}} supports Gateway API by default. To learn how to use Gateway API supported by the {{site.kic_product_name}}, see [Using Gateway API](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-gateway-api/).
 {% endif_version %}

--- a/app/_src/kubernetes-ingress-controller/guides/prometheus-grafana.md
+++ b/app/_src/kubernetes-ingress-controller/guides/prometheus-grafana.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
+title: Integrate the Kong Ingress Controller with Prometheus/Grafana
 ---
 
 The {{site.kic_product_name}} can give you visibility into how {{site.base_gateway}} is performing and how the services in your Kubernetes cluster are responding to the inbound traffic.

--- a/app/_src/kubernetes-ingress-controller/guides/using-ingress-with-grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-ingress-with-grpc.md
@@ -117,7 +117,9 @@ Ensure that you have it installed on your local system.
 
 ## Enable the `GatewayAlpha` feature gate
 
-If you are using the Gateway API, you need to enable the [`GatewayAlpha`](/kubernetes-ingress-controller/{{page.kong_version}}/references/feature-gates) feature gate in the Kubernetes Ingress Controller.
+If you are using the Gateway API, you need to enable the 
+[`GatewayAlpha`](/kubernetes-ingress-controller/{{page.kong_version}}/references/feature-gates) 
+feature gate in the {{site.kic_product_name}}.
 
 ## Deploy a gRPC test application
 

--- a/app/_src/kubernetes-ingress-controller/index.md
+++ b/app/_src/kubernetes-ingress-controller/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the Kong Gateway
 ---
 

--- a/app/_src/kubernetes-ingress-controller/references/annotations.md
+++ b/app/_src/kubernetes-ingress-controller/references/annotations.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller annotations
+title: Kong Ingress Controller annotations
 ---
 
 The {{site.kic_product_name}} supports the following annotations on various

--- a/app/_src/kubernetes-ingress-controller/references/feature-gates.md
+++ b/app/_src/kubernetes-ingress-controller/references/feature-gates.md
@@ -2,7 +2,7 @@
 title: Feature Gates
 ---
 
-Upstream [Kubernetes][k8s] includes [feature gates][gates], which enable or disable features with flags and track the maturity of a feature using [feature stages][stages]. Here in the Kubernetes Ingress Controller (KIC), we use the same definitions of `feature gates` and `feature stages` from upstream Kubernetes to define our own list of features.
+Upstream [Kubernetes][k8s] includes [feature gates][gates], which enable or disable features with flags and track the maturity of a feature using [feature stages][stages]. Here in the {{site.kic_product_name}} (KIC), we use the same definitions of `feature gates` and `feature stages` from upstream Kubernetes to define our own list of features.
 
 Using feature gates enables contributors to add and manage new (and potentially experimental) functionality to the KIC in a controlled manner. The features will be "hidden" until generally available (GA) and the progress and maturity of features on their path to GA will be documented. Feature gates also create a clear path for deprecating features.
 

--- a/app/_src/kubernetes-ingress-controller/references/version-compatibility.md
+++ b/app/_src/kubernetes-ingress-controller/references/version-compatibility.md
@@ -2,7 +2,7 @@
 title: Version Compatibility
 ---
 
-Kong's Ingress Controller is compatible with different flavors of Kong.
+Kong's Kubernetes ingress controller is compatible with different flavors of Kong.
 The following sections detail on compatibility between versions for the last
 five controller versions. Compatibility for older versions is available in
 those versions' documentation.

--- a/app/_src/kubernetes-ingress-controller/support-policy.md
+++ b/app/_src/kubernetes-ingress-controller/support-policy.md
@@ -6,7 +6,7 @@ content-type: reference
 
 The support for {{site.kic_product_name}} software versions is explained in this topic.
 
-## Version support for Kong Ingress Controller (Enterprise)
+## Version support for {{site.kic_product_name}} (Enterprise)
 
 Kong primarily follows [semantic versioning](https://semver.org/) (SemVer) with its products.
 
@@ -141,7 +141,7 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
 |  1.0.x   |  2020-10-05   |     2021-10-05      |      2023-10-05       |
 |  0.x.x   |  2018-06-02   |     2019-06-02      |      2020-06-02       |
 
-> *Table 1: Version Support for Kong Ingress Controller*
+> *Table 1: Version Support for {{site.kic_product_name}}*
 
 {% include_cached /md/support-policy.md %}
 

--- a/app/_src/mesh/production/gateway/kic.md
+++ b/app/_src/mesh/production/gateway/kic.md
@@ -3,7 +3,7 @@ title: Configure Kong Ingress Controller as a gateway
 content_type: how-to
 ---
 
-This guide explains how to configure [Kong Ingress Controller (KIC)](link to KIC doc) as a gateway for Kong Mesh. This allows you to _______. 
+This guide explains how to configure [{{site.kic_product_name}} (KIC)](link to KIC doc) as a gateway for Kong Mesh. This allows you to _______. 
 
 To configure KIC as a gateway, you must (general overview of the steps here). 
 

--- a/app/contributing/conditional-rendering.md
+++ b/app/contributing/conditional-rendering.md
@@ -36,7 +36,7 @@ You can use conditional rendering by version for any content in the `app/_src` o
 As we add new functionality, we want content on a page to be displayed only for specific releases of a product. 
 You can use the `if_version` block for this, or `if_plugin_version` for any content in the Plugin Hub.
 
-* `if_version` is used by {{site.base_gateway}}, {{site.mesh_product_name}}, Kubernetes Ingress Controller, and decK documentation.
+* `if_version` is used by {{site.base_gateway}}, {{site.mesh_product_name}}, {{site.kic_product_name}}, and decK documentation.
 * `if_plugin_version` can only be used for plugin documentation in the `app/_hub` directory.
 
 `if_version` and `if_plugin_version` support the following filters:

--- a/app/enterprise/2.1.x/introduction/index.md
+++ b/app/enterprise/2.1.x/introduction/index.md
@@ -35,7 +35,7 @@ Kong Developer Portal (Kong Dev Portal) is used to onboard new developers and to
 
 ### Kong for Kubernetes
 
-Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes Ingress Controller. A Kubernetes Ingress Controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, RepliaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
+Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes ingress controller. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, RepliaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
 
 ### Kong Manager
 

--- a/app/enterprise/2.2.x/introduction/index.md
+++ b/app/enterprise/2.2.x/introduction/index.md
@@ -33,9 +33,9 @@ Kong Admin API provides a RESTful interface for administration and configuration
 
 Kong Developer Portal (Kong Dev Portal) is used to onboard new developers and to generate API documentation, create custom pages, manage API versions, and secure developer access. For more information, see [_Kong Developer Portal_](/enterprise/{{page.kong_version}}/developer-portal/).
 
-### Kubernetes Ingress Controller
+### Kong Ingress Controller
 
-Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes Ingress Controller. A Kubernetes Ingress Controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
+Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes ingress controller. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
 
 ### Kong Manager
 

--- a/app/enterprise/2.3.x/index.md
+++ b/app/enterprise/2.3.x/index.md
@@ -32,9 +32,9 @@ Kong Admin API provides a RESTful interface for administration and configuration
 
 Kong Developer Portal (Kong Dev Portal) is used to onboard new developers and to generate API documentation, create custom pages, manage API versions, and secure developer access. For more information, see [_Kong Developer Portal_](/enterprise/{{page.kong_version}}/developer-portal/).
 
-### Kubernetes Ingress Controller
+### Kong Ingress Controller
 
-Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes Ingress Controller. A Kubernetes Ingress Controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
+Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes ingress controller. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
 
 ### Kong Manager
 

--- a/app/enterprise/2.4.x/index.md
+++ b/app/enterprise/2.4.x/index.md
@@ -32,9 +32,9 @@ Kong Admin API provides a RESTful interface for administration and configuration
 
 Kong Developer Portal (Kong Dev Portal) is used to onboard new developers and to generate API documentation, create custom pages, manage API versions, and secure developer access. For more information, see [_Kong Developer Portal_](/enterprise/{{page.kong_version}}/developer-portal/).
 
-### Kubernetes Ingress Controller
+### Kong Ingress Controller
 
-Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes Ingress Controller. A Kubernetes Ingress Controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
+Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes ingress controller. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
 
 ### Kong Manager
 

--- a/app/enterprise/2.5.x/index.md
+++ b/app/enterprise/2.5.x/index.md
@@ -32,9 +32,9 @@ Kong Admin API provides a RESTful interface for administration and configuration
 
 Kong Developer Portal (Kong Dev Portal) is used to onboard new developers and to generate API documentation, create custom pages, manage API versions, and secure developer access. For more information, see [_Kong Developer Portal_](/enterprise/{{page.kong_version}}/developer-portal/).
 
-### Kubernetes Ingress Controller
+### Kong Ingress Controller
 
-Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes Ingress Controller. A Kubernetes Ingress Controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
+Kong for Kubernetes Enterprise (K4K8S) is a Kubernetes ingress controller. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an Ingress Controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster. For more information, see [_Kong for Kubernetes_](/enterprise/{{page.kong_version}}/deployment/kong-for-kubernetes-enterprise/).
 
 ### Kong Manager
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -2334,7 +2334,7 @@ RBAC rules involving deny (negative) rules now correctly take precedence over al
 
 * [HTTP Log](/hub/kong-inc/http-log/) (`http-log`)
   * Fixed the `could not update kong admin` internal error caused by empty headers.
-  This error occurred when using this plugin with the Kubernetes Ingress Controller.
+  This error occurred when using this plugin with the Kong Ingress Controller.
 
 * [JWT](/hub/kong-inc/jwt/) (`jwt`)
   * Fixed an issue where the JWT plugin could potentially forward an unverified token to the upstream. 

--- a/app/konnect/runtime-manager/kic.md
+++ b/app/konnect/runtime-manager/kic.md
@@ -31,7 +31,7 @@ Here are a few benefits of running KIC in {{site.konnect_short_name}} over a sel
 
 To associate your KIC runtime instances with {{site.konnect_short_name}}, use the setup wizard to add your KIC deployment to a KIC runtime group.  
 
-In {{site.konnect_short_name}}, navigate to {% konnect_icon runtimes %} **[Runtime Manager](https://cloud.konghq.com/runtime-manager)**, then click **New Runtime Group** > **Kubernetes Ingress Controller**.
+In {{site.konnect_short_name}}, navigate to {% konnect_icon runtimes %} **[Runtime Manager](https://cloud.konghq.com/runtime-manager)**, then click **New Runtime Group** > **Kong Ingress Controller**.
 
 {:.note}
 > **Note**: KIC OSS users can connect to {{site.konnect_short_name}}’s Free tier, while KIC Enterprise users can connect to {{site.konnect_short_name}}’s Enterprise tier.

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Deployment
+title: Kong Ingress Controller Deployment
 ---
 
 The {{site.kic_product_name}} is designed to be deployed in a variety of ways

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/deployment.md
@@ -193,7 +193,7 @@ loss of functionality.
 
 #### Without a database
 
-In DB-less deployments, Kong's Ingress controller runs
+In DB-less deployments, Kong's Kubernetes ingress controller runs
 alongside Kong and configures Kong and dynamically configures
 Kong as per the changes it receives from the Kubernetes API server.
 

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/design.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/design.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Design
+title: Kong Ingress Controller Design
 ---
 
 ## Overview

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller and Ingress Class
+title: Kong Ingress Controller and Ingress Class
 ---
 
 ## Introduction
@@ -174,4 +174,4 @@ referenced by other resources that do.
 
 [class-annotation]: /kubernetes-ingress-controller/{{page.kong_version}}/references/annotations/#kubernetesioingressclass
 [knative-class]: /kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kong-with-knative/#ingress-class
-[knative-override]: https://knative.tips/networking/ingress-override/
+[knative-override]: https://knative.dev/docs/serving/services/ingress-class/

--- a/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.0.x/concepts/ingress-versions.md
@@ -170,4 +170,4 @@ v1beta1 Ingresses.
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
 [deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io
+[ingress-class-api]: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/

--- a/app/kubernetes-ingress-controller/1.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/getting-started-istio.md
@@ -1,5 +1,5 @@
 ---
-title: Running the Kubernetes Ingress Controller with Istio
+title: Running the Kong Ingress Controller with Istio
 ---
 
 In this guide, you will:

--- a/app/kubernetes-ingress-controller/1.0.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Kubernetes Ingress Controller
+title: Getting started with the Kong Ingress Controller
 ---
 
 ## Installation

--- a/app/kubernetes-ingress-controller/1.0.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/prometheus-grafana.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
+title: Integrate the Kong Ingress Controller with Prometheus/Grafana
 ---
 
 The {{site.kic_product_name}} can give you visibility not only into how Kong is

--- a/app/kubernetes-ingress-controller/1.0.x/index.md
+++ b/app/kubernetes-ingress-controller/1.0.x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 ---
 
 ## Concepts

--- a/app/kubernetes-ingress-controller/1.0.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/1.0.x/references/annotations.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller annotations
+title: Kong Ingress Controller annotations
 ---
 
 The {{site.kic_product_name}} supports the following annotations on various

--- a/app/kubernetes-ingress-controller/1.0.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/1.0.x/references/version-compatibility.md
@@ -2,7 +2,7 @@
 title: Version Compatibility
 ---
 
-Kong's Ingress Controller is compatible with different flavors of Kong.
+Kong's Kubernetes ingress controller is compatible with different flavors of Kong.
 The following sections detail on compatibility between versions.
 
 ## Kong

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Deployment
+title: Kong Ingress Controller Deployment
 ---
 
 The {{site.kic_product_name}} is designed to be deployed in a variety of ways

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/deployment.md
@@ -193,7 +193,7 @@ loss of functionality.
 
 #### Without a database
 
-In DB-less deployments, Kong's Ingress controller runs
+In DB-less deployments, Kong's Kubernetes ingress controller runs
 alongside Kong and configures Kong and dynamically configures
 Kong as per the changes it receives from the Kubernetes API server.
 

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/design.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/design.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Design
+title: Kong Ingress Controller Design
 ---
 
 ## Overview

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller and Ingress Class
+title: Kong Ingress Controller and Ingress Class
 ---
 
 ## Introduction
@@ -174,4 +174,4 @@ referenced by other resources that do.
 
 [class-annotation]: /kubernetes-ingress-controller/{{page.kong_version}}/references/annotations/#kubernetesioingressclass
 [knative-class]: /kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kong-with-knative/#ingress-class
-[knative-override]: https://knative.tips/networking/ingress-override/
+[knative-override]: https://knative.dev/docs/serving/services/ingress-class/

--- a/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.1.x/concepts/ingress-versions.md
@@ -170,4 +170,4 @@ v1beta1 Ingresses.
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
 [deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io
+[ingress-class-api]: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/

--- a/app/kubernetes-ingress-controller/1.1.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/getting-started-istio.md
@@ -1,5 +1,5 @@
 ---
-title: Running the Kubernetes Ingress Controller with Istio
+title: Running the Kong Ingress Controller with Istio
 ---
 
 In this guide, you will:

--- a/app/kubernetes-ingress-controller/1.1.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Kubernetes Ingress Controller
+title: Getting started with the Kong Ingress Controller
 ---
 
 ## Installation

--- a/app/kubernetes-ingress-controller/1.1.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/prometheus-grafana.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
+title: Integrate the Kong Ingress Controller with Prometheus/Grafana
 ---
 
 The {{site.kic_product_name}} can give you visibility not only into how Kong is

--- a/app/kubernetes-ingress-controller/1.1.x/index.md
+++ b/app/kubernetes-ingress-controller/1.1.x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 ---
 
 ## Concepts

--- a/app/kubernetes-ingress-controller/1.1.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/1.1.x/references/annotations.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller annotations
+title: Kong Ingress Controller annotations
 ---
 
 The {{site.kic_product_name}} supports the following annotations on various

--- a/app/kubernetes-ingress-controller/1.1.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/1.1.x/references/version-compatibility.md
@@ -2,7 +2,7 @@
 title: Version Compatibility
 ---
 
-Kong's Ingress Controller is compatible with different flavors of Kong.
+Kong's Kubernetes ingress controller is compatible with different flavors of Kong.
 The following sections detail on compatibility between versions.
 
 ## Kong

--- a/app/kubernetes-ingress-controller/1.2.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/1.2.x/concepts/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Deployment
+title: Kong Ingress Controller Deployment
 ---
 
 The {{site.kic_product_name}} is designed to be deployed in a variety of ways

--- a/app/kubernetes-ingress-controller/1.2.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/1.2.x/concepts/deployment.md
@@ -193,7 +193,7 @@ loss of functionality.
 
 #### Without a database
 
-In DB-less deployments, Kong's Ingress controller runs
+In DB-less deployments, Kong's Kubernetes ingress controller runs
 alongside Kong and configures Kong and dynamically configures
 Kong as per the changes it receives from the Kubernetes API server.
 

--- a/app/kubernetes-ingress-controller/1.2.x/concepts/design.md
+++ b/app/kubernetes-ingress-controller/1.2.x/concepts/design.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Design
+title: Kong Ingress Controller Design
 ---
 
 ## Overview

--- a/app/kubernetes-ingress-controller/1.2.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/1.2.x/concepts/ingress-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller and Ingress Class
+title: Kong Ingress Controller and Ingress Class
 ---
 
 ## Introduction
@@ -174,4 +174,4 @@ referenced by other resources that do.
 
 [class-annotation]: /kubernetes-ingress-controller/{{page.kong_version}}/references/annotations/#kubernetesioingressclass
 [knative-class]: /kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kong-with-knative/#ingress-class
-[knative-override]: https://knative.tips/networking/ingress-override/
+[knative-override]: https://knative.dev/docs/serving/services/ingress-class/

--- a/app/kubernetes-ingress-controller/1.2.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.2.x/concepts/ingress-versions.md
@@ -170,4 +170,4 @@ v1beta1 Ingresses.
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
 [deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io
+[ingress-class-api]: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/

--- a/app/kubernetes-ingress-controller/1.2.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/getting-started-istio.md
@@ -1,5 +1,5 @@
 ---
-title: Running the Kubernetes Ingress Controller with Istio
+title: Running the Kong Ingress Controller with Istio
 ---
 
 In this guide, you will:

--- a/app/kubernetes-ingress-controller/1.2.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Kubernetes Ingress Controller
+title: Getting started with the Kong Ingress Controller
 ---
 
 ## Installation

--- a/app/kubernetes-ingress-controller/1.2.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/prometheus-grafana.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
+title: Integrate the Kong Ingress Controller with Prometheus/Grafana
 ---
 
 The {{site.kic_product_name}} can give you visibility not only into how Kong is

--- a/app/kubernetes-ingress-controller/1.2.x/index.md
+++ b/app/kubernetes-ingress-controller/1.2.x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the {{site.base_gateway}}
 ---
 

--- a/app/kubernetes-ingress-controller/1.2.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/1.2.x/references/annotations.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller annotations
+title: Kong Ingress Controller annotations
 ---
 
 The {{site.kic_product_name}} supports the following annotations on various

--- a/app/kubernetes-ingress-controller/1.2.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/1.2.x/references/version-compatibility.md
@@ -2,7 +2,7 @@
 title: Version Compatibility
 ---
 
-Kong's Ingress Controller is compatible with different flavors of Kong.
+Kong's Kubernetes ingress controller is compatible with different flavors of Kong.
 The following sections detail on compatibility between versions.
 
 ## Kong

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Deployment
+title: Kong Ingress Controller Deployment
 ---
 
 The {{site.kic_product_name}} is designed to be deployed in a variety of ways

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/deployment.md
@@ -193,7 +193,7 @@ loss of functionality.
 
 #### Without a database
 
-In DB-less deployments, Kong's Ingress controller runs
+In DB-less deployments, Kong's Kubernetes ingress controller runs
 alongside and dynamically configures
 Kong as per the changes it receives from the Kubernetes API server.
 

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/design.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/design.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Design
+title: Kong Ingress Controller Design
 ---
 
 ## Overview

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/ingress-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller and Ingress Class
+title: Kong Ingress Controller and Ingress Class
 ---
 
 ## Introduction
@@ -174,4 +174,4 @@ referenced by other resources that do.
 
 [class-annotation]: /kubernetes-ingress-controller/{{page.kong_version}}/references/annotations/#kubernetesioingressclass
 [knative-class]: /kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kong-with-knative/#ingress-class
-[knative-override]: https://knative.tips/networking/ingress-override/
+[knative-override]: https://knative.dev/docs/serving/services/ingress-class/

--- a/app/kubernetes-ingress-controller/1.3.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/1.3.x/concepts/ingress-versions.md
@@ -168,4 +168,4 @@ v1beta1 Ingresses.
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
 [deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io
+[ingress-class-api]: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/

--- a/app/kubernetes-ingress-controller/1.3.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/getting-started-istio.md
@@ -1,5 +1,5 @@
 ---
-title: Running the Kubernetes Ingress Controller with Istio
+title: Running the Kong Ingress Controller with Istio
 ---
 
 In this guide, you will:

--- a/app/kubernetes-ingress-controller/1.3.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Kubernetes Ingress Controller
+title: Getting started with the Kong Ingress Controller
 ---
 
 ## Installation

--- a/app/kubernetes-ingress-controller/1.3.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/prometheus-grafana.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
+title: Integrate the Kong Ingress Controller with Prometheus/Grafana
 ---
 
 The {{site.kic_product_name}} can give you visibility not only into how Kong is

--- a/app/kubernetes-ingress-controller/1.3.x/index.md
+++ b/app/kubernetes-ingress-controller/1.3.x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the {{site.base_gateway}}
 ---
 

--- a/app/kubernetes-ingress-controller/1.3.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/1.3.x/references/annotations.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller annotations
+title: Kong Ingress Controller annotations
 ---
 
 The {{site.kic_product_name}} supports the following annotations on various

--- a/app/kubernetes-ingress-controller/1.3.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/1.3.x/references/version-compatibility.md
@@ -2,7 +2,7 @@
 title: Version Compatibility
 ---
 
-Kong's Ingress Controller is compatible with different flavors of Kong.
+Kong's Kubernetes ingress controller is compatible with different flavors of Kong.
 The following sections detail on compatibility between versions.
 
 ## Kong

--- a/app/kubernetes-ingress-controller/2.0.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/2.0.x/concepts/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Deployment
+title: Kong Ingress Controller Deployment
 ---
 
 The {{site.kic_product_name}} is designed to be deployed in a variety of ways

--- a/app/kubernetes-ingress-controller/2.0.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/2.0.x/concepts/deployment.md
@@ -192,7 +192,7 @@ loss of functionality.
 
 #### Without a database
 
-In DB-less deployments, Kong's Ingress controller runs
+In DB-less deployments, Kong's Kubernetes ingress controller runs
 alongside and dynamically configures
 Kong as per the changes it receives from the Kubernetes API server.
 

--- a/app/kubernetes-ingress-controller/2.0.x/concepts/design.md
+++ b/app/kubernetes-ingress-controller/2.0.x/concepts/design.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Design
+title: Kong Ingress Controller Design
 ---
 
 ## Overview

--- a/app/kubernetes-ingress-controller/2.0.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/2.0.x/concepts/ingress-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller and Ingress Class
+title: Kong Ingress Controller and Ingress Class
 ---
 
 ## Introduction
@@ -130,5 +130,5 @@ referenced by other resources that do.
 
 [class-annotation]:/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations/#kubernetesioingressclass
 [knative-class]:/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kong-with-knative/#ingress-class
-[knative-override]:https://knative.tips/networking/ingress-override/
+[knative-override]:https://knative.dev/docs/serving/services/ingress-class/
 [ingress-class-name]:https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

--- a/app/kubernetes-ingress-controller/2.0.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/2.0.x/concepts/ingress-versions.md
@@ -168,5 +168,5 @@ v1beta1 Ingresses.
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
 [deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io
+[ingress-class-api]: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/
 [rfc-2606]:https://datatracker.ietf.org/doc/html/rfc2606

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -1,5 +1,5 @@
 ---
-title: Running the Kubernetes Ingress Controller with Istio
+title: Running the Kong Ingress Controller with Istio
 ---
 
 This guide walks you through deploying {{site.base_gateway}} with {{site.kic_product_name}} 

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Kubernetes Ingress Controller
+title: Getting started with the Kong Ingress Controller
 ---
 
 ## Installation

--- a/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/prometheus-grafana.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
+title: Integrate the Kong Ingress Controller with Prometheus/Grafana
 ---
 
 The {{site.kic_product_name}} can give you visibility into how {{site.base_gateway}} is performing and how the services in your Kubernetes cluster are responding to the inbound traffic.

--- a/app/kubernetes-ingress-controller/2.0.x/guides/upgrade.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/upgrade.md
@@ -6,7 +6,7 @@ This guide walks through backwards incompatible changes in the Kong Kubernetes
 Ingress Controller (KIC) from v1.3.x to v2.0.x to help operators evaluate if any
 changes to their configuration are needed to upgrade, provides
 guidance on how to build testing environments to validate the upgrade, and
-walks through an upgrade of the Kubernetes Ingress Controller (KIC) using
+walks through an upgrade of the Kong Ingress Controller (KIC) using
 its [Helm Chart][chart].
 
 ## Prerequisites

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-udpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-udpingress.md
@@ -23,7 +23,7 @@ DNS server Kubernetes uses for internal DNS
 * Deploy a CoreDNS `Pod` and `Service`
 * Route UDP traffic to it using `UDPIngress`
 
-This guide assumes that you've deployed the Kong Kubernetes Ingress Controller (KIC)
+This guide assumes that you've deployed the Kong Ingress Controller (KIC)
 using the [Helm Chart][chart]. If you have deployed the KIC in a different way, you
 may need to make some manual adjustments to some of the provided instructions.
 
@@ -225,7 +225,7 @@ DNS server outside of the cluster using Kong's `UDPIngress` resource.
 
 ## Exposing UDP Ports on Kong
 
-The Kong Kubernetes Ingress Controller (KIC) doesn't have a
+The Kong Ingress Controller (KIC) doesn't have a
 mechanism to automatically enable new UDP ports for exposing your
 Kubernetes UDP `Services`, so you need to explicitly configure {{site.base_gateway}} to expose
 these ports prior to deploying any `UDPIngress` resources.

--- a/app/kubernetes-ingress-controller/2.0.x/guides/using-udpingress.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/using-udpingress.md
@@ -23,7 +23,7 @@ DNS server Kubernetes uses for internal DNS
 * Deploy a CoreDNS `Pod` and `Service`
 * Route UDP traffic to it using `UDPIngress`
 
-This guide assumes that you've deployed the Kong Ingress Controller (KIC)
+This guide assumes that you've deployed the {{site.kic_product_name}} (KIC)
 using the [Helm Chart][chart]. If you have deployed the KIC in a different way, you
 may need to make some manual adjustments to some of the provided instructions.
 
@@ -40,7 +40,7 @@ the {{site.kic_product_name}} on your Kubernetes cluster.
 
 > **Note**: This feature is compatible with:
 > * {{site.base_gateway}} versions 2.0.0 and above.
-> * Kong Ingress Controller versions 2.0.0 and above.
+> * {{site.kic_product_name}} versions 2.0.0 and above.
 
 ## Create a namespace
 
@@ -225,7 +225,7 @@ DNS server outside of the cluster using Kong's `UDPIngress` resource.
 
 ## Exposing UDP Ports on Kong
 
-The Kong Ingress Controller (KIC) doesn't have a
+The {{site.kic_product_name}} (KIC) doesn't have a
 mechanism to automatically enable new UDP ports for exposing your
 Kubernetes UDP `Services`, so you need to explicitly configure {{site.base_gateway}} to expose
 these ports prior to deploying any `UDPIngress` resources.

--- a/app/kubernetes-ingress-controller/2.0.x/index.md
+++ b/app/kubernetes-ingress-controller/2.0.x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the {{site.base_gateway}}
 ---
 

--- a/app/kubernetes-ingress-controller/2.0.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/annotations.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller annotations
+title: Kong Ingress Controller annotations
 ---
 
 The {{site.kic_product_name}} supports the following annotations on various

--- a/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/2.0.x/references/version-compatibility.md
@@ -2,7 +2,7 @@
 title: Version Compatibility
 ---
 
-Kong's Ingress Controller is compatible with different flavors of Kong.
+Kong's Kubernetes ingress controller is compatible with different flavors of Kong.
 The following sections detail on compatibility between versions.
 
 ## Kong

--- a/app/kubernetes-ingress-controller/2.1.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/2.1.x/concepts/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Deployment
+title: Kong Ingress Controller Deployment
 ---
 
 The {{site.kic_product_name}} is designed to be deployed in a variety of ways

--- a/app/kubernetes-ingress-controller/2.1.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/2.1.x/concepts/deployment.md
@@ -192,7 +192,7 @@ loss of functionality.
 
 #### Without a database
 
-In DB-less deployments, Kong's Ingress controller runs
+In DB-less deployments, Kong's Kubernetes ingress controller runs
 alongside and dynamically configures
 Kong as per the changes it receives from the Kubernetes API server.
 

--- a/app/kubernetes-ingress-controller/2.1.x/concepts/design.md
+++ b/app/kubernetes-ingress-controller/2.1.x/concepts/design.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Design
+title: Kong Ingress Controller Design
 ---
 
 ## Overview

--- a/app/kubernetes-ingress-controller/2.1.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/2.1.x/concepts/ingress-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller and Ingress Class
+title: Kong Ingress Controller and Ingress Class
 ---
 
 ## Introduction
@@ -130,5 +130,5 @@ referenced by other resources that do.
 
 [class-annotation]:/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations/#kubernetesioingressclass
 [knative-class]:/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kong-with-knative/#ingress-class
-[knative-override]:https://knative.tips/networking/ingress-override/
+[knative-override]:https://knative.dev/docs/serving/services/ingress-class/
 [ingress-class-name]:https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

--- a/app/kubernetes-ingress-controller/2.1.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/2.1.x/concepts/ingress-versions.md
@@ -168,5 +168,5 @@ v1beta1 Ingresses.
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
 [deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io
+[ingress-class-api]: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/
 [rfc-2606]:https://datatracker.ietf.org/doc/html/rfc2606

--- a/app/kubernetes-ingress-controller/2.1.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/getting-started-istio.md
@@ -1,5 +1,5 @@
 ---
-title: Running the Kubernetes Ingress Controller with Istio
+title: Running the Kong Ingress Controller with Istio
 ---
 
 This guide walks you through deploying {{site.base_gateway}} with {{site.kic_product_name}} 

--- a/app/kubernetes-ingress-controller/2.1.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Kubernetes Ingress Controller
+title: Getting started with the Kong Ingress Controller
 ---
 
 ## Installation

--- a/app/kubernetes-ingress-controller/2.1.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/prometheus-grafana.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
+title: Integrate the Kong Ingress Controller with Prometheus/Grafana
 ---
 
 The {{site.kic_product_name}} can give you visibility into how {{site.base_gateway}} is performing and how the services in your Kubernetes cluster are responding to the inbound traffic.

--- a/app/kubernetes-ingress-controller/2.1.x/guides/upgrade.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/upgrade.md
@@ -6,7 +6,7 @@ This guide walks through backwards incompatible changes in the Kong Kubernetes
 Ingress Controller (KIC) to v2.1.x to help operators evaluate if any
 changes to their configuration are needed to upgrade, provides
 guidance on how to build testing environments to validate the upgrade, and
-walks through an upgrade of the Kubernetes Ingress Controller (KIC) using
+walks through an upgrade of the {{site.kic_product_name}} (KIC) using
 its [Helm Chart][chart].
 
 ## Prerequisites

--- a/app/kubernetes-ingress-controller/2.1.x/guides/using-udpingress.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/using-udpingress.md
@@ -40,7 +40,7 @@ the {{site.kic_product_name}} on your Kubernetes cluster.
 
 > **Note**: This feature is compatible with:
 > * {{site.base_gateway}} versions 2.0.0 and above.
-> * Kong Ingress Controller versions 2.0.0 and above.
+> * {{site.kic_product_name}} versions 2.0.0 and above.
 
 ## Create a namespace
 

--- a/app/kubernetes-ingress-controller/2.1.x/guides/using-udpingress.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/using-udpingress.md
@@ -23,7 +23,7 @@ DNS server Kubernetes uses for internal DNS
 * Deploy a CoreDNS `Pod` and `Service`
 * Route UDP traffic to it using `UDPIngress`
 
-This guide assumes that you've deployed the Kong Kubernetes Ingress Controller (KIC)
+This guide assumes that you've deployed the {{site.kic_product_name}} (KIC)
 using the [Helm Chart][chart]. If you have deployed the KIC in a different way, you
 may need to make some manual adjustments to some of the provided instructions.
 
@@ -225,7 +225,7 @@ DNS server outside of the cluster using Kong's `UDPIngress` resource.
 
 ## Exposing UDP Ports on Kong
 
-The Kong Kubernetes Ingress Controller (KIC) doesn't have a
+The {{site.kic_product_name}} (KIC) doesn't have a
 mechanism to automatically enable new UDP ports for exposing your
 Kubernetes UDP `Services`, so you need to explicitly configure {{site.base_gateway}} to expose
 these ports prior to deploying any `UDPIngress` resources.

--- a/app/kubernetes-ingress-controller/2.1.x/index.md
+++ b/app/kubernetes-ingress-controller/2.1.x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the {{site.base_gateway}}
 ---
 

--- a/app/kubernetes-ingress-controller/2.1.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/2.1.x/references/annotations.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller annotations
+title: Kong Ingress Controller annotations
 ---
 
 The {{site.kic_product_name}} supports the following annotations on various

--- a/app/kubernetes-ingress-controller/2.1.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/2.1.x/references/version-compatibility.md
@@ -2,7 +2,7 @@
 title: Version Compatibility
 ---
 
-Kong's Ingress Controller is compatible with different flavors of Kong.
+Kong's Kubernetes ingress controller is compatible with different flavors of Kong.
 The following sections detail on compatibility between versions for the last
 five controller versions. Compatibility for older versions is available in
 those versions' documentation.

--- a/app/kubernetes-ingress-controller/2.2.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/2.2.x/concepts/deployment.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Deployment
+title: Kong Ingress Controller Deployment
 ---
 
 The {{site.kic_product_name}} is designed to be deployed in a variety of ways

--- a/app/kubernetes-ingress-controller/2.2.x/concepts/deployment.md
+++ b/app/kubernetes-ingress-controller/2.2.x/concepts/deployment.md
@@ -192,7 +192,7 @@ loss of functionality.
 
 #### Without a database
 
-In DB-less deployments, Kong's Ingress controller runs
+In DB-less deployments, Kong's Kubernetes ingress controller runs
 alongside and dynamically configures
 Kong as per the changes it receives from the Kubernetes API server.
 

--- a/app/kubernetes-ingress-controller/2.2.x/concepts/design.md
+++ b/app/kubernetes-ingress-controller/2.2.x/concepts/design.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller Design
+title: Kong Ingress Controller Design
 ---
 
 ## Overview

--- a/app/kubernetes-ingress-controller/2.2.x/concepts/ingress-classes.md
+++ b/app/kubernetes-ingress-controller/2.2.x/concepts/ingress-classes.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller and Ingress Class
+title: Kong Ingress Controller and Ingress Class
 ---
 
 ## Introduction
@@ -130,5 +130,5 @@ referenced by other resources that do.
 
 [class-annotation]:/kubernetes-ingress-controller/{{page.kong_version}}/references/annotations/#kubernetesioingressclass
 [knative-class]:/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-kong-with-knative/#ingress-class
-[knative-override]:https://knative.tips/networking/ingress-override/
+[knative-override]:https://knative.dev/docs/serving/services/ingress-class/
 [ingress-class-name]:https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

--- a/app/kubernetes-ingress-controller/2.2.x/concepts/ingress-versions.md
+++ b/app/kubernetes-ingress-controller/2.2.x/concepts/ingress-versions.md
@@ -168,5 +168,5 @@ v1beta1 Ingresses.
 [lambda-plugin]: /hub/kong-inc/aws-lambda/
 [external-name]: https://kubernetes.io/docs/concepts/services-networking/service/#externalname
 [deprecated-annotation]: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
-[ingress-class-api]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io
+[ingress-class-api]: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/
 [rfc-2606]:https://datatracker.ietf.org/doc/html/rfc2606

--- a/app/kubernetes-ingress-controller/2.2.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/getting-started-istio.md
@@ -1,5 +1,5 @@
 ---
-title: Running the Kubernetes Ingress Controller with Istio
+title: Running the Kong Ingress Controller with Istio
 ---
 
 This guide walks you through deploying {{site.base_gateway}} with {{site.kic_product_name}} 

--- a/app/kubernetes-ingress-controller/2.2.x/guides/getting-started.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started with the Kubernetes Ingress Controller
+title: Getting started with the Kong Ingress Controller
 ---
 
 ## Installation

--- a/app/kubernetes-ingress-controller/2.2.x/guides/prometheus-grafana.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/prometheus-grafana.md
@@ -1,5 +1,5 @@
 ---
-title: Integrate the Kubernetes Ingress Controller with Prometheus/Grafana
+title: Integrate the Kong Ingress Controller with Prometheus/Grafana
 ---
 
 The {{site.kic_product_name}} can give you visibility into how {{site.base_gateway}} is performing and how the services in your Kubernetes cluster are responding to the inbound traffic.

--- a/app/kubernetes-ingress-controller/2.2.x/guides/using-udpingress.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/using-udpingress.md
@@ -40,7 +40,7 @@ the {{site.kic_product_name}} on your Kubernetes cluster.
 
 > **Note**: This feature is compatible with:
 > * {{site.base_gateway}} versions 2.0.0 and above.
-> * Kong Ingress Controller versions 2.0.0 and above.
+> * {{site.kic_product_name}} versions 2.0.0 and above.
 
 ## Create a namespace
 

--- a/app/kubernetes-ingress-controller/2.2.x/guides/using-udpingress.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/using-udpingress.md
@@ -23,7 +23,7 @@ DNS server Kubernetes uses for internal DNS
 * Deploy a CoreDNS `Pod` and `Service`
 * Route UDP traffic to it using `UDPIngress`
 
-This guide assumes that you've deployed the Kong Kubernetes Ingress Controller (KIC)
+This guide assumes that you've deployed the {{site.kic_product_name}} (KIC)
 using the [Helm Chart][chart]. If you have deployed the KIC in a different way, you
 may need to make some manual adjustments to some of the provided instructions.
 
@@ -225,7 +225,7 @@ DNS server outside of the cluster using Kong's `UDPIngress` resource.
 
 ## Exposing UDP Ports on Kong
 
-The Kong Kubernetes Ingress Controller (KIC) doesn't have a
+The {{site.kic_product_name}} (KIC) doesn't have a
 mechanism to automatically enable new UDP ports for exposing your
 Kubernetes UDP `Services`, so you need to explicitly configure {{site.base_gateway}} to expose
 these ports prior to deploying any `UDPIngress` resources.

--- a/app/kubernetes-ingress-controller/2.2.x/index.md
+++ b/app/kubernetes-ingress-controller/2.2.x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the {{site.base_gateway}}
 ---
 

--- a/app/kubernetes-ingress-controller/2.2.x/references/annotations.md
+++ b/app/kubernetes-ingress-controller/2.2.x/references/annotations.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller annotations
+title: Kong Ingress Controller annotations
 ---
 
 The {{site.kic_product_name}} supports the following annotations on various

--- a/app/kubernetes-ingress-controller/2.2.x/references/version-compatibility.md
+++ b/app/kubernetes-ingress-controller/2.2.x/references/version-compatibility.md
@@ -2,7 +2,7 @@
 title: Version Compatibility
 ---
 
-Kong's Ingress Controller is compatible with different flavors of Kong.
+Kong's Kubernetes ingress controller is compatible with different flavors of Kong.
 The following sections detail on compatibility between versions for the last
 five controller versions. Compatibility for older versions is available in
 those versions' documentation.

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -211,7 +211,7 @@ hub-filters:
 ee_product_name: Kong Enterprise
 ce_product_name: Kong Gateway (OSS)
 base_gateway: Kong Gateway
-kic_product_name: Kubernetes Ingress Controller
+kic_product_name: Kong Ingress Controller
 konnect_product_name: Kong Konnect
 konnect_short_name: Konnect
 konnect_saas: Kong Konnect

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -197,7 +197,7 @@ ee_product_name: Kong Enterprise
 ce_product_name: Kong Gateway (OSS)
 base_gateway: Kong Gateway
 set_flag_values_prefix: kuma.
-kic_product_name: Kubernetes Ingress Controller
+kic_product_name: Kong Ingress Controller
 konnect_product_name: Kong Konnect
 konnect_short_name: Konnect
 konnect_saas: Kong Konnect

--- a/spec/fixtures/app/_src/kubernetes-ingress-controller/index.md
+++ b/spec/fixtures/app/_src/kubernetes-ingress-controller/index.md
@@ -1,4 +1,4 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the Kong Gateway
 ---

--- a/spec/fixtures/app/kubernetes-ingress-controller/2.1.x/index.md
+++ b/spec/fixtures/app/kubernetes-ingress-controller/2.1.x/index.md
@@ -1,4 +1,4 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the {{site.base_gateway}}
 ---

--- a/spec/fixtures/app/kubernetes-ingress-controller/2.2.x/index.md
+++ b/spec/fixtures/app/kubernetes-ingress-controller/2.2.x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Ingress Controller
+title: Kong Ingress Controller
 subtitle: An ingress controller for the {{site.base_gateway}}
 ---
 


### PR DESCRIPTION
### Description

Renaming Kubernetes Ingress Controller to Kong Ingress Controller to satisfy CNCF requirements.
https://konghq.atlassian.net/browse/DOCU-3164

### Testing instructions

Netlify link: https://kic-rename--kongdocs.netlify.app/kubernetes-ingress-controller/latest/

Had to enable a branch preview, as the previous (overwritten) redirect changes weren't working correctly, even with a deploy cache clear.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

