### PR TITLE
Define sustaining mode, deprecated, and removed

### DIFF
--- a/app/_includes/md/availability-stages.md
+++ b/app/_includes/md/availability-stages.md
@@ -27,3 +27,24 @@ If feature documentation doesn't have a tech preview, alpha, or beta label, then
 You can deploy GA features to production environments.
 
 Interfaces are guaranteed to follow a [semantic versioning](https://semver.org/) model for any changes.
+
+## Sustaining mode
+
+No new features will be added to any components in Sustaining Mode. 
+
+Features in Sustaining Mode are no longer available in self-managed {{site.base_gateway}}, but are available in 
+{{site.konnect_short_name}}. The {{site.konnect_short_name}} versions of these features will continue 
+to have new development.
+
+## Deprecated
+
+A deprecated feature or functionality is no longer is active development, and is generally
+planned for removal in a future version. Deprecations are announced 6 months before removal.
+
+We recommend transitioning away from features when they become deprecated.
+
+Bug fixes for deprecated features may occur, but are not guaranteed. 
+
+## Removed
+
+When a feature is removed, it is no longer supported, compatible, or available in the product.


### PR DESCRIPTION
### Description

Definitions for "deprecated", "removed", and "sustaining mode" stages. Adding them because we're adding "sustaining mode" for some features and that needs to be defined; covering deprecated and removed as the alternatives.

I thought about putting these in the glossary instead of with the availability stages, but it seems to me that these definitions are part of a feature's lifecycle and fit in the same category.

This is very much a draft. I'm basing this on knowledge that I have about features we've deprecated/removed. Needs official approval.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

