### PR TITLE
chore: fix API parameter in wrong version

### DIFF
--- a/app/_data/docs_nav_gateway_3.1.x.yml
+++ b/app/_data/docs_nav_gateway_3.1.x.yml
@@ -544,6 +544,7 @@ items:
     items:
       - text: Overview
         url: /admin-api/
+        src: admin-api/admin-api-3.1.x
       - text: Information Routes
         url: /admin-api/#information-routes
       - text: Health Routes

--- a/app/_src/gateway/admin-api/admin-api-3.1.x.md
+++ b/app/_src/gateway/admin-api/admin-api-3.1.x.md
@@ -210,7 +210,6 @@ plugin_body: |
     `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
     `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
     `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
-    `instance_name`<br>*optional* | The Plugin instance name.
     `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
     `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
     `enabled` | Whether the plugin is applied. Default: `true`.
@@ -226,7 +225,6 @@ plugin_json: |
         "route": null,
         "service": null,
         "consumer": null,
-        "instance_name": rate-limiting-foo,
         "config": {"hour":500, "minute":20},
         "protocols": ["http", "https"],
         "enabled": true,
@@ -238,7 +236,6 @@ plugin_data: |
     "data": [{
         "id": "02621eee-8309-4bf6-b36b-a82017a5393e",
         "name": "rate-limiting",
-        "instance_name": "rate-limiting-foo",
         "created_at": 1422386534,
         "updated_at": 1422386534,
         "route": null,


### PR DESCRIPTION
fix issue with instance_name showing up in 3.1


This is fixed by adding a new API markdown file and referencing it from the 3.1 nav bar. 