### PR TITLE
Chore: Update changelog to add note about overrides endpoint deprecation. 

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_changelog.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_changelog.md
@@ -3,7 +3,7 @@
 **{{site.base_gateway}} 3.4.x**
 * The `redis` strategy now catches strategy connection failures.
 
-* The `/consumer_groups/:id/overrides` endpoint has been deprecated. While this endpoint will still function, we strongly recommend transitioning to the new and improved method for managing overrides, as documented in the [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/) guide. You can also find detailed information on creating consumer groups in the [API Documentation](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/25d728a0-cfe3-4cf4-8e90-93a5bb15cfd9#/default/post-consumer_groups).
+* The `/consumer_groups/:id/overrides` endpoint has been deprecated. While this endpoint will still function, we strongly recommend transitioning to the new and improved method for managing consumer groups, as documented in the [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/) guide. You can also find detailed information on creating consumer groups in the [API Documentation](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/25d728a0-cfe3-4cf4-8e90-93a5bb15cfd9#/default/post-consumer_groups).
 
 **{{site.base_gateway}} 3.2.1**
 * The shared Redis connector now supports username + password authentication for cluster connections, improving on the existing single-node connection support. This automatically applies to all plugins using the shared Redis configuration.

--- a/app/_hub/kong-inc/rate-limiting-advanced/_changelog.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_changelog.md
@@ -3,6 +3,8 @@
 **{{site.base_gateway}} 3.4.x**
 * The `redis` strategy now catches strategy connection failures.
 
+* The `/consumer_groups/:id/overrides` endpoint has been deprecated. While this endpoint will still function, we strongly recommend transitioning to the new and improved method for managing overrides, as documented in the [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/) guide. You can also find detailed information on creating consumer groups in the [API Documentation](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/25d728a0-cfe3-4cf4-8e90-93a5bb15cfd9#/default/post-consumer_groups).
+
 **{{site.base_gateway}} 3.2.1**
 * The shared Redis connector now supports username + password authentication for cluster connections, improving on the existing single-node connection support. This automatically applies to all plugins using the shared Redis configuration.
 

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -67,7 +67,7 @@ This affects the following plugins:
 
 ### Rate Limiting Advanced
 
-The `/consumer_groups/:id/overrides` endpoint has been deprecated. While this endpoint will still function, we strongly recommend transitioning to the new and improved method for managing overrides, as documented in the [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/) guide. 
+The `/consumer_groups/:id/overrides` endpoint has been deprecated. While this endpoint will still function, we strongly recommend transitioning to the new and improved method for managing consumer groups, as documented in the [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/) guide. 
 
 ## Known issues
 

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -65,6 +65,10 @@ This affects the following plugins:
   * [Datadog](/hub/kong-inc/datadog/)
   * [Zipkin](/hub/kong-inc/zipkin/)
 
+### Rate Limiting Advanced
+
+The `/consumer_groups/:id/overrides` endpoint has been deprecated. While this endpoint will still function, we strongly recommend transitioning to the new and improved method for managing overrides, as documented in the [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/) guide. 
+
 ## Known issues
 
 Some referenceable configuration fields, such as the `http_endpoint` field


### PR DESCRIPTION
Updated the changelog to add information about the overrides endpoint deprecation and instructions on how to view the consumer groups API, and use the new guide that contains the new routes. 