### PR TITLE
Fix kong.tools.queue changelog entry

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -66,7 +66,7 @@ instead of the previous 1 (trace all requests).
       If you use queues in these plugins, new parameters must be configured.
       See each plugin's documentation for details.
 
-  * The module `kong.tools.batch_queue` has been renamed to `kong.tools.batch` and 
+  * The module `kong.tools.batch_queue` has been renamed to `kong.tools.queue` and 
   the API was changed.  If your custom plugin uses queues, it must 
   be updated to use the new API.
   [#10172](https://github.com/Kong/kong/pull/10172)


### PR DESCRIPTION
### Description

Parameter is incorrectly named in our changelog, but correctly named in the OSS one: https://github.com/Kong/kong/blob/master/CHANGELOG.md#plugins-4

You can verify by looking at the linked eng PR.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

