### PR TITLE
Add ability to render specific products and plugin hub

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -30,3 +30,8 @@ TokenIgnores = {%.*?%}, \
 {{.*?}}, \
 (?:)(/[(A-Za-z0-9)(\055/)(_)]*/), \
 ({\#.*})
+
+[README.md]
+BasedOnStyles = kong
+kong.Relativeurls = NO
+kong.We = NO

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make run
 In order to speed up build times, it's possible to generate a specific subset of products and their corresponding versions by specifying the `KONG_PRODUCTS` env variable. It takes a comma-separated list of products and for each product, the list of versions the versions to be generated separated by semi-colons, in the following way.
 
 ```bash
-KONG_PRODUCTS='<product>:<version>;<version>,<product>:<version>;hub'
+KONG_PRODUCTS='<product>:<version>;<version>,<product>:<version>,hub'
 ```
 
 For example, running

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ KONG_PRODUCTS=<product>:<version>;<version>,<product>:<version>;hub
 For example, running
 
 ```bash
-KONG_PRODUCTS=gateway:2.8.x;3.3.x,mesh:2.2.x;hub make run
+KONG_PRODUCTS=gateway:2.8.x;3.3.x,mesh:2.2.x,hub make run
 ```
 
 will generate the plugin hub, mesh version `2.2.x`, and gateway versions `2.8.x` and `3.3.x`.

--- a/README.md
+++ b/README.md
@@ -46,26 +46,26 @@ make run
 In order to speed up build times, it's possible to generate a specific subset of products and their corresponding versions by specifying the `KONG_PRODUCTS` env variable. It takes a comma-separated list of products and for each product, the list of versions the versions to be generated separated by semi-colons, in the following way.
 
 ```bash
-KONG_PRODUCTS=<product>:<version>;<version>,<product>:<version>;hub
+KONG_PRODUCTS='<product>:<version>;<version>,<product>:<version>;hub'
 ```
 
 For example, running
 
 ```bash
-KONG_PRODUCTS=gateway:2.8.x;3.3.x,mesh:2.2.x,hub make run
+KONG_PRODUCTS='gateway:2.8.x;3.3.x,mesh:2.2.x;hub' make run
 ```
 
 will generate the plugin hub, mesh version `2.2.x`, and gateway versions `2.8.x` and `3.3.x`.
 It also supports wildcard matching for both products and versions, i.e.
 
 ```bash
-KONG_PRODUCTS=gateway:3.*
+KONG_PRODUCTS='gateway:3.*'
 ```
 
 and 
 
 ```bash
-KONG_PRODUCTS=*:latest
+KONG_PRODUCTS='*:latest'
 ```
  are also possible.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,34 @@ git submodule update --init --recursive
 make run
 ```
 
+### Generating specific products
+
+In order to speed up build times, it's possible to generate a specific subset of products and their corresponding versions by specifying the `KONG_PRODUCTS` env variable. It takes a comma-separated list of products and for each product, the list of versions the versions to be generated separated by semi-colons, in the following way.
+
+```bash
+KONG_PRODUCTS=<product>:<version>;<version>,<product>:<version>;hub
+```
+
+For example, running
+
+```bash
+KONG_PRODUCTS=gateway:2.8.x;3.3.x,mesh:2.2.x;hub make run
+```
+
+will generate the plugin hub, mesh version `2.2.x`, and gateway versions `2.8.x` and `3.3.x`.
+It also supports wildcard matching for both products and versions, i.e.
+
+```bash
+KONG_PRODUCTS=gateway:3.*
+```
+
+and 
+
+```bash
+KONG_PRODUCTS=*:latest
+```
+ are also possible.
+
 ## Plugin contributors
 
 If you have contributed a plugin, you can add a Kong badge to your plugin README.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ KONG_PRODUCTS='<product>:<version>;<version>,<product>:<version>;hub'
 For example, running
 
 ```bash
-KONG_PRODUCTS='gateway:2.8.x;3.3.x,mesh:2.2.x;hub' make run
+KONG_PRODUCTS='gateway:2.8.x;3.3.x,mesh:2.2.x,hub' make run
 ```
 
 will generate the plugin hub, mesh version `2.2.x`, and gateway versions `2.8.x` and `3.3.x`.

--- a/app/_plugins/generators/plugin_single_source_generator.rb
+++ b/app/_plugins/generators/plugin_single_source_generator.rb
@@ -10,6 +10,8 @@ module PluginSingleSource
     def generate(site)
       site.data['ssg_hub'] = []
 
+      return if ENV['KONG_PRODUCTS'] && !ENV['KONG_PRODUCTS'].include?('hub')
+
       generate_pages(site)
     end
 

--- a/app/_plugins/hooks/products_renderer.rb
+++ b/app/_plugins/hooks/products_renderer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class ProductsRenderer
+  def products
+    @products ||= ENV.fetch('KONG_PRODUCTS', '')
+                     .split(',')
+                     .map { |p| p == 'kic' ? 'kubernetes-ingress-controller' : p }
+  end
+
+  def read?(page)
+    products.any? do |product|
+      page.relative_path == 'index.html' || page.relative_path.start_with?(product)
+    end
+  end
+
+  def render?(page)
+    products.any? do |product|
+      page.dir == '/' || page.dir.start_with?("/#{product}")
+    end
+  end
+end
+
+renderer = ProductsRenderer.new
+
+Jekyll::Hooks.register :site, :post_read do |site|
+  if ENV['KONG_PRODUCTS']
+    Jekyll.logger.info "Rendering the following products: #{ENV['KONG_PRODUCTS']}, skipping everything else..."
+
+    site.pages = site.pages.select { |page| renderer.read?(page) }
+  end
+end
+
+Jekyll::Hooks.register :site, :pre_render do |site|
+  if ENV['KONG_PRODUCTS']
+    site.pages = site.pages.select do |page|
+      renderer.render?(page)
+    end
+  end
+end

--- a/app/_plugins/hooks/products_renderer.rb
+++ b/app/_plugins/hooks/products_renderer.rb
@@ -19,11 +19,17 @@ class ProductsRenderer
     end
   end
 
-  def render?(page)
+  def render?(page) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     products.any? do |product, versions|
-      page.dir == '/' ||
+      return true if page.dir == '/'
+
+      case product
+      when '*'
+        versions.any? { |v| page.dir.start_with?(%r{/(\w|-)+/#{v}/}) }
+      else
         (versions.nil? && page.dir.start_with?("/#{product}")) ||
-        (!versions.nil? && versions.any? { |v| page.dir.start_with?("/#{product}/#{v}") })
+          (!versions.nil? && versions.any? { |v| page.dir.start_with?(%r{/#{product}/#{v}}) })
+      end
     end
   end
 end

--- a/spec/app/_plugins/generators/hooks/products_renderer_spec.rb
+++ b/spec/app/_plugins/generators/hooks/products_renderer_spec.rb
@@ -1,0 +1,123 @@
+RSpec.describe ProductsRenderer do
+  describe '#render?' do
+    subject { described_class.new }
+
+    shared_examples_for 'always render home' do
+      it_behaves_like 'renders the page', '/'
+    end
+
+    shared_examples_for 'renders the page' do |page_dir|
+      it { expect(subject.render?(double(dir: page_dir))).to eq(true) }
+    end
+
+    shared_examples_for 'does not render the page' do |page_dir|
+      it { expect(subject.render?(double(dir: page_dir))).to eq(false) }
+    end
+
+    context 'plugin hub' do
+      before do
+        allow(ENV).to receive(:fetch).with('KONG_PRODUCTS', '').and_return('hub')
+      end
+
+      it_behaves_like 'always render home'
+
+      context 'only renders hub pages' do
+        ['/hub/', '/hub/kong-inc/tcp-log/'].each do |page_dir|
+          it_behaves_like 'renders the page', page_dir
+        end
+
+        ['/gateway/', '/konnect/'].each do |page_dir|
+          it_behaves_like 'does not render the page', page_dir
+        end
+      end
+    end
+
+    context 'specifying a product with multiple versions' do
+      before do
+        allow(ENV).to receive(:fetch).with('KONG_PRODUCTS', '').and_return('gateway:2.8.x;3.3.x;latest')
+      end
+
+      it_behaves_like 'always render home'
+
+      [
+        '/gateway/latest/', '/gateway/3.3.x/', '/gateway/2.8.x/',
+        '/gateway/latest/admin-api/', '/gateway/3.3.x/admin-api/', '/gateway/2.8.x/admin-api/'
+      ].each do |page_dir|
+        it_behaves_like 'renders the page', page_dir
+      end
+
+      ['/hub/', '/konnect/', '/gateway/2.7.x/'].each do |page_dir|
+        it_behaves_like 'does not render the page', page_dir
+      end
+    end
+
+    context 'specifying multiple products with multiple versions' do
+      before do
+        allow(ENV).to receive(:fetch).with('KONG_PRODUCTS', '').and_return('gateway:2.8.x;3.3.x;latest,mesh:latest;2.2.x')
+      end
+
+      it_behaves_like 'always render home'
+
+      [
+        '/gateway/latest/', '/gateway/3.3.x/', '/gateway/2.8.x/',
+        '/mesh/latest/', '/mesh/2.2.x/', '/mesh/latest/features/', '/mesh/2.2.x/features',
+        '/gateway/latest/admin-api/', '/gateway/3.3.x/admin-api/', '/gateway/2.8.x/admin-api/'
+      ].each do |page_dir|
+        it_behaves_like 'renders the page', page_dir
+      end
+
+      ['/hub/', '/konnect/', '/gateway/2.7.x/', '/mesh/2.1.x/'].each do |page_dir|
+        it_behaves_like 'does not render the page', page_dir
+      end
+    end
+
+    context 'wildcard matching' do
+      context 'versions wildcard' do
+        before do
+          allow(ENV).to receive(:fetch).with('KONG_PRODUCTS', '').and_return('gateway:3.*')
+        end
+
+        [
+          '/gateway/3.0.x/', '/gateway/3.1.x/', '/gateway/3.2.x/',
+          '/gateway/3.0.x/stability/', '/gateway/3.1.x/stability/', '/gateway/3.2.x/stability/',
+        ].each do |page_dir|
+          it_behaves_like 'renders the page', page_dir
+        end
+
+          [
+            '/gateway/1.8.x/', '/gateway/2.8.x/',
+            '/gateway/1.8.x/stability/', '/gateway/2.8.x/stability/',
+            '/hub/', '/deck/', '/konnect/'
+          ].each do |page_dir|
+            it_behaves_like 'does not render the page', page_dir
+          end
+      end
+
+      context 'products wildcard' do
+        before do
+          allow(ENV).to receive(:fetch).with('KONG_PRODUCTS', '').and_return('*:latest')
+        end
+
+        it_behaves_like 'always render home'
+
+        context 'renders all the latest versions of the products' do
+          [
+            '/gateway/latest/', '/mesh/latest/', '/mesh/latest/features/', '/gateway/latest/admin-api/',
+            '/deck/latest/', '/deck/latest/terminology/',
+            '/kubernetes-ingress-controller/latest/', '/kubernetes-ingress-controller/latest/faq/'
+          ].each do |page_dir|
+            it_behaves_like 'renders the page', page_dir
+          end
+        end
+
+        [
+          '/hub/', '/gateway/2.7.x/', '/mesh/2.1.x/',
+          '/deck/1.23.x/', '/kubernetes-ingress-controller/2.9.x/',
+          '/konnect/', '/konnect/architecture/'
+        ].each do |page_dir|
+          it_behaves_like 'does not render the page', page_dir
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

Render specific products based on the `KONG_PRODUCTS` env variable, which should be a  comma-separated list of the products to be rendered.

For example: 

```
KONG_PRODUCTS=gateway,kic,hub make run
```

generates the pages for:
* gateway
* kubernetes-ingress-controller
* plugin hub

It works by running two [hooks](https://jekyllrb.com/docs/plugins/hooks/#built-in-hook-owners-and-events) in different stages of the generation process:
* `:site, :post_read`: it skips pages that don't start with one of the specified product names - It always generates the home page. 
* `:site, :pre_render`: Mostly for single-sourced pages, it skips pages whose URLs don't start with one of the specified product names.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

