### PR TITLE
feat: Remove Alpine instructions from Docker install instructions for 3.4

### DIFF
--- a/app/_data/tables/install_options_34x.yml
+++ b/app/_data/tables/install_options_34x.yml
@@ -1,0 +1,79 @@
+columns:
+  - name: Kong OSS
+    key: oss
+  - name: Kong Enterprise
+    key: enterprise
+  - name: Officially Supported
+    key: support
+features:
+  - name: "Packages"
+    items:
+      - name: "Debian"
+        url: /gateway/VERSION/install/linux/debian/
+        oss: true
+        enterprise: true
+        support: true
+        icon: /assets/images/icons/documentation/debian-logo.jpg
+      - name: "Ubuntu"
+        url: /gateway/VERSION/install/linux/ubuntu/
+        oss: true
+        enterprise: true
+        support: true
+        icon: /assets/images/icons/documentation/ubuntu.png
+      - name: "RedHat"
+        url: /gateway/VERSION/install/linux/rhel/
+        oss: true
+        enterprise: true
+        support: true
+        icon: /assets/images/icons/documentation/rhel.jpg
+      - name: "Amazon Linux 2"
+        url: /gateway/VERSION/install/linux/amazon-linux/
+        oss: true
+        enterprise: true
+        support: true
+        icon: /assets/images/icons/documentation/amazon-linux.png
+  - name: "Kubernetes"
+    items:
+      - name: "Kubernetes (YAML Manifests)"
+        url: /gateway/VERSION/install/kubernetes/kubectl/
+        oss: true
+        enterprise: true
+        support: false
+        icon: /assets/images/icons/documentation/kubernetes-logo.png
+      - name: "Kubernetes (Helm)"
+        url: /gateway/VERSION/install/kubernetes/helm-quickstart/
+        oss: true
+        enterprise: true
+        support: true
+        icon: /assets/images/icons/documentation/helm-icon-color.svg
+      - name: "OpenShift"
+        url: /gateway/VERSION/install/kubernetes/openshift/
+        oss: true
+        enterprise: true
+        support: true
+        icon: /assets/images/icons/documentation/openshift-logo.png
+
+  - name: "Docker"
+    items:
+      - name: "Debian (bullseye-slim)"
+        oss: true
+        enterprise: true
+        support: true
+        url: /gateway/VERSION/install/docker/
+        icon: /assets/images/icons/documentation/debian-logo.jpg
+      - name: "RHEL (8-ubi)"
+        oss: true
+        enterprise: true
+        support: true
+        url: /gateway/VERSION/install/docker/build-custom-images/
+        icon: /assets/images/icons/documentation/rhel.jpg
+
+  - name: "Other"
+    items:
+      - name: "AWS with Terraform"
+        oss: true
+        enterprise: true
+        support: true
+        url: https://github.com/kong/kong-terraform-aws
+        icon: /assets/images/icons/documentation/terraform.svg
+

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -5,7 +5,7 @@ content_type: how-to
 
 Kong is distributed as prebuilt `apk`, `deb`, and `rpm` packages, in addition to official Docker images hosted on [DockerHub](https://hub.docker.com/r/kong)
 
-Kong builds and verifies [Debian](#dockerhub-debian-link-here) and [RHEL](#dockerhub-rhel-link-here) images for use in production. [Alpine](#dockerhub-alpine-link-here) images are provided for **development purposes only** as they contain development tooling such as `git` for plugin development purposes.
+Kong builds and verifies [Debian](#dockerhub-debian-link-here) and [RHEL](#dockerhub-rhel-link-here) images for use in production. {% if_version lte:3.3.x %}[Alpine](#dockerhub-alpine-link-here) images are provided for **development purposes only** as they contain development tooling such as `git` for plugin development purposes.{% endif_version %}
 
 Our Debian and RHEL images are built with minimal dependencies (as of {{ site.base_gateway }} 3.0) and run through automated security scanners before being published. Any vulnerabilities detected in supported images will be addressed in the next available patch release.
 
@@ -25,13 +25,14 @@ chmod +x docker-entrypoint.sh
     {% if_version eq:3.0.x %}
     * **Alpine**: [.apk]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/raw/names/kong-enterprise-edition-x86_64/versions/{{page.versions.ee}}/kong-enterprise-edition-{{page.versions.ee}}.x86_64.apk.tar.gz)
     {% endif_version %}
-    {% if_version lt:3.0.x gte:3.1.x %}
+    {% if_version lte:3.3.x %}
     * **Alpine**: [.apk]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/alpine/any-version/main/x86_64/kong-enterprise-edition-{{page.versions.ee}}.apk)
     {% endif_version %}
     * **RHEL**:[ .rpm]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/8/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el8.x86_64.rpm)
 
 1. Create a `Dockerfile`, ensuring you replace the filename by the first `COPY` with the name of the {{site.base_gateway}} file you downloaded in step 2:
 
