### PR TITLE
Fix breadcrumbs for plugins how-to

### DIFF
--- a/app/_plugins/generators/plugin_single_source/pages/base.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/base.rb
@@ -59,6 +59,14 @@ module PluginSingleSource
         "https://github.com/Kong/docs.konghq.com/edit/#{@site.config['git_branch']}/app/#{source_file}"
       end
 
+      def breadcrumbs
+        [
+          { text: category_title, url: category_url },
+          { text: @release.metadata['name'], url: permalink.split('/').tap(&:pop).join('/').concat('/') },
+          { text: breadcrumb_title, url: permalink }
+        ]
+      end
+
       private
 
       def url_attributes
@@ -79,14 +87,6 @@ module PluginSingleSource
           'sidenav' => sidenav,
           'edit_link' => edit_link
         }
-      end
-
-      def breadcrumbs
-        [
-          { text: category_title, url: category_url },
-          { text: @release.metadata['name'], url: permalink.split('/').tap(&:pop).join('/').concat('/') },
-          { text: breadcrumb_title, url: permalink }
-        ]
       end
 
       def category_url

--- a/app/_plugins/generators/plugin_single_source/pages/configuration_examples.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/configuration_examples.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative './how_to'
+
 module PluginSingleSource
   module Pages
-    class ConfigurationExamples < Base
+    class ConfigurationExamples < HowTo
       TITLE = 'Basic config examples'
 
       def canonical_url

--- a/app/_plugins/generators/plugin_single_source/pages/how_to.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/how_to.rb
@@ -33,7 +33,31 @@ module PluginSingleSource
         page_title
       end
 
+      def breadcrumbs
+        [
+          { text: category_title, url: category_url },
+          { text: @release.metadata['name'], url: base_how_to_url },
+          { text: 'How to', url: how_to_url },
+          { text: breadcrumb_title, url: permalink }
+        ]
+      end
+
       private
+
+      def base_how_to_url
+        base_path = permalink.split('/').tap(&:pop)
+        if @release.latest?
+          base_path.take(4)
+        else
+          base_path.take(5) # include version
+        end.join('/').concat('/')
+      end
+
+      def how_to_url
+        return unless index_file_exist?
+
+        base_how_to_url.concat('how-to/')
+      end
 
       def file_to_url_segment
         @file_to_url_segment ||= @file
@@ -45,6 +69,10 @@ module PluginSingleSource
 
       def ssg_hub
         false
+      end
+
+      def index_file_exist?
+        File.exist?(File.expand_path('how-to/_index.md', @source_path))
       end
     end
   end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/changelog_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/changelog_spec.rb
@@ -86,4 +86,18 @@ RSpec.describe PluginSingleSource::Pages::Changelog do
       it_behaves_like 'returns the relative path to the top-level _index.md file'
     end
   end
+
+  describe '#breadcrumbs' do
+    let(:is_latest) { true }
+    let(:version) { '2.8.x' }
+    let(:source) { '_index' }
+
+    it 'returns a hash containing the page\'s breadcrumbs' do
+      expect(subject.breadcrumbs).to eq([
+        { text: 'Authentication', url: '/hub/?category=authentication' },
+        { text: 'Kong JWT Signer', url: '/hub/kong-inc/jwt-signer/' },
+        { text: 'Changelog', url: '/hub/kong-inc/jwt-signer/changelog/' }
+      ])
+    end
+  end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/configuration_examples_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/configuration_examples_spec.rb
@@ -33,4 +33,40 @@ RSpec.describe PluginSingleSource::Pages::ConfigurationExamples do
       it { expect(subject.edit_link).to eq('https://github.com/Kong/docs.konghq.com/edit/main/app/_hub/acme/kong-plugin/examples/_index.yml') }
     end
   end
+
+  describe '#breadcrumbs' do
+    context 'when _index.md exist' do
+      let(:is_latest) { true }
+      let(:version) { '2.8.x' }
+      let(:source) { '_index' }
+      let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
+
+      it 'returns a hash containing the page\'s breadcrumbs' do
+        expect(subject.breadcrumbs).to eq([
+          { text: 'Authentication', url: '/hub/?category=authentication' },
+          { text: 'Kong JWT Signer', url: '/hub/kong-inc/jwt-signer/' },
+          { text: 'How to', url: '/hub/kong-inc/jwt-signer/how-to/' },
+          { text: 'Basic config examples', url: '/hub/kong-inc/jwt-signer/how-to/basic-example/' }
+        ])
+      end
+    end
+
+    context 'when _index.md does not exist' do
+      let(:plugin) { PluginSingleSource::Plugin::Base.make_for(dir: 'acme/kong-plugin', site:) }
+      let(:is_latest) { true }
+      let(:version) { '2.8.x' }
+      let(:source) { '_index' }
+      let(:file) { 'how-to/_local-testing.md' }
+      let(:source_path) { File.expand_path("_hub/acme/kong-plugin/#{source}/", site.source) }
+
+      it 'returns a hash containing the page\'s breadcrumbs' do
+        expect(subject.breadcrumbs).to eq([
+          { text: 'Logging', url: '/hub/?category=logging' },
+          { text: 'Sample plugin', url: '/hub/acme/kong-plugin/' },
+          { text: 'How to', url: nil },
+          { text: 'Basic config examples', url: '/hub/acme/kong-plugin/how-to/basic-example/' }
+        ])
+      end
+    end
+  end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
@@ -120,4 +120,19 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
       it { expect(subject.edit_link).to eq('https://github.com/Kong/docs.konghq.com/edit/main/spec/fixtures/app/_hub/acme/kong-plugin/schemas/_index.json') }
     end
   end
