### PR TITLE
Fix Gateway 3.4 LTS date

### DIFF
--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -48,7 +48,7 @@ Kong supports the following versions of {{site.ee_product_name}}:
 
 {% navtabs %}
   {% navtab 3.4 LTS %}
-    {% include_cached gateway-support.html version="3.4" data=site.data.tables.support.gateway.versions.34 eol="August 2024" %}
+    {% include_cached gateway-support.html version="3.4" data=site.data.tables.support.gateway.versions.34 eol="August 2026" %}
   {% endnavtab %}
   {% navtab 3.3 %}
     {% include_cached gateway-support.html version="3.3" data=site.data.tables.support.gateway.versions.33 eol="May 2024" %}


### PR DESCRIPTION
### Description

LTS releases are supported for 3 years from release. Update Gateway 3.4 to August 2026

### Testing instructions

Netlify link: /gateway/latest/support-policy/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
