### PR TITLE
fix(konnect-sso): both auth types are allowed

### DIFF
--- a/app/konnect/org-management/oidc-idp.md
+++ b/app/konnect/org-management/oidc-idp.md
@@ -10,12 +10,6 @@ OpenID Connect.
 This authentication method allows your users to log in to {{site.konnect_saas}}
 using their IdP credentials, without needing a separate login.
 
-You can't mix authentication methods in {{site.konnect_saas}}. With IdP
-authentication enabled, all non-admin {{site.konnect_short_name}} users have to
-log in through your IdP. Only the {{site.konnect_short_name}} org
-owner can continue to log in with {{site.konnect_short_name}}'s native
-authentication.
-
 ## Prerequisites
 
 * {{site.konnect_short_name}} must be added to your IdP as an application


### PR DESCRIPTION
Administrators can allow login via Konnect built-in methods (username and password) or via their Idp. These are not mutually exclusive.


### Description

Removed the statement that only one auth type is allowed, because that is no longer true.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

