### PR TITLE
Clean up multiple auth methods doc

### DIFF
--- a/app/_src/gateway/kong-plugins/authentication/allowing-multiple-authentication-methods.md
+++ b/app/_src/gateway/kong-plugins/authentication/allowing-multiple-authentication-methods.md
@@ -7,102 +7,196 @@ for all requests without regard for whether a request has been authenticated
 via some other plugin. Configuring an anonymous consumer on your authentication
 plugins allows you to offer clients multiple options for authentication.
 
-To begin, [create a Service](/gateway/{{page.kong_version}}/admin-api/#service-object) and then create three consumers:
+## Set up consumers
 
-```bash
-curl -sX POST localhost:8001/consumers \
-  -H "Content-Type: application/json" \
-  --data '{"username": "anonymous"}'
+To begin, [create a service](/gateway/{{page.kong_version}}/admin-api/#service-object),
+then create three consumers:
 
-# {"created_at":1517528237000,"username":"anonymous","id":"d955c0cb-1a6e-4152-9440-414ebb8fee8a"}
 
-curl -sX POST localhost:8001/consumers \
-  -H "Content-Type: application/json" \
-  --data '{"username": "medvezhonok"}'
+1. Consumer 1:
+    ```bash
+    curl -sX POST localhost:8001/consumers \
+      -H "Content-Type: application/json" \
+      --data '{"username": "anonymous"}'
+    
+    ```
 
-# {"created_at":1517528259000,"username":"medvezhonok","id":"b3c95318-a932-4bb2-9d74-1298a3ffc87c"}
+    Response:
+    ```json
+    {"created_at":1517528237000,"username":"anonymous","id":"d955c0cb-1a6e-4152-9440-414ebb8fee8a"}
+    ```
 
-curl -sX POST kong-admin:8001/consumers \
-  -H "Content-Type: application/json" \
-  --data '{"username": "ezhik"}'
+    The `anonymous` consumer does not correspond to any real user, and will only serve as a fallback.
 
-# {"created_at":1517528266000,"username":"ezhik","id":"47e74a17-dc08-4786-a8cf-d8e4f38a5459"}
-```
+1. Consumer 2:
+    ```sh
+    curl -sX POST localhost:8001/consumers \
+      -H "Content-Type: application/json" \
+      --data '{"username": "medvezhonok"}'
+    ```
 
-The `anonymous` consumer does not correspond to any real user, and will only serve as a fallback.
+    Response:
+    ```json
+    {"created_at":1517528259000,"username":"medvezhonok","id":"b3c95318-a932-4bb2-9d74-1298a3ffc87c"}
+    ```
+
+1. Consumer 3:
+    
+    ```sh
+    curl -sX POST localhost:8001/consumers \
+      -H "Content-Type: application/json" \
+      --data '{"username": "ezhik"}'
+    ```
+
+    Response:
+    ```json
+    {"created_at":1517528266000,"username":"ezhik","id":"47e74a17-dc08-4786-a8cf-d8e4f38a5459"}
+    ```
+
+
+## Set up authentication plugins
 
 Next, we add both Key Auth and Basic Auth plugins to our service, and set the anonymous fallback to the consumer we created earlier.
 
-```bash
-curl -sX POST kong-admin:8001/services/example-service/plugins/ \
-  -H "Content-Type: application/json" \
-  --data '{"name": "key-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
 
-# {"created_at":1517528304000,"config":{"key_in_body":false,"hide_credentials":true,"anonymous":"d955c0cb-1a6e-4152-9440-414ebb8fee8a","run_on_preflight":true,"key_names":["apikey"]},"id":"bb884f7b-4e48-4166-8c80-c858b5a4c357","name":"key-auth","service_id":"a2a168a8-4491-4fe1-9426-cde3b5fcd45b","enabled":true}
+1. Add the Key Auth plugin:
 
-curl -sX POST kong-admin:8001/services/example-service/plugins/ \
-  -H "Content-Type: application/json" \
-  --data '{"name": "basic-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
+    ```bash
+    curl -sX POST localhost:8001/services/example-service/plugins/ \
+      -H "Content-Type: application/json" \
+      --data '{"name": "key-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
+    ```
+    
+    Response:
+    ```json
+    {"created_at":1517528304000,"config":{"key_in_body":false,"hide_credentials":true,"anonymous":"d955c0cb-1a6e-4152-9440-414ebb8fee8a","run_on_preflight":true,"key_names":["apikey"]},"id":"bb884f7b-4e48-4166-8c80-c858b5a4c357","name":"key-auth","service_id":"a2a168a8-4491-4fe1-9426-cde3b5fcd45b","enabled":true}
+    ```
 
-# {"created_at":1517528499000,"config":{"hide_credentials":true,"anonymous":"d955c0cb-1a6e-4152-9440-414ebb8fee8a"},"id":"e5a40543-debe-4225-a879-a54901368e6d","name":"basic-auth","service_id":"a2a168a8-4491-4fe1-9426-cde3b5fcd45b","enabled":true}
-```
+1. Add the Basic Auth plugin:
+
+    ```sh
+    curl -sX POST localhost:8001/services/example-service/plugins/ \
+      -H "Content-Type: application/json" \
+      --data '{"name": "basic-auth", "config": { "hide_credentials": true, "anonymous": "d955c0cb-1a6e-4152-9440-414ebb8fee8a"} }'
+    ```
+  
+    Response:
+    ```json
+    {"created_at":1517528499000,"config":{"hide_credentials":true,"anonymous":"d955c0cb-1a6e-4152-9440-414ebb8fee8a"},"id":"e5a40543-debe-4225-a879-a54901368e6d","name":"basic-auth","service_id":"a2a168a8-4491-4fe1-9426-cde3b5fcd45b","enabled":true}
+    ```
 
 If using [OpenID Connect](/hub/kong-inc/openid-connect/), you must also set `config.consumer_claim` along with `anonymous`, as setting `anonymous` alone will not map that consumer.
 
-At this point unauthenticated requests and requests with invalid credentials are still allowed. The anonymous consumer is allowed, and will be applied to any request that does not pass a set of credentials associated with some other consumer.
+## Test with anonymous consumer
 
-```bash
-curl -s example.com:8000/user-agent
+At this point, unauthenticated requests and requests with invalid credentials are still allowed. The anonymous consumer is allowed, and will be applied to any request that does not pass a set of credentials associated with some other consumer.
 
-# {"user-agent": "curl/7.58.0"}
 
-curl -s example.com:8000/user-agent?apikey=nonsense
+1. Check without credentials:
+    
+    ```bash
+    curl -s example.com:8000/user-agent
+    ```
 
-# {"user-agent": "curl/7.58.0"}
-```
+    Response:
+    ```json
+    {"user-agent": "curl/7.58.0"}
+    ```
+
+1. Check with nonsense credentials:
+    ```sh
+    curl -s example.com:8000/user-agent?apikey=nonsense
+    ```
+    
+    Response:
+    ```json
+    {"user-agent": "curl/7.58.0"}
+    ```
+
+
+## Configure credentials 
 
 We'll now add a Key Auth credential for one consumer, and a Basic Auth credential for another.
 
-```bash
-curl -sX POST kong-admin:8001/consumers/medvezhonok/basic-auth \
-  -H "Content-Type: application/json" \
-  --data '{"username": "medvezhonok", "password": "hunter2"}'
+1. Add a Basic Auth credential to one consumer:
+    ```bash
+    curl -sX POST localhost:8001/consumers/medvezhonok/basic-auth \
+      -H "Content-Type: application/json" \
+      --data '{"username": "medvezhonok", "password": "hunter2"}'
+    ```
 
-# {"created_at":1517528647000,"id":"bb350b87-f0d2-4605-b997-e28a116d8b6d","username":"medvezhonok","password":"f239a0404351d7170201e7f92fa9b3159e47bb01","consumer_id":"b3c95318-a932-4bb2-9d74-1298a3ffc87c"}
+    Response:
+    ```json
+    {"created_at":1517528647000,"id":"bb350b87-f0d2-4605-b997-e28a116d8b6d","username":"medvezhonok","password":"f239a0404351d7170201e7f92fa9b3159e47bb01","consumer_id":"b3c95318-a932-4bb2-9d74-1298a3ffc87c"}
+    ```
 
-curl -sX POST kong-admin:8001/consumers/ezhik/key-auth \
-  -H "Content-Type: application/json" \
-  --data '{"key": "hunter3"}'
+1. Add a Key Auth credential to another consumer:
+    ```sh
+    curl -sX POST localhost:8001/consumers/ezhik/key-auth \
+      -H "Content-Type: application/json" \
+      --data '{"key": "hunter3"}'
+    ```
 
-# {"id":"06412d6e-8d41-47f7-a911-3c821ec98f1b","created_at":1517528730000,"key":"hunter3","consumer_id":"47e74a17-dc08-4786-a8cf-d8e4f38a5459"}
-```
+    Response:
+    ```json
+    {"id":"06412d6e-8d41-47f7-a911-3c821ec98f1b","created_at":1517528730000,"key":"hunter3","consumer_id":"47e74a17-dc08-4786-a8cf-d8e4f38a5459"}
+    ```
 
-Lastly, we add a Request Terminator to the anonymous consumer.
+1. Lastly, add a Request Terminator to the anonymous consumer:
 
-```bash
-curl -sX POST kong-admin:8001/consumers/d955c0cb-1a6e-4152-9440-414ebb8fee8a/plugins/ \
-  -H "Content-Type: application/json" \
-  --data '{"name": "request-termination", "config": { "status_code": 401, "content_type": "application/json; charset=utf-8", "body": "{\"error\": \"Authentication required\"}"} }'
+    ```bash
+    curl -sX POST localhost:8001/consumers/d955c0cb-1a6e-4152-9440-414ebb8fee8a/plugins/ \
+      -H "Content-Type: application/json" \
+      --data '{"name": "request-termination", "config": { "status_code": 401, "content_type": "application/json; charset=utf-8", "body": "{\"error\": \"Authentication required\"}"} }'
+    ```
 
-# {"created_at":1517528791000,"config":{"status_code":401,"content_type":"application\/json; charset=utf-8","body":"{\"error\": \"Authentication required\"}"},"id":"21fc5f6f-363f-4d79-b533-ce26d4478879","name":"request-termination","enabled":true,"consumer_id":"d955c0cb-1a6e-4152-9440-414ebb8fee8a"}
-```
+    Response:
+    ```json
+    {"created_at":1517528791000,"config":{"status_code":401,"content_type":"application\/json; charset=utf-8","body":"{\"error\": \"Authentication required\"}"},"id":"21fc5f6f-363f-4d79-b533-ce26d4478879","name":"request-termination","enabled":true,"consumer_id":"d955c0cb-1a6e-4152-9440-414ebb8fee8a"}
+    ```
 
-Requests with missing or invalid credentials are now rejected, whereas authorized requests using either authentication method are allowed.
+## Validate credentials 
 
-```bash
-curl -s example.com:8000/user-agent?apikey=nonsense
+Validate one more time. Requests with missing or invalid credentials are now rejected, whereas authorized requests using either authentication method are allowed.
 
-# {"error": "Authentication required"}
+1. Test with a nonsense API key:
 
-curl -s example.com:8000/user-agent
+    ```bash
+    curl -s localhost:8000/user-agent?apikey=nonsense
+    ```
+    
+    Response:
+    ```json
+    {"error": "Authentication required"}
+    ```
 
-# {"error": "Authentication required"}
+1. Test without an API key:
+    ```sh
+    curl -s localhost:8000/user-agent
+    ```
+    
+    Response:
+    ```json
+    {"error": "Authentication required"}
+    ```
 
-curl -s example.com:8000/user-agent?apikey=hunter3
+1. Test with the configured API key:
 
-# {"user-agent": "curl/7.58.0"}
+    ```sh
+    curl -s localhost:8000/user-agent?apikey=hunter3
+    ```
 
-curl -s example.com:8000/user-agent -u medvezhonok:hunter2
+    Response:
+    ```json
+    {"user-agent": "curl/7.58.0"}
+    ```
 
-# {"user-agent": "curl/7.58.0"}
-```
+1. Test with the configured basic auth credentials:
+    ```sh
+    curl -s localhost:8000/user-agent -u medvezhonok:hunter2
+    ```
+
+    Response:
+    ```json
+    {"user-agent": "curl/7.58.0"}
+    ```


### PR DESCRIPTION
### Description

Address issue https://github.com/Kong/docs.konghq.com/issues/5789 by replacing all random hostnames with `localhost`.

Also took the opportunity to clean this topic up:

 * split codeblocks
 * added steps and headings


### Testing instructions

Netlify link: https://deploy-preview-5795--kongdocs.netlify.app/gateway/latest/kong-plugins/authentication/allowing-multiple-authentication-methods/#validate-credentials


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

