### PR TITLE
Remove merge conflict from datadog plugin

### DIFF
--- a/app/_hub/kong-inc/datadog/_index.md
+++ b/app/_hub/kong-inc/datadog/_index.md
@@ -18,7 +18,6 @@ the `config` parameter section of the plugin.
 
 ---
 
->>>>>>> ce6fc59bed (Reworked plugin queues (#5088))
 ## Metrics
 The Datadog plugin currently logs the following metrics to the Datadog server about a service or route.
 


### PR DESCRIPTION
### Description

There was some invalid markdown from a merge conflict present on the file causing the page to render a weird-looking section.

Before:

<img width="1752" alt="Screenshot 2023-06-01 at 11 12 34" src="https://github.com/Kong/docs.konghq.com/assets/715229/02df1f7e-c4c1-40db-b03f-6f334d4fa365">

After:
<img width="1584" alt="Screenshot 2023-06-01 at 12 23 06" src="https://github.com/Kong/docs.konghq.com/assets/715229/e5fa46d4-a07e-4b3e-8178-da1674dc1585">


### Testing instructions

Netlify link: https://deploy-preview-5655--kongdocs.netlify.app/hub/kong-inc/datadog/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

