### PR TITLE
fix: redirect /mesh/konnect to /mesh/latest

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -639,6 +639,7 @@
 
 
 # KONG MESH
+/mesh/konnect/* /mesh/latest/:splat
 /mesh/1.0.x/features/   /mesh/1.0.x/features/vault
 /mesh/1.1.x/features/   /mesh/1.1.x/features/vault
 /mesh/:version/features/windows/     /mesh/:version/installation/windows/


### PR DESCRIPTION
### Description

This is useful as doc links on MinK use konnect as a version which is always going to be the latest version

Fix #Kong/kong-mesh-gui#642


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

