### PR TITLE
Fix performance issue caused by plugin pages without `source_file`

### DIFF
--- a/app/_plugins/generators/plugin_single_source/pages/configuration.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/configuration.rb
@@ -25,7 +25,9 @@ module PluginSingleSource
         @dropdown_url ||= "#{base_url}VERSION/configuration/"
       end
 
-      def source_file; end
+      def source_file
+        @file.gsub('app/', '')
+      end
 
       def content
         ''

--- a/app/_plugins/generators/plugin_single_source/pages/configuration_examples.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/configuration_examples.rb
@@ -27,7 +27,9 @@ module PluginSingleSource
         @dropdown_url ||= "#{base_url}VERSION/how-to/basic-example/"
       end
 
-      def source_file; end
+      def source_file
+        @file.gsub('app/', '')
+      end
 
       def content
         ''

--- a/app/_plugins/generators/plugin_single_source/plugin/release.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/release.rb
@@ -60,7 +60,7 @@ module PluginSingleSource
 
         @configuration ||= Pages::Configuration.new(
           release: self,
-          file: nil,
+          file: schema.file_path,
           source_path: pages_source_path
         )
       end
@@ -70,7 +70,7 @@ module PluginSingleSource
 
         @configuration_examples ||= Pages::ConfigurationExamples.new(
           release: self,
-          file: nil,
+          file: schema.example_file_path,
           source_path: pages_source_path
         )
       end

--- a/app/_plugins/generators/plugin_single_source/plugin/schemas/base.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/schemas/base.rb
@@ -53,6 +53,12 @@ module PluginSingleSource
                        .example
         end
 
+        def example_file_path
+          @example_file_path ||= Examples::Base
+                                 .make_for(vendor:, name: plugin_name, version:)
+                                 .file_path
+        end
+
         def protocols_field
           @protocols_field ||= fields.detect { |f| f.key?('protocols') }&.values&.first || {}
         end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/configuration_examples_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/configuration_examples_spec.rb
@@ -2,8 +2,9 @@ RSpec.describe PluginSingleSource::Pages::ConfigurationExamples do
   let(:plugin_name) { 'kong-inc/jwt-signer' }
   let(:plugin) { PluginSingleSource::Plugin::Base.make_for(dir: plugin_name, site:) }
   let(:release) { PluginSingleSource::Plugin::Release.new(site:, version:, plugin:, is_latest:, source:) }
+  let(:file) { "app/_src/.repos/kong-plugins/examples/jwt-signer/_#{version}.yaml" }
 
-  subject { described_class.new(release:, file: nil, source_path:) }
+  subject { described_class.new(release:, file:, source_path:) }
 
   describe '#edit_link' do
     let(:is_latest) { true }
@@ -29,6 +30,7 @@ RSpec.describe PluginSingleSource::Pages::ConfigurationExamples do
     context 'third-party plugins' do
       let(:plugin_name) { 'acme/kong-plugin' }
       let(:source_path) { File.expand_path('_hub/acme/kong-plugin/', site.source) }
+      let(:file) { 'app/_hub/acme/kong-plugin/examples/_index.yml' }
 
       it { expect(subject.edit_link).to eq('https://github.com/Kong/docs.konghq.com/edit/main/app/_hub/acme/kong-plugin/examples/_index.yml') }
     end
@@ -66,6 +68,30 @@ RSpec.describe PluginSingleSource::Pages::ConfigurationExamples do
           { text: 'How to', url: nil },
           { text: 'Basic config examples', url: '/hub/acme/kong-plugin/how-to/basic-example/' }
         ])
+      end
+    end
+  end
+
+  describe '#source_file' do
+    let(:is_latest) { true }
+    let(:source) { '_index' }
+    let(:version) { '2.8.x' }
+
+    context 'third-party plugins' do
+      let(:plugin_name) { 'acme/kong-plugin' }
+      let(:source_path) { File.expand_path('_hub/acme/kong-plugin/', site.source) }
+      let(:file) { 'app/_hub/acme/kong-plugin/examples/_index.yml' }
+
+      it 'returns the relative path from app/ to the example file' do
+        expect(subject.source_file).to eq('_hub/acme/kong-plugin/examples/_index.yml')
+      end
+    end
+
+    context 'kong plugins' do
+      let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
+
+      it 'returns the relative path from app/ to the example file' do
+        expect(subject.source_file).to eq('_src/.repos/kong-plugins/examples/jwt-signer/_2.8.x.yaml')
       end
     end
   end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
