### PR TITLE
chore: add compatibility issues for v3.4

### DIFF
--- a/app/_data/tables/version_errors_konnect.yml
+++ b/app/_data/tables/version_errors_konnect.yml
@@ -1,3 +1,4 @@
+go run internal/private/generators/01compat-changes/main.go
 ---
 messages:
   - ID: D100
@@ -1844,8 +1845,8 @@ messages:
   - ID: P188
     Severity: error
     Description: |
-      For the `ip-restriction` plugin, the'protocols` array contains one or both of:
-      `TLS`, `TCP`.This is not supported in Kong Gateway versions < 3.4.0.0. These
+      For the `ip-restriction` plugin, the `protocols` array contains one or both of:
+      `TLS`, `TCP`. This is not supported in Kong Gateway versions < 3.4.0.0. These
       values have been removed and plugin features that rely on these values are not
       working as intended. If `TLS` and/or `TCP` were the only values, then protocols
       has been reset to the default values of [`HTTP`, `HTTPS`, `GRPC`, `GRPCS`].
@@ -1856,17 +1857,19 @@ messages:
   - ID: P189
     Severity: error
     Description: |
-      Kong Gateway version only supports the wRPC protocol which has been removed from
-      Kong Gateway >= 3.2.0.0. Konnect will be removing support for these releases of
-      Kong Gateway on 2023/09/30. After this date these versions of Kong Gateway will
-      not be able to establish connections with Konnect to retrieve configuration
-      changes. Kong recommends upgrading to Kong Gateway 3.4.0.0 LTS.
+      Only Kong Gateway versions >= 3.1.0.0 and < 3.1.1.2 support the wRPC protocol which 
+      has been removed from Kong Gateway >= 3.2.0.0. Konnect will be removing support for 
+      these releases of Kong Gateway on 2023/09/30. After this date these versions of 
+      Kong Gateway will not be able to establish connections with Konnect to retrieve 
+      configuration changes. Kong recommends upgrading to Kong Gateway 3.4.0.0 LTS.
     Resolution: |
       Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      N/A
   - ID: P190
     Severity: warning
     Description: |
-      For the `vaults` entity, the'prefix` value contains hyphens. This is not
+      For the `vaults` entity, the `prefix` value contains hyphens. This is not
       supported in Kong Gateway versions < 3.3.0.0. Hyphens have been converted to
       underscores.
     Resolution: |

--- a/app/_data/tables/version_errors_konnect.yml
+++ b/app/_data/tables/version_errors_konnect.yml
@@ -574,14 +574,6 @@ messages:
       Please upgrade Kong Gateway to version `3.1.0.0` or above.
     DocumentationURL: |
       [Request Transformer Advanced plugin](/hub/kong-inc/request-transformer-advanced/)
-  - ID: D155
-    Severity: error
-    Description: |
-      Plugin `datadog-tracing` is not available in Kong Gateway versions < 3.2.0.0.
-    Resolution: |
-      Please upgrade Kong Gateway to version `3.2.0.0` or above.
-    DocumentationURL: |
-      [Datadog Tracing plugin](/hub/kong-inc/datadog-tracing/)
   - ID: D156
     Severity: warning
     Description: |
@@ -610,18 +602,18 @@ messages:
       For the `openid-connect` plugin, one or more `config` fields are set but Kong
       Gateway versions < 3.2.0.0 do not support these fields. The plugin configuration
       has been updated and these fields have been mapped to their old names:
