### PR TITLE
deprecated `overrides` endpoint note, cascade endpoint added to workspace delete.

### DIFF
--- a/api-specs/Gateway-EE/3.4/kong-ee-3.4.yaml
+++ b/api-specs/Gateway-EE/3.4/kong-ee-3.4.yaml
@@ -7659,7 +7659,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/group_name_or_id'
     put:
-      summary: Configure rate limiting for a consumer group
+      summary: Configure rate limiting for a consumer group. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.
       operationId: put-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced
       responses:
         '201':

--- a/app/_src/gateway/admin-api/index.md
+++ b/app/_src/gateway/admin-api/index.md
@@ -4869,7 +4869,7 @@ entity. This allows a proper separation of secrets and configuration and
 prevents secret sprawl.
 
 {% if_version gte:3.4.x %}
-Support for secrets rotation can be managed using [TTLs](/gateway/latest/kong-enterprise/secrets-management/advanced-usage).
+Secrets rotation can be managed using [TTLs](/gateway/latest/kong-enterprise/secrets-management/advanced-usage).
 {% endif_version %}
 
 Vaults can be both [tagged and filtered by tags](#tags).

--- a/app/_src/gateway/admin-api/index.md
+++ b/app/_src/gateway/admin-api/index.md
@@ -4868,6 +4868,10 @@ stored in a vault, instead of storing the certificate and key within the
 entity. This allows a proper separation of secrets and configuration and
 prevents secret sprawl.
 
+{% if_version gte:3.4.x %}
+Support for secrets rotation can be managed using [TTLs](/gateway/latest/kong-enterprise/secrets-management/advanced-usage).
+{% endif_version %}
+
 Vaults can be both [tagged and filtered by tags](#tags).
 
 

--- a/app/_src/gateway/admin-api/workspaces/reference.md
+++ b/app/_src/gateway/admin-api/workspaces/reference.md
@@ -283,19 +283,23 @@ HTTP 200 OK
 <div class="endpoint delete">/workspaces/{name or id}</div>
 
 {% if_version lte:3.3.x %}
+
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the workspace to delete
+
+{:.note}
+> **Note:** All entities within a workspace must be deleted before the
+workspace itself can be.
+
 {% endif_version %}
+
 {% if_version gte:3.4.x %}
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the workspace to delete
 `cascade` | The `cascade` option lets you delete a workspace and all of its entities in one request.
-{% endif_version %}
-{:.note}
-> **Note:** All entities within a workspace must be deleted before the
-workspace itself can be.
+
 
 **Response**
 
@@ -309,7 +313,7 @@ Perform a cascading delete. Normally, deleting a workspace requires its entities
 ```
 DELETE /workspaces/{name or id}?cascade=true
 ```
-
+{% endif_version %}
 ## Update a workspace
 
 **Endpoint**

--- a/app/_src/gateway/admin-api/workspaces/reference.md
+++ b/app/_src/gateway/admin-api/workspaces/reference.md
@@ -147,6 +147,7 @@ Attributes | Description
 ---:| ---
 `id`<br>**conditional** | The **workspaces'** unique ID, if replacing it.*
 
+
 * The behavior of `PUT` endpoints is the following: if the request payload **does
 not** contain an entity's primary key (`id` for workspaces), the entity will be
 created with the given payload. If the request payload **does** contain an
@@ -281,10 +282,17 @@ HTTP 200 OK
 
 <div class="endpoint delete">/workspaces/{name or id}</div>
 
+{% if_version lte:3.3.x %}
 Attributes | Description
 ---:| ---
 `name or id`<br>**required** | The unique identifier **or** the name of the workspace to delete
-
+{% endif_version %}
+{% if_version gte:3.4.x %}
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the workspace to delete
+`cascade` | The `cascade` option lets you delete a workspace and all of its entities in one request.
+{% endif_version %}
 {:.note}
 > **Note:** All entities within a workspace must be deleted before the
 workspace itself can be.


### PR DESCRIPTION
Added these two things to the markdown documentation. 