### PR TITLE
Plugin configuration edit links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/kumahq/kuma-website.git
 [submodule "app/_src/.repos/kong-plugins"]
 	path = app/_src/.repos/kong-plugins
-	url = https://github.com/fabianrbz/kong-plugins-docs-toolkit.git
+	url = https://github.com/Kong/docs-plugin-toolkit.git

--- a/app/_includes/plugins/header.html
+++ b/app/_includes/plugins/header.html
@@ -30,8 +30,8 @@
 
     <div class="github-links">
       <div class="github-links--edit">
-        {% if page.source_file %}
-          <a href="https://github.com/Kong/docs.konghq.com/edit/{{ site.git_branch }}/app/{{ page.source_file }}">
+        {% if page.edit_link %}
+          <a href="{{ page.edit_link }}">
             <img src="/assets/images/logos/logo-github-white.svg" alt="github-edit-page"/>Edit this page
           </a>
         {% endif %}

--- a/app/_plugins/generators/plugin_single_source/pages/base.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/base.rb
@@ -55,6 +55,10 @@ module PluginSingleSource
         raise NotImplementedError, 'implement this in subclass'
       end
 
+      def edit_link
+        "https://github.com/Kong/docs.konghq.com/edit/#{@site.config['git_branch']}/app/#{source_file}"
+      end
+
       private
 
       def url_attributes
@@ -72,7 +76,8 @@ module PluginSingleSource
           'title' => page_title,
           'versions_dropdown' => ::Jekyll::Drops::Plugins::VersionsDropdown.new(self),
           'breadcrumbs' => ::Jekyll::Drops::Plugins::Breadcrumbs.new(breadcrumbs).breadcrumbs,
-          'sidenav' => sidenav
+          'sidenav' => sidenav,
+          'edit_link' => edit_link
         }
       end
 

--- a/app/_plugins/generators/plugin_single_source/pages/configuration.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/configuration.rb
@@ -41,6 +41,19 @@ module PluginSingleSource
 
       def icon; end
 
+      def edit_link
+        if @release.vendor == 'kong-inc'
+          if @release.enterprise_plugin?
+            "https://github.com/Kong/kong-ee/edit/master/plugins-ee/#{@release.name}/kong/plugins/#{@release.name}/schema.lua"
+          else
+            name = @release.name == 'serverless-functions' ? 'pre-function' : @release.name
+            "https://github.com/Kong/kong/edit/master/kong/plugins/#{name}/schema.lua"
+          end
+        elsif @release.schema
+          "https://github.com/Kong/docs.konghq.com/edit/#{@site.config['git_branch']}/#{@release.schema.file_path}"
+        end
+      end
+
       private
 
       def ssg_hub

--- a/app/_plugins/generators/plugin_single_source/pages/configuration_examples.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/configuration_examples.rb
@@ -44,7 +44,12 @@ module PluginSingleSource
       end
 
       def edit_link
-        "https://github.com/Kong/docs.konghq.com/edit/#{@site.config['git_branch']}/app/_layouts/plugins/configuration_examples.html"
+        if @release.vendor == 'kong-inc'
+          name = @release.name == 'serverless-functions' ? 'pre-function' : @release.name
+          "https://github.com/Kong/docs-plugin-toolkit/edit/main/examples/#{name}/_#{@release.version}.yaml"
+        else
+          "https://github.com/Kong/docs.konghq.com/edit/#{@site.config['git_branch']}/app/_hub/#{@release.vendor}/#{@release.name}/examples/_index.yml"
+        end
       end
 
       private

--- a/app/_plugins/generators/plugin_single_source/pages/configuration_examples.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/configuration_examples.rb
@@ -43,6 +43,10 @@ module PluginSingleSource
         ''
       end
 
+      def edit_link
+        "https://github.com/Kong/docs.konghq.com/edit/#{@site.config['git_branch']}/app/_layouts/plugins/configuration_examples.html"
+      end
+
       private
 
       def ssg_hub

--- a/app/_plugins/generators/plugin_single_source/plugin/release.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/release.rb
@@ -106,6 +106,10 @@ module PluginSingleSource
         @schema ||= Schemas::Base.make_for(vendor:, name:, version:)
       end
 
+      def enterprise_plugin?
+        !!metadata['enterprise'] && !!!metadata['free']
+      end
+
       private
 
       def validate_source!

