### PR TITLE
Doc: Fix HIT section in proxy-cache doc.

### DIFF
--- a/app/_src/gateway/get-started/proxy-caching.md
+++ b/app/_src/gateway/get-started/proxy-caching.md
@@ -109,7 +109,7 @@ will potentially be cached.
    |State| Description                                                                                                                                          |
    |---|------------------------------------------------------------------------------------------------------------------------------------------------------|
    |Miss| The request could be satisfied in cache, but an entry for the resource was not found in cache, and the request was proxied upstream.                 |
-   |Hit| The request was satisifed and served from the cache.                                                                                                 |
+   |Hit| The request was satisfied and served from the cache.                                                                                                 |
    |Refresh| The resource was found in cache, but could not satisfy the request, due to Cache-Control behaviors or reaching its hard-coded `cache_ttl` threshold. |
    |Bypass| The request could not be satisfied from cache based on plugin configuration.                                                                         |
 

--- a/app/_src/gateway/get-started/proxy-caching.md
+++ b/app/_src/gateway/get-started/proxy-caching.md
@@ -106,12 +106,12 @@ will potentially be cached.
 
    The `X-Cache-Status` headers can return the following cache results:
 
-   |State| Description|
-   |---|---|
-   |Miss| The request could be satisfied in cache, but an entry for the resource was not found in cache, and the request was proxied upstream.|
-   |Hit| The request could be satisfied in cache, but an entry for the resource was not found in cache, and the request was proxied upstream.|
-   |Refresh| The resource was found in cache, but could not satisfy the request, due to Cache-Control behaviors or reaching its hard-coded `cache_ttl` threshold.|
-   |Bypass| The request could not be satisfied from cache based on plugin configuration.|
+   |State| Description                                                                                                                                          |
+   |---|------------------------------------------------------------------------------------------------------------------------------------------------------|
+   |Miss| The request could be satisfied in cache, but an entry for the resource was not found in cache, and the request was proxied upstream.                 |
+   |Hit| The request was satisifed and served from the cache.                                                                                                 |
+   |Refresh| The resource was found in cache, but could not satisfy the request, due to Cache-Control behaviors or reaching its hard-coded `cache_ttl` threshold. |
+   |Bypass| The request could not be satisfied from cache based on plugin configuration.                                                                         |
 
 ### Service level proxy caching
 


### PR DESCRIPTION
### Description

What did you change and why?
The `HIT` section in the proxy-cache doc was wrong and contained the same content as the `MISS` section. Fix the content  in the `HIT` section.
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

