### PR TITLE
New parameter `worker_events_max_payload` for in kong.conf

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -419,6 +419,17 @@ Default: none
 
 ---
 {% endif_version %}
+
+{% if_version gte:3.4.x %}
+### worker_events_max_payload
+
+Specifies the max payload size the `worker_events` can accept. The max allowed
+is 16MB. **Note:** Increasing this value has potential negative impact on Kong's
+response latency and memory usage.
+
+**Default:** `65535`. 
+{% endif_version %}
+
 ## Hybrid Mode section
 
 ### role


### PR DESCRIPTION



### Description

`lua-resty-events` lib will be bumped to 0.2.0, which provide a new parameter to specify the max payload size the events lib can accept, then Kong should support it as well.

FTI-4963

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

