### PR TITLE
Support for 3rd party Konnect badges

### DIFF
--- a/app/_plugins/drops/plugins/badges.rb
+++ b/app/_plugins/drops/plugins/badges.rb
@@ -16,7 +16,7 @@ module Jekyll
         end
 
         def konnect?
-          @publisher == KONG_INC && !!@metadata['konnect']
+          !!@metadata['konnect']
         end
 
         def enterprise?

--- a/docs/templates/partner-plugin-template/_metadata.yml
+++ b/docs/templates/partner-plugin-template/_metadata.yml
@@ -48,6 +48,9 @@ enterprise: # true OR false
   # (Required) Set true if the plugin is *only* available with an Enterprise subscription.
   # Set false if your plugin is open-source and works with open-source Kong Gateway.
 
+konnect: # true OR false
+   # (Required) Set true if compatible with Konnect. Set false if not.
+
 dbless_compatible:
   # (Required) Degree of compatibility with Kong Gateway's DB-less mode. 
   # One of the following values allowed: 'yes', 'no' or 'partially'.


### PR DESCRIPTION
### Description

Make it possible to set `konnect: true` in a 3rd party plugin's metadata to have the "Konnect Compatible" badge show up on the Hub.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

