### PR TITLE
mention requirement for outbound traffic for kic+konnect

### DIFF
--- a/app/_src/kubernetes-ingress-controller/concepts/deployment.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/deployment.md
@@ -375,7 +375,7 @@ builds on top of it. The difference is that {{site.kic_product_name}} additional
 using the public [Admin API][admin] of the {{site.konnect_short_name}}'s Runtime Manager. The connection between {{site.kic_product_name}}
 and {{site.konnect_short_name}} is secured using mutual TLS.
 
-As {{site.kic_product_name}} calls {{site.konnect_short_name}}'s APIs, outbound traffic from {{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` hosts.
+As {{site.kic_product_name}} calls {{site.konnect_short_name}}'s APIs, outbound traffic from {{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` [hosts](/konnect/network#hostnames).
 
 {:.important}
 > {{site.kic_product_name}}'s Runtime Group in {{site.konnect_short_name}} is **read-only**.

--- a/app/_src/kubernetes-ingress-controller/concepts/deployment.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/deployment.md
@@ -375,6 +375,9 @@ builds on top of it. The difference is that {{site.kic_product_name}} additional
 using the public [Admin API][admin] of the {{site.konnect_short_name}}'s Runtime Manager. The connection between {{site.kic_product_name}}
 and {{site.konnect_short_name}} is secured using mutual TLS.
 
