### PR TITLE
Chore: Add more style rules to Vale

### DIFF
--- a/.github/styles/kong/First-person.yml
+++ b/.github/styles/kong/First-person.yml
@@ -1,0 +1,13 @@
+extends: existence
+message: "Avoid first-person pronouns such as '%s'."
+link: 'https://developers.google.com/style/pronouns#personal-pronouns'
+ignorecase: true
+level: error
+nonword: true
+tokens:
+  - (?:^|\s)I\s
+  - (?:^|\s)I,\s
+  - \bI'm\b
+  - \bme\b
+  - \bmy\b
+  - \bmine\b

--- a/.github/styles/kong/Relativeurls.yml
+++ b/.github/styles/kong/Relativeurls.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Use relative URLs for docs URLs for example: [Get Started](/gateway/latest/get-started/) instead of [Get Started](https://docs.konghq.com/gateway/3.3.x/get-started/)."
+nonword: true
+level: error
+scope: raw
+tokens:
+  - '\[[^\]]*\]\(https?:\/\/docs\.konghq\.com[^\)]*\)'

--- a/.github/styles/kong/Relativeurls.yml
+++ b/.github/styles/kong/Relativeurls.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Use relative URLs for docs URLs for example: [Get Started](/gateway/latest/get-started/) instead of [Get Started](https://docs.konghq.com/gateway/3.3.x/get-started/)."
+message: "Use relative URLs for docs URLs for example: [Get Started](/gateway/latest/get-started/) instead of [Get Started](https://docs.konghq.com/gateway/3.3.x/get-started/). If a direct URL is necessary, use {{ site.links.web }} instead of `https://docs.konghq.com`."
 nonword: true
 level: error
 scope: raw

--- a/.github/styles/kong/Relativeurls.yml
+++ b/.github/styles/kong/Relativeurls.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Use relative URLs for docs URLs for example: [Get Started](/gateway/latest/get-started/) instead of [Get Started](https://docs.konghq.com/gateway/3.3.x/get-started/). If a direct URL is necessary, use {{ site.links.web }} instead of `https://docs.konghq.com`."
+message: "Use relative URLs for docs URLs. For example, use [Get Started](/gateway/latest/get-started/) instead of [Get Started](https://docs.konghq.com/gateway/3.3.x/get-started/). If a direct URL is necessary, use {{ site.links.web }} instead of `https://docs.konghq.com`."
 nonword: true
 level: error
 scope: raw

--- a/.github/styles/kong/We.yml
+++ b/.github/styles/kong/We.yml
@@ -1,0 +1,11 @@
+extends: existence
+message: "Try to avoid using first-person plural like '%s'."
+link: 'https://developers.google.com/style/pronouns#personal-pronouns'
+level: warning
+ignorecase: true
+tokens:
+  - we
+  - we'(?:ve|re)
+  - ours?
+  - us
+  - let's


### PR DESCRIPTION
https://kongstrong.slack.com/archives/G012HLJ4GJJ/p1685972120560589

Based on a comment made in Slack this week. I added rules directly from [here](https://github.com/errata-ai/Google/tree/master/Google). 

We rule is set to warning, and the first person pronoun rule is set to error. In my opinion "I's" and "me's" should auto fail, the other rule can be used locally on a directory to remove We's and catch them in the moment. 


edit: 
Added rule to catch absolute URLs that should be relative

tested it on the following cases: 

```
[Kong Admin API Documentation](gateway/latest/admin-api/)
[Kong Admin API Documentation](https://docs.konghq.com/gateway/latest/admin-api/)

[Kong Admin API Documentation](https://google.com)
```

And: 
```
curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} sh -


`curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} sh -`


```
