### PR TITLE
Update the output of /clustering/data-planes, which is out-of-date.

### DIFF
--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
@@ -596,6 +596,7 @@ curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
 
 The output shows all of the connected data plane instances in the cluster:
 
+{% if_version gte:3.3.x %}
 ```json
 {
     "data": [
@@ -623,8 +624,31 @@ The output shows all of the connected data plane instances in the cluster:
         }
     ],
     "next": null
-}%
+}
 ```
+{% endif_version %}
+{% if_version lte:3.2.x %}
+```
+{
+    "data": [
+        {
+            "config_hash": "a9a166c59873245db8f1a747ba9a80a7",
+            "hostname": "data-plane-2",
+            "id": "ed58ac85-dba6-4946-999d-e8b5071607d4",
+            "ip": "192.168.10.3",
+            "last_seen": 1580623199,
+            "status": "connected"
+        },
+        {
+            "config_hash": "a9a166c59873245db8f1a747ba9a80a7",
+            "hostname": "data-plane-1",
+            "id": "ed58ac85-dba6-4946-999d-e8b5071607d4",
+            "ip": "192.168.10.4",
+            "last_seen": 1580623200,
+            "status": "connected"
+        }
+```
+{% endif_version %}
 
 ## References
 

--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
@@ -600,24 +600,30 @@ The output shows all of the connected data plane instances in the cluster:
 {
     "data": [
         {
-            "config_hash": "a9a166c59873245db8f1a747ba9a80a7",
-            "hostname": "data-plane-2",
-            "id": "ed58ac85-dba6-4946-999d-e8b5071607d4",
-            "ip": "192.168.10.3",
-            "last_seen": 1580623199,
-            "status": "connected"
+            "ip": "172.24.0.10",
+            "updated_at": 1689266492,
+            "config_hash": "595214af5fb356cc569313184c64d9b7",
+            "sync_status": "normal",
+            "version": "3.3.0.0",
+            "id": "10424658-f139-476c-b74f-e0a6e6ec9402",
+            "hostname": "kongDP1",
+            "ttl": 1209593,
+            "last_seen": 1689266492
         },
         {
-            "config_hash": "a9a166c59873245db8f1a747ba9a80a7",
-            "hostname": "data-plane-1",
-            "id": "ed58ac85-dba6-4946-999d-e8b5071607d4",
-            "ip": "192.168.10.4",
-            "last_seen": 1580623200,
-            "status": "connected"
+            "ip": "172.24.0.11",
+            "updated_at": 1689266472,
+            "config_hash": "595214af5fb356cc569313184c64d9b7",
+            "sync_status": "normal",
+            "version": "3.3.0.0",
+            "id": "3487f520-4f52-4ee5-ad6f-50756822f0c5",
+            "hostname": "kongDP2",
+            "ttl": 1209572,
+            "last_seen": 1689266472
         }
     ],
     "next": null
-}
+}%
 ```
 
 ## References


### PR DESCRIPTION
### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Netlify link: https://deploy-preview-5807--kongdocs.netlify.app/gateway/latest/production/deployment-topologies/hybrid-mode/setup/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

