### PR TITLE
Fix referenceable fields table

### DIFF
--- a/app/_plugins/tags/referenceable_fields/table_tag.rb
+++ b/app/_plugins/tags/referenceable_fields/table_tag.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Jekyll
+  class ReferenceableFieldsTable < Liquid::Tag
+    def render(context) # rubocop:disable Metrics/AbcSize
+      environment = context.environments.first
+
+      super
+
+      version = context.environments.first['page']['kong_version']
+      hub = context.registers[:site].data['ssg_hub']
+
+      @referenceable_fields = ReferenceableFields.run(version:, hub:)
+
+      template_file = File.read(File.expand_path('table_template.erb', __dir__))
+      template = ERB.new(template_file)
+      template.result(binding)
+    end
+  end
+
+  class ReferenceableFields
+    FILES_PATH = 'app/_src/.repos/kong-plugins/data/referenceable_fields/'
+
+    def self.run(version:, hub:)
+      new(version:, hub:).run
+    end
+
+    def initialize(version:, hub:)
+      @version = version
+      @hub = hub
+    end
+
+    def run
+      referenceable_fields.each_with_object({}) do |(slug, fields), result|
+        page = plugin_page(slug)
+
+        next unless page
+
+        result[slug] = [page.data['name'], fields]
+      end
+    end
+
+    def referenceable_fields
+      @referenceable_fields ||= JSON.parse(
+        File.read(File.join(FILES_PATH, "#{@version}.json"))
+      )
+    end
+
+    def plugin_page(slug)
+      @hub.detect { |plugin| plugin.data['extn_slug'] == slug }
+    end
+  end
+end
+
+Liquid::Template.register_tag('referenceable_fields_table', Jekyll::ReferenceableFieldsTable)

--- a/app/_plugins/tags/referenceable_fields/table_template.erb
+++ b/app/_plugins/tags/referenceable_fields/table_template.erb
@@ -23,4 +23,4 @@
 
 {:.note}
 > **Note**: The Vault plugin interacts with the `vaults` and `vault_credentials` entities.
-For these entities, the <code>vaults.vault_token</code> and <code>vault_credentials.secret_token</code>  parameters are referenceable
+For these entities, the <code>vaults.vault_token</code> and <code>vault_credentials.secret_token</code> parameters are referenceable.

--- a/app/_plugins/tags/referenceable_fields/table_template.erb
+++ b/app/_plugins/tags/referenceable_fields/table_template.erb
@@ -1,0 +1,26 @@
+<% if @referenceable_fields %>
+ <table>
+   <thead>
+       <th>Plugin</th>
+       <th>Referenceable fields</th>
+   </thead>
+   <tbody>
+     <% @referenceable_fields.each do |plugin_slug, (plugin_name, fields)| %>
+       <tr>
+         <td>
+           <a href="/hub/kong-inc/<%= plugin_slug %>/configuration/"><%= plugin_name %></a>
+         </td>
+         <td>
+           <% fields.each do |field| %>
+             <code><%= field %></code>
+           <% end %>
+         </td>
+       </tr>
+     <% end %>
+   </tbody>
+ </table>
+<% end %>
+
+{:.note}
+> **Note**: The Vault plugin interacts with the `vaults` and `vault_credentials` entities.
+For these entities, the <code>vaults.vault_token</code> and <code>vault_credentials.secret_token</code>  parameters are referenceable

--- a/app/_src/gateway/kong-enterprise/secrets-management/index.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/index.md
@@ -77,43 +77,7 @@ vault backend. These fields are labelled as `referenceable`.
 The following plugins support vault references for specific fields. 
 See each plugin's documentation for more information on each field:
 
