### PR TITLE
fix(kic): correct curl --resolve option

### DIFF
--- a/app/_includes/md/kic/http-test-routing.md
+++ b/app/_includes/md/kic/http-test-routing.md
@@ -12,7 +12,7 @@ Create routing configuration to proxy `{{ path }}` requests to the echo server:
 Test the routing rule:
 
 ```bash
-curl -i http://{{ hostname }}{{ path }} --resolve {{ hostname }}:80:$PROXY_IP
+curl -i http://{{ hostname }}{{ path }} --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```text

--- a/app/_src/kubernetes-ingress-controller/guides/configure-acl-plugin.md
+++ b/app/_src/kubernetes-ingress-controller/guides/configure-acl-plugin.md
@@ -55,7 +55,7 @@ right ACL.
 Requests without credentials are now rejected:
 
 ```bash
-curl -si http://kong.example/lemon --resolve kong.example:80:$PROXY_IP
+curl -si http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```text
@@ -169,7 +169,7 @@ Do the same for `USER_JWT` for the `user-jwt` Secret.
 Once you have the JWTs stored, you can send them in an `Authorization` header:
 
 ```bash
-curl -I -H "Authorization: Bearer ${USER_JWT}" http://kong.example/lemon --resolve kong.example:80:$PROXY_IP
+curl -I -H "Authorization: Bearer ${USER_JWT}" http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```text
@@ -313,8 +313,8 @@ kongconsumer.configuration.konghq.com/user patched
 The `admin` consumer can now access either URL:
 
 ```bash
-curl -sI http://kong.example/lemon -H "Authorization: Bearer ${ADMIN_JWT}" --resolve kong.example:80:$PROXY_IP | grep HTTP
-curl -sI http://kong.example/lime -H "Authorization: Bearer ${ADMIN_JWT}" --resolve kong.example:80:$PROXY_IP | grep HTTP
+curl -sI http://kong.example/lemon -H "Authorization: Bearer ${ADMIN_JWT}" --connect-to kong.example:80:${PROXY_IP##http://} | grep HTTP
+curl -sI http://kong.example/lime -H "Authorization: Bearer ${ADMIN_JWT}" --connect-to kong.example:80:${PROXY_IP##http://} | grep HTTP
 ```
 Response:
 ```text
@@ -325,8 +325,8 @@ HTTP/1.1 200 OK
 `user`, however, can only access the URL that permits the `user` group:
 
 ```bash
-curl -sI http://kong.example/lemon -H "Authorization: Bearer ${USER_JWT}" --resolve kong.example:80:$PROXY_IP | grep HTTP
-curl -sI http://kong.example/lime -H "Authorization: Bearer ${USER_JWT}" --resolve kong.example:80:$PROXY_IP | grep HTTP
+curl -sI http://kong.example/lemon -H "Authorization: Bearer ${USER_JWT}" --connect-to kong.example:80:${PROXY_IP##http://} | grep HTTP
+curl -sI http://kong.example/lime -H "Authorization: Bearer ${USER_JWT}" --connect-to kong.example:80:${PROXY_IP##http://} | grep HTTP
 ```
 Response:
 ```text

--- a/app/_src/kubernetes-ingress-controller/guides/getting-started.md
+++ b/app/_src/kubernetes-ingress-controller/guides/getting-started.md
@@ -73,7 +73,7 @@ gateway.gateway.networking.k8s.io/kong patched
 After, requests will serve the configured certificate:
 
 ```bash
-curl -ksv https://kong.example/echo --resolve kong.example:443:$PROXY_IP 2>&1 | grep -A1 "certificate:"
+curl -ksv https://kong.example/echo --connect-to kong.example:443:${PROXY_IP##http://} 2>&1 | grep -A1 "certificate:"
 ```
 Response:
 ```text
@@ -127,7 +127,7 @@ Kong will now apply your plugin configuration to all routes associated with
 this resource. To test it, send another request through the proxy:
 
 ```bash
-curl -i http://kong.example/echo --resolve kong.example:80:$PROXY_IP
+curl -i http://kong.example/echo --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```text
@@ -202,7 +202,7 @@ service/echo annotated
 Kong will now enforce a rate limit to requests proxied to this Service:
 
 ```bash
-curl -i http://kong.example/echo --resolve kong.example:80:$PROXY_IP
+curl -i http://kong.example/echo --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```text

