### PR TITLE
Fix CP outage handling missing param

### DIFF
--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -2,6 +2,7 @@
 title: How to Configure Data Plane Resilience
 badge: enterprise
 content_type: how-to
+toc: false
 ---
 
 Starting in version 3.2, {{site.base_gateway}} can be configured to support configuring new data planes in the event of a control plane outage. This feature works by designating a backup node and allowing it read/write access to a data store. This backup node will automatically push valid {{site.base_gateway}} configurations to the data store. In the event of a control plane outage when a new node is created, it will pull the latest {{site.base_gateway}} configuration from the data store, configure itself, and start proxying requests. 
@@ -128,6 +129,7 @@ The example below uses MinIO to demonstrate configuring a backup node:
       AWS_ACCESS_KEY_ID: <access_key_write>
       AWS_SECRET_ACCESS_KEY: <secret_access_key_write>
       KONG_CLUSTER_FALLBACK_CONFIG_EXPORT: "on"
+      KONG_CLUSTER_FALLBACK_CONFIG_STORAGE: s3://test-bucket/test-prefix
       AWS_CONFIG_STORAGE_ENDPOINT: http://minio:9000/
 ```
 


### PR DESCRIPTION
### Description

Add missing KONG_CLUSTER_FALLBACK_CONFIG_STORAGE param for S3 object storage.

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1688009597867569

Also disabled the "On this page" table of contents, as it doesn't work properly when headers are nested inside tabs.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

