### PR TITLE
add support status of kong router flavors of kic 2.10

### DIFF
--- a/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
+++ b/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
@@ -13,18 +13,22 @@ The router can be configured in the following [modes][gateway-router-flavor]:
 The compatibilities of router flavors between different {{site.kic_product_name}} versions and {{site.base_gateway}} are shown in the following table.
 {{site.kic_product_name}} in versions 2.6.x and lower does not support {{site.base_gateway}} 3.0 and later, so the version of {{site.kic_product_name}} begins at 2.7.x.
 
-| {{site.kic_product_name}}          |             2.7.x              |             2.8.x              |             2.9.x              |           2.10.x                |
-|:-----------------------------------|:------------------------------:|:------------------------------:|:------------------------------:|:-------------------------------:|
-| Kong 3.x  `traditional`            |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   | <i class="fa fa-check"></i>     |
-| Kong 3.x  `traditional_compatible` | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*)  | 
-| Kong 3.x  `expressions`            |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   | <i class="fa fa-times"></i>(**) |
+| {{site.kic_product_name}}          |             2.7.x              |             2.8.x              |             2.9.x              |           2.10.x               |
+|:-----------------------------------|:------------------------------:|:------------------------------:|:------------------------------:|:------------------------------:|
+| Kong 3.x  `traditional`            |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   | <i class="fa fa-check"></i>    |
+| Kong 3.x  `traditional_compatible` | <i class="fa fa-check"></i>(1) | <i class="fa fa-check"></i>(1) | <i class="fa fa-check"></i>(1) | <i class="fa fa-check"></i>(1) | 
+| Kong 3.x  `expressions`            |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   | <i class="fa fa-times"></i>(2) |
 
-(*) Most use cases are supported. Regexes with a backslash (`\`) followed by a non-escaped character (for example, `\j` or `\/`) in matches of paths or headers
-may not be accepted when {{site.base_gateway}} 3.x is configured to use the `traditional_compatible` router.
+(1) Most use cases are supported. The incompatible cases comes from the difference of regular expression standards in differen routers:
+`traditional` router accepts [PCRE 2][pcre-2-regex] regular expressions, but `traditional_compatible` and `expressions` routers accepts regulart expression in [Rust][rust-regex].
+The most significant difference is that Regular expressions with a backslash (`\`) followed by a non-escaped character (for example, `\j` or `\/`) in matches of paths or headers
+are accepted in `traditional` router but not accepted when {{site.base_gateway}} 3.x is configured to use the `traditional_compatible` router.
 
-(**) Limited support of expression based router (alpha maturity). Please refer to [expression router concept page][kic-expression-router-2-10]
+(2) Limited support of expression based router (alpha maturity). Please refer to [expression router concept page][kic-expression-router-2-10]
 to see detailed status of supporting {{site.base_gateway}} with expression router.
 
 [gateway-expression-router]:/gateway/latest/key-concepts/routes/expressions/
 [gateway-router-flavor]:/gateway/latest/reference/configuration/#router_flavor
+[pcre-2-regex]:https://www.pcre.org/current/doc/html/pcre2syntax.html
+[rust-regex]:https://docs.rs/regex/latest/regex/
 [kic-expression-router-2-10]:/kubernetes-ingress-controller/2.10.x/concepts/expression-based-router

--- a/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
+++ b/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
@@ -13,17 +13,18 @@ The router can be configured in the following [modes][gateway-router-flavor]:
 The compatibilities of router flavors between different {{site.kic_product_name}} versions and {{site.base_gateway}} are shown in the following table.
 {{site.kic_product_name}} in versions 2.6.x and lower does not support {{site.base_gateway}} 3.0 and later, so the version of {{site.kic_product_name}} begins at 2.7.x.
 
-| {{site.kic_product_name}}            |             2.7.x              |             2.8.x              |             2.9.x              |
-|:-------------------------------------|:------------------------------:|:------------------------------:|:------------------------------:|
-| Kong 3.0.x  `traditional`            |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   |
-| Kong 3.0.x  `traditional_compatible` | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) |
-| Kong 3.0.x  `expressions`            |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   |
-| Kong 3.1.x  `traditional`            |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   |
-| Kong 3.1.x  `traditional_compatible` | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) |
-| Kong 3.1.x  `expressions`            |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   |
+| {{site.kic_product_name}}          |             2.7.x              |             2.8.x              |             2.9.x              |           2.10.x                |
+|:-----------------------------------|:------------------------------:|:------------------------------:|:------------------------------:|:-------------------------------:|
+| Kong 3.x  `traditional`            |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   |  <i class="fa fa-check"></i>   | <i class="fa fa-check"></i>     |
+| Kong 3.x  `traditional_compatible` | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*) | <i class="fa fa-times"></i>(*)  | 
+| Kong 3.x  `expressions`            |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   |  <i class="fa fa-times"></i>   | <i class="fa fa-times"></i>(**) |
 
 (*) Most use cases are supported. Regexes with a backslash (`\`) followed by a non-escaped character (for example, `\j` or `\/`) in matches of paths or headers
-may not be accepted when {{site.base_gateway}} 3.0 is configured to use the `traditional_compatible` router.
+may not be accepted when {{site.base_gateway}} 3.x is configured to use the `traditional_compatible` router.
+
+(**) Limited support of expression based router (alpha stage). Please refer to [expression router concept page][kic-expression-router-2-10]
+to see detailed status of supporting {{site.base_gateway}} with expression router.
 
 [gateway-expression-router]:/gateway/latest/key-concepts/routes/expressions/
 [gateway-router-flavor]:/gateway/latest/reference/configuration/#router_flavor
+[kic-expression-router-2-10]:/kubernetes-ingress-controller/2.10.x/concepts/expression-based-router

--- a/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
+++ b/app/_src/kubernetes-ingress-controller/references/supported-router-flavors.md
@@ -22,7 +22,7 @@ The compatibilities of router flavors between different {{site.kic_product_name}
 (*) Most use cases are supported. Regexes with a backslash (`\`) followed by a non-escaped character (for example, `\j` or `\/`) in matches of paths or headers
 may not be accepted when {{site.base_gateway}} 3.x is configured to use the `traditional_compatible` router.
 
-(**) Limited support of expression based router (alpha stage). Please refer to [expression router concept page][kic-expression-router-2-10]
+(**) Limited support of expression based router (alpha maturity). Please refer to [expression router concept page][kic-expression-router-2-10]
 to see detailed status of supporting {{site.base_gateway}} with expression router.
 
 [gateway-expression-router]:/gateway/latest/key-concepts/routes/expressions/


### PR DESCRIPTION
### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

Update supported router flavors of KIC 2.10.x. fixes https://github.com/Kong/kubernetes-ingress-controller/issues/4086. 


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
https://deploy-preview-5678--kongdocs.netlify.app/kubernetes-ingress-controller/latest/references/supported-router-flavors/
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->


