### PR TITLE
Set `kong_version` to hub pages.

### DIFF
--- a/app/_plugins/blocks/inline_plugin_example/config.rb
+++ b/app/_plugins/blocks/inline_plugin_example/config.rb
@@ -68,7 +68,7 @@ module Jekyll
       end
 
       def version
-        @version ||= @page['kong_version']
+        @version ||= @page['kong_version'] || @page['version']
       end
     end
   end

--- a/app/_plugins/generators/plugin_single_source/plugin/base.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/base.rb
@@ -46,10 +46,6 @@ module PluginSingleSource
         @sources ||= Hash.new { |_k, _v| '_index' }
       end
 
-      def set_version?
-        releases.size > 1
-      end
-
       def ext_data
         {}
       end

--- a/app/_plugins/generators/plugin_single_source/plugin/page_data.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/page_data.rb
@@ -26,8 +26,7 @@ module PluginSingleSource
         {
           'is_latest' => @release.latest?,
           'seo_noindex' => @release.latest? ? nil : true,
-          'version' => @release.set_version? ? @release.version : nil,
-          'kong_version' => @release.version,
+          'version' => @release.version,
           'extn_slug' => @release.name,
           'extn_publisher' => @release.vendor,
           'extn_release' => @release.version,

--- a/app/_plugins/generators/plugin_single_source/plugin/page_data.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/page_data.rb
@@ -27,6 +27,7 @@ module PluginSingleSource
           'is_latest' => @release.latest?,
           'seo_noindex' => @release.latest? ? nil : true,
           'version' => @release.set_version? ? @release.version : nil,
+          'kong_version' => @release.version,
           'extn_slug' => @release.name,
           'extn_publisher' => @release.vendor,
           'extn_release' => @release.version,

--- a/app/_plugins/generators/plugin_single_source/plugin/release.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/release.rb
@@ -10,7 +10,7 @@ module PluginSingleSource
 
       attr_reader :version, :source, :site
 
-      def_delegators :@plugin, :ext_data, :vendor, :name, :dir, :set_version?
+      def_delegators :@plugin, :ext_data, :vendor, :name, :dir
 
       def initialize(site:, version:, plugin:, source:, is_latest:)
         @site = site

--- a/app/_plugins/generators/plugin_single_source/plugin/unversioned.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/unversioned.rb
@@ -4,7 +4,12 @@ module PluginSingleSource
   module Plugin
     class Unversioned < Base
       def releases
-        @releases ||= ['1.0.0'] # If there's no version, assume it's 1.0.0
+        @releases ||= if vendor == 'kong-inc'
+                        ['1.0.0'] # If there's no version, assume it's 1.0.0
+                      else
+                        # If there's no version, assume it's latest
+                        [KongVersions.to_semver(KongVersions.gateway(site).max)]
+                      end
       end
 
       def extension?

--- a/spec/app/_plugins/blocks/inline_plugin_example/config_spec.rb
+++ b/spec/app/_plugins/blocks/inline_plugin_example/config_spec.rb
@@ -96,4 +96,22 @@ RSpec.describe Jekyll::InlinePluginExample::Config do
   describe '#title' do
     it { expect(subject.title).to eq('Opinionated Example') }
   end
+
+  describe '#schema' do
+    context 'when the page has `version` set instead of `kong_version`' do
+      let(:page) { { 'version' => '3.2.x' } }
+
+      it 'returns the schema' do
+        expect(subject.schema).to be_an_instance_of(::PluginSingleSource::Plugin::Schemas::Kong)
+      end
+    end
+
+    context 'when the page has `kong_version` set' do
+      let(:page) { { 'kong_version' => '3.2.x' } }
+
+      it 'returns the schema' do
+        expect(subject.schema).to be_an_instance_of(::PluginSingleSource::Plugin::Schemas::Kong)
+      end
+    end
+  end
 end

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/page_data_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/page_data_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe PluginSingleSource::Plugin::PageData do
           'extn_release' => '2.8.x',
           'extn_icon' => '/assets/images/icons/hub/kong-inc_jwt-signer.png',
           'layout' => 'extension',
-          'book' => 'plugins/kong-inc/jwt-signer/2.8.x'
+          'book' => 'plugins/kong-inc/jwt-signer/2.8.x',
+          'kong_version' => '2.8.x'
         )
       end
 
