### PR TITLE
[DOCU-3232] Plugin hub home icon

### DIFF
--- a/app/_assets/images/icons/documentation/hub/icn-breadcrumbs.svg
+++ b/app/_assets/images/icons/documentation/hub/icn-breadcrumbs.svg
@@ -1,8 +1,8 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_442_2950" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
-<rect width="20" height="20" fill="#D9D9D9"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_886_4635" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<rect width="24" height="24" fill="#D9D9D9"/>
 </mask>
-<g mask="url(#mask0_442_2950)">
-<path d="M3 9V3H9V9H3ZM3 17V11H9V17H3ZM11 9V3H17V9H11ZM11 17V11H17V17H11ZM4.5 7.5H7.5V4.5H4.5V7.5ZM12.5 7.5H15.5V4.5H12.5V7.5ZM12.5 15.5H15.5V12.5H12.5V15.5ZM4.5 15.5H7.5V12.5H4.5V15.5Z" fill="white"/>
+<g mask="url(#mask0_886_4635)">
+<path d="M6 19H9V13H15V19H18V10L12 5.5L6 10V19ZM4 21V9L12 3L20 9V21H13V15H11V21H4Z" fill="white"/>
 </g>
 </svg>


### PR DESCRIPTION
### Description

Changing the home icon in plugin hub breadcrumbs to something clearer, as we had multiple people be confused about the previous one.

https://konghq.atlassian.net/browse/DOCU-3232

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

