### PR TITLE
Fix links in hub/kong-inc/acme

### DIFF
--- a/app/_hub/kong-inc/acme/_index.md
+++ b/app/_hub/kong-inc/acme/_index.md
@@ -130,8 +130,8 @@ To configure a storage type other than `kong`, refer to [lua-resty-acme](https:/
 ## Get started with the ACME plugin
 
 * [Configuration reference](/hub/kong-inc/acme/configuration/)
-* [Basic configuration example](/hub/kong-inc/acme/configuration/examples/)
+* [Basic configuration example](/hub/kong-inc/acme/how-to/basic-example/)
 * [Learn how to use the plugin](/hub/kong-inc/acme/how-to/)
-* [Configure the ACME plugin with Redis](/hub/kong-inc/acme/how-to/re)
+* [Configure the ACME plugin with Redis](/hub/kong-inc/acme/how-to/redis/)
 * [Local testing and development](/hub/kong-inc/acme/how-to/local-testing-development/)
 * [ACME plugin API reference](/hub/kong-inc/acme/api/)

--- a/app/_hub/kong-inc/acme/how-to/_index.md
+++ b/app/_hub/kong-inc/acme/how-to/_index.md
@@ -21,7 +21,7 @@ users can set this config to `system` to auto pick CA-bundle from OS.
 For each the domain that needs a certificate, make sure `DOMAIN/.well-known/acme-challenge`
 is mapped to a route in Kong. You can check this by sending
 `curl KONG_IP/.well-known/acme-challenge/x -H "host:DOMAIN"` and getting the response `Not found`.
-You can also [use the Admin API](/hub/kong-inc/acme/reference/api/#create-certificates) to verify the setup.
+You can also [use the Admin API](/hub/kong-inc/acme/api/#create-certificates) to verify the setup.
 If not, add a route and a dummy service to catch this route.
 
 1. Add a sample service if needed:
@@ -114,10 +114,10 @@ curl http://localhost:8001/acme -XPATCH
 
 ## More information
 
-* [Local testing and development guide](/hub/kong-inc/how-to/local-testing-development/)
-* Monitoring and debugging: The ACME plugin exposes monitoring and debuggin endpoints 
+* [Local testing and development guide](/hub/kong-inc/acme/how-to/local-testing-development/)
+* Monitoring and debugging: The ACME plugin exposes monitoring and debugging endpoints 
 through the {{site.base_gateway}} Admin API. See the 
-[ACME API reference](/hub/kong-inc/acme/reference/api/) for more information.
+[ACME API reference](/hub/kong-inc/acme/api/) for more information.
 * [ACME plugin configuration reference](/hub/kong-inc/acme/configuration/) and 
-[basic configuration examples](/hub/kong-inc/acme/configuration/examples/)
+[basic configuration examples](/hub/kong-inc/acme/how-to/basic-example/)
 


### PR DESCRIPTION
### Description

What did you change and why?
 
Fix links to basic examples, API, and how-tos


### Testing instructions

Make sure that the links in the following section work. I also fixed a typo and links in related files.
[Netlify link](https://deploy-preview-5773--kongdocs.netlify.app/hub/kong-inc/acme/#get-started-with-the-acme-plugin)


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

