### PR TITLE
fix(kic): remove redundant comma

### DIFF
--- a/app/_src/gateway/install/kubernetes/helm.md
+++ b/app/_src/gateway/install/kubernetes/helm.md
@@ -18,7 +18,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 - Helm 3
@@ -77,7 +77,7 @@ If you plan to use RBAC, you must create a secret for the superuser account pass
 If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal, you must also configure the Session plugin and store its config in a Kubernetes secret:
 
 1.  Create a session config file for Kong Manager:
-    
+
     {% if_version lte:3.1.x %}
     ```bash
     echo '{"cookie_name":"admin_session","cookie_samesite":"off","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > admin_gui_session_conf

--- a/app/_src/gateway/install/kubernetes/kubectl.md
+++ b/app/_src/gateway/install/kubernetes/kubectl.md
@@ -15,7 +15,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 

--- a/app/_src/gateway/install/kubernetes/openshift.md
+++ b/app/_src/gateway/install/kubernetes/openshift.md
@@ -13,7 +13,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 - Helm 3

--- a/app/_src/kubernetes-ingress-controller/guides/getting-started-istio.md
+++ b/app/_src/kubernetes-ingress-controller/guides/getting-started-istio.md
@@ -38,7 +38,7 @@ This guide shows how to:
 
 ### Prerequisites
 
-* A Kubernetes cluster, v1.19 or later
+* A Kubernetes cluster v1.19 or later
 * [kubectl][kubectl] v1.19 or later
 * [Helm][helm] v3.5 or later
 * [cURL][curl] version 7.x.x

--- a/app/gateway/2.6.x/install-and-run/helm.md
+++ b/app/gateway/2.6.x/install-and-run/helm.md
@@ -18,7 +18,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 - Helm 3

--- a/app/gateway/2.6.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.6.x/install-and-run/kubernetes.md
@@ -15,7 +15,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -13,7 +13,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 - Helm 3

--- a/app/gateway/2.7.x/install-and-run/helm.md
+++ b/app/gateway/2.7.x/install-and-run/helm.md
@@ -18,7 +18,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 - Helm 3

--- a/app/gateway/2.7.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.7.x/install-and-run/kubernetes.md
@@ -15,7 +15,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 

--- a/app/gateway/2.7.x/install-and-run/openshift.md
+++ b/app/gateway/2.7.x/install-and-run/openshift.md
@@ -13,7 +13,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 - Helm 3

--- a/app/gateway/2.8.x/install-and-run/helm.md
+++ b/app/gateway/2.8.x/install-and-run/helm.md
@@ -18,7 +18,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 - Helm 3

--- a/app/gateway/2.8.x/install-and-run/kubernetes.md
+++ b/app/gateway/2.8.x/install-and-run/kubernetes.md
@@ -15,7 +15,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 

--- a/app/gateway/2.8.x/install-and-run/openshift.md
+++ b/app/gateway/2.8.x/install-and-run/openshift.md
@@ -13,7 +13,7 @@ The {{site.base_gateway}} software is governed by the
 
 ## Prerequisites
 
-- A Kubernetes cluster, v1.19 or later
+- A Kubernetes cluster v1.19 or later
 - `kubectl` v1.19 or later
 - (Enterprise only) A `license.json` file from Kong
 - Helm 3

--- a/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/getting-started-istio.md
@@ -38,7 +38,7 @@ This guide shows how to:
 
 ### Prerequisites
 
-* A Kubernetes cluster, v1.19 or later
+* A Kubernetes cluster v1.19 or later
 * [kubectl][kubectl] v1.19 or later
 * [Helm][helm] v3.5 or later
 * [cURL][curl] version 7.x.x

--- a/app/kubernetes-ingress-controller/2.1.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/getting-started-istio.md
@@ -38,7 +38,7 @@ This guide shows how to:
 
 ### Prerequisites
 
-* A Kubernetes cluster, v1.19 or later
+* A Kubernetes cluster v1.19 or later
 * [kubectl][kubectl] v1.19 or later
 * [Helm][helm] v3.5 or later
 * [cURL][curl] version 7.x.x

--- a/app/kubernetes-ingress-controller/2.2.x/guides/getting-started-istio.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/getting-started-istio.md
@@ -38,7 +38,7 @@ This guide shows how to:
 
 ### Prerequisites
 
-* A Kubernetes cluster, v1.19 or later
+* A Kubernetes cluster v1.19 or later
 * [kubectl][kubectl] v1.19 or later
 * [Helm][helm] v3.5 or later
 * [cURL][curl] version 7.x.x


### PR DESCRIPTION
### Description

What did you change and why?

Redundant comma, others items don't have it before specifying version

### Testing instructions

Netlify link: https://deploy-preview-5743--kongdocs.netlify.app/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