@@ -90,7 +91,8 @@ RSpec.describe PluginSingleSource::Plugin::PageData do
           'extn_release' => '2.5.x',
           'extn_icon' => '/assets/images/icons/hub/kong-inc_jwt-signer.png',
           'layout' => 'extension',
-          'book' => 'plugins/kong-inc/jwt-signer/2.5.x'
+          'book' => 'plugins/kong-inc/jwt-signer/2.5.x',
+          'kong_version' => '2.5.x'
         )
       end
 

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/page_data_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/page_data_spec.rb
@@ -48,8 +48,7 @@ RSpec.describe PluginSingleSource::Plugin::PageData do
           'extn_release' => '2.8.x',
           'extn_icon' => '/assets/images/icons/hub/kong-inc_jwt-signer.png',
           'layout' => 'extension',
-          'book' => 'plugins/kong-inc/jwt-signer/2.8.x',
-          'kong_version' => '2.8.x'
+          'book' => 'plugins/kong-inc/jwt-signer/2.8.x'
         )
       end
 
@@ -91,8 +90,7 @@ RSpec.describe PluginSingleSource::Plugin::PageData do
           'extn_release' => '2.5.x',
           'extn_icon' => '/assets/images/icons/hub/kong-inc_jwt-signer.png',
           'layout' => 'extension',
-          'book' => 'plugins/kong-inc/jwt-signer/2.5.x',
-          'kong_version' => '2.5.x'
+          'book' => 'plugins/kong-inc/jwt-signer/2.5.x'
         )
       end
 

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/unversioned_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/unversioned_spec.rb
@@ -11,13 +11,20 @@ RSpec.describe PluginSingleSource::Plugin::Unversioned do
     it { expect(subject.extension?).to eq(false) }
   end
 
-  describe '#set_version?' do
-    it { expect(subject.set_version?).to eq(false) }
-  end
-
   describe '#releases' do
-    it 'defaults to `1.0.0`' do
-      expect(subject.releases).to eq(['1.0.0'])
+    context 'kong plugins' do
+      let(:name) { 'jq' }
+      let(:author) { 'kong-inc' }
+
+      it 'defaults to `1.0.0`' do
+        expect(subject.releases).to eq(['1.0.0'])
+      end
+    end
+
+    context 'third-party plugins' do
+      it 'defaults to `latest`' do
+        expect(subject.releases).to eq(['3.0.0'])
+      end
     end
   end
 

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/versioned_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/versioned_spec.rb
@@ -11,12 +11,6 @@ RSpec.describe PluginSingleSource::Plugin::Versioned do
     it { expect(subject.extension?).to eq(true) }
   end
 
-  describe '#set_version?' do
-    context 'when there is more than one release' do
-      it { expect(subject.set_version?).to eq(true) }
-    end
-  end
-
   describe '#releases' do
     let(:name) { 'jwt-signer' }
 

--- a/spec/app/_plugins/generators/versions_spec.rb
+++ b/spec/app/_plugins/generators/versions_spec.rb
@@ -349,7 +349,9 @@ RSpec.describe Jekyll::Versions do
       context 'plugins' do
         let(:relative_path) { '_hub/acme/kong-plugin/_index.md' }
 
-        it_behaves_like 'does not set `release` and `version` to the page'
+        it 'does not set `release' do
+          expect(page.data['release']).to be_nil
+        end
       end
 
       context 'single sourced pages' do


### PR DESCRIPTION
### Description

What did you change and why?

Inline plugin examples rely on pages having a `kong_version` set so that they can select the right version of the plugin's schema.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

