### PR TITLE
chore: Split app reg plugin how-tos

### DIFF
--- a/.github/styles/kongplugins/plugin-ignore.txt
+++ b/.github/styles/kongplugins/plugin-ignore.txt
@@ -650,6 +650,7 @@ namespaceuri
 NATs
 nav_title
 navtab
+nav_title
 nbf
 new_body
 no_proxy

--- a/app/_hub/kong-inc/application-registration/_index.md
+++ b/app/_hub/kong-inc/application-registration/_index.md
@@ -15,12 +15,12 @@ Application Registration plugin.
 
 The Application Registration plugin is used in tandem with supported {{site.base_gateway}} authorization
 plugins, depending on your configured Dev
-Portal authorization provider. Either {{site.base_gateway}} (`kong-oauth2`) or a third-party OAuth provider
-(`external-oauth2`) can be the system of record (SoR) for application credentials. For more
+Portal authorization provider. These authorization plugins use either {{site.base_gateway}} (`kong-oauth2`) or a third-party OAuth 
+provider (`external-oauth2`) as the system of record (SoR) for application credentials. 
+
+An authorization provider strategy **must be set** before configuring the Application Registration plugin. For more
 information, see
 [Configure an Authorization Provider Strategy](/gateway/latest/kong-enterprise/dev-portal/applications/auth-provider-strategy/).
-
-To learn how to set up key authentication, see [Enable Key Authentication for Application Registration](/gateway/latest/kong-enterprise/dev-portal/applications/enable-key-auth-plugin/).
 
 Supported authorization plugins for use with application registration:
 
@@ -30,44 +30,18 @@ Supported authorization plugins for use with application registration:
 | [Key Auth](/hub/kong-inc/key-auth/)| `kong-oauth2` |
 | [OIDC](/hub/kong-inc/openid-connect/)| `external-oauth2` |
 
+To learn how to set up key authentication, see [Enable Key Authentication for Application Registration](/gateway/latest/kong-enterprise/dev-portal/applications/enable-key-auth-plugin/).
+
 If you plan to use the external OAuth option with OIDC, review the
 [supported OAuth workflows](/gateway/latest/kong-enterprise/dev-portal/authentication/3rd-party-oauth/).
 
-## Examples
+## Get started with the Application Registration plugin
 
-Replace `<DNSorIP>` with your host name or IP address, `{service}` with
-your Service name, and `<my_service_display_name>` with the
-`display_name` of your Service for examples in this section.
-
-### Enable automatic registration approval
-
-Enable `auto_approve` so that application registration requests are
-automatically approved.
-
-```
-curl -X POST http://<DNSorIP>:8001/services/{service} \
-    --data "name=application-registration"  \
-    --data "config.display_name=<my_service_display_name>" \
-    --data "config.auto_approve=true
-```
-
-Update your current configuration by running a PATCH command. Replace `{plugin_id}` with the `id` of your plugin.
-
-```
-curl -X PATCH http://<DNSorIP>:8001/plugins/{plugin_id} \
-  --data "config.auto_approve=true"
-```
-### Enable show issuer URL
-
-Enable `show_issuer` to expose the **Issuer URL** in the **Service Details** dialog.
-
-**Note:** Exposing the [Issuer URL](/gateway/latest/kong-enterprise/dev-portal/applications/enable-application-registration#show-url-issuer) is essential
-for the
-[Authorization Code Flow](/gateway/latest/kong-enterprise/dev-portal/authentication/3rd-party-oauth/#ac-flow) configured for third-party identity providers.
-
-Update your current configuration by running a PATCH command. Replace `{plugin_id}` with the `id` of your plugin.
-
-```
-curl -X PATCH http://<DNSorIP>:8001/plugins/{plugin_id} \
-  --data "config.show_issuer=true"
-```
+* [Configuration reference](/hub/kong-inc/application-registration/configuration/)
+* [Basic configuration example](/hub/kong-inc/application-registration/how-to/basic-example/)
+* [Learn how to use the plugin](/hub/kong-inc/application-registration/how-to/)
+* [Authorization provider strategies](/gateway/latest/kong-enterprise/dev-portal/applications/auth-provider-strategy/#portal-app-auth)
+* [Using key authentication with application registration](/gateway/latest/kong-enterprise/dev-portal/applications/enable-key-auth-plugin/)
+* [Third-party OAuth2 support](/gateway/latest/kong-enterprise/dev-portal/authentication/3rd-party-oauth/)
+* [Application registration with Okta](/gateway/latest/kong-enterprise/dev-portal/authentication/okta-config/)
+* [Application registration with Azure AD](/gateway/latest/kong-enterprise/dev-portal/authentication/azure-oidc-config/)

--- a/app/_hub/kong-inc/application-registration/how-to/_index.md
+++ b/app/_hub/kong-inc/application-registration/how-to/_index.md
@@ -1,0 +1,52 @@
+---
+nav_title: Getting started with app registration
+---
+
+## Using the plugin
+
+You can follow the [basic examples](/hub/kong-inc/application-registration/how-to/basic-example/) to enable
+your plugin using your preferred method. Or, follow this guide for some specific scenarios.
+
+### Prerequisites
+
+Before using this plugin, [set an authorization provider strategy in `kong.conf`](/gateway/latest/kong-enterprise/dev-portal/applications/auth-provider-strategy/#portal-app-auth). 
+
+### Enable automatic registration approval
+
+You can enable `auto_approve` so that application registration requests are
+automatically approved.
+
+The following example creates an instance of the plugin with `auto_approve` enabled.
+Replace `<service>` with your service name or ID, and `<my_service_display_name>` with the
+`display_name` of your service:
+
+```
+curl -X POST http://localhost:8001/services/<service> \
+    --data "name=application-registration"  \
+    --data "config.display_name=<my_service_display_name>" \
+    --data "config.auto_approve=true
+```
+
+Or, you can update your current configuration with a `PATCH` request.
+Replace `<plugin_id>` with the `id` of your plugin.
+
+```
+curl -X PATCH http://localhost:8001/plugins/<plugin_id> \
+  --data "config.auto_approve=true"
+```
+
+### Enable show issuer URL
+
+Enable `show_issuer` to expose the **Issuer URL** in the **Service Details** dialog.
+
+{:.note}
+> **Note:** Exposing the [Issuer URL](/gateway/latest/kong-enterprise/dev-portal/applications/enable-application-registration#show-url-issuer) is essential
+for the [Authorization Code Flow](/gateway/latest/kong-enterprise/dev-portal/authentication/3rd-party-oauth/#ac-flow) 
+configured for third-party identity providers.
+
+Update your current configuration with a `PATCH` request. Replace `<plugin_id>` with the `id` of your plugin.
+
+```
+curl -X PATCH http://localhost:8001/plugins/<plugin_id> \
+  --data "config.show_issuer=true"
+```


### PR DESCRIPTION
### Description

Split app reg plugin doc into the "Using this plugin" section. 
Cross-linked a ton of content from the Gateway docs to hopefully make it easier to find app reg info. 

Was making this change as part of the OIDC plugin branch originally and it got too big (no surprise). 

### Testing instructions

[Overview](https://deploy-preview-5875--kongdocs.netlify.app/hub/kong-inc/application-registration/)
[Getting started](https://deploy-preview-5875--kongdocs.netlify.app/hub/kong-inc/application-registration/how-to/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

