### PR TITLE
fix: Adjust the margin on the "old version" header in plugin docs

### DIFF
--- a/app/_assets/stylesheets/pages/extension.less
+++ b/app/_assets/stylesheets/pages/extension.less
@@ -311,6 +311,7 @@
     border: none;
     border-radius: 4px;
     margin-top: 20px;
+    margin-bottom: 15px;
     .font-source-sans();
   }
 }


### PR DESCRIPTION
### Description

Fixing the banner margin. If there's no header on the page, this happens:

![Screenshot 2023-08-01 at 10 40 12 AM](https://github.com/Kong/docs.konghq.com/assets/54370747/d791e70a-1ce7-4976-92a4-b4459478d2ba)

Post-fix, we have this:
![Screenshot 2023-08-01 at 10 40 19 AM](https://github.com/Kong/docs.konghq.com/assets/54370747/5537b75d-9be7-46f3-bfd9-f147a96732e0)

### Testing instructions

Look through old versions in any plugin doc.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

