### PR TITLE
Added Access phase to Response as seen in Konnect API

### DIFF
--- a/app/konnect/api/runtime-groups-config/index.md
+++ b/app/konnect/api/runtime-groups-config/index.md
@@ -230,7 +230,7 @@ plugin_json: |
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"],
-        "ordering": {"before":["plugin-name"]}
+        "ordering": {"before":{"access":["plugin-name"]}}
     }
 
 plugin_data: |
@@ -247,7 +247,7 @@ plugin_data: |
         "protocols": ["http", "https"],
         "enabled": true,
         "tags": ["user-level", "low-priority"],
-        "ordering": {"before":["plugin-name"]}
+        "ordering": {"before":{"access":["plugin-name"]}}
     }, {
         "id": "66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4",
         "name": "rate-limiting",
@@ -259,7 +259,7 @@ plugin_data: |
         "protocols": ["tcp", "tls"],
         "enabled": true,
         "tags": ["admin", "high-priority", "critical"],
-        "ordering": {"after":["plugin-name"]}
+        "ordering": {"after":{"access":["plugin-name"]}}
     }],
 
 certificate_body: |


### PR DESCRIPTION
### Description

Support case had been filed pointing out that the Konnect API response output in the docs were missing the "access" phase part of the Ordering line. We confirmed in a test that it is indeed in the responses whenever Dynamic Ordering is used on any plugin in the Konnect environment.


### Testing instructions

N/A

### Checklist 

- [Y] Review label added <!-- (see below) -->
- [Y] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)