### PR TITLE
Add hook that displays the total number of pages generated

### DIFF
--- a/app/_plugins/hooks/total_pages.rb
+++ b/app/_plugins/hooks/total_pages.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  Jekyll.logger.info "Total number of pages generated: #{site.pages.size}"
+end


### PR DESCRIPTION
### Description

What did you change and why?
 
Add a hook that outputs the number of generated pages after the site builds.
Makes it easy to keep track of how many pages are added by each PR.

![Screenshot 2023-07-14 at 09 54 24](https://github.com/Kong/docs.konghq.com/assets/715229/a98be2c3-1e8a-4bed-85b9-3bdc8d33a38b)


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

