### PR TITLE
docs(cli): db_export now supports Kong Gateway enterprise version

### DIFF
--- a/app/_src/gateway/reference/cli.md
+++ b/app/_src/gateway/reference/cli.md
@@ -69,10 +69,6 @@ Options:
 
 ```
 
-{:.note}
-> **Note:** `db_export` is only supported with open-source
-{{site.base_gateway}} packages.
-
 ---
 
 


### PR DESCRIPTION
### Description

`db_export` now supports Kong Gateway enterprise version (at least since `3.3.0.0`).

The note on the official page is no longer valid. So, remove it.

![image](https://github.com/Kong/docs.konghq.com/assets/6426329/c2fb2008-1b26-4e18-b14e-2e9201e40318)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

