### PR TITLE
Update systemd.md

### DIFF
--- a/app/_src/gateway/production/running-kong/systemd.md
+++ b/app/_src/gateway/production/running-kong/systemd.md
@@ -81,7 +81,7 @@ sudo systemctl status kong
 The official systemd service is located at `/lib/systemd/system/kong-enterprise-edition.service` for
 {{site.base_gateway}}, or at `/lib/systemd/system/kong.service` for {{site.ce_product_name}}.
 
-## Add a sample systemd service file for reference
+Note that the official Kong systemd service doesn't set `user` or `group` as `root`, which is required to run the system file. See the example below with both `user` and `group` both set to `root`:
 
 ```
 [Unit]

--- a/app/_src/gateway/production/running-kong/systemd.md
+++ b/app/_src/gateway/production/running-kong/systemd.md
@@ -81,6 +81,35 @@ sudo systemctl status kong
 The official systemd service is located at `/lib/systemd/system/kong-enterprise-edition.service` for
 {{site.base_gateway}}, or at `/lib/systemd/system/kong.service` for {{site.ce_product_name}}.
 
+## Add a sample systemd service file for reference
+
+```
+[Unit]
+Description=Kong Enterprise Edition
+Documentation=https://docs.konghq.com/enterprise/
+After=syslog.target network.target remote-fs.target nss-lookup.target
+[Service]
+User=root
+Group=root
+ExecStartPre=/usr/local/bin/kong prepare -p /usr/local/kong -c /home/ec2-user/kong.conf
+ExecStart=/usr/local/openresty/nginx/sbin/nginx -p /usr/local/kong -c nginx.conf
+ExecReload=/usr/local/bin/kong prepare -p /usr/local/kong
+ExecReload=/usr/local/openresty/nginx/sbin/nginx -p /usr/local/kong -c nginx.conf -s reload
+ExecStop=/bin/kill -s QUIT $MAINPID
+PrivateTmp=true
+# All environment variables prefixed with KONG_ and capitalized will override
+# the settings specified in the /etc/kong/kong.conf.default file.
+#
+# For example:
+#   log_level = debug in the .conf file -> KONG_LOG_LEVEL=debug env var.
+Environment=KONG_NGINX_DAEMON=off
+# You can control this limit through /etc/security/limits.conf
+LimitNOFILE=infinity
+[Install]
+WantedBy=multi-user.target
+```
+
+
 For scenarios where customizations are needed (for example, configuring Kong
 or modifying the service file behavior), we recommend creating another service
 at `/etc/systemd/system/kong-enterprise-edition.service` for


### PR DESCRIPTION
### Description

What did you change and why?

I got an error with the default systemd file. The issue is that we need to add on the user and group as root (2 additional lines) to run the system file. I have added an example here. 

The next question of how to run as non-root will be raised. Understand that we do have a doc here: https://docs.konghq.com/gateway/latest/production/running-kong/kong-user/, but the important note is sending mixed signal that Kong can be only run as root. Requesting for engineering team to work on a tested solution to run Kong without root - that will be more palatable to users who are more concerned with security

 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

