### PR TITLE
fix: correcting dead example link on ACL plugin page

### DIFF
--- a/app/_hub/kong-inc/acl/_index.md
+++ b/app/_hub/kong-inc/acl/_index.md
@@ -3,6 +3,6 @@ You can't configure an ACL with both `allow` and `deny` configurations. An ACL w
 ## Get started with the ACL plugin
 
 * [Configuration reference](/hub/kong-inc/acl/configuration/)
-* [Basic configuration example](/hub/kong-inc/acl/configuration/examples/)
+* [Basic configuration example](/hub/kong-inc/acl/how-to/basic-example/)
 * [Learn how to use the plugin](/hub/kong-inc/acl/how-to/)
 * [ACME plugin API reference](/hub/kong-inc/acl/api/)


### PR DESCRIPTION
### Description

This simply updates a dead link on the [ACL plugin page](https://docs.konghq.com/hub/kong-inc/acl/). This appears to be an issue across all versions of page. As such, we may need to fix this across all release branches.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


1. Open the ACL plugin page found [here](https://docs.konghq.com/hub/kong-inc/acl/).
2. Click on the "Basic configuration example" link, does it work?

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->