### PR TITLE
Clarify group claims / team mapping in Konnect Okta setup

### DIFF
--- a/app/konnect/org-management/okta-idp.md
+++ b/app/konnect/org-management/okta-idp.md
@@ -29,7 +29,7 @@ Here are the steps you need to complete, in both Okta and
 {{site.konnect_short_name}}.
 First, complete the following in Okta:
 * [Set up an Okta application](#prepare-the-okta-application)
-* [Set up claims in Okta](#set-up-claims-in-okta)
+* [Set up claims in Okta](#set-up-claims-in-okta) (if using group claims for team mapping)
 
 Then, you can set up {{site.konnect_short_name}} to talk to the Okta application:
 * [Set up Okta IDP in {{site.konnect_short_name}}](#set-up-konnect), referring
@@ -66,9 +66,7 @@ Create a new application in Okta to manage {{site.konnect_saas}} account integra
 
 ### Set up claims in Okta
 
-The connection between {{site.konnect_short_name}} and Okta uses OpenID Connect
-tokens. To have Okta send the correct information to your {{site.konnect_short_name}} org, set up
-claims to extract that information.
+This only needs to be followed if intending to use group claims for Konnect team mappings, this is an optional step. The connection between {{site.konnect_short_name}} and Okta uses OpenID Connect tokens. To have Okta send the correct information to your {{site.konnect_short_name}} org, set up claims to extract that information.
 
 1. Open your Okta account in a new browser tab.
 

--- a/app/konnect/org-management/okta-idp.md
+++ b/app/konnect/org-management/okta-idp.md
@@ -29,7 +29,7 @@ Here are the steps you need to complete, in both Okta and
 {{site.konnect_short_name}}.
 First, complete the following in Okta:
 * [Set up an Okta application](#prepare-the-okta-application)
-* (Optional) If using group claims for team mapping, [set up claims in Okta](#set-up-claims-in-okta).
+* (Optional) If using group claims for team mapping, [set up claims in Okta](#optional-set-up-claims-in-okta).
 
 Then, you can set up {{site.konnect_short_name}} to talk to the Okta application:
 * [Set up Okta IDP in {{site.konnect_short_name}}](#set-up-konnect), referring

--- a/app/konnect/org-management/okta-idp.md
+++ b/app/konnect/org-management/okta-idp.md
@@ -29,7 +29,7 @@ Here are the steps you need to complete, in both Okta and
 {{site.konnect_short_name}}.
 First, complete the following in Okta:
 * [Set up an Okta application](#prepare-the-okta-application)
-* [Set up claims in Okta](#set-up-claims-in-okta) (if using group claims for team mapping)
+* (Optional) If using group claims for team mapping, [set up claims in Okta](#set-up-claims-in-okta).
 
 Then, you can set up {{site.konnect_short_name}} to talk to the Okta application:
 * [Set up Okta IDP in {{site.konnect_short_name}}](#set-up-konnect), referring
@@ -64,9 +64,11 @@ Create a new application in Okta to manage {{site.konnect_saas}} account integra
 
     Leave this page open. You'll need the connection details here to configure your {{site.konnect_saas}} account.
 
-### Set up claims in Okta
+### (Optional) Set up claims in Okta
 
-This only needs to be followed if intending to use group claims for Konnect team mappings, this is an optional step. The connection between {{site.konnect_short_name}} and Okta uses OpenID Connect tokens. To have Okta send the correct information to your {{site.konnect_short_name}} org, set up claims to extract that information.
+If you are intending to use group claims for Konnect team mappings, follow this guide to set them up. Otherwise, skip to [Add a user to your application](#add-a-user-to-your-application).
+
+The connection between {{site.konnect_short_name}} and Okta uses OpenID Connect tokens. To have Okta send the correct information to your {{site.konnect_short_name}} org, set up claims to extract that information.
 
 1. Open your Okta account in a new browser tab.
 


### PR DESCRIPTION
### Description

Clarified that the claim set up is optional as group claims are only needed if the admin intends to use Konnect team mapping functionality. It was marked optional in one sentence, but when looking at the later part it implied it's a requirement, so attempted to clarify this in the docs.
 
[Internal Slack thread](https://kongstrong.slack.com/archives/C0254TZHXHS/p1687378547342099?thread_ts=1687364981.012979&cid=C0254TZHXHS)

### Testing instructions

Netlify link: https://deploy-preview-5737--kongdocs.netlify.app/

### Checklist 

- [Y] Review label added <!-- (see below) -->
- [Y] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
