### PR TITLE
Reordered 3.2.2.3 to be below 3.3.0.0 in the changelog

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -5,16 +5,6 @@ no_version: true
 
 <!-- vale off -->
 
-
-## 3.2.2.3 
-**Release Date** 2023/06/07
-
-### Fixes
-* Fixed an error with the `/config` endpoint. If `flatten_errors=1` was set and an invalid config was sent to the endpoint, a 500 error was incorrectly returned.
-
-### Deprecations
-* **Alpine deprecation reminder:** Kong has announced our intent to remove support for Alpine images and packages later this year. These images and packages are available in 3.2 and will continue to be available in 3.3. We will stop building Alpine images and packages in Kong Gateway 3.4.
-
 ## 3.3.0.0
 **Release Date** 2023/05/19
 
@@ -415,6 +405,15 @@ This should be a 400 because the configuration is invalid.
 
 * When the OpenID Connect (OIDC) plugin is configured to reference HashiCorp Vault in the `config.client_secret` field (for example, `{vault://hcv/clientSecret}`),
 it does not look up the secret correctly.
+
+## 3.2.2.3 
+**Release Date** 2023/06/07
+
+### Fixes
+* Fixed an error with the `/config` endpoint. If `flatten_errors=1` was set and an invalid config was sent to the endpoint, a 500 error was incorrectly returned.
+
+### Deprecations
+* **Alpine deprecation reminder:** Kong has announced our intent to remove support for Alpine images and packages later this year. These images and packages are available in 3.2 and will continue to be available in 3.3. We will stop building Alpine images and packages in Kong Gateway 3.4.
 
 ## 3.2.2.2
 **Release Date** 2023/05/19


### PR DESCRIPTION
### Description

Changelog entry for 3.2.2.3 was higher than 3.3.0.0, swapped these two so that 3.3.0.0 was above 3.2.2.3 to keep the versions ordered properly.


### Testing instructions

N/A

### Checklist 

- [Y] Review label added <!-- (see below) -->
- [Y] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)