-      `session_idling_timeout` => `session_cookie_idletime`, `session_memcached_host`
-      => `session_memcache_host`, `authorization_rolling_timeout` =>
-      `authorization_cookie_lifetime`, `session_rolling_timeout` =>
-      `session_cookie_lifetime`, `session_cookie_same_site` =>
-      `session_cookie_samesite`, `session_cookie_http_only` =>
-      `session_cookie_httponly`, `session_memcached_prefix` =>
-      `session_memcache_prefix`, `session_memcached_socket` =>
-      `session_memcache_socket`, `session_memcached_port` => `session_memcache_port`,
-      `session_redis_cluster_max_redirections` =>
-      `session_redis_cluster_maxredirections`, `authorization_cookie_same_site` =>
+      `authorization_rolling_timeout` => `authorization_cookie_lifetime`,
+      `session_cookie_same_site` => `session_cookie_samesite`,
+      `session_memcached_host` => `session_memcache_host`, `session_memcached_port` =>
+      `session_memcache_port`, `session_redis_cluster_max_redirections` =>
+      `session_redis_cluster_maxredirections`, `session_memcached_socket` =>
+      `session_memcache_socket`, `authorization_cookie_same_site` =>
       `authorization_cookie_samesite`, `authorization_cookie_http_only` =>
-      `authorization_cookie_httponly`
+      `authorization_cookie_httponly`, `session_rolling_timeout` =>
+      `session_cookie_lifetime`, `session_idling_timeout` =>
+      `session_cookie_idletime`, `session_cookie_http_only` =>
+      `session_cookie_httponly`, `session_memcached_prefix` =>
+      `session_memcache_prefix`
     Resolution: |
       Please upgrade Kong Gateway to version `3.2.0.0` or above.
     DocumentationURL: |
@@ -685,14 +677,15 @@ messages:
       For the `saml` plugin, one or more `config` fields are set but Kong Gateway
       versions < 3.2.0.0 do not support these fields. The plugin configuration has
       been updated and these fields have been mapped to their old names:
-      `session_memcached_prefix` => `session_memcache_prefix`,
-      `session_idling_timeout` => `session_cookie_idletime`, `session_rolling_timeout`
-      => `session_cookie_lifetime`, `session_cookie_same_site` =>
-      `session_cookie_samesite`, `session_memcached_port` => `session_memcache_port`,
+      `session_idling_timeout` => `session_cookie_idletime`,
+      `session_memcached_socket` => `session_memcache_socket`,
+      `session_memcached_port` => `session_memcache_port`,
       `session_redis_cluster_max_redirections` =>
-      `session_redis_cluster_maxredirections`, `session_cookie_http_only` =>
-      `session_cookie_httponly`, `session_memcached_socket` =>
-      `session_memcache_socket`, `session_memcached_host` => `session_memcache_host`
+      `session_redis_cluster_maxredirections`, `session_rolling_timeout` =>
+      `session_cookie_lifetime`, `session_cookie_same_site` =>
+      `session_cookie_samesite`, `session_cookie_http_only` =>
+      `session_cookie_httponly`, `session_memcached_prefix` =>
+      `session_memcache_prefix`, `session_memcached_host` => `session_memcache_host`
     Resolution: |
       Please upgrade Kong Gateway to version `3.2.0.0` or above.
     DocumentationURL: |
@@ -847,6 +840,94 @@ messages:
       Please upgrade Kong Gateway to version `3.3.0.0` or above.
     DocumentationURL: |
       [Proxy Cache Advanced plugin](/hub/kong-inc/proxy-cache-advanced/)