+As {{site.kic_product_name}} calls the {{site.konnect_short_name}}'s APIs, outbound traffic from the
+{{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` hosts.
+
 {:.important}
 > {{site.kic_product_name}}'s Runtime Group in {{site.konnect_short_name}} is **read-only**.
 > Although the configuration displayed in {{site.konnect_short_name}} will match the configuration used by proxy instances, it cannot be modified from the GUI.

--- a/app/_src/kubernetes-ingress-controller/concepts/deployment.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/deployment.md
@@ -375,8 +375,7 @@ builds on top of it. The difference is that {{site.kic_product_name}} additional
 using the public [Admin API][admin] of the {{site.konnect_short_name}}'s Runtime Manager. The connection between {{site.kic_product_name}}
 and {{site.konnect_short_name}} is secured using mutual TLS.
 
-As {{site.kic_product_name}} calls the {{site.konnect_short_name}}'s APIs, outbound traffic from the
-{{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` hosts.
+As {{site.kic_product_name}} calls {{site.konnect_short_name}}'s APIs, outbound traffic from {{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` hosts.
 
 {:.important}
 > {{site.kic_product_name}}'s Runtime Group in {{site.konnect_short_name}} is **read-only**.

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -29,28 +29,32 @@ want to use port `3001` for the proxy, map `3001:8000`.
 
 ## Hostnames
 
-Runtime instances initiate the connection to the {{site.konnect_short_name}} control plane. 
+Depending on your Runtime Group type, you may need to add hostnames to your firewall allowlist.
+
+{% navtabs %}
+{% navtab Kong Gateway %}
+Runtime instances initiate the connection to the {{site.konnect_short_name}} control plane.
 They require access through firewalls to communicate with the control plane.
 
-To let a runtime instances request and receive configuration, and send telemetry data, 
+To let runtime instances request and receive configuration, and send telemetry data,
 add the following hostnames to the firewall allowlist:
 
 * `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
 * `<region>.api.konghq.com`: The {{site.konnect_short_name}} API.
-    Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations.
-    Region can be `us`, `eu`, or `global`.
+  Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations.
+  Region can be `us`, `eu`, or `global`.
 * `<runtime-group-id>.<region>.cp0.konghq.com`: Handles configuration for a runtime group.
-    Runtime instances connect to this host to receive configuration updates.
-    This hostname is unique to each organization and runtime group.
+  Runtime instances connect to this host to receive configuration updates.
+  This hostname is unique to each organization and runtime group.
 * `<runtime-group-id>.<region>.tp0.konghq.com`: Gathers telemetry data for a runtime group.
-    This hostname is unique to each organization and runtime group.
+  This hostname is unique to each organization and runtime group.
 
 You can find the configuration and telemetry hostnames through the Runtime Manager:
 
 1. Open a runtime group.
 2. Click **Add runtime instance**.
 3. Choose the Linux or Kubernetes tab and note the hostnames in the code block
-for the following parameters:
+   for the following parameters:
 
     ```
     cluster_control_plane = example.us.cp0.konghq.com:443
@@ -58,6 +62,36 @@ for the following parameters:
     cluster_telemetry_endpoint = example.us.tp0.konghq.com:443
     cluster_telemetry_server_name = example.us.tp0.konghq.com
     ```
+{% endnavtab %}
+
+{% navtab Kong Ingress Controller %}
+
+{{site.kic_product_name}} initiates the connection to {{site.konnect_short_name}} [Runtime Configuration API](/konnect/api/runtime-groups-config/) to:
+
+* synchronize the configuration of the {{site.base_gateway}} instances with {{site.konnect_short_name}},
+* register runtime instances,
+* fetch license information.
+
+Runtime instances initiate the connection to {{site.konnect_short_name}} APIs to report Analytics data.
+
+The following hostnames must be allowed through firewalls to enable these connections:
+
+* `cloud.konghq.com`: The {{site.konnect_short_name}} platform.
+* `<region>.api.konghq.com`: The {{site.konnect_short_name}} API.
+* `<runtime-group-id>.<region>.tp0.konghq.com`: Telemetry endpoint for a runtime group, required for Analytics.
+  This hostname is unique to each organization and runtime group. 
+
+You can find the Telemetry hostname through the Runtime Manager:
+
+1. Open a runtime group.
+2. Click **Runtime group actions** > **View Connection Instructions**.
+3. Look for the following parameter in the `Install the KIC` section: 
+
+    ```
+    cluster_telemetry_endpoint: "example.us.tp0.konghq.com:443"
+    ```
+{% endnavtab %}
+{% endnavtabs %}
 
 {:.note}
 > **Note**: Visit [https://ip-addresses.origin.konghq.com/ip-addresses.json](https://ip-addresses.origin.konghq.com/ip-addresses.json) for the list of IPs associated to regional hostnames. You can also subscribe to [https://ip-addresses.origin.konghq.com/rss](https://ip-addresses.origin.konghq.com/rss) for updates.  

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -66,11 +66,11 @@ You can find the configuration and telemetry hostnames through the Runtime Manag
 
 {% navtab Kong Ingress Controller %}
 
-{{site.kic_product_name}} initiates the connection to {{site.konnect_short_name}} [Runtime Configuration API](/konnect/api/runtime-groups-config/) to:
+{{site.kic_product_name}} initiates the connection to the {{site.konnect_short_name}} [Runtime Configuration API](/konnect/api/runtime-groups-config/) to:
 
-* synchronize the configuration of the {{site.base_gateway}} instances with {{site.konnect_short_name}},
-* register runtime instances,
-* fetch license information.
+* Synchronize the configuration of the {{site.base_gateway}} instances with {{site.konnect_short_name}}
+* Register runtime instances
+* Fetch license information
 
 Runtime instances initiate the connection to {{site.konnect_short_name}} APIs to report Analytics data.
 

--- a/app/konnect/runtime-manager/kic.md
+++ b/app/konnect/runtime-manager/kic.md
@@ -43,6 +43,9 @@ If you don't have an existing KIC deployment, you need the following before usin
 * `kubectl` or `oc` (if you're working with OpenShift) installed and configured to communicate with your Kubernetes TLS
 * [Helm 3](https://helm.sh/docs/intro/install/) installed
 
+Also, as {{site.kic_product_name}} calls the {{site.konnect_short_name}}'s APIs, outbound traffic from the
+{{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` hosts.
+
 ### View KIC entities
 
 After your KIC deployment is connected to {{site.konnect_short_name}}, you can view the details for each runtime instance in your KIC runtime groups. 

--- a/app/konnect/runtime-manager/kic.md
+++ b/app/konnect/runtime-manager/kic.md
@@ -42,9 +42,7 @@ If you don't have an existing KIC deployment, you need the following before usin
 *  A Kubernetes cluster 
 * `kubectl` or `oc` (if you're working with OpenShift) installed and configured to communicate with your Kubernetes TLS
 * [Helm 3](https://helm.sh/docs/intro/install/) installed
-
-Also, as {{site.kic_product_name}} calls the {{site.konnect_short_name}}'s APIs, outbound traffic from the
-{{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` hosts.
+* Because {{site.kic_product_name}} calls {{site.konnect_short_name}}'s APIs, outbound traffic from {{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` hosts.
 
 ### View KIC entities
 

--- a/app/konnect/runtime-manager/kic.md
+++ b/app/konnect/runtime-manager/kic.md
@@ -42,7 +42,7 @@ If you don't have an existing KIC deployment, you need the following before usin
 *  A Kubernetes cluster 
 * `kubectl` or `oc` (if you're working with OpenShift) installed and configured to communicate with your Kubernetes TLS
 * [Helm 3](https://helm.sh/docs/intro/install/) installed
-* Because {{site.kic_product_name}} calls {{site.konnect_short_name}}'s APIs, outbound traffic from {{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` hosts.
+* Because {{site.kic_product_name}} calls {{site.konnect_short_name}}'s APIs, outbound traffic from {{site.kic_product_name}}'s pods must be allowed to reach {{site.konnect_short_name}}'s `*.konghq.com` [hosts](/konnect/network#hostnames).
 
 ### View KIC entities
 


### PR DESCRIPTION
### Description

If our users have traffic restrictions of any kind for the outbound traffic, it's worth to mention what hosts they should have allow-listed for KIC+Konnect integration.
 
Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4298.


### Testing instructions

https://deploy-preview-5781--kongdocs.netlify.app/kubernetes-ingress-controller/latest/concepts/deployment/
https://deploy-preview-5781--kongdocs.netlify.app/konnect/runtime-manager/kic/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

