### PR TITLE
Add docs on using Kong Enterprise with KIC

### DIFF
--- a/app/_data/docs_nav_kic_2.10.x.yml
+++ b/app/_data/docs_nav_kic_2.10.x.yml
@@ -73,6 +73,8 @@ items:
         url: /guides/upgrade
       - text: Upgrading to Kong 3.x
         url: /guides/upgrade-kong-3x
+      - text: Using Kong Enterprise
+        url: /guides/choose-gateway-image
       - text: Getting Started using Istio
         url: /guides/getting-started-istio
       - text: Using Custom Resources

--- a/app/_data/docs_nav_kic_2.6.x.yml
+++ b/app/_data/docs_nav_kic_2.6.x.yml
@@ -71,6 +71,8 @@ items:
         url: /guides/upgrade
       - text: Upgrading to Kong 3.x
         url: /guides/upgrade-kong-3x
+      - text: Using Kong Enterprise
+        url: /guides/choose-gateway-image
       - text: Getting Started using Istio
         url: /guides/getting-started-istio
       - text: Using Custom Resources

--- a/app/_data/docs_nav_kic_2.7.x.yml
+++ b/app/_data/docs_nav_kic_2.7.x.yml
@@ -71,6 +71,8 @@ items:
         url: /guides/upgrade
       - text: Upgrading to Kong 3.x
         url: /guides/upgrade-kong-3x
+      - text: Using Kong Enterprise
+        url: /guides/choose-gateway-image
       - text: Getting Started using Istio
         url: /guides/getting-started-istio
       - text: Using Custom Resources

--- a/app/_data/docs_nav_kic_2.8.x.yml
+++ b/app/_data/docs_nav_kic_2.8.x.yml
@@ -71,6 +71,8 @@ items:
         url: /guides/upgrade
       - text: Upgrading to Kong 3.x
         url: /guides/upgrade-kong-3x
+      - text: Using Kong Enterprise
+        url: /guides/choose-gateway-image
       - text: Getting Started using Istio
         url: /guides/getting-started-istio
       - text: Using Custom Resources

--- a/app/_data/docs_nav_kic_2.9.x.yml
+++ b/app/_data/docs_nav_kic_2.9.x.yml
@@ -73,6 +73,8 @@ items:
         url: /guides/upgrade
       - text: Upgrading to Kong 3.x
         url: /guides/upgrade-kong-3x
+      - text: Using Kong Enterprise
+        url: /guides/choose-gateway-image
       - text: Getting Started using Istio
         url: /guides/getting-started-istio
       - text: Using Custom Resources

--- a/app/_src/kubernetes-ingress-controller/guides/choose-gateway-image.md
+++ b/app/_src/kubernetes-ingress-controller/guides/choose-gateway-image.md
@@ -24,7 +24,11 @@ gateway:
 {% endnavtab %}
 {% endnavtabs %}
 
-Once these changes have been made, run `helm upgrade <release_name> <chart_name> -n <namespace> --values ./values.yaml` to switch to the new image.
+Once these changes have been made, switch to the new image:
+
+```sh
+helm upgrade <release_name> <chart_name> -n <namespace> --values ./values.yaml
+```
 
 You can check which images are being used with the following query:
 

--- a/app/_src/kubernetes-ingress-controller/guides/choose-gateway-image.md
+++ b/app/_src/kubernetes-ingress-controller/guides/choose-gateway-image.md
@@ -1,0 +1,33 @@
+---
+title: Using Kong Enterprise
+---
+
+{{ site.kic_product_name }} supports both {{ site.base_gateway }} OSS and Enterprise. If you install {{ site.kic_product_name }} using the default Helm charts, {{ site.base_gateway }} OSS will be installed.
+
+To switch from {{ site.base_gateway }} OSS to {{ site.base_gateway }} Enterprise, choose the correct tab for the Helm chart that you are using then set the following keys in your `values.yaml`:
+
+{% navtabs %}
+{% navtab kong/kong %}
+```yaml
+image:
+  repository: kong/kong-gateway
+  tag: {{ site.data.kong_latest_gateway.ee-version }}
+```
+{% endnavtab %}
+{% navtab kong/ingress %}
+```yaml
+gateway:
+  image:
+    repository: kong/kong-gateway
+    tag: {{ site.data.kong_latest_gateway.ee-version }}
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+Once these changes have been made, run `helm upgrade <release_name> <chart_name> -n <namespace> --values ./values.yaml` to switch to the new image.
+
+You can check which images are being used with the following query:
+
+```bash
+kubectl get pods -n kong -o jsonpath="{.items[*].spec.containers[*].image}"
+```

--- a/app/_src/kubernetes-ingress-controller/guides/choose-gateway-image.md
+++ b/app/_src/kubernetes-ingress-controller/guides/choose-gateway-image.md
@@ -4,7 +4,7 @@ title: Using Kong Enterprise
 
 {{ site.kic_product_name }} supports both {{ site.base_gateway }} OSS and Enterprise. If you install {{ site.kic_product_name }} using the default Helm charts, {{ site.base_gateway }} OSS will be installed.
 
-To switch from {{ site.base_gateway }} OSS to {{ site.base_gateway }} Enterprise, choose the correct tab for the Helm chart that you are using then set the following keys in your `values.yaml`:
+To switch from {{ site.base_gateway }} OSS to {{ site.base_gateway }} Enterprise, choose the tab for the Helm chart that you're using, then set the following keys in your `values.yaml`:
 
 {% navtabs %}
 {% navtab kong/kong %}


### PR DESCRIPTION
### Description

Adds instructions on how to use `kong/kong-gateway` with KIC

This can go in to `main` as it's not specifically tied to KIC/Konnect

### Testing instructions

Netlify link: [/kubernetes-ingress-controller/latest/guides/choose-gateway-image/](https://deploy-preview-5700--kongdocs.netlify.app//kubernetes-ingress-controller/latest/guides/choose-gateway-image/)


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)