### PR TITLE
fix(kic): rbac permission for Endpoints is redundant for KIC >=2.10

### DIFF
--- a/app/_src/kubernetes-ingress-controller/concepts/deployment.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/deployment.md
@@ -70,7 +70,11 @@ stored in the Kubernetes object store.
 
 It needs read permissions (get, list, watch) on the following Kubernetes resources:
 
+{% if_version lte:2.9.x inline: true%}
+
 - Endpoints
+
+{%- endif_version %}
 {% if_version gte:2.9.x inline: true%}
 
 - EndpointSlices


### PR DESCRIPTION
### Description

[KIC from version 2.10.0](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#changed-1) no longer relies on `Endpoints` anywhere. RBAC permissions for them have been already removed in respective Helm Chart https://github.com/Kong/charts/pull/798
 



### Testing instructions

Netlify link: https://deploy-preview-5708--kongdocs.netlify.app


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

