### PR TITLE
chore: Fix URL in plugin endpoint

### DIFF
--- a/app/konnect/api/runtime-groups-config/index.md
+++ b/app/konnect/api/runtime-groups-config/index.md
@@ -1381,7 +1381,7 @@ understand what fields a plugin accepts, and can be used for building
 third-party integrations to the Kong's plugin system.
 
 
-<div class="endpoint get">/schemas/plugins/{plugin name}</div>
+<div class="endpoint get">/{runtimeGroupId}/core-entities/schemas/plugins/{plugin_name}</div>
 
 #### Response
 


### PR DESCRIPTION
Fixes incorrect URL https://docs.konghq.com/konnect/api/runtime-groups-config/#retrieve-plugin-schema

https://kongstrong.slack.com/archives/C03NRECFJPM/p1686350903083519


