### PR TITLE
Prevent badges' tooltips from being loaded in /hub

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -578,25 +578,27 @@ jQuery(function () {
 
 // Tooltips for badges
 jQuery(function () {
-  $(".badge.enterprise").append(
-    '<div class="tooltip"><span class="tooltiptext">Available with Enterprise subscription - <a target="_blank" href="https://konghq.com/contact-sales">Contact Sales</a></span></div>'
-  );
-  $(".badge.plus").append(
-    '<div class="tooltip"><span class="tooltiptext">Available with Plus subscription (Kong Konnect)</span></div>'
-  );
-  $(".badge.free").append(
-    '<div class="tooltip"><span class="tooltiptext">Available in Enterprise Free mode (without a license)</span></div>'
-  );
-  $(".badge.oss").append(
-    '<div class="tooltip"><span class="tooltiptext" >Available in Kong open-source only</span></div>'
-  );
-  $(".badge.dbless").append(
-    '<div class="tooltip"><span class="tooltiptext">Compatible with DB-less deployments</span></div>'
-  );
-  $(".badge.konnect").append(
-    '<div class="tooltip"><span class="tooltiptext">Available in the Kong Konnect app</span></div>'
-  );
-  $(".badge.techpartner").append(
-    '<div class="tooltip"><span class="tooltiptext">Verified Kong technical partner</span></div>'
-  );
+  if ($(".page.page-hub").length === 0) {
+    $(".badge.enterprise").append(
+      '<div class="tooltip"><span class="tooltiptext">Available with Enterprise subscription - <a target="_blank" href="https://konghq.com/contact-sales">Contact Sales</a></span></div>'
+    );
+    $(".badge.plus").append(
+      '<div class="tooltip"><span class="tooltiptext">Available with Plus subscription (Kong Konnect)</span></div>'
+    );
+    $(".badge.free").append(
+      '<div class="tooltip"><span class="tooltiptext">Available in Enterprise Free mode (without a license)</span></div>'
+    );
+    $(".badge.oss").append(
+      '<div class="tooltip"><span class="tooltiptext" >Available in Kong open-source only</span></div>'
+    );
+    $(".badge.dbless").append(
+      '<div class="tooltip"><span class="tooltiptext">Compatible with DB-less deployments</span></div>'
+    );
+    $(".badge.konnect").append(
+      '<div class="tooltip"><span class="tooltiptext">Available in the Kong Konnect app</span></div>'
+    );
+    $(".badge.techpartner").append(
+      '<div class="tooltip"><span class="tooltiptext">Verified Kong technical partner</span></div>'
+    );
+  }
 });


### PR DESCRIPTION
### Description

[Jira ticket](https://konghq.atlassian.net/browse/DOCU-3221)
Prevent badges' tooltips from being displayed in `/hub`. We already have the links' titles and the tooltips were overlapping them.

Before:

![tooltips](https://github.com/Kong/docs.konghq.com/assets/715229/21879389-9501-4a4c-b37e-24576f15d274)

### Testing instructions

[Netlify link](https://deploy-preview-5716--kongdocs.netlify.app/hub/)


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

