### PR TITLE
Update using-tcpingress.md

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/using-tcpingress.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-tcpingress.md
@@ -37,7 +37,7 @@ To expose TCP listens, update the Deployment's environment variables and port
 configuration:
 
 ```bash
-kubectl patch deploy -n kong ingress-kong --patch '{
+kubectl patch deploy -n kong proxy-kong --patch '{
   "spec": {
     "template": {
       "spec": {


### PR DESCRIPTION
Modified patch command to reference correct Kong deployment.


### Description

What did you change and why?
 
The "kubectl patch" command referenced the wrong Kong K8s deployment and therefore fails when applied as documented.  The command, as written, may still be applicable to older versions of the KIC but does not work with the latest version I tested with which is v2.10.0.  I believe that in older versions of the KIC there was just a single deployment but in the new architecture, the GW is separate from the controller and so there are now two deployments in the kong namespace.  


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->
review:sme
<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

