### PR TITLE
Add changelog entry for 3.4.x changes in the ip-restriction plugin

### DIFF
--- a/app/_hub/kong-inc/ip-restriction/_changelog.md
+++ b/app/_hub/kong-inc/ip-restriction/_changelog.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+**{{site.base_gateway}} 3.4.x**
+- Added support for the "tcp", "tls", "grpc" and "grpcs" protocols.
+
 **{{site.base_gateway}} 3.0.x**
 - Removed the deprecated `whitelist` and `blacklist` parameters.
 They are no longer supported.

--- a/app/_hub/kong-inc/ip-restriction/_changelog.md
+++ b/app/_hub/kong-inc/ip-restriction/_changelog.md
@@ -1,7 +1,7 @@
 ## Changelog
 
 **{{site.base_gateway}} 3.4.x**
-- Added support for the "tcp", "tls", "grpc" and "grpcs" protocols.
+- Added support for the `tcp`, `tls`, `grpc`, and `grpcs` protocols.
 
 **{{site.base_gateway}} 3.0.x**
 - Removed the deprecated `whitelist` and `blacklist` parameters.


### PR DESCRIPTION
### Description

An upcoming change in Kong Gateway will add support for additional protocols in the ip-restriction plugin.  The plugin is slightly underdocumented, but the change is now mentioned in the changelog.

https://github.com/Kong/kong/pull/10245

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

KAG-722