+  - ID: D178
+    Severity: error
+    Description: |
+      For the `rate-limiting-advanced` plugin, instances have been configured on a
+      specific consumer_group. This is not supported in Kong Gateway versions <
+      3.4.0.0. The plugin has been removed in the data-plane.
+    Resolution: |
+      Unset the `consumer_group` fields for the plugin, or upgrade Kong Gateway to a
+      version >= 3.4.0.0.
+    DocumentationURL: |
+      [Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/)
+  - ID: D179
+    Severity: error
+    Description: |
+      For the `request-transformer-advanced` plugin, instances have been configured on
+      a specific consumer_group. This is not supported in Kong Gateway versions <
+      3.4.0.0. The plugin has been removed in the data-plane.
+    Resolution: |
+      Unset the `consumer_group` fields for the plugin, or upgrade Kong Gateway to a
+      version >= 3.4.0.0.
+    DocumentationURL: |
+      [Request Transformer Advanced plugin](/hub/kong-inc/request-transformer-advanced/)
+  - ID: D180
+    Severity: error
+    Description: |
+      For the `response-transformer-advanced` plugin, instances have been configured
+      on a specific consumer_group. This is not supported in Kong Gateway versions <
+      3.4.0.0. The plugin has been removed in the data-plane.
+    Resolution: |
+      Unset the `consumer_group` fields for the plugin, or upgrade Kong Gateway to a
+      version >= 3.4.0.0.
+    DocumentationURL: |
+      [Response Transformer Advanced plugin](/hub/kong-inc/response-transformer-advanced/)
+  - ID: D181
+    Severity: error
+    Description: |
+      For the `request-transformer` plugin, instances have been configured on a
+      specific consumer_group. This is not supported in Kong Gateway versions <
+      3.4.0.0. The plugin has been removed in the data-plane.
+    Resolution: |
+      Unset the `consumer_group` fields for the plugin, or upgrade Kong Gateway to a
+      version >= 3.4.0.0.
+    DocumentationURL: |
+      [Request Transformer plugin](/hub/kong-inc/request-transformer/)
+  - ID: D182
+    Severity: error
+    Description: |
+      For the `response-transformer` plugin, instances have been configured on a
+      specific consumer_group. This is not supported in Kong Gateway versions <
+      3.4.0.0. The plugin has been removed in the data-plane.
+    Resolution: |
+      Unset the `consumer_group` fields for the plugin, or upgrade Kong Gateway to a
+      version >= 3.4.0.0.
+    DocumentationURL: |
+      [Response Transformer plugin](/hub/kong-inc/response-transformer/)
+  - ID: D183
+    Severity: error
+    Description: |
+      For the `openid-connect` plugin, one or more of the following `config` fields
+      are set: `expose_error_code` but Kong Gateway versions < 3.4.0.0 do not support
+      these fields. Plugin features that rely on these fields are not working as
+      intended.
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      [OpenID Connect plugin](/hub/kong-inc/openid-connect/)
+  - ID: D184
+    Severity: error
+    Description: |
+      For the `kafka-log` plugin, one or more of the following `config` fields are
+      set: `custom_fields_by_lua` but Kong Gateway versions < 3.4.0.0 do not support
+      these fields. Plugin features that rely on these fields are not working as
+      intended.
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      [Kafka Log plugin](/hub/kong-inc/kafka-log/)
+  - ID: D185
+    Severity: error
+    Description: |
+      For the `openid-connect` plugin, one or more of the following `config` fields
+      are set: `token_cache_key_include_scope` but Kong Gateway versions < 3.4.0.0 do
+      not support these fields. Plugin features that rely on these fields are not
+      working as intended.
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      [OpenID Connect plugin](/hub/kong-inc/openid-connect/)
   - ID: P101
     Severity: error
     Description: |
@@ -1422,9 +1503,9 @@ messages:
       For the `session` plugin, one or more `config` fields are set but Kong Gateway
       versions < 3.2.0.0 do not support these fields. The plugin configuration has
       been updated and these fields have been mapped to their old names:
-      `rolling_timeout` => `cookie_lifetime`, `idling_timeout` => `cookie_idletime`,
-      `stale_ttl` => `cookie_discard`, `cookie_same_site` => `cookie_samesite`,
-      `cookie_http_only` => `cookie_httponly`
+      `cookie_same_site` => `cookie_samesite`, `cookie_http_only` =>
+      `cookie_httponly`, `rolling_timeout` => `cookie_lifetime`, `idling_timeout` =>
+      `cookie_idletime`, `stale_ttl` => `cookie_discard`
     Resolution: |
       Please upgrade Kong Gateway to version `3.2.0.0` or above.
     DocumentationURL: |
