### PR TITLE
Fix cookie_domain example

### DIFF
--- a/app/_src/gateway/install/kubernetes/helm.md
+++ b/app/_src/gateway/install/kubernetes/helm.md
@@ -100,7 +100,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
     {% endif_version %}
     {% if_version gte:3.2.x %}
@@ -112,7 +112,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_same_site` properties as follows:
 
     ```
-    echo '{"cookie_name":"portal_session","cookie_same_site":"Lax","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_same_site":"Lax","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
     {% endif_version %}
 

--- a/app/_src/gateway/install/kubernetes/openshift.md
+++ b/app/_src/gateway/install/kubernetes/openshift.md
@@ -93,7 +93,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
     {% endif_version %}
     {% if_version gte:3.2.x %}
@@ -105,7 +105,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
     {% endif_version %}
 

--- a/app/enterprise/2.1.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.1.x/deployment/installation/kong-on-kubernetes.md
@@ -124,7 +124,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create secret:
@@ -148,7 +148,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create secret:

--- a/app/enterprise/2.2.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.2.x/deployment/installation/kong-on-kubernetes.md
@@ -124,7 +124,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create secret:
@@ -148,7 +148,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create secret:

--- a/app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.3.x/deployment/installation/kong-on-kubernetes.md
@@ -168,7 +168,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create the secret.
@@ -212,7 +212,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create the secret.

--- a/app/enterprise/2.4.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.4.x/deployment/installation/kong-on-kubernetes.md
@@ -168,7 +168,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create the secret.
@@ -212,7 +212,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create the secret.

--- a/app/enterprise/2.5.x/deployment/installation/kong-on-kubernetes.md
+++ b/app/enterprise/2.5.x/deployment/installation/kong-on-kubernetes.md
@@ -168,7 +168,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create the secret.
@@ -212,7 +212,7 @@ In the following steps, replace `<your-password>` with a secure password.
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 3. Create the secret.

--- a/app/gateway/2.6.x/install-and-run/helm.md
+++ b/app/gateway/2.6.x/install-and-run/helm.md
@@ -92,7 +92,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 1.  Create the secret:

--- a/app/gateway/2.6.x/install-and-run/openshift.md
+++ b/app/gateway/2.6.x/install-and-run/openshift.md
@@ -85,7 +85,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 1.  Create the secret:

--- a/app/gateway/2.7.x/install-and-run/helm.md
+++ b/app/gateway/2.7.x/install-and-run/helm.md
@@ -92,7 +92,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 1.  Create the secret:

--- a/app/gateway/2.7.x/install-and-run/openshift.md
+++ b/app/gateway/2.7.x/install-and-run/openshift.md
@@ -85,7 +85,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 1.  Create the secret:

--- a/app/gateway/2.8.x/install-and-run/helm.md
+++ b/app/gateway/2.8.x/install-and-run/helm.md
@@ -92,7 +92,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 1.  Create the secret:

--- a/app/gateway/2.8.x/install-and-run/openshift.md
+++ b/app/gateway/2.8.x/install-and-run/openshift.md
@@ -85,7 +85,7 @@ If you create an RBAC superuser and plan to work with Kong Manager or Dev Portal
     and `cookie_samesite` properties as follows:
 
     ```
-    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com">,"secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
+    $ echo '{"cookie_name":"portal_session","cookie_samesite":"off","cookie_domain":"<.your_subdomain.com>","secret":"<your-password>","cookie_secure":false,"storage":"kong"}' > portal_session_conf
     ```
 
 1.  Create the secret:


### PR DESCRIPTION
### Description

What did you change and why?
The cookie_domain example in the docs has a minor "typo". 
 
### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

Please advise - which branch I should target - but as many versions are "affected" main seems the correct one?


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

