### PR TITLE
Install foreman before running scheduled broken link checker

### DIFF
--- a/.github/workflows/scheduled-broken-link-checker.yml
+++ b/.github/workflows/scheduled-broken-link-checker.yml
@@ -28,6 +28,8 @@ jobs:
         run: bundle config path ${{ github.workspace }}/vendor/bundle
       - name: Bundle Install
         run: bundle install --jobs 4 --retry 3
+      - name: Install foreman
+        run: gem install foreman
 
       # Configure Node to build assets
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### Description

What did you change and why?
 
The scheduled broken link checker requires `foreman` to be installed but we include it in the as a dev dependency.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

