### PR TITLE
Update enable-rbac.md

### DIFF
--- a/app/_src/gateway/production/access-control/enable-rbac.md
+++ b/app/_src/gateway/production/access-control/enable-rbac.md
@@ -466,6 +466,7 @@ and if they do, the admin can grant them individually.
       --data 'endpoint=/rbac/*' \
       --data 'workspace=teamA' \
       --data 'actions=*' \
+      --data 'negative=true' \
       -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
     ```
 
@@ -494,6 +495,7 @@ and if they do, the admin can grant them individually.
       --data 'endpoint=/workspaces/*' \
       --data 'workspace=teamA' \
       --data 'actions=*' \
+      --data 'negative=true' \
       -H 'Kong-Admin-Token:n5bhjgv0speXp4N7rSUzUj8PGnl3F5eG'
     ```
 


### PR DESCRIPTION
negative=true flag should be indicated for the curl command for these examples here as negative=false is set by default without specific indication


### Description

--data negative=true flag was left out in this example


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

