### PR TITLE
doc: add documentation for limits on configuration resources

### DIFF
--- a/app/konnect/runtime-manager/configuration/index.md
+++ b/app/konnect/runtime-manager/configuration/index.md
@@ -125,3 +125,34 @@ With **Keys**, you can centrally store and easily access key sets and keys in {{
 * PEM
 
 To learn more about the details of this feature, reference the [{{site.base_gateway}} key reference documentation](/gateway/latest/reference/key-management/). The {{site.konnect_short_name}} keys feature is built using {{site.base_gateway}} ability to manage keys, the documentation available can serve as a reference for both {{site.base_gateway}} and {{site.konnect_short_name}}.
+
+## Configuration limits
+
+The following limits apply to each runtime group for the configuration resources:
+
+| Resource Name | Limit |
+| --- | --- |
+| Access Control List | 50,000 |
+| Asymmetric Key | 1,000 |
+| Asymmetric KeySet | 1,000 |
+| Basic Authentication | 50,000 |
+| Certificate Authority Certificate | 1,000 |
+| Certificate | 1,000 |
+| Consumer | 50,000 |
+| Consumer Group | 1,000 |
+| Consumer Group Rate Limiting Advanced Configuration | 1,000 |
+| Custom Plugins | 100 |
+| Data Plane Client Certificate | 32 |
+| DeGraphQL Route | 1,000 |
+| GraphQL Rate Limiting Cost Decoration | 1,000 |
+| Hash-based Message Authentication | 50,000 |
+| JSON Web Token | 50,000 |
+| Key (API Key) Authentication | 50,000 |
+| Mutual Transport Layer Security Authentication | 50,000 |
+| Plugin Configuration | 10,000 |
+| Route | 10,000 |
+| Server Name Indication | 1,000 |
+| Service | 10,000 |
+| Target | 10,000 |
+| Upstream | 10,000 |
+| Vault | 1,000 |

--- a/app/konnect/runtime-manager/configuration/index.md
+++ b/app/konnect/runtime-manager/configuration/index.md
@@ -128,9 +128,9 @@ To learn more about the details of this feature, reference the [{{site.base_gate
 
 ## Configuration limits
 
-The following limits apply to each runtime group for the configuration resources:
+The following entity resource limits apply to each runtime group for the configuration:
 
-| Resource Name | Limit |
+| Resource name | Entity resource limit |
 | --- | --- |
 | Access Control List | 50,000 |
 | Asymmetric Key | 1,000 |


### PR DESCRIPTION
### Description

What did you change and why?
 
This update adds new documentation around the limits for each resource within a runtime group. These limits are per runtime group and not global to the organization.

Jira: [KOKO-960](https://konghq.atlassian.net/browse/KOKO-960)

### Testing instructions

Netlify link: https://deploy-preview-5658--kongdocs.netlify.app/konnect/runtime-manager/configuration/#configuration-limits


### Checklist 

- [X] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->



[KOKO-960]: https://konghq.atlassian.net/browse/KOKO-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