### PR TITLE
Fix release date for 3.2.2.3

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -7,7 +7,7 @@ no_version: true
 
 
 ## 3.2.2.3 
-**Release Date** 2023/06/06
+**Release Date** 2023/06/07
 
 ### Fixes
 * Fixed an error with the `/config` endpoint. If `flatten_errors=1` was set and an invalid config was sent to the endpoint, a 500 error was incorrectly returned.


### PR DESCRIPTION
fix 3.2.2.3 release date


### Description

fixing the 3.2.2.3 release date that I missed on PR5673


### Testing instructions

Netlify link: (https://deploy-preview-5680--kongdocs.netlify.app/gateway/changelog/)


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

