### PR TITLE
Add sentence to ssl_cipher description

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -1037,6 +1037,8 @@ conform to the pattern defined by `openssl ciphers`.
 
 This value is ignored if `ssl_cipher_suite` is not `custom`.
 
+If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter.
+
 **Default:** none
 
 


### PR DESCRIPTION
### Description

What did you change and why?
- Someone in #docs reported that the description of ssl_ciphers was confusing if you were using DHE ciphers because you'd also have to use another parameter. This fixes the description.
- I'll also change this in Kong-ee, I just haven't made the PR yet.
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
https://kongstrong.slack.com/archives/CDSTDSG9J/p1688483985172189

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

