### PR TITLE
Update expression router documentation for kong 3.4

### DIFF
--- a/app/_src/gateway/reference/router-expressions-language.md
+++ b/app/_src/gateway/reference/router-expressions-language.md
@@ -54,6 +54,10 @@ For example, you can not perform string comparisons on a integer type field.
 | `http.host`  | Lists of domains that match a route. | String |
 | `http.path` | Normalized request path (without query parameters). | String |
 | `http.headers.header_name` | Value of header `Header-Name`. Header names are converted to lower case, and `-` are replaced to `_`. | String |
+| `net.src.ip` | Source IP address of incoming connection. | IpAddr |
+| `net.src.port` | Source port number of incoming connection. | Int |
+| `dst.src.ip` | Destination IP address of incoming connection. | IpAddr |
+| `dst.src.port` | Destination port number of incoming connection. | Int |
 
 ## String
 
@@ -64,8 +68,7 @@ For example, you can not perform string comparisons on a integer type field.
 | ~ | Regex matching |
 | ^= | Prefix matching |
 | =^ | Suffix matching |
-| in | Contains |
-| not in | Does not contain |
+| contains | Contains |
 
 ## String transformations
 
@@ -84,13 +87,14 @@ For example, you can not perform string comparisons on a integer type field.
 | < | Less than |
 | <= | Less than or equal |
 
-## IP
+## IpAddr
 
 | Operator | Meaning |
 | --- | ----------- |
 | == | Equals |
 | != | Not equals |
-| in | Contains |
+| in | In CIDR |
+| not in | Not in CIDR |
 
 ## Boolean
 


### PR DESCRIPTION
### Description

Kong gateway 3.4 added stream expression support and changed some behaviors,
We should update the reference doc for kong 3.4.

https://konghq.atlassian.net/browse/KAG-2149

https://github.com/Kong/kong/pull/11071


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

