### PR TITLE
feat(gha): allow verbose link checking

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           cd tools/broken-link-checker
           npm ci
-          node run.js pr --base_url https://deploy-preview-${{ github.event.pull_request.number }}--kongdocs.netlify.app
+          node run.js pr \
+            --base_url https://deploy-preview-${{ github.event.pull_request.number }}--kongdocs.netlify.app \
+            ${{ runner.debug != '' && '--verbose' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}


### PR DESCRIPTION
### Description

What did you change and why?
 
Explicitly seeing the links that the link-checker tool is verifying can be a useful part of the review process. 


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

