### PR TITLE
Pin vale version

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@v2
         with:
+          version: 2.24.0
           # path where vale checks checking only modified files.
           filter_mode: file
           fail_on_error: true


### PR DESCRIPTION
Pin vale version to 2.24 to fix terms.yml not reading the `custom` key. 