### PR TITLE
Chore: Fix vale, Update Github action

### DIFF
--- a/.github/styles/kong/Terms.yml
+++ b/.github/styles/kong/Terms.yml
@@ -3,7 +3,6 @@ message: Use '%s' instead of '%s'.
 level: error
 ignorecase: true
 scope: text
-custom: true
 swap:
 
   datacenter: data center

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -89,7 +89,6 @@ jobs:
           version: 2.24.0
           # path where vale checks checking only modified files.
           filter_mode: file
-          fail_on_error: true
           vale_flags: "--glob=!app/_src/.repos/kuma/**"
           reporter: github-pr-review
         env:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,9 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: errata-ai/vale-action@v2
+      - uses: errata-ai/vale-action@reviewdog
         with:
-          version: 2.24.0
+          #version: 2.24.0
           # path where vale checks checking only modified files.
           filter_mode: file
           vale_flags: "--glob=!app/_src/.repos/kuma/**"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@v2
         with:
-          #version: 2.24.0
+          version: 2.24.0
           # path where vale checks checking only modified files.
           filter_mode: file
           vale_flags: "--glob=!app/_src/.repos/kuma/**"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           #version: 2.24.0
           # path where vale checks checking only modified files.
+          fail_on_error: true
           filter_mode: file
           vale_flags: "--glob=!app/_src/.repos/kuma/**"
           reporter: github-pr-review

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@v2
         with:
-          version: 2.24.0
+          #version: 2.24.0
           # path where vale checks checking only modified files.
           filter_mode: file
           vale_flags: "--glob=!app/_src/.repos/kuma/**"

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,7 +3,7 @@ StylesPath = .github/styles
 # The minimum alert level to display (suggestion, warning, or error).
 #
 # CI builds will only fail on error-level alerts.
-MinAlertLevel = error
+MinAlertLevel = suggestion
 
 [formats]
 mdx = md

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,7 +3,7 @@ StylesPath = .github/styles
 # The minimum alert level to display (suggestion, warning, or error).
 #
 # CI builds will only fail on error-level alerts.
-MinAlertLevel = suggestion
+MinAlertLevel = error
 
 [formats]
 mdx = md

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -7,6 +7,8 @@ chapter: 9
 tst 
 we
 We
+blacklist
+netwrk
 Kong Gatewey
   file name
 

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -5,18 +5,6 @@ chapter: 9
 ---
 
 
-we
-We
-[non relative link](https://docs.konghq.com/konnect/architecture/)
-We
-I am
-blacklist
-whitelist
-ntrk
-netwrk
-Kong Gatewey
-  file name
-
 If you are serious about your plugin, you probably want to write tests for it.
 Unit testing Lua is easy, and [many testing
 frameworks](http://lua-users.org/wiki/UnitTesting) are available. However, you

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -8,6 +8,8 @@ chapter: 9
 we
 We
 blacklist
+whitelist
+ntwrk
 netwrk
 Kong Gatewey
   file name

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -4,7 +4,7 @@ book: plugin_dev
 chapter: 9
 ---
 
-tst 
+
 we
 We
 blacklist

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -7,6 +7,9 @@ chapter: 9
 
 we
 We
+[non relative link](https://docs.konghq.com/konnect/architecture/)
+We
+I am 
 blacklist
 whitelist
 ntrk

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -9,7 +9,7 @@ we
 We
 [non relative link](https://docs.konghq.com/konnect/architecture/)
 We
-I am 
+I am
 blacklist
 whitelist
 ntrk

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -4,6 +4,10 @@ book: plugin_dev
 chapter: 9
 ---
 
+tst 
+we
+We
+Kong Gatewey
 If you are serious about your plugin, you probably want to write tests for it.
 Unit testing Lua is easy, and [many testing
 frameworks](http://lua-users.org/wiki/UnitTesting) are available. However, you

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -9,7 +9,7 @@ we
 We
 blacklist
 whitelist
-ntwrk
+ntrk
 netwrk
 Kong Gatewey
   file name

--- a/app/_src/gateway/plugin-development/tests.md
+++ b/app/_src/gateway/plugin-development/tests.md
@@ -8,6 +8,8 @@ tst
 we
 We
 Kong Gatewey
+  file name
+
 If you are serious about your plugin, you probably want to write tests for it.
 Unit testing Lua is easy, and [many testing
 frameworks](http://lua-users.org/wiki/UnitTesting) are available. However, you


### PR DESCRIPTION

Updated Github action to use Reviewdog

```
steps:
      - uses: actions/checkout@v3
      - uses: errata-ai/vale-action@reviewdog
```




![image](https://github.com/Kong/docs.konghq.com/assets/23319190/31c9276e-3655-448a-8bf4-3a5442f83d0e)

Vale is failing, I suspect it has something to do with pinning the version, removing the parameter `-fail-on-error` makes this work while still preserving the error reporting ability: 
![image](https://github.com/Kong/docs.konghq.com/assets/23319190/14bf1032-6703-4fc2-944b-0484f0883e4e)


However, this makes the PR pass even with errors reported 

![image](https://github.com/Kong/docs.konghq.com/assets/23319190/00e19e50-42b1-4df6-b52f-240ce6366a71)

