### PR TITLE
Remove links to doc-assets

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -489,7 +489,7 @@ jQuery(function () {
    * {% include_cached image-modal.html disable_image_expand=page.disable_image_expand %}
    *
    * To disable for a specific img tag add 'no-image-expand' class. Example:
-   * <img class="install-icon no-image-expand" src="https://doc-assets.konghq.com/install-logos/docker.png" alt="docker" />
+   * <img class="install-icon no-image-expand" src="/assets/images/docs/install-logos/docker.png" alt="docker" />
    *
    * To disable for whole page you can add 'disable_image_expand: true' to page Front Matter block. Example:
    * ---

--- a/app/enterprise/2.1.x/deployment/installation/overview.md
+++ b/app/enterprise/2.1.x/deployment/installation/overview.md
@@ -8,7 +8,7 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
     <div class="install-description">Install the Kong Ingress Controller with the Kong Gateway (Enterprise) on AWS</div>
   </a>
@@ -71,17 +71,17 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/B084L6PQPY?ref_=srh_res_product_title" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
   </a>
 
   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongee2020ubuntuxenial?tab=Overview" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
+    <img class="install-icon" src="/assets/images/icons/documentation/azure.svg" alt="Azure" />
     <div class="install-text">Azure</div>
   </a>
 
@@ -91,7 +91,7 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <img class="install-icon" src="/assets/images/icons/documentation/rhel.jpg" alt="Red Hat Marketplace" />
     <div class="install-text">Red Hat</div>
   </a>
 

--- a/app/enterprise/2.1.x/deployment/installation/overview.md
+++ b/app/enterprise/2.1.x/deployment/installation/overview.md
@@ -14,7 +14,7 @@ disable_image_expand: true
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/docker" class="docs-grid-install-block">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/docker.png" alt="docker" />
+    <img class="install-icon" src="/assets/images/icons/documentation/docker.png" alt="docker" />
     <div class="install-text">Docker</div>
     <div class="install-description">Install Kong Enterprise on Docker</div>
   </a>
@@ -40,22 +40,22 @@ disable_image_expand: true
 {% navtab Operating Systems %}
 <div class="docs-grid-install">
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/centos" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/centos.gif" alt="centos" />
+    <img class="install-icon" src="/assets/images/icons/documentation/centos.gif" alt="centos" />
     <div class="install-text">CentOS</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 1</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux-2" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 2</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/ubuntu" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/ubuntu.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/ubuntu.png" alt="aws" />
     <div class="install-text">Ubuntu</div>
   </a>
 

--- a/app/enterprise/2.1.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/enterprise/2.1.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -17,18 +17,8 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 
-![Appearance Tab](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab.png)
-
-The predefined variables refer to the following elements:
-
-![Appearance Tab - Variables](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-arrows.png)
-
-Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file
-
-![Appearance Tab - Color Picker](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab-variable-hover.png)
+Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file.
 
 ## Editing Theme Files with the Editor
 
 The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/enterprise/{{page.kong_version}}/developer-portal/using-the-editor/) for more information on how to edit, preview, and save files in the Editor.
-
-![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/enterprise/2.1.x/developer-portal/theme-customization/emails.md
+++ b/app/enterprise/2.1.x/developer-portal/theme-customization/emails.md
@@ -104,9 +104,7 @@ Email templates can now be edited in the Portal Editor along with the rest of th
 1. Log into Kong Manager and navigate to the Workspace whose Dev Portal you wish to edit.
 2. Select the **Editor** from the sidebar under **Dev Portal**.
 
-The email templates can be found under the **Emails** section in the Portal Editor sidebar:
-
-![Portal Editor - Emails](https://doc-assets.konghq.com/1.3/dev-portal/editor/dev-portal-emails.png)
+The email templates can be found under the **Emails** section in the Portal Editor sidebar.
 
 ### Editing via the Portal CLI Tool
 

--- a/app/enterprise/2.1.x/developer-portal/using-the-editor.md
+++ b/app/enterprise/2.1.x/developer-portal/using-the-editor.md
@@ -6,8 +6,6 @@ title: Using the Editor
 
 Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
-![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
-
 ### Prerequisites
 
 * Kong Enterprise 1.3 or later
@@ -20,14 +18,7 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
-![Launch Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-sidebar-button.png)
-
-
-This will launch the **Editor Mode**:
-
-![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
-
-
+This will launch the **Editor Mode**.
 
 
 ### Navigating the Editor
@@ -40,21 +31,13 @@ When enabled, the Dev Portal is pre-populated with Kong's default theme. The fil
 4. Portal Preview - View a live preview of the selected Dev Portal file.
 5. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
 
-![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
-
 ### Editing Files
 
 Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
-![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
-
-
-
 ### Adding new files
 
 Clicking the `New File +` button opens the New File Dialog.
-
-![Add New File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-new-file.png)
 
 Once created, files will immediately be available from within the Editor.
 
@@ -72,5 +55,3 @@ Authentication is handled by `readable_by` value on content pages (for gui view,
 To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
 
 **NOTE:** This action cannot be undone.
-
-![Deleting Files](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-delete-file.png)

--- a/app/enterprise/2.1.x/kong-manager/add-service.md
+++ b/app/enterprise/2.1.x/kong-manager/add-service.md
@@ -30,33 +30,24 @@ access to **Kong Manager**
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Services** tab under **API Gateway**.
 
-    ![Service Page](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/01-service-page.png)
-
 2. Click the **New Service** button to open the **Create Service** dialog.
 Fill in a **Name** and a **URL** for the **Service**.<br/><br/>For example, set the
 name to `test-service` with the URL `http://mockbin.org`.
 
-    ![Create Service Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/02-service-name.png)
 <br/><br/>Kong Manager also allows **Services** to be configured using **Protocol**,
 **Host**, **Path**, and **Port** (optional). To configure the **Service** using
 this method, click the **Add using Protocol, Host, and Path** option.
 
-    ![Configure Using Protocol](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/03-service-protocol.png)  
 <br/>In addition, Kong Manager exposes several **Advanced Fields**
 and their default configuration values: <br/>`Retries: 5`<br/>
 `Connect Timeout: 60000` (in ms)<br/>`Write Timeout: 60000` (in ms)<br/>
 `Read Timeout: 60000` (in ms)<br/><br/>Adjusting these values is optional and can be
 edited later.
 
-    ![Advanced Fields](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/04-service-advanced-fields.png)
-
-
 3. Create the **Service** by clicking the **Create** button.<br/><br/>If successful, you are automatically redirected to the
 **Service's Overview** page.<br/><br/>The **Service Overview** page displays
 information and **Activity** on the **Service**, as well as any **Routes** or
 **Plugins** that have been connected to the **Service**.
-
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/05-service-overview.png)
 
 
 ### Step 2 - Create a New Route attached to the Service
@@ -65,13 +56,10 @@ information and **Activity** on the **Service**, as well as any **Routes** or
 [Step 1](#step-1---create-a-new-service), click the **Create New Route** button
 located in the **Routes** tab at the bottom of the page.
 
-    ![Create Route Service ID](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/06-service-route-object.png)
-
 2. To create a **Route** you must provide the **Service** `name` and `id`, this
 will be automatically filled out if the form was accessed via the
 **Service Overview** page.
 
-    ![Step 7](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/07-route-service-id.png)
 <br/><br/>If this field is not automatically filled, the **Service Id** can be
 found via the **Services Overview** page, accessed by clicking on the **Services**
 tab on the side navigation and then clicking the **clipboard** icon next to the
@@ -82,13 +70,9 @@ desired **Service's Id** field.
 name the **Route** `test-route` with the **Host** `example.com`. Once completed,
 click **Create Route**.
 
-    ![Create Route Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/08-route-form-example.png)
-
 4. If created successfully, the page will be automatically redirected back to
 the **Service Overview** page, and the new **Route** will now appear under the
 **Routes** tab.
-
-    ![Completed Route](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/10-completed-route.png)
 
 ### Step 3 - Test the new Service and Route
 

--- a/app/enterprise/2.1.x/kong-manager/administration/admins/invite.md
+++ b/app/enterprise/2.1.x/kong-manager/administration/admins/invite.md
@@ -34,8 +34,6 @@ invitation, they will only be able to log in with that email address. Assign the
 
 4. On the **Teams** page, the new invitee will appear on the **Admins** list with the under **Invited**. Once they accept the invitation, the user will be listed in the main **Admins** list. 
 
-    ![Invited Admins](https://doc-assets.konghq.com/1.3/manager/teams/teams-invited-admin.png)
-
 5. The newly invited **Admin** will have the ability to set a password. If the **Admin** ever forgets the password, it is possible for them to reset it through a recovery email.
 
 
@@ -47,8 +45,6 @@ If a mail server is not yet set up, it is still possible to invite Admins to reg
 
 2. If the "View" link is clicked next to the invited Admin's name, a 
     `register_url` is displayed on the invitee's details page. 
-
-    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
 
 3. Copy and directly send this link to the invited Admin so that they may set 
     up their credentials and log in. 

--- a/app/enterprise/2.1.x/kong-manager/administration/rbac/index.md
+++ b/app/enterprise/2.1.x/kong-manager/administration/rbac/index.md
@@ -50,8 +50,6 @@ mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**:
 
 These roles can be viewed in the **Teams** tab under **Roles**
 
-![Default Roles in New Workspaces](https://doc-assets.konghq.com/1.3/manager/teams/kong-manager-default-roles.png)
-
 ⚠️ **IMPORTANT**: Any Role assigned in the **Default Workspace** will have
 **Permissions** applied to all subsequently created **Workspaces**. A **Super Admin** in
 in `default` has RBAC **Permissions** across all **Workspaces**.

--- a/app/enterprise/2.1.x/kong-manager/enable-plugin.md
+++ b/app/enterprise/2.1.x/kong-manager/enable-plugin.md
@@ -26,21 +26,15 @@ Plugin via the command line, checkout the
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Plugins** tab under **API Gateway**.
 
-    ![Plugins Tab](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/01-plugin-tab.png)
-
 2. Click the **Add New Plugin** button to open the **Plugins** page, which lists
 all the **Kong Enterprise** bundled **Plugins** available.
 <br/><br/>Scroll to the **Traffic Control** section and select **Rate Limiting EE**.
 
-    ![Rate Limiting EE](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/02-rate-limiting.png)
 <br/><br/>This will open the **Plugin Configuration** form for **Rate Limiting EE**.
 
-    ![Configuration Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/03-plugin-form.png)
 <br/>Note that the **Plugin** will automatically be enabled when the form is
 submitted. Toggle the **This plugin is Enabled** button at the top of the form
 to configure the **Plugin** without enabling it.
-
-    ![Toggle Enable](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/04-toggle-enable.png)
 
 3. Define the **Plugin** as *global* or *scoped*.
 <br/><br/>*Global* will apply the **Plugin** to *every* **Service** and
@@ -49,9 +43,6 @@ to configure the **Plugin** without enabling it.
 **Consumer**.
 <br/><br/>To use this option, select the **Scoped** radio button and select the
 desired **Service**, **Route**, or **Consumer** from the dropdown.
-
-    ![Connect test-service](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/05-global-scoped.png)
-
 
 4. Fill out the **configuration** form.<br/><br/>For **Rate Limiting EE** the
 following fields are *required*:<br/>-`config.limit`<br/>-`config.sync_rate`<br/>
@@ -69,9 +60,6 @@ enable the **Plugin**. If it is successful, the page will automatically
 redirect to the **Plugin Overview**, with the **Rate Limiting** Plugin
 listed.
 
-    ![Plugin Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/06-plugin-overview.png)
 <br/><br/>If the **Plugin** is *scoped* to a **Service**, **Route**, or
 **Consumer**, the **Plugin** will also be listed on that object's **Overview**
 page.
-
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/07-service-plugin-table.png)

--- a/app/enterprise/2.1.x/kong-manager/overview.md
+++ b/app/enterprise/2.1.x/kong-manager/overview.md
@@ -11,5 +11,3 @@ Here are some of the things you can do with Kong Manager:
 * Activate or deactivate plugins with a couple of clicks.
 * Group your teams, services, plugins, consumer management, and everything else exactly how you want them.
 * Monitor performance: visualize cluster-wide, workspace-level, or even object-level health using intuitive, customizable dashboards.
-
-![Welcome to Kong Manager](https://doc-assets.konghq.com/1.3/manager/kong-manager-workspaces-overview.png)

--- a/app/enterprise/2.1.x/plugins/oidc-cognito.md
+++ b/app/enterprise/2.1.x/plugins/oidc-cognito.md
@@ -11,28 +11,16 @@ In this configuration, we use User Pools.
 1. Log in to AWS Console.
 1. Navigate to the Amazon Cognito Service.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito1.png">
-
 1. Click on **Manage User Pools**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito2.png">
 
 1. Click the **Create a user pool** button on the right-hand side.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito3.png">
-
 1. Enter a pool name; we use “test-pool” for this example.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito4.png">
-
 1. Click **Step Through Settings**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito5.png">
     
 1. Select **Email address or phone number**, and under that, select **Allow email addresses**. Select the following standard attributes as required: email, family name, given name.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito6.png">
-    
 1. Click **Next step**.
 1. Accept the defaults for **Password settings**, then click **Next step**.
 1. Accept the defaults for **MFA and verifications**, then click **Next step**.
@@ -42,12 +30,8 @@ In this configuration, we use User Pools.
 1. We can create an application definition later. Keep things simple for now and click **Next step**.
 1. We don’t have any need for Triggers or customized Sign Up/Sign In behavior for this example. Scroll down and click **Save Changes**.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito7.png">
-
 1. Click **Create pool**. Wait a moment for the success message.
 1. Make a note of the **Pool ID**. You will need this when configuring the application later.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito8.png">
 
 ## Application Definition
 
@@ -55,60 +39,36 @@ You need to add an OAuth2 application definition to the User Pool we just create
 
 1. Go to the App clients screen in the AWS Cognito management screen for the User Pool we just created.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito9.png">
-
 1. Click “Add an app client”.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito10.png">
-
-1. Enter an App client name. This demo is using “kong-api”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito11.png">
+1. Enter an App client name. This demo is using “kong-api”.
     
 1. Enter a Refresh token expiration (in days). We will use the default of 30 days.
 1. Do not select “Generate client secret”. This example will use a public client.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito12.png">
     
 1. Do not select any other checkboxes.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito13.png">
     
 1. Click the “Set attribute read and write permissions” button.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito14.png">
     
 1. Let’s make this simple and only give the user read and write access to the required attributes. So, uncheck everything except the email, given name, and family name fields.
-    
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito15.png">
-    
+
 1. Click “Create app client”
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito16.png">
-
 1. Click “Show Details”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito17.png">
 
 1. Take note of the App client ID. We will need that later.
 1. Go to the App integration -> App client settings screen.
 1. Click the “Cognito User Pool” checkbox under Enabled Identity Providers.
 1. Add “https://kong-ee:8446/default, https://kong-ee:8447/default/, https://kong-ee:8447/default/auth, https://kong-ee:8443/cognito” to the Callback URLs field. Note that AWS Cognito doesn’t support HTTP callback URLs. This field should include the API and Dev Portal URLs that you want to secure using AWS Cognito.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito18.png">
-
 1. Click the “Authorization code grant” checkbox under Allowed OAuth Flows.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito19.png">
-    
 1. Click the checkboxes next to email, OpenID, aws.cognito.signin.user.admin, and profile.
 1. Click the “Save changes” button.
 1. Click on the domain name tab.
 1. Add a sub-domain name.
 1. Click the Check Availability button.
 1. As long as it reports “This domain is available”, the name you have chosen will work.
-    
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito21.png">
     
 1. Click the “Save changes” button.
 

--- a/app/enterprise/2.1.x/plugins/oidc-google.md
+++ b/app/enterprise/2.1.x/plugins/oidc-google.md
@@ -58,7 +58,7 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service

--- a/app/enterprise/2.1.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.1.x/plugins/oidc-okta.md
@@ -126,7 +126,7 @@ Claim value is set in the Authorization server and its name matches the value of
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/kong-manager/enable-plugin/

--- a/app/enterprise/2.1.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.1.x/plugins/oidc-okta.md
@@ -30,41 +30,21 @@ as an authorized redirect URI in Okta (under the **Authentication** section of y
 
 1. [Register an Application][okta-register-app]. Select the **Applications** page, click **Add Application**.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/01-add-application.png">
-
 2. Select **Web** as the platform.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/02-web-app.png">
 
 3. Fill out the Application's Settings.
 
     **Login re-direct URIs** is a URI that corresponds to a Route you have configured in Kong that will use Okta to authenticate. **Group Assignment** defines who is allowed to use this application. **Grant Type Allowed** indicates the Grant types to allow for your application.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/03-app-settings.png">
-
 4. After submitting the Application configuration, the client credentials will display on the **General** page.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/04-client-id-secret.png">
 
 5. [Define and configure an Authorization server][okta-authorization-server]. Select the **API** page and add an Authorization Server if you don't have an existing one to use.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/05-auth-server.png">
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/06-name-auth.png">
-
 6. Click **Save** and view your Authorization Server Settings.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/07-auth-server-settings.png">
 
 7. If you created a new Authorization server in step 5, also create a default policy under **Access Policies**.
 
-    ![Access Policy](/assets/images/docs/ee/plugins/oidc-use-case/okta8.png)
-
-    ![default Policy](/assets/images/docs/ee/plugins/oidc-use-case/okta9.png)
-
 8. If you want to control access based on groups, create a new **Claim** in the Authorization server.
-
-    ![groups claim](/assets/images/docs/ee/plugins/oidc-use-case/okta10.png)
 
 ## Plugin Configuration
 

--- a/app/enterprise/2.1.x/studio/using-insomnia-designer.md
+++ b/app/enterprise/2.1.x/studio/using-insomnia-designer.md
@@ -15,22 +15,12 @@ Once you've designed your spec, you can generate requests and fully test and deb
 
 2. In the upper right hand corner click **Test**
 
-![Test](https://doc-assets.konghq.com/studio/1.0/debugging/test.png)
-
 3. Kong Studio will prompt you to "Generate Requests", note that this will overwrite any existing test activity. Click **Generate Requests** to agree.
-
-![Generate Requests](https://doc-assets.konghq.com/studio/1.0/debugging/generate-requests.png)
 
 Kong Studio will generate the sample requests from the spec file and display them in the **Debug** view
 
-![Sample Requests](https://doc-assets.konghq.com/studio/1.0/debugging/sample-requests.png)
-
 4. Click on a request on the **Workspace sidebar** to populate that request into the **Request Panel**
-
-![Request Panel](https://doc-assets.konghq.com/studio/1.0/debugging/request-panel.png)
 
 5. Click **Send** to test the request. The response will render in the **Response Panel**
 
-![Response Panel](https://doc-assets.konghq.com/studio/1.0/debugging/response-panel.png)
-
-To lean more about generating requests and to full leverage the power of Insomnia, head over to [Insomnia's Documentation](https://support.insomnia.rest/)
+To learn more about generating requests and to full leverage the power of Insomnia, head over to [Insomnia's Documentation](https://support.insomnia.rest/)

--- a/app/enterprise/2.2.x/deployment/installation/overview.md
+++ b/app/enterprise/2.2.x/deployment/installation/overview.md
@@ -8,7 +8,7 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
     <div class="install-description">Install the Kong Ingress Controller with the {{site.ee_product_name}} on AWS</div>
   </a>
@@ -71,17 +71,17 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
   </a>
 
   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongee2020ubuntuxenial?tab=Overview" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
+    <img class="install-icon" src="/assets/images/icons/documentation/azure.svg" alt="Azure" />
     <div class="install-text">Azure</div>
   </a>
 
@@ -91,7 +91,7 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <img class="install-icon" src="/assets/images/icons/documentation/rhel.jpg" alt="Red Hat Marketplace" />
     <div class="install-text">Red Hat</div>
   </a>
 

--- a/app/enterprise/2.2.x/deployment/installation/overview.md
+++ b/app/enterprise/2.2.x/deployment/installation/overview.md
@@ -14,7 +14,7 @@ disable_image_expand: true
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/docker" class="docs-grid-install-block">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/docker.png" alt="docker" />
+    <img class="install-icon" src="/assets/images/icons/documentation/docker.png" alt="docker" />
     <div class="install-text">Docker</div>
     <div class="install-description">Install {{site.ee_product_name}} on Docker</div>
   </a>
@@ -40,22 +40,22 @@ disable_image_expand: true
 {% navtab Operating Systems %}
 <div class="docs-grid-install">
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/centos" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/centos.gif" alt="centos" />
+    <img class="install-icon" src="/assets/images/icons/documentation/centos.gif" alt="centos" />
     <div class="install-text">CentOS</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 1</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux-2" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 2</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/ubuntu" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/ubuntu.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/ubuntu.png" alt="aws" />
     <div class="install-text">Ubuntu</div>
   </a>
 

--- a/app/enterprise/2.2.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/enterprise/2.2.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -17,18 +17,9 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 
-![Appearance Tab](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab.png)
-
-The predefined variables refer to the following elements:
-
-![Appearance Tab - Variables](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-arrows.png)
-
-Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file
-
-![Appearance Tab - Color Picker](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab-variable-hover.png)
+Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file.
 
 ## Editing Theme Files with the Editor
 
 The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/enterprise/{{page.kong_version}}/developer-portal/using-the-editor/) for more information on how to edit, preview, and save files in the Editor.
 
-![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/enterprise/2.2.x/developer-portal/theme-customization/emails.md
+++ b/app/enterprise/2.2.x/developer-portal/theme-customization/emails.md
@@ -104,9 +104,7 @@ Email templates can now be edited in the Portal Editor along with the rest of th
 1. Log into Kong Manager and navigate to the Workspace whose Dev Portal you wish to edit.
 2. Select the **Editor** from the sidebar under **Dev Portal**.
 
-The email templates can be found under the **Emails** section in the Portal Editor sidebar:
-
-![Portal Editor - Emails](https://doc-assets.konghq.com/1.3/dev-portal/editor/dev-portal-emails.png)
+The email templates can be found under the **Emails** section in the Portal Editor sidebar.
 
 ### Editing via the Portal CLI Tool
 

--- a/app/enterprise/2.2.x/developer-portal/using-the-editor.md
+++ b/app/enterprise/2.2.x/developer-portal/using-the-editor.md
@@ -6,8 +6,6 @@ title: Using the Editor
 
 Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
-![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
-
 ### Prerequisites
 
 * Kong Enterprise 1.3 or later
@@ -20,13 +18,7 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
-![Launch Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-sidebar-button.png)
-
-
-This will launch the **Editor Mode**:
-
-![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
-
+This will launch the **Editor Mode**.
 
 
 
@@ -40,21 +32,13 @@ When enabled, the Dev Portal is pre-populated with Kong's default theme. The fil
 4. Portal Preview - View a live preview of the selected Dev Portal file.
 5. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
 
-![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
-
 ### Editing Files
 
 Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
-![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
-
-
-
 ### Adding new files
 
 Clicking the `New File +` button opens the New File Dialog.
-
-![Add New File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-new-file.png)
 
 Once created, files will immediately be available from within the Editor.
 
@@ -72,5 +56,3 @@ Authentication is handled by `readable_by` value on content pages (for gui view,
 To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
 
 **NOTE:** This action cannot be undone.
-
-![Deleting Files](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-delete-file.png)

--- a/app/enterprise/2.2.x/kong-manager/add-service.md
+++ b/app/enterprise/2.2.x/kong-manager/add-service.md
@@ -30,33 +30,24 @@ access to **Kong Manager**
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Services** tab under **API Gateway**.
 
-    ![Service Page](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/01-service-page.png)
-
 2. Click the **New Service** button to open the **Create Service** dialog.
 Fill in a **Name** and a **URL** for the **Service**.<br/><br/>For example, set the
 name to `test-service` with the URL `http://mockbin.org`.
 
-    ![Create Service Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/02-service-name.png)
 <br/><br/>Kong Manager also allows **Services** to be configured using **Protocol**,
 **Host**, **Path**, and **Port** (optional). To configure the **Service** using
 this method, click the **Add using Protocol, Host, and Path** option.
-
-    ![Configure Using Protocol](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/03-service-protocol.png)  
+  
 <br/>In addition, Kong Manager exposes several **Advanced Fields**
 and their default configuration values: <br/>`Retries: 5`<br/>
 `Connect Timeout: 60000` (in ms)<br/>`Write Timeout: 60000` (in ms)<br/>
 `Read Timeout: 60000` (in ms)<br/><br/>Adjusting these values is optional and can be
 edited later.
 
-    ![Advanced Fields](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/04-service-advanced-fields.png)
-
-
 3. Create the **Service** by clicking the **Create** button.<br/><br/>If successful, you are automatically redirected to the
 **Service's Overview** page.<br/><br/>The **Service Overview** page displays
 information and **Activity** on the **Service**, as well as any **Routes** or
 **Plugins** that have been connected to the **Service**.
-
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/05-service-overview.png)
 
 
 ### Step 2 - Create a New Route attached to the Service
@@ -65,13 +56,10 @@ information and **Activity** on the **Service**, as well as any **Routes** or
 [Step 1](#step-1---create-a-new-service), click the **Create New Route** button
 located in the **Routes** tab at the bottom of the page.
 
-    ![Create Route Service ID](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/06-service-route-object.png)
-
 2. To create a **Route** you must provide the **Service** `name` and `id`, this
 will be automatically filled out if the form was accessed via the
 **Service Overview** page.
 
-    ![Step 7](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/07-route-service-id.png)
 <br/><br/>If this field is not automatically filled, the **Service Id** can be
 found via the **Services Overview** page, accessed by clicking on the **Services**
 tab on the side navigation and then clicking the **clipboard** icon next to the
@@ -82,13 +70,9 @@ desired **Service's Id** field.
 name the **Route** `test-route` with the **Host** `example.com`. Once completed,
 click **Create Route**.
 
-    ![Create Route Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/08-route-form-example.png)
-
 4. If created successfully, the page will be automatically redirected back to
 the **Service Overview** page, and the new **Route** will now appear under the
 **Routes** tab.
-
-    ![Completed Route](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/10-completed-route.png)
 
 ### Step 3 - Test the new Service and Route
 

--- a/app/enterprise/2.2.x/kong-manager/administration/admins/invite.md
+++ b/app/enterprise/2.2.x/kong-manager/administration/admins/invite.md
@@ -34,8 +34,6 @@ invitation, they will only be able to log in with that email address. Assign the
 
 4. On the **Teams** page, the new invitee will appear on the **Admins** list with the under **Invited**. Once they accept the invitation, the user will be listed in the main **Admins** list. 
 
-    ![Invited Admins](https://doc-assets.konghq.com/1.3/manager/teams/teams-invited-admin.png)
-
 5. The newly invited **Admin** will have the ability to set a password. If the **Admin** ever forgets the password, it is possible for them to reset it through a recovery email.
 
 
@@ -47,8 +45,6 @@ If a mail server is not yet set up, it is still possible to invite Admins to reg
 
 2. If the "View" link is clicked next to the invited Admin's name, a 
     `register_url` is displayed on the invitee's details page. 
-
-    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
 
 3. Copy and directly send this link to the invited Admin so that they may set 
     up their credentials and log in. 

--- a/app/enterprise/2.2.x/kong-manager/administration/rbac/index.md
+++ b/app/enterprise/2.2.x/kong-manager/administration/rbac/index.md
@@ -50,8 +50,6 @@ mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**:
 
 These roles can be viewed in the **Teams** tab under **Roles**
 
-![Default Roles in New Workspaces](https://doc-assets.konghq.com/1.3/manager/teams/kong-manager-default-roles.png)
-
 ⚠️ **IMPORTANT**: Any Role assigned in the **Default Workspace** will have
 **Permissions** applied to all subsequently created **Workspaces**. A **Super Admin** in
 in `default` has RBAC **Permissions** across all **Workspaces**.

--- a/app/enterprise/2.2.x/kong-manager/enable-plugin.md
+++ b/app/enterprise/2.2.x/kong-manager/enable-plugin.md
@@ -26,21 +26,15 @@ Plugin via the command line, checkout the
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Plugins** tab under **API Gateway**.
 
-    ![Plugins Tab](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/01-plugin-tab.png)
-
 2. Click the **Add New Plugin** button to open the **Plugins** page, which lists
 all the **Kong Enterprise** bundled **Plugins** available.
 <br/><br/>Scroll to the **Traffic Control** section and select **Rate Limiting EE**.
 
-    ![Rate Limiting EE](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/02-rate-limiting.png)
 <br/><br/>This will open the **Plugin Configuration** form for **Rate Limiting EE**.
 
-    ![Configuration Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/03-plugin-form.png)
 <br/>Note that the **Plugin** will automatically be enabled when the form is
 submitted. Toggle the **This plugin is Enabled** button at the top of the form
 to configure the **Plugin** without enabling it.
-
-    ![Toggle Enable](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/04-toggle-enable.png)
 
 3. Define the **Plugin** as *global* or *scoped*.
 <br/><br/>*Global* will apply the **Plugin** to *every* **Service** and
@@ -49,9 +43,6 @@ to configure the **Plugin** without enabling it.
 **Consumer**.
 <br/><br/>To use this option, select the **Scoped** radio button and select the
 desired **Service**, **Route**, or **Consumer** from the dropdown.
-
-    ![Connect test-service](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/05-global-scoped.png)
-
 
 4. Fill out the **configuration** form.<br/><br/>For **Rate Limiting EE** the
 following fields are *required*:<br/>-`config.limit`<br/>-`config.sync_rate`<br/>
@@ -69,9 +60,7 @@ enable the **Plugin**. If it is successful, the page will automatically
 redirect to the **Plugin Overview**, with the **Rate Limiting** Plugin
 listed.
 
-    ![Plugin Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/06-plugin-overview.png)
 <br/><br/>If the **Plugin** is *scoped* to a **Service**, **Route**, or
 **Consumer**, the **Plugin** will also be listed on that object's **Overview**
 page.
 
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/07-service-plugin-table.png)

--- a/app/enterprise/2.2.x/kong-manager/overview.md
+++ b/app/enterprise/2.2.x/kong-manager/overview.md
@@ -11,5 +11,3 @@ Here are some of the things you can do with Kong Manager:
 * Activate or deactivate plugins with a couple of clicks.
 * Group your teams, services, plugins, consumer management, and everything else exactly how you want them.
 * Monitor performance: visualize cluster-wide, workspace-level, or even object-level health using intuitive, customizable dashboards.
-
-![Welcome to Kong Manager](https://doc-assets.konghq.com/1.3/manager/kong-manager-workspaces-overview.png)

--- a/app/enterprise/2.2.x/plugins/oidc-cognito.md
+++ b/app/enterprise/2.2.x/plugins/oidc-cognito.md
@@ -11,27 +11,15 @@ In this configuration, we use User Pools.
 1. Log in to AWS Console.
 1. Navigate to the Amazon Cognito Service.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito1.png">
-
 1. Click on **Manage User Pools**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito2.png">
 
 1. Click the **Create a user pool** button on the right-hand side.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito3.png">
-
 1. Enter a pool name; we use “test-pool” for this example.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito4.png">
-
 1. Click **Step Through Settings**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito5.png">
     
 1. Select **Email address or phone number**, and under that, select **Allow email addresses**. Select the following standard attributes as required: email, family name, given name.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito6.png">
     
 1. Click **Next step**.
 1. Accept the defaults for **Password settings**, then click **Next step**.
@@ -42,12 +30,8 @@ In this configuration, we use User Pools.
 1. We can create an application definition later. Keep things simple for now and click **Next step**.
 1. We don’t have any need for Triggers or customized Sign Up/Sign In behavior for this example. Scroll down and click **Save Changes**.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito7.png">
-
 1. Click **Create pool**. Wait a moment for the success message.
 1. Make a note of the **Pool ID**. You will need this when configuring the application later.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito8.png">
 
 ## Application Definition
 
@@ -55,51 +39,28 @@ You need to add an OAuth2 application definition to the User Pool we just create
 
 1. Go to the App clients screen in the AWS Cognito management screen for the User Pool we just created.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito9.png">
-
 1. Click “Add an app client”.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito10.png">
-
 1. Enter an App client name. This demo is using “kong-api”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito11.png">
     
 1. Enter a Refresh token expiration (in days). We will use the default of 30 days.
 1. Do not select “Generate client secret”. This example will use a public client.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito12.png">
     
 1. Do not select any other checkboxes.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito13.png">
     
 1. Click the “Set attribute read and write permissions” button.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito14.png">
     
 1. Let’s make this simple and only give the user read and write access to the required attributes. So, uncheck everything except the email, given name, and family name fields.
     
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito15.png">
-    
 1. Click “Create app client”
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito16.png">
-
 1. Click “Show Details”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito17.png">
-
 1. Take note of the App client ID. We will need that later.
 1. Go to the App integration -> App client settings screen.
 1. Click the “Cognito User Pool” checkbox under Enabled Identity Providers.
 1. Add “https://kong-ee:8446/default, https://kong-ee:8447/default/, https://kong-ee:8447/default/auth, https://kong-ee:8443/cognito” to the Callback URLs field. Note that AWS Cognito doesn’t support HTTP callback URLs. This field should include the API and Dev Portal URLs that you want to secure using AWS Cognito.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito18.png">
-
 1. Click the “Authorization code grant” checkbox under Allowed OAuth Flows.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito19.png">
     
 1. Click the checkboxes next to email, OpenID, aws.cognito.signin.user.admin, and profile.
 1. Click the “Save changes” button.
@@ -107,8 +68,6 @@ You need to add an OAuth2 application definition to the User Pool we just create
 1. Add a sub-domain name.
 1. Click the Check Availability button.
 1. As long as it reports “This domain is available”, the name you have chosen will work.
-    
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito21.png">
     
 1. Click the “Save changes” button.
 

--- a/app/enterprise/2.2.x/plugins/oidc-google.md
+++ b/app/enterprise/2.2.x/plugins/oidc-google.md
@@ -58,7 +58,7 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service

--- a/app/enterprise/2.2.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.2.x/plugins/oidc-okta.md
@@ -30,31 +30,17 @@ as an authorized redirect URI in Okta (under the **Authentication** section of y
 
 1. [Register an Application][okta-register-app]. Select the **Applications** page, click **Add Application**.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/01-add-application.png">
-
 2. Select **Web** as the platform.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/02-web-app.png">
 
 3. Fill out the Application's Settings.
 
     **Login re-direct URIs** is a URI that corresponds to a Route you have configured in Kong that will use Okta to authenticate. **Group Assignment** defines who is allowed to use this application. **Grant Type Allowed** indicates the Grant types to allow for your application.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/03-app-settings.png">
-
 4. After submitting the Application configuration, the client credentials will display on the **General** page.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/04-client-id-secret.png">
 
 5. [Define and configure an Authorization server][okta-authorization-server]. Select the **API** page and add an Authorization Server if you don't have an existing one to use.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/05-auth-server.png">
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/06-name-auth.png">
-
 6. Click **Save** and view your Authorization Server Settings.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/07-auth-server-settings.png">
 
 ## Plugin Configuration
 

--- a/app/enterprise/2.2.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.2.x/plugins/oidc-okta.md
@@ -119,7 +119,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/kong-manager/enable-plugin/

--- a/app/enterprise/2.2.x/studio/using-insomnia-designer.md
+++ b/app/enterprise/2.2.x/studio/using-insomnia-designer.md
@@ -15,22 +15,12 @@ Once you've designed your spec, you can generate requests and fully test and deb
 
 2. In the upper right hand corner click **Test**
 
-![Test](https://doc-assets.konghq.com/studio/1.0/debugging/test.png)
-
 3. Kong Studio will prompt you to "Generate Requests", note that this will overwrite any existing test activity. Click **Generate Requests** to agree.
-
-![Generate Requests](https://doc-assets.konghq.com/studio/1.0/debugging/generate-requests.png)
 
 Kong Studio will generate the sample requests from the spec file and display them in the **Debug** view
 
-![Sample Requests](https://doc-assets.konghq.com/studio/1.0/debugging/sample-requests.png)
-
 4. Click on a request on the **Workspace sidebar** to populate that request into the **Request Panel**
 
-![Request Panel](https://doc-assets.konghq.com/studio/1.0/debugging/request-panel.png)
-
 5. Click **Send** to test the request. The response will render in the **Response Panel**
-
-![Response Panel](https://doc-assets.konghq.com/studio/1.0/debugging/response-panel.png)
 
 To lean more about generating requests and to full leverage the power of Insomnia, head over to [Insomnia's Documentation](https://support.insomnia.rest/)

--- a/app/enterprise/2.3.x/deployment/installation/overview.md
+++ b/app/enterprise/2.3.x/deployment/installation/overview.md
@@ -8,7 +8,7 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
     <div class="install-description">Install the Kong Ingress Controller with the {{site.ee_product_name}} on AWS</div>
   </a>
@@ -71,17 +71,17 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
   </a>
 
   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongee2020ubuntuxenial?tab=Overview" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
+    <img class="install-icon" src="/assets/images/icons/documentation/azure.svg" alt="Azure" />
     <div class="install-text">Azure</div>
   </a>
 
@@ -91,7 +91,7 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <img class="install-icon" src="/assets/images/icons/documentation/rhel.jpg" alt="Red Hat Marketplace" />
     <div class="install-text">Red Hat</div>
   </a>
 

--- a/app/enterprise/2.3.x/deployment/installation/overview.md
+++ b/app/enterprise/2.3.x/deployment/installation/overview.md
@@ -14,7 +14,7 @@ disable_image_expand: true
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/docker" class="docs-grid-install-block">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/docker.png" alt="docker" />
+    <img class="install-icon" src="/assets/images/icons/documentation/docker.png" alt="docker" />
     <div class="install-text">Docker</div>
     <div class="install-description">Install {{site.ee_product_name}} on Docker</div>
   </a>
@@ -40,22 +40,22 @@ disable_image_expand: true
 {% navtab Operating Systems %}
 <div class="docs-grid-install">
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/centos" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/centos.gif" alt="centos" />
+    <img class="install-icon" src="/assets/images/icons/documentation/centos.gif" alt="centos" />
     <div class="install-text">CentOS</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 1</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux-2" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 2</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/ubuntu" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/ubuntu.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/ubuntu.png" alt="aws" />
     <div class="install-text">Ubuntu</div>
   </a>
 

--- a/app/enterprise/2.3.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/enterprise/2.3.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -17,18 +17,9 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 
-![Appearance Tab](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab.png)
-
-The predefined variables refer to the following elements:
-
-![Appearance Tab - Variables](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-arrows.png)
-
 Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file
-
-![Appearance Tab - Color Picker](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab-variable-hover.png)
 
 ## Editing Theme Files with the Editor
 
 The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/enterprise/{{page.kong_version}}/developer-portal/using-the-editor/) for more information on how to edit, preview, and save files in the Editor.
 
-![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/enterprise/2.3.x/developer-portal/theme-customization/emails.md
+++ b/app/enterprise/2.3.x/developer-portal/theme-customization/emails.md
@@ -106,8 +106,6 @@ Email templates can now be edited in the Portal Editor along with the rest of th
 
 The email templates can be found under the **Emails** section in the Portal Editor sidebar:
 
-![Portal Editor - Emails](https://doc-assets.konghq.com/1.3/dev-portal/editor/dev-portal-emails.png)
-
 ### Editing via the Portal CLI Tool
 
 1. Clone [https://github.com/Kong/kong-portal-templates] master branch, and navigate into its directory.

--- a/app/enterprise/2.3.x/developer-portal/using-the-editor.md
+++ b/app/enterprise/2.3.x/developer-portal/using-the-editor.md
@@ -6,8 +6,6 @@ title: Using the Editor
 
 Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
-![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
-
 ### Prerequisites
 
 * Kong Enterprise 1.3 or later
@@ -20,14 +18,7 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
-![Launch Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-sidebar-button.png)
-
-
-This will launch the **Editor Mode**:
-
-![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
-
-
+This will launch the **Editor Mode**.
 
 
 ### Navigating the Editor
@@ -40,21 +31,13 @@ When enabled, the Dev Portal is pre-populated with Kong's default theme. The fil
 4. Portal Preview - View a live preview of the selected Dev Portal file.
 5. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
 
-![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
-
 ### Editing Files
 
 Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
-![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
-
-
-
 ### Adding new files
 
 Clicking the `New File +` button opens the New File Dialog.
-
-![Add New File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-new-file.png)
 
 Once created, files will immediately be available from within the Editor.
 
@@ -72,5 +55,3 @@ Authentication is handled by `readable_by` value on content pages (for gui view,
 To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
 
 **NOTE:** This action cannot be undone.
-
-![Deleting Files](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-delete-file.png)

--- a/app/enterprise/2.3.x/kong-manager/add-service.md
+++ b/app/enterprise/2.3.x/kong-manager/add-service.md
@@ -30,34 +30,24 @@ access to **Kong Manager**
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Services** tab under **API Gateway**.
 
-    ![Service Page](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/01-service-page.png)
-
 2. Click the **New Service** button to open the **Create Service** dialog.
 Fill in a **Name** and a **URL** for the **Service**.<br/><br/>For example, set the
 name to `test-service` with the URL `http://mockbin.org`.
 
-    ![Create Service Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/02-service-name.png)
 <br/><br/>Kong Manager also allows **Services** to be configured using **Protocol**,
 **Host**, **Path**, and **Port** (optional). To configure the **Service** using
 this method, click the **Add using Protocol, Host, and Path** option.
 
-    ![Configure Using Protocol](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/03-service-protocol.png)  
 <br/>In addition, Kong Manager exposes several **Advanced Fields**
 and their default configuration values: <br/>`Retries: 5`<br/>
 `Connect Timeout: 60000` (in ms)<br/>`Write Timeout: 60000` (in ms)<br/>
 `Read Timeout: 60000` (in ms)<br/><br/>Adjusting these values is optional and can be
 edited later.
 
-    ![Advanced Fields](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/04-service-advanced-fields.png)
-
-
 3. Create the **Service** by clicking the **Create** button.<br/><br/>If successful, you are automatically redirected to the
 **Service's Overview** page.<br/><br/>The **Service Overview** page displays
 information and **Activity** on the **Service**, as well as any **Routes** or
 **Plugins** that have been connected to the **Service**.
-
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/05-service-overview.png)
-
 
 ### Step 2 - Create a New Route attached to the Service
 
@@ -65,13 +55,10 @@ information and **Activity** on the **Service**, as well as any **Routes** or
 [Step 1](#step-1---create-a-new-service), click the **Create New Route** button
 located in the **Routes** tab at the bottom of the page.
 
-    ![Create Route Service ID](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/06-service-route-object.png)
-
 2. To create a **Route** you must provide the **Service** `name` and `id`, this
 will be automatically filled out if the form was accessed via the
 **Service Overview** page.
 
-    ![Step 7](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/07-route-service-id.png)
 <br/><br/>If this field is not automatically filled, the **Service Id** can be
 found via the **Services Overview** page, accessed by clicking on the **Services**
 tab on the side navigation and then clicking the **clipboard** icon next to the
@@ -82,13 +69,9 @@ desired **Service's Id** field.
 name the **Route** `test-route` with the **Host** `example.com`. Once completed,
 click **Create Route**.
 
-    ![Create Route Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/08-route-form-example.png)
-
 4. If created successfully, the page will be automatically redirected back to
 the **Service Overview** page, and the new **Route** will now appear under the
 **Routes** tab.
-
-    ![Completed Route](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/10-completed-route.png)
 
 ### Step 3 - Test the new Service and Route
 

--- a/app/enterprise/2.3.x/kong-manager/administration/admins/invite.md
+++ b/app/enterprise/2.3.x/kong-manager/administration/admins/invite.md
@@ -34,8 +34,6 @@ invitation, they will only be able to log in with that email address. Assign the
 
 4. On the **Teams** page, the new invitee will appear on the **Admins** list with the under **Invited**. Once they accept the invitation, the user will be listed in the main **Admins** list. 
 
-    ![Invited Admins](https://doc-assets.konghq.com/1.3/manager/teams/teams-invited-admin.png)
-
 5. The newly invited **Admin** will have the ability to set a password. If the **Admin** ever forgets the password, it is possible for them to reset it through a recovery email.
 
 
@@ -47,8 +45,6 @@ If a mail server is not yet set up, it is still possible to invite Admins to reg
 
 2. If the "View" link is clicked next to the invited Admin's name, a 
     `register_url` is displayed on the invitee's details page. 
-
-    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
 
 3. Copy and directly send this link to the invited Admin so that they may set 
     up their credentials and log in. 

--- a/app/enterprise/2.3.x/kong-manager/administration/rbac/index.md
+++ b/app/enterprise/2.3.x/kong-manager/administration/rbac/index.md
@@ -48,9 +48,7 @@ mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**:
 `workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and
 `workspace-portal-admin`.
 
-These roles can be viewed in the **Teams** tab under **Roles**
-
-![Default Roles in New Workspaces](https://doc-assets.konghq.com/1.3/manager/teams/kong-manager-default-roles.png)
+These roles can be viewed in the **Teams** tab under **Roles**.
 
 ⚠️ **IMPORTANT**: Any Role assigned in the **Default Workspace** will have
 **Permissions** applied to all subsequently created **Workspaces**. A **Super Admin** in

--- a/app/enterprise/2.3.x/kong-manager/enable-plugin.md
+++ b/app/enterprise/2.3.x/kong-manager/enable-plugin.md
@@ -26,21 +26,15 @@ Plugin via the command line, checkout the
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Plugins** tab under **API Gateway**.
 
-    ![Plugins Tab](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/01-plugin-tab.png)
-
 2. Click the **Add New Plugin** button to open the **Plugins** page, which lists
 all the **Kong Enterprise** bundled **Plugins** available.
 <br/><br/>Scroll to the **Traffic Control** section and select **Rate Limiting EE**.
 
-    ![Rate Limiting EE](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/02-rate-limiting.png)
 <br/><br/>This will open the **Plugin Configuration** form for **Rate Limiting EE**.
 
-    ![Configuration Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/03-plugin-form.png)
 <br/>Note that the **Plugin** will automatically be enabled when the form is
 submitted. Toggle the **This plugin is Enabled** button at the top of the form
 to configure the **Plugin** without enabling it.
-
-    ![Toggle Enable](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/04-toggle-enable.png)
 
 3. Define the **Plugin** as *global* or *scoped*.
 <br/><br/>*Global* will apply the **Plugin** to *every* **Service** and
@@ -49,9 +43,6 @@ to configure the **Plugin** without enabling it.
 **Consumer**.
 <br/><br/>To use this option, select the **Scoped** radio button and select the
 desired **Service**, **Route**, or **Consumer** from the dropdown.
-
-    ![Connect test-service](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/05-global-scoped.png)
-
 
 4. Fill out the **configuration** form.<br/><br/>For **Rate Limiting EE** the
 following fields are *required*:<br/>-`config.limit`<br/>-`config.sync_rate`<br/>
@@ -69,9 +60,7 @@ enable the **Plugin**. If it is successful, the page will automatically
 redirect to the **Plugin Overview**, with the **Rate Limiting** Plugin
 listed.
 
-    ![Plugin Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/06-plugin-overview.png)
 <br/><br/>If the **Plugin** is *scoped* to a **Service**, **Route**, or
 **Consumer**, the **Plugin** will also be listed on that object's **Overview**
 page.
 
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/07-service-plugin-table.png)

--- a/app/enterprise/2.3.x/kong-manager/overview.md
+++ b/app/enterprise/2.3.x/kong-manager/overview.md
@@ -12,4 +12,3 @@ Here are some of the things you can do with Kong Manager:
 * Group your teams, services, plugins, consumer management, and everything else exactly how you want them.
 * Monitor performance: visualize cluster-wide, workspace-level, or even object-level health using intuitive, customizable dashboards.
 
-![Welcome to Kong Manager](https://doc-assets.konghq.com/1.3/manager/kong-manager-workspaces-overview.png)

--- a/app/enterprise/2.3.x/plugins/oidc-cognito.md
+++ b/app/enterprise/2.3.x/plugins/oidc-cognito.md
@@ -10,29 +10,11 @@ In this configuration, we use User Pools.
 
 1. Log in to AWS Console.
 1. Navigate to the Amazon Cognito Service.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito1.png">
-
 1. Click on **Manage User Pools**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito2.png">
-
 1. Click the **Create a user pool** button on the right-hand side.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito3.png">
-
 1. Enter a pool name; we use “test-pool” for this example.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito4.png">
-
 1. Click **Step Through Settings**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito5.png">
-    
 1. Select **Email address or phone number**, and under that, select **Allow email addresses**. Select the following standard attributes as required: email, family name, given name.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito6.png">
-    
 1. Click **Next step**.
 1. Accept the defaults for **Password settings**, then click **Next step**.
 1. Accept the defaults for **MFA and verifications**, then click **Next step**.
@@ -41,75 +23,34 @@ In this configuration, we use User Pools.
 1. Select **No** for **Do you want to remember your user’s devices**, then click **Next step**.
 1. We can create an application definition later. Keep things simple for now and click **Next step**.
 1. We don’t have any need for Triggers or customized Sign Up/Sign In behavior for this example. Scroll down and click **Save Changes**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito7.png">
-
 1. Click **Create pool**. Wait a moment for the success message.
 1. Make a note of the **Pool ID**. You will need this when configuring the application later.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito8.png">
 
 ## Application Definition
 
 You need to add an OAuth2 application definition to the User Pool we just created.
 
 1. Go to the App clients screen in the AWS Cognito management screen for the User Pool we just created.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito9.png">
-
 1. Click “Add an app client”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito10.png">
-
 1. Enter an App client name. This demo is using “kong-api”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito11.png">
-    
 1. Enter a Refresh token expiration (in days). We will use the default of 30 days.
 1. Do not select “Generate client secret”. This example will use a public client.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito12.png">
-    
 1. Do not select any other checkboxes.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito13.png">
-    
 1. Click the “Set attribute read and write permissions” button.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito14.png">
-    
 1. Let’s make this simple and only give the user read and write access to the required attributes. So, uncheck everything except the email, given name, and family name fields.
-    
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito15.png">
-    
-1. Click “Create app client”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito16.png">
-
+1. Click “Create app client”.
 1. Click “Show Details”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito17.png">
-
 1. Take note of the App client ID. We will need that later.
 1. Go to the App integration -> App client settings screen.
 1. Click the “Cognito User Pool” checkbox under Enabled Identity Providers.
 1. Add “https://kong-ee:8446/default, https://kong-ee:8447/default/, https://kong-ee:8447/default/auth, https://kong-ee:8443/cognito” to the Callback URLs field. Note that AWS Cognito doesn’t support HTTP callback URLs. This field should include the API and Dev Portal URLs that you want to secure using AWS Cognito.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito18.png">
-
 1. Click the “Authorization code grant” checkbox under Allowed OAuth Flows.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito19.png">
-    
 1. Click the checkboxes next to email, OpenID, aws.cognito.signin.user.admin, and profile.
 1. Click the “Save changes” button.
 1. Click on the domain name tab.
 1. Add a sub-domain name.
 1. Click the Check Availability button.
 1. As long as it reports “This domain is available”, the name you have chosen will work.
-    
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito21.png">
-    
 1. Click the “Save changes” button.
 
 Now that you have created an Amazon Cognito User Pool and Application Definition, we can configure the OpenID Connect plugin in Kong. We can then test integration between Dev Portal and Amazon Cognito. 

--- a/app/enterprise/2.3.x/plugins/oidc-google.md
+++ b/app/enterprise/2.3.x/plugins/oidc-google.md
@@ -58,7 +58,7 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service

--- a/app/enterprise/2.3.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.3.x/plugins/oidc-okta.md
@@ -30,31 +30,17 @@ as an authorized redirect URI in Okta (under the **Authentication** section of y
 
 1. [Register an Application][okta-register-app]. Select the **Applications** page, click **Add Application**.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/01-add-application.png">
-
 2. Select **Web** as the platform.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/02-web-app.png">
 
 3. Fill out the Application's Settings.
 
     **Login re-direct URIs** is a URI that corresponds to a Route you have configured in Kong that will use Okta to authenticate. **Group Assignment** defines who is allowed to use this application. **Grant Type Allowed** indicates the Grant types to allow for your application.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/03-app-settings.png">
-
 4. After submitting the Application configuration, the client credentials will display on the **General** page.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/04-client-id-secret.png">
 
 5. [Define and configure an Authorization server][okta-authorization-server]. Select the **API** page and add an Authorization Server if you don't have an existing one to use.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/05-auth-server.png">
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/06-name-auth.png">
-
 6. Click **Save** and view your Authorization Server Settings.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/07-auth-server-settings.png">
 
 ## Plugin Configuration
 

--- a/app/enterprise/2.3.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.3.x/plugins/oidc-okta.md
@@ -119,7 +119,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/kong-manager/enable-plugin/

--- a/app/enterprise/2.4.x/deployment/installation/overview.md
+++ b/app/enterprise/2.4.x/deployment/installation/overview.md
@@ -8,7 +8,7 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
     <div class="install-description">Install the Kong Ingress Controller with the {{site.ee_product_name}} on AWS</div>
   </a>
@@ -71,17 +71,17 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
   </a>
 
   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongee2020ubuntuxenial?tab=Overview" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
+    <img class="install-icon" src="/assets/images/icons/documentation/azure.svg" alt="Azure" />
     <div class="install-text">Azure</div>
   </a>
 
@@ -91,7 +91,7 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <img class="install-icon" src="/assets/images/icons/documentation/rhel.jpg" alt="Red Hat Marketplace" />
     <div class="install-text">Red Hat</div>
   </a>
 

--- a/app/enterprise/2.4.x/deployment/installation/overview.md
+++ b/app/enterprise/2.4.x/deployment/installation/overview.md
@@ -14,7 +14,7 @@ disable_image_expand: true
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/docker" class="docs-grid-install-block">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/docker.png" alt="docker" />
+    <img class="install-icon" src="/assets/images/icons/documentation/docker.png" alt="docker" />
     <div class="install-text">Docker</div>
     <div class="install-description">Install {{site.ee_product_name}} on Docker</div>
   </a>
@@ -40,22 +40,22 @@ disable_image_expand: true
 {% navtab Operating Systems %}
 <div class="docs-grid-install">
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/centos" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/centos.gif" alt="centos" />
+    <img class="install-icon" src="/assets/images/icons/documentation/centos.gif" alt="centos" />
     <div class="install-text">CentOS</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 1</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux-2" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 2</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/ubuntu" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/ubuntu.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/ubuntu.png" alt="aws" />
     <div class="install-text">Ubuntu</div>
   </a>
 

--- a/app/enterprise/2.4.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/enterprise/2.4.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -17,18 +17,9 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 
-![Appearance Tab](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab.png)
-
-The predefined variables refer to the following elements:
-
-![Appearance Tab - Variables](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-arrows.png)
-
-Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file
-
-![Appearance Tab - Color Picker](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab-variable-hover.png)
+Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file.
 
 ## Editing Theme Files with the Editor
 
 The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/enterprise/{{page.kong_version}}/developer-portal/using-the-editor/) for more information on how to edit, preview, and save files in the Editor.
 
-![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/enterprise/2.4.x/developer-portal/theme-customization/emails.md
+++ b/app/enterprise/2.4.x/developer-portal/theme-customization/emails.md
@@ -104,9 +104,7 @@ Email templates can now be edited in the Portal Editor along with the rest of th
 1. Log into Kong Manager and navigate to the Workspace whose Dev Portal you wish to edit.
 2. Select the **Editor** from the sidebar under **Dev Portal**.
 
-The email templates can be found under the **Emails** section in the Portal Editor sidebar:
-
-![Portal Editor - Emails](https://doc-assets.konghq.com/1.3/dev-portal/editor/dev-portal-emails.png)
+The email templates can be found under the **Emails** section in the Portal Editor sidebar.
 
 ### Editing via the Portal CLI Tool
 

--- a/app/enterprise/2.4.x/developer-portal/using-the-editor.md
+++ b/app/enterprise/2.4.x/developer-portal/using-the-editor.md
@@ -6,8 +6,6 @@ title: Using the Editor
 
 Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
-![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
-
 ### Prerequisites
 
 * Kong Enterprise 1.3 or later
@@ -20,15 +18,7 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
-![Launch Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-sidebar-button.png)
-
-
-This will launch the **Editor Mode**:
-
-![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
-
-
-
+This will launch the **Editor Mode**.
 
 ### Navigating the Editor
 
@@ -40,21 +30,13 @@ When enabled, the Dev Portal is pre-populated with Kong's default theme. The fil
 4. Portal Preview - View a live preview of the selected Dev Portal file.
 5. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
 
-![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
-
 ### Editing Files
 
 Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
-![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
-
-
-
 ### Adding new files
 
 Clicking the `New File +` button opens the New File Dialog.
-
-![Add New File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-new-file.png)
 
 Once created, files will immediately be available from within the Editor.
 
@@ -72,5 +54,3 @@ Authentication is handled by `readable_by` value on content pages (for gui view,
 To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
 
 **NOTE:** This action cannot be undone.
-
-![Deleting Files](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-delete-file.png)

--- a/app/enterprise/2.4.x/kong-manager/add-service.md
+++ b/app/enterprise/2.4.x/kong-manager/add-service.md
@@ -30,34 +30,24 @@ access to **Kong Manager**
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Services** tab under **API Gateway**.
 
-    ![Service Page](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/01-service-page.png)
-
 2. Click the **New Service** button to open the **Create Service** dialog.
 Fill in a **Name** and a **URL** for the **Service**.<br/><br/>For example, set the
 name to `test-service` with the URL `http://mockbin.org`.
 
-    ![Create Service Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/02-service-name.png)
 <br/><br/>Kong Manager also allows **Services** to be configured using **Protocol**,
 **Host**, **Path**, and **Port** (optional). To configure the **Service** using
 this method, click the **Add using Protocol, Host, and Path** option.
 
-    ![Configure Using Protocol](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/03-service-protocol.png)  
 <br/>In addition, Kong Manager exposes several **Advanced Fields**
 and their default configuration values: <br/>`Retries: 5`<br/>
 `Connect Timeout: 60000` (in ms)<br/>`Write Timeout: 60000` (in ms)<br/>
 `Read Timeout: 60000` (in ms)<br/><br/>Adjusting these values is optional and can be
 edited later.
 
-    ![Advanced Fields](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/04-service-advanced-fields.png)
-
-
 3. Create the **Service** by clicking the **Create** button.<br/><br/>If successful, you are automatically redirected to the
 **Service's Overview** page.<br/><br/>The **Service Overview** page displays
 information and **Activity** on the **Service**, as well as any **Routes** or
 **Plugins** that have been connected to the **Service**.
-
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/05-service-overview.png)
-
 
 ### Step 2 - Create a New Route attached to the Service
 
@@ -65,13 +55,10 @@ information and **Activity** on the **Service**, as well as any **Routes** or
 [Step 1](#step-1---create-a-new-service), click the **Create New Route** button
 located in the **Routes** tab at the bottom of the page.
 
-    ![Create Route Service ID](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/06-service-route-object.png)
-
 2. To create a **Route** you must provide the **Service** `name` and `id`, this
 will be automatically filled out if the form was accessed via the
 **Service Overview** page.
 
-    ![Step 7](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/07-route-service-id.png)
 <br/><br/>If this field is not automatically filled, the **Service Id** can be
 found via the **Services Overview** page, accessed by clicking on the **Services**
 tab on the side navigation and then clicking the **clipboard** icon next to the
@@ -82,13 +69,9 @@ desired **Service's Id** field.
 name the **Route** `test-route` with the **Host** `example.com`. Once completed,
 click **Create Route**.
 
-    ![Create Route Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/08-route-form-example.png)
-
 4. If created successfully, the page will be automatically redirected back to
 the **Service Overview** page, and the new **Route** will now appear under the
 **Routes** tab.
-
-    ![Completed Route](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/10-completed-route.png)
 
 ### Step 3 - Test the new Service and Route
 

--- a/app/enterprise/2.4.x/kong-manager/administration/admins/invite.md
+++ b/app/enterprise/2.4.x/kong-manager/administration/admins/invite.md
@@ -32,9 +32,7 @@ invitation, they will only be able to log in with that email address. Assign the
     directly. See the next section.
 
 
-4. On the **Teams** page, the new invitee will appear on the **Admins** list with the under **Invited**. Once they accept the invitation, the user will be listed in the main **Admins** list. 
-
-    ![Invited Admins](https://doc-assets.konghq.com/1.3/manager/teams/teams-invited-admin.png)
+4. On the **Teams** page, the new invitee will appear on the **Admins** list with the under **Invited**. Once they accept the invitation, the user will be listed in the main **Admins** list.
 
 5. The newly invited **Admin** will have the ability to set a password. If the **Admin** ever forgets the password, it is possible for them to reset it through a recovery email.
 
@@ -46,9 +44,7 @@ If a mail server is not yet set up, it is still possible to invite Admins to reg
 1. Invite an **Admin** as described in the section above. 
 
 2. If the "View" link is clicked next to the invited Admin's name, a 
-    `register_url` is displayed on the invitee's details page. 
-
-    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
+    `register_url` is displayed on the invitee's details page.
 
 3. Copy and directly send this link to the invited Admin so that they may set 
     up their credentials and log in. 

--- a/app/enterprise/2.4.x/kong-manager/administration/rbac/index.md
+++ b/app/enterprise/2.4.x/kong-manager/administration/rbac/index.md
@@ -48,9 +48,7 @@ mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**:
 `workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and
 `workspace-portal-admin`.
 
-These roles can be viewed in the **Teams** tab under **Roles**
-
-![Default Roles in New Workspaces](https://doc-assets.konghq.com/1.3/manager/teams/kong-manager-default-roles.png)
+These roles can be viewed in the **Teams** tab under **Roles**.
 
 ⚠️ **IMPORTANT**: Any Role assigned in the **Default Workspace** will have
 **Permissions** applied to all subsequently created **Workspaces**. A **Super Admin**

--- a/app/enterprise/2.4.x/kong-manager/enable-plugin.md
+++ b/app/enterprise/2.4.x/kong-manager/enable-plugin.md
@@ -26,21 +26,15 @@ Plugin via the command line, checkout the
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Plugins** tab under **API Gateway**.
 
-    ![Plugins Tab](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/01-plugin-tab.png)
-
 2. Click the **Add New Plugin** button to open the **Plugins** page, which lists
 all the **Kong Enterprise** bundled **Plugins** available.
 <br/><br/>Scroll to the **Traffic Control** section and select **Rate Limiting EE**.
 
-    ![Rate Limiting EE](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/02-rate-limiting.png)
 <br/><br/>This will open the **Plugin Configuration** form for **Rate Limiting EE**.
 
-    ![Configuration Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/03-plugin-form.png)
 <br/>Note that the **Plugin** will automatically be enabled when the form is
 submitted. Toggle the **This plugin is Enabled** button at the top of the form
 to configure the **Plugin** without enabling it.
-
-    ![Toggle Enable](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/04-toggle-enable.png)
 
 3. Define the **Plugin** as *global* or *scoped*.
 <br/><br/>*Global* will apply the **Plugin** to *every* **Service** and
@@ -49,9 +43,6 @@ to configure the **Plugin** without enabling it.
 **Consumer**.
 <br/><br/>To use this option, select the **Scoped** radio button and select the
 desired **Service**, **Route**, or **Consumer** from the dropdown.
-
-    ![Connect test-service](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/05-global-scoped.png)
-
 
 4. Fill out the **configuration** form.<br/><br/>For **Rate Limiting EE** the
 following fields are *required*:<br/>-`config.limit`<br/>-`config.sync_rate`<br/>
@@ -69,9 +60,6 @@ enable the **Plugin**. If it is successful, the page will automatically
 redirect to the **Plugin Overview**, with the **Rate Limiting** Plugin
 listed.
 
-    ![Plugin Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/06-plugin-overview.png)
 <br/><br/>If the **Plugin** is *scoped* to a **Service**, **Route**, or
 **Consumer**, the **Plugin** will also be listed on that object's **Overview**
 page.
-
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/07-service-plugin-table.png)

--- a/app/enterprise/2.4.x/kong-manager/overview.md
+++ b/app/enterprise/2.4.x/kong-manager/overview.md
@@ -12,4 +12,3 @@ Here are some of the things you can do with Kong Manager:
 * Group your teams, services, plugins, consumer management, and everything else exactly how you want them.
 * Monitor performance: visualize cluster-wide, workspace-level, or even object-level health using intuitive, customizable dashboards.
 
-![Welcome to Kong Manager](https://doc-assets.konghq.com/1.3/manager/kong-manager-workspaces-overview.png)

--- a/app/enterprise/2.4.x/plugins/oidc-cognito.md
+++ b/app/enterprise/2.4.x/plugins/oidc-cognito.md
@@ -10,29 +10,11 @@ In this configuration, we use User Pools.
 
 1. Log in to AWS Console.
 1. Navigate to the Amazon Cognito Service.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito1.png">
-
 1. Click on **Manage User Pools**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito2.png">
-
 1. Click the **Create a user pool** button on the right-hand side.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito3.png">
-
 1. Enter a pool name; we use “test-pool” for this example.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito4.png">
-
 1. Click **Step Through Settings**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito5.png">
-
 1. Select **Email address or phone number**, and under that, select **Allow email addresses**. Select the following standard attributes as required: email, family name, given name.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito6.png">
-
 1. Click **Next step**.
 1. Accept the defaults for **Password settings**, then click **Next step**.
 1. Accept the defaults for **MFA and verifications**, then click **Next step**.
@@ -41,55 +23,23 @@ In this configuration, we use User Pools.
 1. Select **No** for **Do you want to remember your user’s devices**, then click **Next step**.
 1. We can create an application definition later. Keep things simple for now and click **Next step**.
 1. We don’t have any need for Triggers or customized Sign Up/Sign In behavior for this example. Scroll down and click **Save Changes**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito7.png">
-
 1. Click **Create pool**. Wait a moment for the success message.
 1. Make a note of the **Pool ID**. You will need this when configuring the application later.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito8.png">
 
 ## Application Definition
 
 You need to add an OAuth2 application definition to the User Pool we just created.
 
 1. Go to the App clients screen in the AWS Cognito management screen for the User Pool we just created.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito9.png">
-
 1. Click “Add an app client”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito10.png">
-
-1. Enter an App client name. This demo is using “kong-api”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito11.png">
-
+1. Enter an App client name. This demo is using “kong-api”.
 1. Enter a Refresh token expiration (in days). We will use the default of 30 days.
 1. Do not select “Generate client secret”. This example will use a public client.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito12.png">
-
 1. Do not select any other checkboxes.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito13.png">
-
 1. Click the “Set attribute read and write permissions” button.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito14.png">
-
 1. Let’s make this simple and only give the user read and write access to the required attributes. So, uncheck everything except the email, given name, and family name fields.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito15.png">
-
-1. Click “Create app client”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito16.png">
-
+1. Click “Create app client”.
 1. Click “Show Details”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito17.png">
-
 1. Take note of the App client ID. We will need that later.
 1. Go to the App integration -> App client settings screen.
 1. Click the “Cognito User Pool” checkbox under Enabled Identity Providers.
@@ -102,21 +52,13 @@ You need to add an OAuth2 application definition to the User Pool we just create
     Note that AWS Cognito doesn’t support HTTP callback URLs. This field should
     include the API and Dev Portal URLs that you want to secure using AWS Cognito.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito18.png">
-
 1. Click the “Authorization code grant” checkbox under Allowed OAuth Flows.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito19.png">
-
 1. Click the checkboxes next to email, OpenID, aws.cognito.signin.user.admin, and profile.
 1. Click the “Save changes” button.
 1. Click on the domain name tab.
 1. Add a sub-domain name.
 1. Click the Check Availability button.
 1. As long as it reports “This domain is available”, the name you have chosen will work.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito21.png">
-
 1. Click the “Save changes” button.
 
 Now that you have created an Amazon Cognito User Pool and Application Definition, we can configure the OpenID Connect plugin in Kong. We can then test integration between Dev Portal and Amazon Cognito.

--- a/app/enterprise/2.4.x/plugins/oidc-google.md
+++ b/app/enterprise/2.4.x/plugins/oidc-google.md
@@ -59,7 +59,7 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service

--- a/app/enterprise/2.4.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.4.x/plugins/oidc-okta.md
@@ -30,31 +30,17 @@ as an authorized redirect URI in Okta (under the **Authentication** section of y
 
 1. [Register an Application][okta-register-app]. Select the **Applications** page, click **Add Application**.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/01-add-application.png">
-
 2. Select **Web** as the platform.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/02-web-app.png">
 
 3. Fill out the Application's Settings.
 
     **Login re-direct URIs** is a URI that corresponds to a Route you have configured in Kong that will use Okta to authenticate. **Group Assignment** defines who is allowed to use this application. **Grant Type Allowed** indicates the Grant types to allow for your application.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/03-app-settings.png">
-
 4. After submitting the Application configuration, the client credentials will display on the **General** page.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/04-client-id-secret.png">
 
 5. [Define and configure an Authorization server][okta-authorization-server]. Select the **API** page and add an Authorization Server if you don't have an existing one to use.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/05-auth-server.png">
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/06-name-auth.png">
-
 6. Click **Save** and view your Authorization Server Settings.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/07-auth-server-settings.png">
 
 ## Plugin Configuration
 

--- a/app/enterprise/2.4.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.4.x/plugins/oidc-okta.md
@@ -119,7 +119,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/kong-manager/enable-plugin/

--- a/app/enterprise/2.5.x/deployment/installation/overview.md
+++ b/app/enterprise/2.5.x/deployment/installation/overview.md
@@ -8,7 +8,7 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
     <div class="install-description">Install the Kong Ingress Controller with the {{site.ee_product_name}} on AWS</div>
   </a>
@@ -71,17 +71,17 @@ disable_image_expand: true
 <div class="docs-grid-install">
 
   <a href="https://aws.amazon.com/marketplace/pp/prodview-blxz2rdsx5cc6" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS AMI" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS AMI" />
     <div class="install-text">AWS (AMI)</div>
   </a>
 
   <a href="https://aws.amazon.com/marketplace/pp/B086MZ3TV3?qid=1586561274348&sr=0-4&ref_=srh_res_product_title" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/06/11-aws_logo_smile_1200x630-1.png" alt="AWS EKS" />
+    <img class="install-icon" src="/assets/images/icons/documentation/aws.svg" alt="AWS EKS" />
     <div class="install-text">AWS (EKS)</div>
   </a>
 
   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/konginc1581527938760.kongee2020ubuntuxenial?tab=Overview" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Azure_.png" alt="Azure" />
+    <img class="install-icon" src="/assets/images/icons/documentation/azure.svg" alt="Azure" />
     <div class="install-text">Azure</div>
   </a>
 
@@ -91,7 +91,7 @@ disable_image_expand: true
   </a>
 
   <a href="https://marketplace.redhat.com/en-us/products/kong-enterprise-rhm" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://2tjosk2rxzc21medji3nfn1g-wpengine.netdna-ssl.com/wp-content/uploads/2020/05/Red-Hat-Marketplace-logo-832-320-1.png" alt="Red Hat Marketplace" />
+    <img class="install-icon" src="/assets/images/icons/documentation/rhel.jpg" alt="Red Hat Marketplace" />
     <div class="install-text">Red Hat</div>
   </a>
 

--- a/app/enterprise/2.5.x/deployment/installation/overview.md
+++ b/app/enterprise/2.5.x/deployment/installation/overview.md
@@ -14,7 +14,7 @@ disable_image_expand: true
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/docker" class="docs-grid-install-block">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/docker.png" alt="docker" />
+    <img class="install-icon" src="/assets/images/icons/documentation/docker.png" alt="docker" />
     <div class="install-text">Docker</div>
     <div class="install-description">Install {{site.ee_product_name}} on Docker</div>
   </a>
@@ -40,22 +40,22 @@ disable_image_expand: true
 {% navtab Operating Systems %}
 <div class="docs-grid-install">
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/centos" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/centos.gif" alt="centos" />
+    <img class="install-icon" src="/assets/images/icons/documentation/centos.gif" alt="centos" />
     <div class="install-text">CentOS</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 1</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/amazon-linux-2" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/amazon-linux.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/amazon-linux.png" alt="aws" />
     <div class="install-text">Amazon Linux 2</div>
   </a>
 
   <a href="/enterprise/{{page.kong_version}}/deployment/installation/ubuntu" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="https://doc-assets.konghq.com/install-logos/ubuntu.png" alt="aws" />
+    <img class="install-icon" src="/assets/images/icons/documentation/ubuntu.png" alt="aws" />
     <div class="install-text">Ubuntu</div>
   </a>
 

--- a/app/enterprise/2.5.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/enterprise/2.5.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -17,18 +17,8 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 
-![Appearance Tab](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab.png)
-
-The predefined variables refer to the following elements:
-
-![Appearance Tab - Variables](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-arrows.png)
-
-Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file
-
-![Appearance Tab - Color Picker](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab-variable-hover.png)
+Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file.
 
 ## Editing Theme Files with the Editor
 
 The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/enterprise/{{page.kong_version}}/developer-portal/using-the-editor/) for more information on how to edit, preview, and save files in the Editor.
-
-![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/enterprise/2.5.x/developer-portal/theme-customization/emails.md
+++ b/app/enterprise/2.5.x/developer-portal/theme-customization/emails.md
@@ -104,9 +104,7 @@ Email templates can now be edited in the Portal Editor along with the rest of th
 1. Log into Kong Manager and navigate to the Workspace whose Dev Portal you wish to edit.
 2. Select the **Editor** from the sidebar under **Dev Portal**.
 
-The email templates can be found under the **Emails** section in the Portal Editor sidebar:
-
-![Portal Editor - Emails](https://doc-assets.konghq.com/1.3/dev-portal/editor/dev-portal-emails.png)
+The email templates can be found under the **Emails** section in the Portal Editor sidebar.
 
 ### Editing via the Portal CLI Tool
 

--- a/app/enterprise/2.5.x/developer-portal/using-the-editor.md
+++ b/app/enterprise/2.5.x/developer-portal/using-the-editor.md
@@ -6,8 +6,6 @@ title: Using the Editor
 
 Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
-![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
-
 ### Prerequisites
 
 * Kong Enterprise 1.3 or later
@@ -20,12 +18,7 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
-![Launch Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-sidebar-button.png)
-
-
-This will launch the **Editor Mode**:
-
-![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
+This will launch the **Editor Mode**.
 
 
 
@@ -40,21 +33,13 @@ When enabled, the Dev Portal is pre-populated with Kong's default theme. The fil
 4. Portal Preview - View a live preview of the selected Dev Portal file.
 5. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
 
-![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
-
 ### Editing Files
 
 Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
-![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
-
-
-
 ### Adding new files
 
 Clicking the `New File +` button opens the New File Dialog.
-
-![Add New File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-new-file.png)
 
 Once created, files will immediately be available from within the Editor.
 
@@ -72,5 +57,3 @@ Authentication is handled by `readable_by` value on content pages (for gui view,
 To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
 
 **NOTE:** This action cannot be undone.
-
-![Deleting Files](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-delete-file.png)

--- a/app/enterprise/2.5.x/kong-manager/add-service.md
+++ b/app/enterprise/2.5.x/kong-manager/add-service.md
@@ -30,34 +30,24 @@ access to **Kong Manager**
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Services** tab under **API Gateway**.
 
-    ![Service Page](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/01-service-page.png)
-
 2. Click the **New Service** button to open the **Create Service** dialog.
 Fill in a **Name** and a **URL** for the **Service**.<br/><br/>For example, set the
 name to `test-service` with the URL `http://mockbin.org`.
 
-    ![Create Service Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/02-service-name.png)
 <br/><br/>Kong Manager also allows **Services** to be configured using **Protocol**,
 **Host**, **Path**, and **Port** (optional). To configure the **Service** using
 this method, click the **Add using Protocol, Host, and Path** option.
 
-    ![Configure Using Protocol](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/03-service-protocol.png)  
 <br/>In addition, Kong Manager exposes several **Advanced Fields**
 and their default configuration values: <br/>`Retries: 5`<br/>
 `Connect Timeout: 60000` (in ms)<br/>`Write Timeout: 60000` (in ms)<br/>
 `Read Timeout: 60000` (in ms)<br/><br/>Adjusting these values is optional and can be
 edited later.
 
-    ![Advanced Fields](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/04-service-advanced-fields.png)
-
-
 3. Create the **Service** by clicking the **Create** button.<br/><br/>If successful, you are automatically redirected to the
 **Service's Overview** page.<br/><br/>The **Service Overview** page displays
 information and **Activity** on the **Service**, as well as any **Routes** or
 **Plugins** that have been connected to the **Service**.
-
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/05-service-overview.png)
-
 
 ### Step 2 - Create a New Route attached to the Service
 
@@ -65,13 +55,10 @@ information and **Activity** on the **Service**, as well as any **Routes** or
 [Step 1](#step-1---create-a-new-service), click the **Create New Route** button
 located in the **Routes** tab at the bottom of the page.
 
-    ![Create Route Service ID](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/06-service-route-object.png)
-
 2. To create a **Route** you must provide the **Service** `name` and `id`, this
 will be automatically filled out if the form was accessed via the
 **Service Overview** page.
 
-    ![Step 7](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/07-route-service-id.png)
 <br/><br/>If this field is not automatically filled, the **Service Id** can be
 found via the **Services Overview** page, accessed by clicking on the **Services**
 tab on the side navigation and then clicking the **clipboard** icon next to the
@@ -82,13 +69,9 @@ desired **Service's Id** field.
 name the **Route** `test-route` with the **Host** `example.com`. Once completed,
 click **Create Route**.
 
-    ![Create Route Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/08-route-form-example.png)
-
 4. If created successfully, the page will be automatically redirected back to
 the **Service Overview** page, and the new **Route** will now appear under the
 **Routes** tab.
-
-    ![Completed Route](https://doc-assets.konghq.com/0.35/getting-started/add-a-service/10-completed-route.png)
 
 ### Step 3 - Test the new Service and Route
 

--- a/app/enterprise/2.5.x/kong-manager/administration/admins/invite.md
+++ b/app/enterprise/2.5.x/kong-manager/administration/admins/invite.md
@@ -34,8 +34,6 @@ invitation, they will only be able to log in with that email address. Assign the
 
 4. On the **Teams** page, the new invitee will appear on the **Admins** list with the under **Invited**. Once they accept the invitation, the user will be listed in the main **Admins** list. 
 
-    ![Invited Admins](https://doc-assets.konghq.com/1.3/manager/teams/teams-invited-admin.png)
-
 5. The newly invited **Admin** will have the ability to set a password. If the **Admin** ever forgets the password, it is possible for them to reset it through a recovery email.
 
 
@@ -46,9 +44,7 @@ If a mail server is not yet set up, it is still possible to invite Admins to reg
 1. Invite an **Admin** as described in the section above. 
 
 2. If the "View" link is clicked next to the invited Admin's name, a 
-    `register_url` is displayed on the invitee's details page. 
-
-    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
+    `register_url` is displayed on the invitee's details page.
 
 3. Copy and directly send this link to the invited Admin so that they may set 
     up their credentials and log in. 

--- a/app/enterprise/2.5.x/kong-manager/administration/rbac/index.md
+++ b/app/enterprise/2.5.x/kong-manager/administration/rbac/index.md
@@ -48,9 +48,7 @@ mirror the cluster-level **Roles**, and a fourth unique to each **Workspace**:
 `workspace-read-only`, `workspace-admin`, `workspace-super-admin`, and
 `workspace-portal-admin`.
 
-These roles can be viewed in the **Teams** tab under **Roles**
-
-![Default Roles in New Workspaces](https://doc-assets.konghq.com/1.3/manager/teams/kong-manager-default-roles.png)
+These roles can be viewed in the **Teams** tab under **Roles**.
 
 ⚠️ **IMPORTANT**: Any Role assigned in the **Default Workspace** will have
 **Permissions** applied to all subsequently created **Workspaces**. A **Super Admin**

--- a/app/enterprise/2.5.x/kong-manager/enable-plugin.md
+++ b/app/enterprise/2.5.x/kong-manager/enable-plugin.md
@@ -26,21 +26,15 @@ Plugin via the command line, checkout the
 1. Choose the desired **Workspace** in **Kong Manager** and navigate to the
 **Plugins** tab under **API Gateway**.
 
-    ![Plugins Tab](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/01-plugin-tab.png)
-
 2. Click the **Add New Plugin** button to open the **Plugins** page, which lists
 all the **Kong Enterprise** bundled **Plugins** available.
 <br/><br/>Scroll to the **Traffic Control** section and select **Rate Limiting EE**.
 
-    ![Rate Limiting EE](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/02-rate-limiting.png)
 <br/><br/>This will open the **Plugin Configuration** form for **Rate Limiting EE**.
 
-    ![Configuration Form](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/03-plugin-form.png)
 <br/>Note that the **Plugin** will automatically be enabled when the form is
 submitted. Toggle the **This plugin is Enabled** button at the top of the form
 to configure the **Plugin** without enabling it.
-
-    ![Toggle Enable](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/04-toggle-enable.png)
 
 3. Define the **Plugin** as *global* or *scoped*.
 <br/><br/>*Global* will apply the **Plugin** to *every* **Service** and
@@ -49,9 +43,6 @@ to configure the **Plugin** without enabling it.
 **Consumer**.
 <br/><br/>To use this option, select the **Scoped** radio button and select the
 desired **Service**, **Route**, or **Consumer** from the dropdown.
-
-    ![Connect test-service](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/05-global-scoped.png)
-
 
 4. Fill out the **configuration** form.<br/><br/>For **Rate Limiting EE** the
 following fields are *required*:<br/>-`config.limit`<br/>-`config.sync_rate`<br/>
@@ -69,9 +60,6 @@ enable the **Plugin**. If it is successful, the page will automatically
 redirect to the **Plugin Overview**, with the **Rate Limiting** Plugin
 listed.
 
-    ![Plugin Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/06-plugin-overview.png)
 <br/><br/>If the **Plugin** is *scoped* to a **Service**, **Route**, or
 **Consumer**, the **Plugin** will also be listed on that object's **Overview**
 page.
-
-    ![Service Overview](https://doc-assets.konghq.com/0.35/getting-started/add-a-plugin/07-service-plugin-table.png)

--- a/app/enterprise/2.5.x/kong-manager/overview.md
+++ b/app/enterprise/2.5.x/kong-manager/overview.md
@@ -11,5 +11,3 @@ Here are some of the things you can do with Kong Manager:
 * Activate or deactivate plugins with a couple of clicks.
 * Group your teams, services, plugins, consumer management, and everything else exactly how you want them.
 * Monitor performance: visualize cluster-wide, workspace-level, or even object-level health using intuitive, customizable dashboards.
-
-![Welcome to Kong Manager](https://doc-assets.konghq.com/1.3/manager/kong-manager-workspaces-overview.png)

--- a/app/enterprise/2.5.x/plugins/oidc-cognito.md
+++ b/app/enterprise/2.5.x/plugins/oidc-cognito.md
@@ -10,29 +10,11 @@ In this configuration, we use User Pools.
 
 1. Log in to AWS Console.
 1. Navigate to the Amazon Cognito Service.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito1.png">
-
 1. Click on **Manage User Pools**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito2.png">
-
 1. Click the **Create a user pool** button on the right-hand side.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito3.png">
-
 1. Enter a pool name; we use “test-pool” for this example.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito4.png">
-
 1. Click **Step Through Settings**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito5.png">
-
 1. Select **Email address or phone number**, and under that, select **Allow email addresses**. Select the following standard attributes as required: email, family name, given name.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito6.png">
-
 1. Click **Next step**.
 1. Accept the defaults for **Password settings**, then click **Next step**.
 1. Accept the defaults for **MFA and verifications**, then click **Next step**.
@@ -41,55 +23,23 @@ In this configuration, we use User Pools.
 1. Select **No** for **Do you want to remember your user’s devices**, then click **Next step**.
 1. We can create an application definition later. Keep things simple for now and click **Next step**.
 1. We don’t have any need for Triggers or customized Sign Up/Sign In behavior for this example. Scroll down and click **Save Changes**.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito7.png">
-
 1. Click **Create pool**. Wait a moment for the success message.
 1. Make a note of the **Pool ID**. You will need this when configuring the application later.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito8.png">
 
 ## Application Definition
 
 You need to add an OAuth2 application definition to the User Pool we just created.
 
 1. Go to the App clients screen in the AWS Cognito management screen for the User Pool we just created.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito9.png">
-
 1. Click “Add an app client”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito10.png">
-
-1. Enter an App client name. This demo is using “kong-api”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito11.png">
-
+1. Enter an App client name. This demo is using “kong-api”.
 1. Enter a Refresh token expiration (in days). We will use the default of 30 days.
 1. Do not select “Generate client secret”. This example will use a public client.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito12.png">
-
 1. Do not select any other checkboxes.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito13.png">
-
 1. Click the “Set attribute read and write permissions” button.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito14.png">
-
 1. Let’s make this simple and only give the user read and write access to the required attributes. So, uncheck everything except the email, given name, and family name fields.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito15.png">
-
-1. Click “Create app client”
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito16.png">
-
+1. Click “Create app client”.
 1. Click “Show Details”.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito17.png">
-
 1. Take note of the App client ID. We will need that later.
 1. Go to the App integration -> App client settings screen.
 1. Click the “Cognito User Pool” checkbox under Enabled Identity Providers.
@@ -102,21 +52,13 @@ You need to add an OAuth2 application definition to the User Pool we just create
     Note that AWS Cognito doesn’t support HTTP callback URLs. This field should
     include the API and Dev Portal URLs that you want to secure using AWS Cognito.
 
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito18.png">
-
 1. Click the “Authorization code grant” checkbox under Allowed OAuth Flows.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito19.png">
-
 1. Click the checkboxes next to email, OpenID, aws.cognito.signin.user.admin, and profile.
 1. Click the “Save changes” button.
 1. Click on the domain name tab.
 1. Add a sub-domain name.
 1. Click the Check Availability button.
 1. As long as it reports “This domain is available”, the name you have chosen will work.
-
-    <img src="https://doc-assets.konghq.com/oidc/cognito/cognito21.png">
-
 1. Click the “Save changes” button.
 
 Now that you have created an Amazon Cognito User Pool and Application Definition, we can configure the OpenID Connect plugin in Kong. We can then test integration between Dev Portal and Amazon Cognito.

--- a/app/enterprise/2.5.x/plugins/oidc-google.md
+++ b/app/enterprise/2.5.x/plugins/oidc-google.md
@@ -59,7 +59,7 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service

--- a/app/enterprise/2.5.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.5.x/plugins/oidc-okta.md
@@ -30,31 +30,17 @@ as an authorized redirect URI in Okta (under the **Authentication** section of y
 
 1. [Register an Application][okta-register-app]. Select the **Applications** page, click **Add Application**.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/01-add-application.png">
-
 2. Select **Web** as the platform.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/02-web-app.png">
 
 3. Fill out the Application's Settings.
 
     **Login re-direct URIs** is a URI that corresponds to a Route you have configured in Kong that will use Okta to authenticate. **Group Assignment** defines who is allowed to use this application. **Grant Type Allowed** indicates the Grant types to allow for your application.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/03-app-settings.png">
-
 4. After submitting the Application configuration, the client credentials will display on the **General** page.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/04-client-id-secret.png">
 
 5. [Define and configure an Authorization server][okta-authorization-server]. Select the **API** page and add an Authorization Server if you don't have an existing one to use.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/05-auth-server.png">
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/06-name-auth.png">
-
 6. Click **Save** and view your Authorization Server Settings.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/07-auth-server-settings.png">
 
 ## Plugin Configuration
 

--- a/app/enterprise/2.5.x/plugins/oidc-okta.md
+++ b/app/enterprise/2.5.x/plugins/oidc-okta.md
@@ -119,7 +119,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/kong-manager/enable-plugin/

--- a/app/gateway-oss/2.1.x/kong-for-kubernetes/index.md
+++ b/app/gateway-oss/2.1.x/kong-for-kubernetes/index.md
@@ -10,5 +10,3 @@ title: Kong for Kubernetes
 - Use the power of kubectl (or any custom tooling around kubectl) to configure Kong and get benefits of all Kubernetes, such as declarative configuration, cloud-provider agnostic deployments, RBAC, reconciliation of desired state, and elastic scalability.
 - Kong is configured using a combination of Ingress Resource and Custom Resource Definitions(CRDs).
 - DB-less by default, meaning Kong has the capability of running without a database and using only memory storage for entities.
-
-<img src="https://doc-assets.konghq.com/kubernetes/Kong-for-Kubernetes-Diagram.png" alt="Kong for Kubernetes control diagram">

--- a/app/gateway-oss/2.2.x/kong-for-kubernetes/index.md
+++ b/app/gateway-oss/2.2.x/kong-for-kubernetes/index.md
@@ -10,5 +10,3 @@ title: Kong for Kubernetes
 - Use the power of kubectl (or any custom tooling around kubectl) to configure Kong and get benefits of all Kubernetes, such as declarative configuration, cloud-provider agnostic deployments, RBAC, reconciliation of desired state, and elastic scalability.
 - Kong is configured using a combination of Ingress Resource and Custom Resource Definitions(CRDs).
 - DB-less by default, meaning Kong has the capability of running without a database and using only memory storage for entities.
-
-<img src="https://doc-assets.konghq.com/kubernetes/Kong-for-Kubernetes-Diagram.png" alt="Kong for Kubernetes control diagram">

--- a/app/gateway-oss/2.3.x/kong-for-kubernetes/index.md
+++ b/app/gateway-oss/2.3.x/kong-for-kubernetes/index.md
@@ -10,5 +10,3 @@ title: Kong for Kubernetes
 - Use the power of kubectl (or any custom tooling around kubectl) to configure Kong and get benefits of all Kubernetes, such as declarative configuration, cloud-provider agnostic deployments, RBAC, reconciliation of desired state, and elastic scalability.
 - Kong is configured using a combination of Ingress Resource and Custom Resource Definitions(CRDs).
 - DB-less by default, meaning Kong has the capability of running without a database and using only memory storage for entities.
-
-<img src="https://doc-assets.konghq.com/kubernetes/Kong-for-Kubernetes-Diagram.png" alt="Kong for Kubernetes control diagram">

--- a/app/gateway-oss/2.4.x/kong-for-kubernetes/index.md
+++ b/app/gateway-oss/2.4.x/kong-for-kubernetes/index.md
@@ -10,5 +10,3 @@ title: Kong for Kubernetes
 - Use the power of kubectl (or any custom tooling around kubectl) to configure Kong and get benefits of all Kubernetes, such as declarative configuration, cloud-provider agnostic deployments, RBAC, reconciliation of desired state, and elastic scalability.
 - Kong is configured using a combination of Ingress Resource and Custom Resource Definitions(CRDs).
 - DB-less by default, meaning Kong has the capability of running without a database and using only memory storage for entities.
-
-<img src="https://doc-assets.konghq.com/kubernetes/Kong-for-Kubernetes-Diagram.png" alt="Kong for Kubernetes control diagram">

--- a/app/gateway-oss/2.5.x/kong-for-kubernetes/index.md
+++ b/app/gateway-oss/2.5.x/kong-for-kubernetes/index.md
@@ -10,5 +10,3 @@ title: Kong for Kubernetes
 - Use the power of kubectl (or any custom tooling around kubectl) to configure Kong and get benefits of all Kubernetes, such as declarative configuration, cloud-provider agnostic deployments, RBAC, reconciliation of desired state, and elastic scalability.
 - Kong is configured using a combination of Ingress Resource and Custom Resource Definitions(CRDs).
 - DB-less by default, meaning Kong has the capability of running without a database and using only memory storage for entities.
-
-<img src="https://doc-assets.konghq.com/kubernetes/Kong-for-Kubernetes-Diagram.png" alt="Kong for Kubernetes control diagram">

--- a/app/gateway/2.6.x/configure/auth/oidc-okta.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-okta.md
@@ -119,7 +119,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /gateway/{{page.kong_version}}/admin-api/#service-object
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
-[enable-plugin]: /gateway/{{page.kong_version}}/kong-manager/#plugin-object
+[enable-plugin]: /gateway/{{page.kong_version}}/admin-api/#plugin-object

--- a/app/gateway/2.6.x/configure/auth/oidc-okta.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-okta.md
@@ -30,31 +30,17 @@ as an authorized redirect URI in Okta (under the **Authentication** section of y
 
 1. [Register an Application][okta-register-app]. Select the **Applications** page, click **Add Application**.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/01-add-application.png">
-
 2. Select **Web** as the platform.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/02-web-app.png">
 
 3. Fill out the Application's Settings.
 
     **Login re-direct URIs** is a URI that corresponds to a Route you have configured in Kong that will use Okta to authenticate. **Group Assignment** defines who is allowed to use this application. **Grant Type Allowed** indicates the Grant types to allow for your application.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/03-app-settings.png">
-
 4. After submitting the Application configuration, the client credentials will display on the **General** page.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/04-client-id-secret.png">
 
 5. [Define and configure an Authorization server][okta-authorization-server]. Select the **API** page and add an Authorization Server if you don't have an existing one to use.
 
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/05-auth-server.png">
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/06-name-auth.png">
-
 6. Click **Save** and view your Authorization Server Settings.
-
-    <img src="https://doc-assets.konghq.com/0.35/plugins/oidc-okta/07-auth-server-settings.png">
 
 ## Plugin Configuration
 

--- a/app/gateway/2.6.x/configure/auth/rbac/add-admin.md
+++ b/app/gateway/2.6.x/configure/auth/rbac/add-admin.md
@@ -54,8 +54,6 @@ If a mail server is not yet set up, it is still possible to invite Admins to reg
 2. If the "View" link is clicked next to the invited Admin's name, a
     `register_url` is displayed on the invitee's details page.
 
-    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
-
 3. Copy and directly send this link to the invited Admin so that they may set
     up their credentials and log in.
 

--- a/app/gateway/2.6.x/developer-portal/theme-customization/easy-theme-editing.md
+++ b/app/gateway/2.6.x/developer-portal/theme-customization/easy-theme-editing.md
@@ -16,18 +16,8 @@ The Kong Developer Portal ships with a default theme, including preset images, b
 From the **Workspace** dashboard in **Kong Manager**, click on the **Appearance** tab under **Dev Portal** on the left side bar.
 This will open the Developer Portals theme editor. From this page, the header logo, background colors, font colors, and button styles can be edited using the color picker interface.
 
-![Appearance Tab](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab.png)
-
-The predefined variables refer to the following elements:
-
-![Appearance Tab - Variables](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-arrows.png)
-
 Hovering over an element will show a color picker, as well as a list of predefined colors. These colors are defined by the current template and can be edited in the [theme.conf.yaml](#editing-theme-files-with-the-editor) file
-
-![Appearance Tab - Color Picker](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-appearance-tab-variable-hover.png)
 
 ## Editing Theme Files with the Editor
 
 The Dev Portal Editor within Kong Manager exposes the default Dev Portal theme files. The theme files can be found at the bottom of the file list under *Themes*. The variables exposed in the *Appearance* tab can be edited in the `theme.conf.yaml` file. See [Using the Editor](/gateway/{{page.kong_version}}/developer-portal/using-the-editor/) for more information on how to edit, preview, and save files in the Editor.
-
-![Theme File in Editor](https://doc-assets.konghq.com/1.3/dev-portal/easy-themes/devportal-theme-conf-yaml.png)

--- a/app/gateway/2.6.x/developer-portal/theme-customization/emails.md
+++ b/app/gateway/2.6.x/developer-portal/theme-customization/emails.md
@@ -100,9 +100,7 @@ Email templates can now be edited in the Portal Editor along with the rest of th
 1. Log into Kong Manager and navigate to the Workspace whose Dev Portal you wish to edit.
 2. Select the **Editor** from the sidebar under **Dev Portal**.
 
-The email templates can be found under the **Emails** section in the Portal Editor sidebar:
-
-![Portal Editor - Emails](https://doc-assets.konghq.com/1.3/dev-portal/editor/dev-portal-emails.png)
+The email templates can be found under the **Emails** section in the Portal Editor sidebar.
 
 ### Editing via the Portal CLI Tool
 

--- a/app/gateway/2.6.x/developer-portal/using-the-editor.md
+++ b/app/gateway/2.6.x/developer-portal/using-the-editor.md
@@ -5,8 +5,6 @@ badge: enterprise
 
 Kong Manager offers a robust file editor for editing the template files of the Dev Portal from within the browser.
 
-![Dev Portal Editor](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-homepage.png)
-
 ## Prerequisites
 
 * {{site.base_gateway}} 1.3 or later
@@ -19,13 +17,7 @@ Kong Manager offers a robust file editor for editing the template files of the D
 
 From the **Kong Manager** dashboard of your **Workspace**, click **Editor** under **Dev Portal** in the sidebar.
 
-![Launch Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-sidebar-button.png)
-
-
-This will launch the **Editor Mode**:
-
-![Editor Mode](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-mode-launch.png)
-
+This will launch the **Editor Mode**.
 
 ## Navigating the Editor
 
@@ -37,20 +29,13 @@ When enabled, the Dev Portal is pre-populated with Kong's default theme. The fil
 4. Portal Preview - View a live preview of the selected Dev Portal file.
 5. Toggle View - Choose between three different views: full screen code, split view, and full screen preview mode.
 
-![Dev Portal with Numbers](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-numbers.png)
-
 ## Editing Files
 
 Select a file from the sidebar to open it for editing. This will expose the file to the Code View and show a live update in the Portal Preview. Clicking Save in the top right corner will save the updates to the database and update the file on the Dev Portal.
 
-![Editing a File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-edit-file.png)
-
-
 ## Adding new files
 
 Clicking the `New File +` button opens the New File Dialog.
-
-![Add New File](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-new-file.png)
 
 Once created, files will immediately be available from within the Editor.
 
@@ -68,5 +53,3 @@ Authentication is handled by `readable_by` value on content pages (for gui view,
 To delete a file from within the Editor, right click on the file name and select **Delete** from the popup menu.
 
 **NOTE:** This action cannot be undone.
-
-![Deleting Files](https://doc-assets.konghq.com/1.3/dev-portal/editor/devportal-editor-delete-file.png)

--- a/app/gateway/2.7.x/configure/auth/rbac/add-admin.md
+++ b/app/gateway/2.7.x/configure/auth/rbac/add-admin.md
@@ -54,8 +54,6 @@ If a mail server is not yet set up, it is still possible to invite Admins to reg
 2. If the "View" link is clicked next to the invited Admin's name, a
     `register_url` is displayed on the invitee's details page.
 
-    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
-
 3. Copy and directly send this link to the invited Admin so that they may set
     up their credentials and log in.
 

--- a/app/gateway/2.8.x/configure/auth/rbac/add-admin.md
+++ b/app/gateway/2.8.x/configure/auth/rbac/add-admin.md
@@ -54,8 +54,6 @@ If a mail server is not yet set up, it is still possible to invite Admins to reg
 2. If the "View" link is clicked next to the invited Admin's name, a
     `register_url` is displayed on the invitee's details page.
 
-    ![Registration URL](https://doc-assets.konghq.com/1.3/manager/teams/teams-invite-admin-generate-registration-link.png)
-
 3. Copy and directly send this link to the invited Admin so that they may set
     up their credentials and log in.
 

--- a/archive/enterprise/0.35-x/plugins/oidc-azuread.md
+++ b/archive/enterprise/0.35-x/plugins/oidc-azuread.md
@@ -81,7 +81,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 [azure-create-app]: https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
 [azure-manifest]: https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-app-manifest#configure-the-app-manifest
 [azure-tenants]: https://docs.microsoft.com/en-us/azure/active-directory/develop/single-and-multi-tenant-apps
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/getting-started/add-service
 [oidc-id-token]: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim

--- a/archive/enterprise/0.35-x/plugins/oidc-okta.md
+++ b/archive/enterprise/0.35-x/plugins/oidc-okta.md
@@ -102,7 +102,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/getting-started/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/getting-started/enable-plugin/

--- a/archive/enterprise/0.36-x/plugins/oidc-okta.md
+++ b/archive/enterprise/0.36-x/plugins/oidc-okta.md
@@ -102,7 +102,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/getting-started/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/getting-started/enable-plugin/

--- a/archive/enterprise/1.3-x/plugins/oidc-google.md
+++ b/archive/enterprise/1.3-x/plugins/oidc-google.md
@@ -58,7 +58,7 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
 [add-service]: /enterprise/{{page.kong_version}}/getting-started/add-service

--- a/archive/enterprise/1.3-x/plugins/oidc-okta.md
+++ b/archive/enterprise/1.3-x/plugins/oidc-okta.md
@@ -102,7 +102,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/getting-started/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/getting-started/enable-plugin/

--- a/archive/enterprise/1.5.x/plugins/oidc-google.md
+++ b/archive/enterprise/1.5.x/plugins/oidc-google.md
@@ -58,7 +58,7 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service

--- a/archive/enterprise/1.5.x/plugins/oidc-okta.md
+++ b/archive/enterprise/1.5.x/plugins/oidc-okta.md
@@ -102,7 +102,7 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[add-certificate]: /1.0.x/admin-api/#add-certificate
+[add-certificate]: /gateway/latest/admin-api/#add-certificate
 [add-service]: /enterprise/{{page.kong_version}}/kong-manager/add-service
 [credential-claim]: https://docs.konghq.com/hub/kong-inc/openid-connect/#configcredential_claim
 [enable-plugin]: /enterprise/{{page.kong_version}}/kong-manager/enable-plugin/


### PR DESCRIPTION
### Description

`https://doc-assets.konghq.com` doesn't exist, and hasn't existed for a while. While all the broken links have since been updated in later versions, we still have a bunch of old content with many broken images. This PR clears them out.

Broken image links flagged by link checker: https://github.com/Kong/docs.konghq.com/actions/runs/5166317733/attempts/1

### Testing instructions

~Broken link test should pass~ It's still failing, but the failures are all 429s from github links, so that's a success.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

