### PR TITLE
Customize netlify's lighthouse plugin to run on specific pages

### DIFF
--- a/app/_includes/plugins/header.html
+++ b/app/_includes/plugins/header.html
@@ -13,7 +13,7 @@
       <ul class="breadcrumbs install">
         <li class="breadcrumb-item">
           <a href="/hub/">
-            <img src="/assets/images/icons/documentation/hub/icn-breadcrumbs.svg">
+            <img src="/assets/images/icons/documentation/hub/icn-breadcrumbs.svg" alt="Plugin Hub icon">
           </a>
         </li>
         {% for breadcrumb in include.breadcrumbs %}

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,9 @@
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
 
+  [plugins.inputs]
+    run_on_success = "true"
+
   [plugins.inputs.settings]
     preset = "desktop"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,6 +22,12 @@
     path = "hub"
 
   [[plugins.inputs.audits]]
+    path = "hub/kong-inc/jwt-signer/"
+
+  [[plugins.inputs.audits]]
+    path = "hub/kong-inc/jwt-signer/configuration/"
+
+  [[plugins.inputs.audits]]
     path = "gateway/latest/"
 
   [[plugins.inputs.audits]]
@@ -35,3 +41,6 @@
 
   [[plugins.inputs.audits]]
     path = "kubernetes-ingress-controller/latest/"
+
+  [[plugins.inputs.audits]]
+    path = "konnect/analytics/use-cases/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,27 @@
 
 [dev]
   autoLaunch = false
+
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+
+  [plugins.inputs.settings]
+    preset = "desktop"
+
+  [[plugins.inputs.audits]]
+    path = "hub"
+
+  [[plugins.inputs.audits]]
+    path = "gateway/latest/"
+
+  [[plugins.inputs.audits]]
+    path = "konnect"
+
+  [[plugins.inputs.audits]]
+    path = "mesh/latest/"
+
+  [[plugins.inputs.audits]]
+    path = "deck/latest/"
+
+  [[plugins.inputs.audits]]
+    path = "kubernetes-ingress-controller/latest/"


### PR DESCRIPTION
### Description

Run lighthouse against each product landing page.
We can keep an eye on this and add thresholds to make the build fail if the changes made generate a bad score

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