@@ -1709,3 +1790,87 @@ messages:
       Please upgrade Kong Gateway to version `3.1.0.0` or above.
     DocumentationURL: |
       [Upstream entity](/gateway/latest/admin-api/#upstream-object)
+  - ID: P183
+    Severity: error
+    Description: |
+      For the `upstream` entity, one or more of the following schema fields are set:
+      `healthchecks.active.headers` but Kong Gateway versions < 3.0.0.0 do not support
+      these fields.
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.0.0.0` or above.
+    DocumentationURL: |
+      [Upstream entity](/gateway/latest/admin-api/#upstream-object)
+  - ID: P184
+    Severity: error
+    Description: |
+      For the `vault` entity, one or more of the following schema fields are set:
+      `config.ttl`, `config.neg_ttl`, `config.resurrect_ttl` but Kong Gateway versions
+      < 3.4.0.0 do not support these fields.
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      [Vaults entity](/gateway/latest/admin-api/#vaults-object)
+  - ID: P185
+    Severity: error
+    Description: |
+      For the `rate-limiting` plugin, one or more of the following `config` fields are
+      set: `sync_rate` but Kong Gateway versions < 3.4.0.0 do not support these
+      fields. Plugin features that rely on these fields are not working as intended.
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      [Rate Limiting plugin](/hub/kong-inc/rate-limiting/)
+  - ID: P186
+    Severity: error
+    Description: |
+      For the `opentelemetry` plugin, the config field `header_type` has been set to
+      `aws`. This is not supported in Kong Gateway versions < 3.4.0.0. Impacted fields
+      have been updated to their default values: `header_type=preserve`
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      [OpenTelemetry plugin](/hub/kong-inc/opentelemetry/)
+  - ID: P187
+    Severity: error
+    Description: |
+      For the `zipkin` plugin, one or more of the fields `header_type`,
+      `default_header_type` has been set to `aws`. This is not supported in Kong
+      Gateway versions < 3.4.0.0. Impacted fields have been updated to their default
+      values: `header_type=preserve` and/or `default_header_type=b3`
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      [Zipkin plugin](/hub/kong-inc/zipkin/)
+  - ID: P188
+    Severity: error
+    Description: |
+      For the `ip-restriction` plugin, the'protocols` array contains one or both of:
+      `TLS`, `TCP`.This is not supported in Kong Gateway versions < 3.4.0.0. These
+      values have been removed and plugin features that rely on these values are not
+      working as intended. If `TLS` and/or `TCP` were the only values, then protocols
+      has been reset to the default values of [`HTTP`, `HTTPS`, `GRPC`, `GRPCS`].
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+    DocumentationURL: |
+      [IP Restriction plugin](/hub/kong-inc/ip-restriction/)
+  - ID: P189
+    Severity: error
+    Description: |
+      Kong Gateway version only supports the wRPC protocol which has been removed from
+      Kong Gateway >= 3.2.0.0. Konnect will be removing support for these releases of
+      Kong Gateway on 2023/09/30. After this date these versions of Kong Gateway will
+      not be able to establish connections with Konnect to retrieve configuration
+      changes. Kong recommends upgrading to Kong Gateway 3.4.0.0 LTS.
+    Resolution: |
+      Please upgrade Kong Gateway to version `3.4.0.0` or above.
+  - ID: P190
+    Severity: warning
+    Description: |
+      For the `vaults` entity, the'prefix` value contains hyphens. This is not
+      supported in Kong Gateway versions < 3.3.0.0. Hyphens have been converted to
+      underscores.
+    Resolution: |
+      Update prefix values to use underscores instead of hyphens, or upgrade to Kong
+      Gateway versions >= 3.3.0.0 which automatically convert hyphens to underscores.
+    DocumentationURL: |
+      [Vaults entity](/gateway/latest/admin-api/#vaults-object)


### PR DESCRIPTION
### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.

JIRA: https://konghq.atlassian.net/browse/KOKO-1173
Adds version compatibility issues for gateway v3.4.
Removes `D155` due to a reversal of support for datadog-tracing between v3.2 and v3.2.2.
Adds a few other non v3.4 changeIDs.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

