### PR TITLE
chore(*): add more explanation when using EKS IRSA to access RDS database

### DIFF
--- a/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
+++ b/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
@@ -27,7 +27,7 @@ Before you enable the AWS IAM authentication, you must configure your AWS RDS da
 - **Assign an IAM role to your Kong Gateway instance.** {{site.base_gateway}} can automatically discover and fetch the AWS credentials to use for the IAM role.
    - If you use an EC2 environment, use the [EC2 IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
    - If you use an ECS cluster, use a [ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html).
-   - If you use an EKS cluster, configure a Kubernetes service account that can annotate your assigned role and configure the pods to use an [IAM role defined by serviceaccount](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html).
+   - If you use an EKS cluster, configure a Kubernetes service account that can annotate your assigned role and configure the pods to use an [IAM role defined by serviceaccount](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html). Using an IAM role defined by serviceaccount requires a request to the AWS STS service, so you also need to make sure that your Kong inside the Pod can access AWS STS service endpoint without problem. (If you're using STS regional endpoints, please make sure you have `AWS_STS_REGIONAL_ENDPOINTS` defined in your environment variables.)
    - If you run {{site.base_gateway}} locally, use the environment variables, like access key and secret key combination by using `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or profile and credential file combination by using `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`
    
    {:.warning}

--- a/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
+++ b/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
@@ -27,7 +27,11 @@ Before you enable the AWS IAM authentication, you must configure your AWS RDS da
 - **Assign an IAM role to your Kong Gateway instance.** {{site.base_gateway}} can automatically discover and fetch the AWS credentials to use for the IAM role.
    - If you use an EC2 environment, use the [EC2 IAM role](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
    - If you use an ECS cluster, use a [ECS task IAM role](https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html).
-   - If you use an EKS cluster, configure a Kubernetes service account that can annotate your assigned role and configure the pods to use an [IAM role defined by serviceaccount](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html). Using an IAM role defined by serviceaccount requires a request to the AWS STS service, so you also need to make sure that your Kong inside the Pod can access AWS STS service endpoint without problem. (If you're using STS regional endpoints, please make sure you have `AWS_STS_REGIONAL_ENDPOINTS` defined in your environment variables.)
+   - If you use an EKS cluster, configure a Kubernetes service account that can annotate your assigned role and configure the pods to use an [IAM role defined by serviceaccount](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html). 
+   
+      Using an IAM role defined by serviceaccount requires a request to the AWS STS service, so you also need to make sure that your Kong instance inside the Pod can access the AWS STS service endpoint. 
+   
+      If you're using STS regional endpoints, make sure you have `AWS_STS_REGIONAL_ENDPOINTS` defined in your environment variables.
    - If you run {{site.base_gateway}} locally, use the environment variables, like access key and secret key combination by using `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, or profile and credential file combination by using `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`
    
    {:.warning}


### PR DESCRIPTION


### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

This PR adds more explanation when user want to use the IAM Role defined by serviceaccount in an EKS environment to access RDS database. A request to the AWS STS service will happen inside this procedure so user have to make sure that they have no network restriction to the AWS STS service.


FTI-5211


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