+
+  describe '#breadcrumbs' do
+    let(:is_latest) { true }
+    let(:version) { '2.8.x' }
+    let(:source) { '_index' }
+    let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
+
+    it 'returns a hash containing the page\'s breadcrumbs' do
+      expect(subject.breadcrumbs).to eq([
+        { text: 'Authentication', url: '/hub/?category=authentication' },
+        { text: 'Kong JWT Signer', url: '/hub/kong-inc/jwt-signer/' },
+        { text: 'Configuration', url: '/hub/kong-inc/jwt-signer/configuration/' }
+      ])
+    end
+  end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/how_to_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/how_to_spec.rb
@@ -129,4 +129,57 @@ RSpec.describe PluginSingleSource::Pages::HowTo do
       end
     end
   end
+
+  describe '#breadcrumbs' do
+    context 'when _index.md exists' do
+      let(:is_latest) { true }
+      let(:version) { '2.8.x' }
+      let(:source) { '_index' }
+      let(:file) { 'how-to/nested/_tutorial.md' }
+      let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
+
+      it 'returns a hash containing the page\'s breadcrumbs' do
+        expect(subject.breadcrumbs).to eq([
+          { text: 'Authentication', url: '/hub/?category=authentication' },
+          { text: 'Kong JWT Signer', url: '/hub/kong-inc/jwt-signer/' },
+          { text: 'How to', url: '/hub/kong-inc/jwt-signer/how-to/' },
+          { text: 'Using the Kong JWT Signer plugin', url: '/hub/kong-inc/jwt-signer/how-to/nested/tutorial/' }
+        ])
+      end
+
+      context 'for older versions' do
+        let(:is_latest) { false }
+        let(:version) { '2.5.x' }
+        let(:source) { '_2.2.x' }
+        let(:source_path) { File.expand_path("_hub/kong-inc/jwt-signer/#{source}/", site.source) }
+
+        it 'returns a hash containing the page\'s breadcrumbs' do
+          expect(subject.breadcrumbs).to eq([
+            { text: 'Authentication', url: '/hub/?category=authentication' },
+            { text: 'Kong JWT Signer', url: '/hub/kong-inc/jwt-signer/2.5.x/' },
+            { text: 'How to', url: '/hub/kong-inc/jwt-signer/2.5.x/how-to/' },
+            { text: 'Using the Kong JWT Signer plugin', url: '/hub/kong-inc/jwt-signer/2.5.x/how-to/nested/tutorial/' }
+          ])
+        end
+      end
+    end
+
+    context 'when _index.md does not exist' do
+      let(:plugin) { PluginSingleSource::Plugin::Base.make_for(dir: 'acme/kong-plugin', site:) }
+      let(:is_latest) { true }
+      let(:version) { '2.8.x' }
+      let(:source) { '_index' }
+      let(:file) { 'how-to/_local-testing.md' }
+      let(:source_path) { File.expand_path("_hub/acme/kong-plugin/#{source}/", site.source) }
+
+      it 'returns a hash containing the page\'s breadcrumbs' do
+        expect(subject.breadcrumbs).to eq([
+          { text: 'Logging', url: '/hub/?category=logging' },
+          { text: 'Sample plugin', url: '/hub/acme/kong-plugin/' },
+          { text: 'How to', url: nil },
+          { text: 'Using the Sample plugin plugin', url: '/hub/acme/kong-plugin/how-to/local-testing/' }
+        ])
+      end
+    end
+  end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/overview_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/overview_spec.rb
@@ -105,4 +105,18 @@ RSpec.describe PluginSingleSource::Pages::Overview do
       end
     end
   end
