### PR TITLE
chore: Breaking changes in Kong Gateway 3.4

### DIFF
--- a/app/_data/docs_nav_gateway_3.4.x.yml
+++ b/app/_data/docs_nav_gateway_3.4.x.yml
@@ -26,10 +26,12 @@ items:
         url: /gateway/changelog
         absolute_url: true
       - text: Breaking Changes	
-        items:	
-          - text: Kong Gateway 3.3.x	
+        items:
+          - text: Kong Gateway 3.4.x	
             url: /breaking-changes/
-            src: /gateway/breaking-changes/33x
+            src: /gateway/breaking-changes/34x
+          - text: Kong Gateway 3.3.x	
+            url: /breaking-changes/33x/
           - text: Kong Gateway 3.2.x
             url: /breaking-changes/32x/
           - text: Kong Gateway 3.1.x
@@ -230,7 +232,7 @@ items:
             src: /gateway/upgrade-v2
           - text: Migrate from OSS to Enterprise
             url: /migrate-ce-to-ke/
-          - text: Migration Guidelines Cassandra to PostgresSQL
+          - text: Migration Guidelines Cassandra to PostgreSQL
             url: /migrate-cassandra-to-postgres
           - text: Breaking Changes
             url: /production/breaking-changes/

--- a/app/_src/gateway/breaking-changes/32x.md
+++ b/app/_src/gateway/breaking-changes/32x.md
@@ -9,11 +9,11 @@ affect your current installation.
 You may need to adopt different upgrade paths depending on your deployment methods, set of features in use,
 custom plugins, for example.
 
-### Plugins
+## Plugins
 
 For breaking changes to plugins, see the [{{site.base_gateway}} Changelog](/gateway/changelog/) for your {{site.base_gateway}} version.
 
-### PostgreSQL SSL version bump
+## PostgreSQL SSL version bump
 
 The default PostgreSQL SSL version has been bumped to TLS 1.2. 
 
@@ -29,18 +29,18 @@ To use the default setting in `kong.conf`, verify that your Postgres server supp
 
 TLS versions lower than `tlsv1_2` are already deprecated and are considered insecure from PostgreSQL 12.x onward.
   
