### PR TITLE
fix default tracing_sampling_rate value

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -190,7 +190,7 @@ Tracer samples a fixed percentage of all spans following the sampling rate.
 
 Example: `0.25`, this should account for 25% of all traces.
 
-**Default:** `1.0`
+**Default:** `0.01`
 
 {% endif_version %}
 

--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -190,7 +190,7 @@ Tracer samples a fixed percentage of all spans following the sampling rate.
 
 Example: `0.25`, this should account for 25% of all traces.
 
-**Default:** `0.01`
+**Default:** `1.0`
 
 {% endif_version %}
 
@@ -243,7 +243,7 @@ Tracer samples a fixed percentage of all spans following the sampling rate.
 
 Example: `0.25`, this should account for 25% of all traces.
 
-**Default:** `1.0`
+**Default:** `0.01`
 
 {% endif_version %}
 


### PR DESCRIPTION
change from 1.0 to 0.01 according to https://github.com/Kong/kong/blob/release/3.3.x/kong.conf.default#L136