+
+  describe '#breadcrumbs' do
+    let(:is_latest) { true }
+    let(:version) { '2.8.x' }
+    let(:source) { '_index' }
+    let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
+
+    it 'returns a hash containing the page\'s breadcrumbs' do
+      expect(subject.breadcrumbs).to eq([
+        { text: 'Authentication', url: '/hub/?category=authentication' },
+        { text: 'Kong JWT Signer', url: '/hub/kong-inc/jwt-signer/' }
+      ])
+    end
+  end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/unversioned_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/unversioned_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PluginSingleSource::Plugin::Unversioned do
 
   describe '#create_pages' do
     it 'generates pages for the plugin' do
-      expect(subject.create_pages.size).to eq(3)
+      expect(subject.create_pages.size).to eq(4)
     end
   end
 end

--- a/spec/app/_plugins/generators/plugin_single_source_generator_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source_generator_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe PluginSingleSource::Generator do
     subject { described_class.new.generate(site) }
 
     it 'generates pages for each version of each plugin' do
-      expect { subject }.to change { site.pages.size }.by(65)
+      expect { subject }.to change { site.pages.size }.by(66)
     end
 
     it 'adds the latest version of the plugin to `data[sshg_hub]`' do

--- a/spec/app/_plugins/generators/seo/index_spec.rb
+++ b/spec/app/_plugins/generators/seo/index_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe SEO::Index do
         '/hub/acme/kong-plugin/' => { 'url' => '/hub/acme/kong-plugin/', 'page' => find_page_by_url('/hub/acme/kong-plugin/') },
         '/hub/acme/kong-plugin/configuration/' => { 'url' => '/hub/acme/kong-plugin/configuration/', 'page' => find_page_by_url('/hub/acme/kong-plugin/configuration/') },
         '/hub/acme/kong-plugin/how-to/basic-example/' => { 'url' => '/hub/acme/kong-plugin/how-to/basic-example/', 'page' => find_page_by_url('/hub/acme/kong-plugin/how-to/basic-example/') },
+        '/hub/acme/kong-plugin/how-to/local-testing/' => { 'url' => '/hub/acme/kong-plugin/how-to/local-testing/', 'page' => find_page_by_url('/hub/acme/kong-plugin/how-to/local-testing/') },
         '/hub/acme/unbundled-plugin/' => { 'url' => '/hub/acme/unbundled-plugin/', 'page' => find_page_by_url('/hub/acme/unbundled-plugin/') },
         '/hub/acme/unbundled-plugin/changelog/' => { 'url' => '/hub/acme/unbundled-plugin/changelog/', 'page' => find_page_by_url('/hub/acme/unbundled-plugin/changelog/') },
         '/hub/acme/unbundled-plugin/configuration/' => { 'url' => '/hub/acme/unbundled-plugin/configuration/', 'page' => find_page_by_url('/hub/acme/unbundled-plugin/configuration/') },

--- a/spec/app/_plugins/generators/seo/sitemap_spec.rb
+++ b/spec/app/_plugins/generators/seo/sitemap_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe SEO::Sitemap do
         { 'changefreq' => 'weekly', 'priority' => '1.0', 'url' => '/hub/acme/kong-plugin/' },
         { 'changefreq' => 'weekly', 'priority' => '1.0', 'url' => '/hub/acme/kong-plugin/configuration/' },
         { 'changefreq' => 'weekly', 'priority' => '1.0', 'url' => '/hub/acme/kong-plugin/how-to/basic-example/' },
+        { 'changefreq' => 'weekly', 'priority' => '1.0', 'url' => '/hub/acme/kong-plugin/how-to/local-testing/' },
         { 'changefreq' => 'weekly', 'priority' => '1.0', 'url' => '/hub/acme/unbundled-plugin/' },
         { 'changefreq' => 'weekly', 'priority' => '1.0', 'url' => '/hub/acme/unbundled-plugin/changelog/' },
         { 'changefreq' => 'weekly', 'priority' => '1.0', 'url' => '/hub/acme/unbundled-plugin/configuration/' }

--- a/spec/fixtures/app/_hub/acme/kong-plugin/how-to/_local-testing.md
+++ b/spec/fixtures/app/_hub/acme/kong-plugin/how-to/_local-testing.md
@@ -1,0 +1,5 @@
+---
+nav_title: Local testing
+---
+
+## Local testing


### PR DESCRIPTION
### Description

[Jira ticket](https://konghq.atlassian.net/browse/DOCU-3308)

What did you change and why?

Add an extra `How To` level for how-to pages.
If the file `how-to/_index.md` exists, this new level contains a link to it. Otherwise, this new level is just plain text.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
* https://deploy-preview-5774--kongdocs.netlify.app/hub/kong-inc/acme/how-to/local-testing-development/
* https://deploy-preview-5774--kongdocs.netlify.app/hub/kong-inc/basic-auth/how-to/basic-example/



### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