--- a/app/_src/kubernetes-ingress-controller/guides/using-consumer-credential-resource.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-consumer-credential-resource.md
@@ -64,7 +64,7 @@ Any request matching the proxying rules defined in the `echo` routing
 configuration will now require a valid API key:
 
 ```bash
-curl -si http://kong.example/echo --resolve kong.example:80:$PROXY_IP
+curl -si http://kong.example/echo --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```
@@ -101,7 +101,7 @@ Now, send a request including the credential (`key-auth` expects an `apikey`
 header with the key by default):
 
 ```bash
-curl -si http://kong.example/echo --resolve kong.example:80:$PROXY_IP -H "apikey: gav"
+curl -si http://kong.example/echo --connect-to kong.example:80:${PROXY_IP##http://} -H "apikey: gav"
 ```
 Response:
 ```text

--- a/app/_src/kubernetes-ingress-controller/guides/using-external-service.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-external-service.md
@@ -38,7 +38,7 @@ service/echo created
 ## Test the Service
 
 ```bash
-curl -si http://kong.example/httpbin/anything --resolve kong.example:80:$PROXY_IP
+curl -si http://kong.example/httpbin/anything --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```

--- a/app/_src/kubernetes-ingress-controller/guides/using-gateway-api.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-gateway-api.md
@@ -321,7 +321,7 @@ After creating an HTTPRoute, accessing `/echo/hostname` forwards a request to th
 echo service's `/hostname` path, which yields the name of the pod that served the request:
 
 ```bash
-curl -i http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl -i http://kong.example/echo/hostname --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 
 ```
@@ -389,13 +389,13 @@ Now, accessing `/echo/hostname` should distribute around 75% of requests to Serv
 echo and around 25% of requests to Service echo2.
 
 ```bash
-curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl http://kong.example/echo/hostname --connect-to kong.example:80:${PROXY_IP##http://}
 echo2-7cb798f47-gh4xg%
-curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl http://kong.example/echo/hostname --connect-to kong.example:80:${PROXY_IP##http://}
 echo-658c5ff5ff-8cvgj%
-curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl http://kong.example/echo/hostname --connect-to kong.example:80:${PROXY_IP##http://}
 echo-658c5ff5ff-8cvgj%
-curl http://kong.example/echo/hostname --resolve kong.example:80:$PROXY_IP
+curl http://kong.example/echo/hostname --connect-to kong.example:80:${PROXY_IP##http://}
 echo-658c5ff5ff-8cvgj%
 ```
 

--- a/app/_src/kubernetes-ingress-controller/guides/using-gateway-discovery.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-gateway-discovery.md
@@ -251,7 +251,7 @@ controller-kong-545d798874-q6h7m ingress-controller time="2023-03-02T15:11:42Z" 
 At this point we should be able to access the `/echo` endpoint from our `htptbin` service:
 
 ```sh
-$ curl -i http://kong.example/echo --resolve kong.example:80:$PROXY_IP
+$ curl -i http://kong.example/echo --connect-to kong.example:80:${PROXY_IP##http://}
 <!DOCTYPE html>
 <html lang="en">
 

--- a/app/_src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-kongplugin-resource.md
@@ -90,7 +90,7 @@ httproute.gateway.networking.k8s.io/lemon annotated
 Requests that match the `lemon` rules will now include the plugin header:
 
 ```bash
-curl -si http://kong.example/lemon --resolve kong.example:80:$PROXY_IP | grep x-added-route
+curl -si http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://} | grep x-added-route
 ```
 Response:
 ```text
@@ -100,7 +100,7 @@ x-added-route: demo
 Requests to the `lime` rules will not:
 
 ```bash
-curl -si http://kong.example/lime --resolve kong.example:80:$PROXY_IP | grep x-added-route | wc -l
+curl -si http://kong.example/lime --connect-to kong.example:80:${PROXY_IP##http://} | grep x-added-route | wc -l
 ```
 Response:
 ```text
@@ -153,7 +153,7 @@ With the Service plugin in place, send requests through the `lemon` and `lime`
 routes:
 
 ```bash
-curl -si http://kong.example/lemon --resolve kong.example:80:$PROXY_IP | grep x-added-
+curl -si http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://} | grep x-added-
 ```
 Response:
 ```text
