### PR TITLE
Update plugins-kubernetes.md: Specify alpine so docker does not defau…

### DIFF
--- a/app/_src/gateway/plugin-development/pluginserver/plugins-kubernetes.md
+++ b/app/_src/gateway/plugin-development/pluginserver/plugins-kubernetes.md
@@ -14,7 +14,7 @@ the {{ site.base_gateway }} image, you must temporarily set the user to `root`.
 This is an example Dockerfile that explains how to mount your plugin in the {{ site.base_gateway }} image:
 
 ```dockerfile
-FROM kong
+FROM kong:alpine
 USER root
 # Example for GO:
 COPY your-go-plugin /usr/local/bin/your-go-plugin


### PR DESCRIPTION
…lt to ubuntu


### Description

Dockerfile did not work as-is because the commands relied on the alpine version, but docker downloaded ubuntu by default for me.