-{% assign hub = site.data.ssg_hub %}
-{% assign kong_extns = hub | where: "publisher", "Kong Inc." %}
-
-<table>
-  <thead>
-      <th>Plugin</th>
-      <th>Referenceable fields</th>
-  </thead>
-  <tbody>
-    {% for extn in kong_extns %}
-    {% assign ref = extn.params.config | find: "referenceable", "true" %}
-    {% if ref %}
-      <tr>
-        <td>
-          <a href="{{extn.url}}">{{ extn.name }}</a>
-        </td>
-        <td> 
-          {% for c in extn.params.config %}
-            {% if c.referenceable == true %}
-            <code>{{ c.name }}</code>
-            {% endif %}
-          {% endfor %}
-        </td>
-      </tr>
-      {% endif %}
-    {% endfor %}
-    <tr>
-      <td>
-        <a href="/hub/kong-inc/vault-auth/">Vault Authentication</a>
-      </td>
-      <td> 
-        <code>vaults.vault_token</code>
-        <code>vault_credentials.secret_token</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
+{% referenceable_fields_table %}
 
 ## Supported backends
 

--- a/spec/app/_plugins/tags/referenceable_fields_spec/table_tag_spec.rb
+++ b/spec/app/_plugins/tags/referenceable_fields_spec/table_tag_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe Jekyll::ReferenceableFieldsTable do
+  let(:version) { '3.2.x' }
+  let(:hub) do
+    [
+      instance_double('PluginSingleSource::SingleSourcePage', data: { 'extn_slug' => 'aws-lambda', 'name' => 'AWS Lambda' } ),
+      instance_double('PluginSingleSource::SingleSourcePage', data: { 'extn_slug' => 'datadog', 'name' => 'Datadog' } )
+    ]
+  end
+
+  let(:json) do
+    <<~JSON
+          {
+            "aws-lambda": [
+              "config.aws_key",
+              "config.aws_secret",
+              "config.aws_assume_role_arn"
+            ],
+            "datadog": [
+              "config.host"
+            ]
+          }
+    JSON
+  end
+
+  before do
+    allow(File).to receive(:read).and_call_original
+
+    expect(File)
+      .to receive(:read)
+      .with('app/_src/.repos/kong-plugins/data/referenceable_fields/3.2.x.json')
+      .and_return(json)
+  end
+
+  describe '#render' do
+    let(:site) { OpenStruct.new('data' => { 'ssg_hub' => hub }) }
+    let(:page) { { 'kong_version' => '3.2.x' } }
+    let(:environment) { { 'page' => page } }
+    let(:liquid_context) { Liquid::Context.new(environment, {}, site: site) }
+    let(:tag) do
+      described_class.parse(
+        'referenceable_fields_table',
+        '',
+        Liquid::Tokenizer.new(''),
+        Liquid::ParseContext.new
+      )
+    end
+
+    subject { Capybara::Node::Simple.new(tag.render(liquid_context)) }
+
+    it 'renders a table listing all the plugins that have referenceable fields' do
+      expect(subject).to have_css('thead th', text: 'Plugin')
+      expect(subject).to have_css('thead th', text: 'Referenceable fields')
+
+      aws_lambda = subject.find('tbody tr:nth-of-type(1)')
+      expect(aws_lambda).to have_link('AWS Lambda', href: '/hub/kong-inc/aws-lambda/configuration/')
+      expect(aws_lambda).to have_css('td', text: 'config.aws_key config.aws_secret config.aws_assume_role_arn', normalize_ws: true)
+
+      datadog = subject.find('tbody tr:nth-of-type(2)')
+      expect(datadog).to have_link('Datadog', href: '/hub/kong-inc/datadog/configuration/')
+      expect(datadog).to have_css('td', text: 'config.host', normalize_ws: true)
+    end
+
+    it 'reders a note about the vault plugin' do
+      expect(subject).to have_content('The Vault plugin interacts with the `vaults` and `vault_credentials` entities.')
+    end
+  end
+
+  describe Jekyll::ReferenceableFields do
+    describe '.run' do
+      subject { described_class.run(version:, hub:) }
+
+      it 'returns a hash with the plugin\'s referenceable fields' do
+        expect(subject).to eq({
+          'aws-lambda' => ['AWS Lambda', ['config.aws_key', 'config.aws_secret', 'config.aws_assume_role_arn']],
+          'datadog' => ['Datadog', ['config.host']]
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

What did you change and why?

Use the newly generated file containing all the plugins that have referenceable fields + the corresponding fields to render the `Referenceable fields` table. It was manually generated/maintained until now.
This will keep the table up to date with the schemas.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