@@ -2,8 +2,9 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
   let(:plugin_name) { 'kong-inc/jwt-signer' }
   let(:plugin) { PluginSingleSource::Plugin::Base.make_for(dir: plugin_name, site:) }
   let(:release) { PluginSingleSource::Plugin::Release.new(site:, version:, plugin:, is_latest:, source:) }
+  let(:file) { "app/_src/.repos/kong-plugins/schemas/jwt-signer/#{version}.json" }
 
-  subject { described_class.new(release:, file: nil, source_path:) }
+  subject { described_class.new(release:, file:, source_path:) }
 
   describe '#data' do
     before do
@@ -19,7 +20,7 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
       it 'returns a hash containing the data needed to render the templates' do
         expect(subject.data).to include({
           'canonical_url' => '/hub/kong-inc/jwt-signer/configuration/',
-          'source_file' => nil,
+          'source_file' => '_src/.repos/kong-plugins/schemas/jwt-signer/2.5.x.json',
           'permalink' => '/hub/kong-inc/jwt-signer/2.5.x/configuration/',
           'ssg_hub' => false,
           'title' => 'Kong JWT Signer Configuration'
@@ -36,7 +37,7 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
       it 'returns a hash containing the data needed to render the templates' do
         expect(subject.data).to include({
           'canonical_url' => nil,
-          'source_file' => nil,
+          'source_file' => '_src/.repos/kong-plugins/schemas/jwt-signer/2.8.x.json',
           'permalink' => '/hub/kong-inc/jwt-signer/configuration/',
           'ssg_hub' => false,
           'title' => 'Kong JWT Signer Configuration'
@@ -51,7 +52,9 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
     let(:version) { '2.8.x' }
     let(:source_path) { File.expand_path('_hub/kong-inc/jwt-signer/', site.source) }
 
-    it { expect(subject.source_file).to be_nil }
+    it 'returns the relative path from app/ to the schema file' do
+      expect(subject.source_file).to eq('_src/.repos/kong-plugins/schemas/jwt-signer/2.8.x.json')
+    end
   end
 
   describe '#canonical_url' do
@@ -108,6 +111,7 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
       context 'non-enterprise plugins' do
         let(:plugin_name) { 'kong-inc/jq' }
         let(:source_path) { File.expand_path('_hub/kong-inc/jq/', site.source) }
+        let(:file) { "app/_src/.repos/kong-plugins/schemas/jq/#{version}.json" }
 
         it { expect(subject.edit_link).to eq('https://github.com/Kong/kong/edit/master/kong/plugins/jq/schema.lua') }
       end
@@ -116,6 +120,7 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
     context 'third-party plugins' do
       let(:plugin_name) { 'acme/kong-plugin' }
       let(:source_path) { File.expand_path('_hub/acme/kong-plugin/', site.source) }
+      let(:file) { "app/_hub/acme/kong-plugin/schemas/_index.json" }
 
       it { expect(subject.edit_link).to eq('https://github.com/Kong/docs.konghq.com/edit/main/spec/fixtures/app/_hub/acme/kong-plugin/schemas/_index.json') }
     end

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/release_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/release_spec.rb
@@ -118,4 +118,30 @@ RSpec.describe PluginSingleSource::Plugin::Release do
       it { expect(subject.enterprise_plugin?).to eq(false) }
     end
   end
+
+  describe '#configuration' do
+    let(:source_path) { "#{site.source}/_hub/kong-inc/jwt-signer/" }
+    let(:file) { "app/_src/.repos/kong-plugins/schemas/jwt-signer/#{version}.json" }
+
+    it 'returns an instance of Pages::Configuration' do
+      expect(PluginSingleSource::Pages::Configuration)
+        .to receive(:new)
+        .with(release: subject, file: , source_path:)
+
+      subject.configuration
+    end
+  end
+
+  describe '#configuration_examples' do
+    let(:source_path) { "#{site.source}/_hub/kong-inc/jwt-signer/" }
+    let(:file) { "app/_src/.repos/kong-plugins/examples/jwt-signer/_#{version}.yaml" }
+
+    it 'returns an instance of Pages::ConfigurationExamples' do
+      expect(PluginSingleSource::Pages::ConfigurationExamples)
+        .to receive(:new)
+        .with(release: subject, file: , source_path:)
+
+      subject.configuration_examples
+    end
+  end
 end


### PR DESCRIPTION
### Description

What did you change and why?
 
We use the `source_file` as the page's `relative_path` which is used internally by Jekyll to konw which pages should be re-generated whenver a file changes.

Configuration and plugin hub example pages were setting it to `nil` causing all those pages to be re-generated whenever any file changed. This fixes the issue by setting the right `source_file` to those pages.

This only affects local build times.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