+{% if_version lte:3.3.x %}
 {% capture dockerfile_run_steps %}COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 USER kong
@@ -118,7 +119,6 @@ RUN set -ex; \
 {{ dockerfile_run_steps }}
 ```
 {% endnavtab %}
-
 {% navtab Alpine %}
 ```dockerfile
 
@@ -147,10 +147,102 @@ RUN set -ex; \
 {{ dockerfile_run_steps }}
 ```
 {% endnavtab %}
-
 {% endnavtabs %}
 {% endcapture %}
 {{ dockerfile | indent }}
+{% endif_version %}
+
+{% if_version gte:3.4.x %}
+{% capture dockerfile_run_steps %}COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+USER kong
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+EXPOSE 8000 8443 8001 8444 8002 8445 8003 8446 8004 8447
+
+STOPSIGNAL SIGQUIT
+
+HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
+
+CMD ["kong", "docker-start"]{% endcapture %}
+
+{% capture dockerfile %}
+{% navtabs codeblock indent %}
+
+{% navtab Debian %}
+```dockerfile
+
+FROM debian:bullseye-slim
+
+COPY kong.deb /tmp/kong.deb
+
+RUN set -ex; \
+    apt-get update \
+    && apt-get install --yes /tmp/kong.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/kong.deb \
+    && chown kong:0 /usr/local/bin/kong \
+    && chown -R kong:0 /usr/local/kong \
+    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
+    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
+    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
+    && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
+    && kong version
+
+{{ dockerfile_run_steps }}
+```
+{% endnavtab %}
+
+{% navtab Ubuntu %}
+```dockerfile
+
+FROM ubuntu:20.04
+
+COPY kong.deb /tmp/kong.deb
+
+RUN set -ex; \
+    apt-get update \
+    && apt-get install --yes /tmp/kong.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/kong.deb \
+    && chown kong:0 /usr/local/bin/kong \
+    && chown -R kong:0 /usr/local/kong \
+    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
+    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
+    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
+    && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
+    && kong version
+
+{{ dockerfile_run_steps }}
+```
+{% endnavtab %}
+
+{% navtab RHEL %}
+```dockerfile
+
+FROM registry.access.redhat.com/ubi8/ubi:8.1
+
+COPY kong.rpm /tmp/kong.rpm
+
+RUN set -ex; \
+    yum install -y /tmp/kong.rpm \
+    && rm /tmp/kong.rpm \
+    && chown kong:0 /usr/local/bin/kong \
+    && chown -R kong:0 /usr/local/kong \
+    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
+    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
+    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
+    && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
+    && kong version
+
+{{ dockerfile_run_steps }}
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ dockerfile | indent }}
+{% endif_version %}
 
 1. Build your image:
 ```bash

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -7,7 +7,7 @@ Kong is distributed as prebuilt `apk`, `deb`, and `rpm` packages, in addition to
 
 Kong builds and verifies [Debian](#dockerhub-debian-link-here) and [RHEL](#dockerhub-rhel-link-here) images for use in production. {% if_version lte:3.3.x %}[Alpine](#dockerhub-alpine-link-here) images are provided for **development purposes only** as they contain development tooling such as `git` for plugin development purposes.{% endif_version %}
 
-Our Debian and RHEL images are built with minimal dependencies (as of {{ site.base_gateway }} 3.0) and run through automated security scanners before being published. Any vulnerabilities detected in supported images will be addressed in the next available patch release.
+The Debian and RHEL images are built with minimal dependencies (as of {{ site.base_gateway }} 3.0) and run through automated security scanners before being published. Any vulnerabilities detected in supported images will be addressed in the next available patch release.
 
 If you would like to build your own images to further customise the base image and any dependencies, follow the instructions below:
 

--- a/app/_src/gateway/install/index.md
+++ b/app/_src/gateway/install/index.md
@@ -5,4 +5,10 @@ disable_image_expand: true
 
 Kong can be installed on many different systems. From bare metal, to virtual machines, and cloud native Kubernetes environments, Kong is a low-demand, high-performing API gateway.
 
+{% if_version lte:3.3.x %}
 {% include install.html config=site.data.tables.install_options %}
+{% endif_version %}
+
+{% if_version gte:3.4.x %}
+{% include install.html config=site.data.tables.install_options_34x %}
+{% endif_version %}


### PR DESCRIPTION
### Description

What did you change and why?
- Since Alpine support is removed in 3.4, I made the Alpine instructions in the Docker install doc conditional
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-2988

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

❗ For reviewers:
- The [tiles on the install overview page](https://docs.konghq.com/gateway/latest/install/), those will need to be updated, but I wasn't sure how to conditionally render those so they only show up for versions lte:3.3.x

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