@@ -161,7 +161,7 @@ x-added-route: demo
 ```
 
 ```bash
-curl -si http://kong.example/lime --resolve kong.example:80:$PROXY_IP | grep x-added-
+curl -si http://kong.example/lime --connect-to kong.example:80:${PROXY_IP##http://} | grep x-added-
 ```
 Response:
 ```text
@@ -202,7 +202,7 @@ httproute.gateway.networking.k8s.io/lemon annotated
 Requests through the `lemon` route now use the Service's plugin:
 
 ```bash
-curl -si http://kong.example/lemon --resolve kong.example:80:$PROXY_IP | grep x-added-
+curl -si http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://} | grep x-added-
 ```
 Response:
 ```text
@@ -258,7 +258,7 @@ plugin requires authentication for all of them:
 
 
 ```bash
-curl -si http://kong.example/lemon --resolve kong.example:80:$PROXY_IP
+curl -si http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```text
@@ -295,7 +295,7 @@ Including this key will now satisfy the authentication requirement enforced by
 the global plugin:
 
 ```bash
-curl -sI http://kong.example/lemon --resolve kong.example:80:$PROXY_IP -H "apikey: gav"
+curl -sI http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://} -H "apikey: gav"
 ```
 Response:
 ```text
@@ -368,7 +368,7 @@ Requests made by the `kotenok` consumer will now include this header, since
 consumer plugins take precedence over both route and service plugins:
 
 ```bash
-curl -si http://kong.example/lemon --resolve kong.example:80:$PROXY_IP -H "apikey: gav" | grep x-added
+curl -si http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://} -H "apikey: gav" | grep x-added
 ```
 Response:
 ```text
@@ -419,8 +419,8 @@ kongconsumer.configuration.konghq.com/kotenok annotated
 The header returned now depend on which route the consumer uses:
 
 ```bash
-echo "lemon\!"; curl -si http://kong.example/lemon --resolve kong.example:80:$PROXY_IP -H "apikey: gav" | grep x-added
-echo "lime\!"; curl -si http://kong.example/lime --resolve kong.example:80:$PROXY_IP -H "apikey: gav" | grep x-added
+echo "lemon\!"; curl -si http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://} -H "apikey: gav" | grep x-added
+echo "lime\!"; curl -si http://kong.example/lime --connect-to kong.example:80:${PROXY_IP##http://} -H "apikey: gav" | grep x-added
 ```
 Response:
 ```text
@@ -436,7 +436,7 @@ Service plugin. When plugins are associated with multiple resources, requests
 must match _all_ of them:
 
 ```bash
-curl -si http://kong.example/lemon --resolve kong.example:80:$PROXY_IP | grep x-added 
+curl -si http://kong.example/lemon --connect-to kong.example:80:${PROXY_IP##http://} | grep x-added 
 ```
 Response:
 ```text

--- a/app/_src/kubernetes-ingress-controller/guides/using-rewrites.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-rewrites.md
@@ -105,7 +105,7 @@ This Ingress will create a Kong route attached to the service we created above.
 It will preserve its path but honor the service's hostname, so this request:
 
 ```bash
-$ curl -svX GET http://myapp.example.com/myapp/foo --resolve myapp.example.com:80:$PROXY_IP
+$ curl -svX GET http://myapp.example.com/myapp/foo --connect-to kong.example:80:${PROXY_IP##http://}
 GET /myapp/foo HTTP/1.1
 Host: myapp.example.com
 User-Agent: curl/7.70.0


### PR DESCRIPTION
### Description

The [`--resolve`](https://curl.se/docs/manpage.html#--resolve) option for `curl` only accepts an argument in the form `{SOURCE IP}:{SOURCE PORT}:{TARGET IP}`; a target port cannot be specified. The option [`--connect-to`](https://curl.se/docs/manpage.html#--connect-to) should be used instead as this can also accept a target port.

Additionally, if users have followed the KIC deployment instructions for minikube, the `PROXY_IP` variable will contain a URL including a scheme (e.g. `http://127.0.0.1:12345`); the scheme should be stripped from the variable before being passed to `curl` to avoid a parsing error.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
https://deploy-preview-5772--kongdocs.netlify.app/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