-### Changes to the Kong-Debug header
+## Changes to the Kong-Debug header
 
 Added the [`allow_debug_header`](/gateway/latest/reference/configuration/#allow_debug_header) 
 configuration property to `kong.conf` to constrain the `Kong-Debug` header for debugging. This option defaults to `off`.
 
 If you were previously relying on the `Kong-Debug` header to provide debugging information, set `allow_debug_header: on` in `kong.conf` to continue doing so.
 
-### JWT plugin
+## JWT plugin
     
 The [JWT plugin](/hub/kong-inc/jwt/) now denies any request that has different tokens in the JWT token search locations.
 
-### Session library upgrade
+## Session library upgrade
 
 The [`lua-resty-session`](https://github.com/bungle/lua-resty-session) library has been upgraded to v4.0.0. 
 This version includes a full rewrite of the session library.

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -63,7 +63,7 @@ This affects the following plugins:
   * [StatsD](/hub/kong-inc/statsd/) 
   * [OpenTelemetry](/hub/kong-inc/opentelemetry/)
   * [Datadog](/hub/kong-inc/datadog/)
-
+  * [Zipkin](/hub/kong-inc/zipkin/)
 ## Known issues
 
 Some referenceable configuration fields, such as the `http_endpoint` field

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -18,16 +18,16 @@ Amazon Linux 2022 artifacts are renamed to Amazon Linux 2023, based on AWS's own
 ### Alpine support removed
 
 Alpine packages and Docker images based on Alpine are no longer supported.
-Starting with Kong Gateway 3.4.0.0, Kong is not building new Alpine images or packages.
+Starting with {{site.base_gateway}} 3.4.0.0, Kong is not building new Alpine images or packages.
 
 ### Ubuntu 18.04 support removed 
 
-Support for running Kong Gateway on Ubuntu 18.04 ("Bionic") is now deprecated,
+Support for running {{site.base_gateway}} on Ubuntu 18.04 ("Bionic") is now deprecated,
 as [Standard Support for Ubuntu 18.04 has ended as of June 2023](https://wiki.ubuntu.com/Releases).
-Starting with Kong Gateway 3.4.0.0, Kong is not building new Ubuntu 18.04
+Starting with {{site.base_gateway}} 3.4.0.0, Kong is not building new Ubuntu 18.04
 images or packages, and Kong will not test package installation on Ubuntu 18.04.
 
-If you need to install Kong Gateway on Ubuntu 18.04, see the documentation for
+If you need to install {{site.base_gateway}} on Ubuntu 18.04, see the documentation for
 [previous versions](/gateway/3.3.x/install/linux/ubuntu/).
 
 ### Cassandra DB support removed
@@ -44,7 +44,7 @@ The following is a list of changes in `kong.conf` in this release.
 Item | Recommended action
 -----|-------------------
 LMDB encryption has been disabled. <br><br> The parameter `declarative_config_encryption_mode` has been removed from `kong.conf`. | No action needed.
-Renamed the configuration property `admin_api_uri` to `admin_gui_api_url`. The old `admin_api_uri` property is considered deprecated and will be fully removed in a future version of Kong Gateway. |  Update your configuration to use `admin_gui_api_url`.
+Renamed the configuration property `admin_api_uri` to `admin_gui_api_url`. The old `admin_api_uri` property is considered deprecated and will be fully removed in a future version of {{site.base_gateway}}. |  Update your configuration to use `admin_gui_api_url`.
 The `database` parameter no longer accepts `cassandra` as an option. <br><br> All Cassandra options have been removed. | If you use Cassandra DB, either [migrate to PostgreSQL](/gateway/{{page.kong_version}}/migrate-cassandra-to-postgres/) (`postgres`) or DB-less mode (`off`).
 
 ## Admin API changes

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -64,6 +64,7 @@ This affects the following plugins:
   * [OpenTelemetry](/hub/kong-inc/opentelemetry/)
   * [Datadog](/hub/kong-inc/datadog/)
   * [Zipkin](/hub/kong-inc/zipkin/)
+
 ## Known issues
 
 Some referenceable configuration fields, such as the `http_endpoint` field

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -1,0 +1,56 @@
+---
+title: Kong Gateway 3.4.x breaking changes
+content_type: reference
+---
+
+Before upgrading, review any configuration or breaking changes in this version and prior versions that
+affect your current installation.
+
+You may need to adopt different upgrade paths depending on your deployment methods, set of features in use,
+custom plugins, for example.
+
+## Plugins
+
+For breaking changes to plugins, see the [{{site.base_gateway}} Changelog](/gateway/changelog/) for your {{site.base_gateway}} version.
+
+## Deployment
+
+### Amazon Linux 2022 to 2023 rename
+
+Amazon Linux 2022 artifacts are renamed to Amazon Linux 2023, based on AWS's own renaming.
+
+### Alpine support removed
+
+Alpine packages and Docker images based on Alpine are no longer supported.
+Starting with Kong Gateway 3.4.0.0, Kong is not building new Alpine images or packages.
+[#10926](https://github.com/Kong/kong/pull/10926)
+
+### Ubuntu 18.04 support removed 
+
+Support for running Kong Gateway on Ubuntu 18.04 ("Bionic") is now deprecated,
+as [Standard Support for Ubuntu 18.04 has ended as of June 2023](https://wiki.ubuntu.com/Releases).
+Starting with Kong Gateway 3.4.0.0, Kong is not building new Ubuntu 18.04
+images or packages, and Kong will not test package installation on Ubuntu 18.04.
+
+    If you need to install Kong Gateway on Ubuntu 18.04, see the documentation for
+    [previous versions](/gateway/3.3.x/install/linux/ubuntu/).
+
+### Cassandra DB support removed
+
+Cassandra DB support has been removed. It is no longer supported as a data store for {{site.base_gateway}}. 
+
+You can migrate from Cassandra DB to PostgreSQL by following the [migration guide](/gateway/{{page.kong_version}}/migrate-cassandra-to-postgres/), 
+or reach out to your support representative for help.
+
+## Configuration changes
+
+The following is a list of changes in `kong.conf`.
+
+Item | Recommended action
+-----|-------------------
+LMDB encryption has been disabled. <br><br> The parameter `declarative_config_encryption_mode` has been removed from `kong.conf`. | No action needed.
+* The `/consumer_groups/:id/overrides` endpoint is deprecated in favor of a more generic plugin scoping mechanism. 
+See the new [consumer groups](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/25d728a0-cfe3-4cf4-8e90-93a5bb15cfd9#/consumer_groups/get-consumer_groups) entity.
+* Renamed the configuration property `admin_api_uri` to `admin_gui_api_url`.
+  The old `admin_api_uri` property is considered deprecated and will be
+  fully removed in a future version of Kong Gateway.

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -9,10 +9,6 @@ affect your current installation.
 You may need to adopt different upgrade paths depending on your deployment methods, set of features in use,
 custom plugins, for example.
 
-## Plugins
-
-For breaking changes to plugins, see the [{{site.base_gateway}} Changelog](/gateway/changelog/) for your {{site.base_gateway}} version.
-
 ## Deployment
 
 ### Amazon Linux 2022 to 2023 rename
@@ -23,7 +19,6 @@ Amazon Linux 2022 artifacts are renamed to Amazon Linux 2023, based on AWS's own
 
 Alpine packages and Docker images based on Alpine are no longer supported.
 Starting with Kong Gateway 3.4.0.0, Kong is not building new Alpine images or packages.
-[#10926](https://github.com/Kong/kong/pull/10926)
 
 ### Ubuntu 18.04 support removed 
 
@@ -32,8 +27,8 @@ as [Standard Support for Ubuntu 18.04 has ended as of June 2023](https://wiki.ub
 Starting with Kong Gateway 3.4.0.0, Kong is not building new Ubuntu 18.04
 images or packages, and Kong will not test package installation on Ubuntu 18.04.
 
-    If you need to install Kong Gateway on Ubuntu 18.04, see the documentation for
-    [previous versions](/gateway/3.3.x/install/linux/ubuntu/).
+If you need to install Kong Gateway on Ubuntu 18.04, see the documentation for
+[previous versions](/gateway/3.3.x/install/linux/ubuntu/).
 
 ### Cassandra DB support removed
 
@@ -44,13 +39,33 @@ or reach out to your support representative for help.
 
 ## Configuration changes
 
-The following is a list of changes in `kong.conf`.
+The following is a list of changes in `kong.conf` in this release.
 
 Item | Recommended action
 -----|-------------------
 LMDB encryption has been disabled. <br><br> The parameter `declarative_config_encryption_mode` has been removed from `kong.conf`. | No action needed.
-* The `/consumer_groups/:id/overrides` endpoint is deprecated in favor of a more generic plugin scoping mechanism. 
+Renamed the configuration property `admin_api_uri` to `admin_gui_api_url`. The old `admin_api_uri` property is considered deprecated and will be fully removed in a future version of Kong Gateway. |  Update your configuration to use `admin_gui_api_url`.
+The `database` parameter no longer accepts `cassandra` as an option. <br><br> All Cassandra options have been removed. | If you use Cassandra DB, either [migrate to PostgreSQL](/gateway/{{page.kong_version}}/migrate-cassandra-to-postgres/) (`postgres`) or DB-less mode (`off`).
+
+## Admin API changes
+
+The `/consumer_groups/:id/overrides` endpoint is deprecated in favor of a more generic plugin scoping mechanism. 
 See the new [consumer groups](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/25d728a0-cfe3-4cf4-8e90-93a5bb15cfd9#/consumer_groups/get-consumer_groups) entity.
-* Renamed the configuration property `admin_api_uri` to `admin_gui_api_url`.
-  The old `admin_api_uri` property is considered deprecated and will be
-  fully removed in a future version of Kong Gateway.
+
+## Plugin changes
+
+Validation for plugin queue related parameters has been improved. Certain parameters now have stricter requirements.
+* `max_batch_size`, `max_entries`, and `max_bytes` are now declared as `integer` instead of `number`. 
+* `initial_retry_delay` and `max_retry_delay` must now be numbers greater than 0.001 (in seconds).
+
+This affects the following plugins:
+  * [HTTP Log](/hub/kong-inc/http-log/)
+  * [StatsD](/hub/kong-inc/statsd/) 
+  * [OpenTelemetry](/hub/kong-inc/opentelemetry/)
+  * [Datadog](/hub/kong-inc/datadog/)
+
+## Known issues
+
+Some referenceable configuration fields, such as the `http_endpoint` field
+of the `http-log` plugin and the `endpoint` field of the `opentelemetry` plugin,
+do not accept reference values due to incorrect field validation.

--- a/app/_src/gateway/migrate-cassandra-to-postgres.md
+++ b/app/_src/gateway/migrate-cassandra-to-postgres.md
@@ -1,5 +1,5 @@
 ---
-title: Cassandra to Postgres Migration Guidelines 
+title: Cassandra to PostgreSQL Migration Guidelines 
 ---
 
 This guide walks you through migrating {{site.base_gateway}} from a Cassandra DB-backed 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -23,7 +23,6 @@ images or packages, and Kong will not test package installation on Ubuntu 18.04.
 
     If you need to install Kong Gateway on Ubuntu 18.04, see the documentation for
     [previous versions](/gateway/3.3.x/install/linux/ubuntu/).
-* Vitals is now off by default. To enable it, set `vitals=on` in Kong configuration.
 * Amazon Linux 2022 artifacts are renamed to Amazon Linux 2023, based on AWS's own renaming.
 * LMDB encryption has been disabled. The option `declarative_config_encryption_mode` has been removed from `kong.conf`.
 * The `/consumer_groups/:id/overrides` endpoint is deprecated in favor of a more generic plugin scoping mechanism. 


### PR DESCRIPTION
### Description

Listing out the deprecations and breaking changes from 3.4. 
Based on changelog.

Removed the entry for `vitals` parameter from the changelog, as the change was reverted, so the default value hasn't changed after all.

### Testing instructions

Netlify link: https://deploy-preview-5914--kongdocs.netlify.app/gateway/latest/breaking-changes/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

