### PR TITLE
Make rightnav collpasible on plugin pages

### DIFF
--- a/app/_assets/stylesheets/pages/docs.less
+++ b/app/_assets/stylesheets/pages/docs.less
@@ -717,6 +717,7 @@
       }
 
       .docs-toc-title,
+      .about-extn-table,
       > ul {
         transform: translateX(200%);
         opacity: 0;

--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -146,6 +146,15 @@
     width: 250px;
     top: 75px;
 
+    @media screen and (min-width: 1101px) {
+      &.collapsed {
+        width: 50px;
+      }
+    }
+    .collapse-toc, .expand-toc {
+      top: 0;
+    }
+
     // "On this page" title
     .docs-toc-title {
       a {

--- a/app/_includes/plugins/right_nav.html
+++ b/app/_includes/plugins/right_nav.html
@@ -1,4 +1,8 @@
 <aside class="docs-toc" id="plugin-toc" >
+  <i class="fa fa-times close-sidebar"></i>
+  <i class="fa fa-chevron-right collapse-toc"></i>
+  <i class="far fa-list-alt expand-toc"></i>
+
   {% unless page.toc == false %}
     {% include_cached toc.html
                       html=include.full_content


### PR DESCRIPTION
### Description

[Jira ticket](https://konghq.atlassian.net/browse/DOCU-3237)

Make the right nav collapsible.


Before:
![right-nav](https://github.com/Kong/docs.konghq.com/assets/715229/222c190f-5014-445b-95cf-26898cc26a56)

After:
![collapsible](https://github.com/Kong/docs.konghq.com/assets/715229/57748251-7d5c-46a9-baae-983bb0f928b8)



### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

