### PR TITLE
fix: Remove inaccurate note about runtime instances

### DIFF
--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -8,12 +8,7 @@ title: Compatibility
 |----------------------------------|:--:|:----:|:-------:|:------:|:------:|
 | {{site.konnect_saas}} |  <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |  <i class="fa fa-check"></i> |  <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
-## Runtime version compatibility
-
-{:.note}
-> **Note:** Currently, the only supported runtime type in
-{{site.konnect_saas}} is a [{{site.base_gateway}}](/gateway/)
-data plane.
+## {{site.base_gateway}} version compatibility
 
 |                                | {{site.konnect_saas}} | First supported patch version
 |--------------------------------|:---------------------:|-----------------------------


### PR DESCRIPTION
### Description
Removing note saying that only Kong Gateway is supported, since we now support Mesh (and KIC, though that's still gateway).

Is there a list of known supported Mesh versions in Konnect @cloudjumpercat ?

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