--- a/spec/app/_plugins/generators/plugin_single_source/pages/configuration_examples_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/configuration_examples_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe PluginSingleSource::Pages::ConfigurationExamples do
+  let(:plugin_name) { 'kong-inc/jwt-signer' }
+  let(:plugin) { PluginSingleSource::Plugin::Base.make_for(dir: plugin_name, site:) }
+  let(:release) { PluginSingleSource::Plugin::Release.new(site:, version:, plugin:, is_latest:, source:) }
+
+  subject { described_class.new(release:, file: nil, source_path:) }
+
+  describe '#edit_link' do
+    let(:is_latest) { true }
+    let(:source) { '_index' }
+    let(:version) { '2.8.x' }
+
+    context 'kong-inc plugins' do
+      context 'enterprise plugins' do
+        let(:plugin_name) { 'kong-inc/jwt-signer' }
+        let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
+
+        it { expect(subject.edit_link).to eq('https://github.com/Kong/docs-plugin-toolkit/edit/main/examples/jwt-signer/_2.8.x.yaml') }
+      end
+
+      context 'non-enterprise plugins' do
+        let(:plugin_name) { 'kong-inc/jq' }
+        let(:source_path) { File.expand_path('_hub/kong-inc/jq/', site.source) }
+
+        it { expect(subject.edit_link).to eq('https://github.com/Kong/docs-plugin-toolkit/edit/main/examples/jq/_2.8.x.yaml') }
+      end
+    end
+
+    context 'third-party plugins' do
+      let(:plugin_name) { 'acme/kong-plugin' }
+      let(:source_path) { File.expand_path('_hub/acme/kong-plugin/', site.source) }
+
+      it { expect(subject.edit_link).to eq('https://github.com/Kong/docs.konghq.com/edit/main/app/_hub/acme/kong-plugin/examples/_index.yml') }
+    end
+  end
+end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe PluginSingleSource::Pages::Configuration do
-  let(:plugin) { PluginSingleSource::Plugin::Base.make_for(dir: 'kong-inc/jwt-signer', site:) }
+  let(:plugin_name) { 'kong-inc/jwt-signer' }
+  let(:plugin) { PluginSingleSource::Plugin::Base.make_for(dir: plugin_name, site:) }
   let(:release) { PluginSingleSource::Plugin::Release.new(site:, version:, plugin:, is_latest:, source:) }
 
   subject { described_class.new(release:, file: nil, source_path:) }
@@ -89,5 +90,34 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
     let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
 
     it { expect(subject.nav_title).to eq('Reference') }
+  end
+
+  describe '#edit_link' do
+    let(:is_latest) { true }
+    let(:source) { '_index' }
+    let(:version) { '2.8.x' }
+
+    context 'kong-inc plugins' do
+      context 'enterprise plugins' do
+        let(:plugin_name) { 'kong-inc/jwt-signer' }
+        let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
+
+        it { expect(subject.edit_link).to eq('https://github.com/Kong/kong-ee/edit/master/plugins-ee/jwt-signer/kong/plugins/jwt-signer/schema.lua') }
+      end
+
+      context 'non-enterprise plugins' do
+        let(:plugin_name) { 'kong-inc/jq' }
+        let(:source_path) { File.expand_path('_hub/kong-inc/jq/', site.source) }
+
+        it { expect(subject.edit_link).to eq('https://github.com/Kong/kong/edit/master/kong/plugins/jq/schema.lua') }
+      end
+    end
+
+    context 'third-party plugins' do
+      let(:plugin_name) { 'acme/kong-plugin' }
+      let(:source_path) { File.expand_path('_hub/acme/kong-plugin/', site.source) }
+
+      it { expect(subject.edit_link).to eq('https://github.com/Kong/docs.konghq.com/edit/main/spec/fixtures/app/_hub/acme/kong-plugin/schemas/_index.json') }
+    end
   end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/release_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/release_spec.rb
@@ -104,4 +104,18 @@ RSpec.describe PluginSingleSource::Plugin::Release do
       it { expect(subject.changelog).to be_nil }
     end
   end
+
+  describe '#enterprise_plugin?' do
+    context 'when the plugin is `enterprise` and not `free`' do
+      let(:plugin_name) { 'acme/unbundled-plugin' }
+
+      it { expect(subject.enterprise_plugin?).to eq(true) }
+    end
+
+    context 'otherwise' do
+      let(:plugin_name) { 'acme/jq' }
+
+      it { expect(subject.enterprise_plugin?).to eq(false) }
+    end
+  end
 end

--- a/spec/fixtures/app/_hub/kong-inc/jq/_metadata.yml
+++ b/spec/fixtures/app/_hub/kong-inc/jq/_metadata.yml
@@ -6,6 +6,8 @@ examples: false
 categories:
   - transformations
 
+free: true
+enterprise: true
 publisher: Kong Inc.
 desc: Transform JSON objects included in API requests or responses using jq programs.
 description: |

--- a/spec/support/shared_contexts/site.rb
+++ b/spec/support/shared_contexts/site.rb
@@ -10,7 +10,8 @@ module SharedContexts
         ).merge(
           source: File.expand_path('../../fixtures/app', __dir__),
           destination: File.expand_path('../../fixtures/dist', __dir__),
-          quiet: true
+          quiet: true,
+          git_branch: 'main'
         )
       )
     end


### PR DESCRIPTION
### Description

[Jira ticket](https://konghq.atlassian.net/browse/DOCU-3280)

What did you change and why?
 
Add `edit this page` link to plugin configuration pages.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

