### PR TITLE
Add foreman gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ group :development do
   gem 'rubocop'
   gem 'rspec'
   gem 'capybara'
+  gem 'foreman'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.15.5)
+    foreman (0.87.2)
     forwardable-extended (2.6.0)
     http_parser.rb (0.8.0)
     i18n (1.12.0)
@@ -169,6 +170,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   capybara
+  foreman
   jekyll (= 4.2.2)
   jekyll-generator-single-source
   jekyll-include-cache

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ install-prerequisites:
 # Installs npm packages and gems.
 install: ruby-version-check
 	npm ci
-	gem install foreman
 	bundle install
 	git submodule update --init
 


### PR DESCRIPTION
### Description

What did you change and why?

Add foreman gem to Gemfile. 
It was added to `make install` but not to the Gemfile, so it was causing some [checks](https://github.com/Kong/docs.konghq.com/actions/runs/5703210629/job/15455607413) to fail.



### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

