### PR TITLE
chore: Add gpg/rsa gateway-34 repo keys

### DIFF
--- a/app/_data/installation/gateway.yml
+++ b/app/_data/installation/gateway.yml
@@ -1,3 +1,6 @@
+"34"
+  rsa_key: 182B189D58356D29
+  gpg_key: 6B5D054B0707DE3B
 "33":
   rsa_key: 4EABB1776918A36F
   gpg_key: 3B738D8FCD250236


### PR DESCRIPTION
### Description

What did you change and why?
 
Had to rotate the `gateway-34` repo gpg/rsa keys today and realized they would be good to add to the docs release.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

