### PR TITLE
[DOCU-3301] Add PostgreSQL 15 note to upgrade doc

### DIFF
--- a/app/_src/gateway/upgrade-v2.md
+++ b/app/_src/gateway/upgrade-v2.md
@@ -133,6 +133,16 @@ The `traditional_compat` router mode has been made more compatible with the beha
 
 {% endif_version %}
 
+{% if_version gte:3.3.x %}
+### Upgrading {{site.base_gateway}} after adopting PostgreSQL 15
+
+PostgreSQL 15 enforces different permission on the public schema than prior versions of PostgreSQL. This requires an extra step to grant the correct permissions to the Kong user to make schema changes. 
+
+You can grant the permissions in one of two ways:
+* Assign the Kong database owner to Kong by running `ALTER DATABASE kong OWNER TO kong`.
+* Temporarily give the Kong user the ability to modify the public schema and then revoke that permission. This option is more restrictive and is a two part process. First, you must grant the right to modify the schema with `GRANT CREATE ON SCHEMA public TO kong` before you run the bootstrap migration commands. After the migrations are done, you can remove this permission by running `REVOKE CREATE ON SCHEMA public FROM kong`.
+{% endif_version %}
+
 {% if_version gte:3.2.x %}
 
 ### PostgreSQL SSL version bump

--- a/app/_src/gateway/upgrade-v2.md
+++ b/app/_src/gateway/upgrade-v2.md
@@ -136,11 +136,13 @@ The `traditional_compat` router mode has been made more compatible with the beha
 {% if_version gte:3.3.x %}
 ### Upgrading {{site.base_gateway}} after adopting PostgreSQL 15
 
-PostgreSQL 15 enforces different permission on the public schema than prior versions of PostgreSQL. This requires an extra step to grant the correct permissions to the Kong user to make schema changes. 
+PostgreSQL 15 enforces different permissions on the public schema than prior versions of PostgreSQL. This requires an extra step to grant the correct permissions to the Kong user to make schema changes. 
 
 You can grant the permissions in one of two ways:
 * Assign the Kong database owner to Kong by running `ALTER DATABASE kong OWNER TO kong`.
-* Temporarily give the Kong user the ability to modify the public schema and then revoke that permission. This option is more restrictive and is a two part process. First, you must grant the right to modify the schema with `GRANT CREATE ON SCHEMA public TO kong` before you run the bootstrap migration commands. After the migrations are done, you can remove this permission by running `REVOKE CREATE ON SCHEMA public FROM kong`.
+* Temporarily give the Kong user the ability to modify the public schema and then revoke that permission. This option is more restrictive and is a two-part process:
+  1. Before you run the bootstrap migration commands, grant the right to modify the schema with `GRANT CREATE ON SCHEMA public TO kong`.
+  2. After the migrations are done, remove this permission by running `REVOKE CREATE ON SCHEMA public FROM kong`.
 {% endif_version %}
 
 {% if_version gte:3.2.x %}


### PR DESCRIPTION
### Description

What did you change and why?

- We were asked to update Gateway 3.3 and later upgrade docs with a [note about PostgreSQL 15 changes](https://konghq.atlassian.net/browse/FTI-5149?focusedCommentId=105115), so I added that.
- I think opening this on the `main` branch is correct since this also impacts 3.3?

 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-3301

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

