### PR TITLE
Use environment instead of branch-specific context 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "exe/build"
   environment = { JEKYLL_ENV = "development", BUNDLE_WITHOUT = "development", NODE_OPTIONS = "--max_old_space_size=8192" }
 
-[context.main.environment]
+[context.production.environment]
   JEKYLL_ENV = "production"
 
 [context.deploy-preview.environment]


### PR DESCRIPTION
### Description

Running the site locally (on `main`) was raising an error 
```
Liquid Exception: Vite Ruby can't find entrypoints/application.js in .jekyll-cache/vite/manifest.json
```

The problem was that `JEKYLL_ENV` was set to production for the [main branch](https://github.com/Kong/docs.konghq.com/blob/main/netlify.toml#L6)

According to netlify’s [docs](https://docs.netlify.com/configure-builds/file-based-configuration/#deploy-contexts), branch-specific contexts override everything else, so it was trying to run it in production mode.

Changing the config to use an environment-specific context instead of a branch-specific one fixes the issue.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

