### PR TITLE
Fix automated package installation tests

### DIFF
--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -20,8 +20,8 @@ You can install {{site.base_gateway}} by downloading an installation package or 
 > **Note:** {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
 
 {% navtabs %}
-{% navtab Package (AL2023) %}
-Install {{site.base_gateway}} on Amazon Linux 2023 from the command line.
+{% navtab Package %}
+Install {{site.base_gateway}} on Amazon Linux from the command line.
 
 1. Download the Kong package:
 
@@ -29,55 +29,12 @@ Install {{site.base_gateway}} on Amazon Linux 2023 from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/amzn/2023/x86_64/kong-enterprise-edition-{{page.versions.ee}}.aws.x86_64.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/amzn/%{amzn}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.aws.x86_64.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/amzn/2023/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
-```
-{% endnavtab %}
-{% endnavtabs_ee %}
-{% endcapture %}
-
-{{ download_package | indent | replace: " </code>", "</code>" }}
-
-2. Install the package:
-
-{% capture install_package %}
-{% navtabs_ee codeblock %}
-{% navtab Kong Gateway %}
-```bash
-sudo yum install kong-enterprise-edition-{{page.versions.ee}}.rpm
-```
-{% endnavtab %}
-{% navtab Kong Gateway (OSS) %}
-```bash
-sudo yum install kong-{{page.versions.ce}}.rpm
-```
-{% endnavtab %}
-{% endnavtabs_ee %}
-{% endcapture %}
-
-{{ install_package | indent | replace: " </code>", "</code>" }}
-
-{% endnavtab %}
-{% navtab Package (Amazon Linux 2) %}
-
-Install {{site.base_gateway}} on Amazon Linux 2 from the command line.
-
-1. Download the Kong package:
-
-{% capture download_package %}
-{% navtabs_ee codeblock %}
-{% navtab Kong Gateway %}
-```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/amzn/2/x86_64/kong-enterprise-edition-{{page.versions.ee}}.aws.x86_64.rpm)
-```
-{% endnavtab %}
-{% navtab Kong Gateway (OSS) %}
-```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/amzn/amzn/2/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/amzn/%{amzn}/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -105,38 +62,7 @@ sudo yum install -y kong-{{page.versions.ce}}.rpm
 {{ install_package | indent | replace: " </code>", "</code>" }}
 
 {% endnavtab %}
-{% navtab YUM repository (AL2023) %}
-
-Install the YUM repository from the command line.
-
-1. Download the Kong YUM repository:
-
-    ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo > /dev/null
-    sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-{{ page.major_minor_version }}'
-    ```
-
-2. Install Kong:
-
-{% capture install_from_repo %}
-{% navtabs_ee codeblock %}
-{% navtab Kong Gateway %}
-```bash
-sudo yum install kong-enterprise-edition-{{page.versions.ee}}
-```
-{% endnavtab %}
-{% navtab Kong Gateway (OSS) %}
-```bash
-sudo yum install kong-{{page.versions.ce}}
-```
-{% endnavtab %}
-{% endnavtabs_ee %}
-{% endcapture %}
-
-{{ install_from_repo | indent | replace: " </code>", "</code>" }}
-
-{% endnavtab %}
-{% navtab YUM repository (Amazon Linux 2) %}
+{% navtab YUM repository %}
 
 Install the YUM repository from the command line.
 

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -86,16 +86,21 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 
 1. Download the Kong package:
 
+{% assign ubuntu_flavor = "jammy" %}
+{% if_version eq:3.0.x %}
+{% assign ubuntu_flavor = "bionic" %}
+{% endif_version %}
+
 {% capture download_package %}
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.amd64.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/jammy/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.amd64.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/{{ ubuntu_flavor }}/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/jammy/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/{{ ubuntu_flavor }}/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}

--- a/tools/install-tester/execute-in-docker.js
+++ b/tools/install-tester/execute-in-docker.js
@@ -17,9 +17,12 @@ module.exports = async function (distro, steps) {
   }
   setup = setup.join(" && ");
 
-  const asUser = `su tester -c 'cd ~ && ${steps
-    .join(" && ")
-    .replace("\n", " && ")} && kong version'`;
+  steps = steps.join(" && ").replace("\n", " && ");
+  if (steps.trim().length == 0) {
+    throw new Error(`Unable to fetch install instructions from docs for ${distro}`);
+  }
+
+  const asUser = `su tester -c 'cd ~ && ${steps} && kong version'`;
 
   const completeString = `${setup} && ${asUser}`;
 

--- a/tools/install-tester/index.js
+++ b/tools/install-tester/index.js
@@ -93,37 +93,44 @@ async function runSingleJob(distro, job, installOption, conditions) {
   const expected = job.outputs[installOption.package];
   debug(`Expecting: ${expected}`);
 
-  const { jobConfig, version, stdout, stderr } = await run(
-    distro,
-    installOption.blocks,
-  );
-  debug(`Got: ${version}`);
+  try {
+    const { jobConfig, version, stdout, stderr } = await run(
+      distro,
+      installOption.blocks,
+    );
+    debug(`Got: ${version}`);
 
-  // Create a file to re-run the command in one + debug
-  fs.writeFileSync(
-    `./output/${job.version}-${distro}-${installOption.package}-${installOption.type}.txt`,
-    `docker run --platform linux/amd64 -it ${
-      jobConfig.image
-    } bash -c "${jobConfig.commands
-      .replace(/"/g, '\\"')
-      .replace(
-        /\$/g,
-        "\\$",
-      )}; sleep 100000"\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`,
-  );
+    // Create a file to re-run the command in one + debug
+    fs.writeFileSync(
+      `./output/${job.version}-${distro}-${installOption.package}-${installOption.type}.txt`,
+      `docker run --platform linux/amd64 -it ${
+        jobConfig.image
+      } bash -c "${jobConfig.commands
+        .replace(/"/g, '\\"')
+        .replace(
+          /\$/g,
+          "\\$",
+        )}; sleep 100000"\n\nSTDOUT:\n${stdout}\n\nSTDERR:\n${stderr}`,
+    );
 
-  if (expected !== version) {
-    console.log(`❌ ${summary} Expected: ${expected}, Got: ${version}`);
-    process.exitCode = 1;
+    if (expected !== version) {
+      console.log(`❌ ${summary} Expected: ${expected}, Got: ${version}`);
+      process.exitCode = 1;
 
-    allStderr += `\n\n---------------------------------------\n❌ ${summary}\n---------------------------------------\n${stderr}`;
+      allStderr += `\n\n---------------------------------------\n❌ ${summary}\n---------------------------------------\n${stderr}`;
 
+      if (!process.env.CONTINUE_ON_ERROR) {
+        console.log(allStderr);
+        process.exit(1);
+      }
+    } else {
+      console.log(`✅ ${summary}`);
+    }
+  } catch (e) {
+    console.log(`⚠️ ${summary} ${e.message}`);
     if (!process.env.CONTINUE_ON_ERROR) {
-      console.log(allStderr);
       process.exit(1);
     }
-  } else {
-    console.log(`✅ ${summary}`);
   }
 
   debug(`====== END ${marker} ======`);


### PR DESCRIPTION
The automated installation tests were failing for multiple reasons:

* The Amazon Linux page had been refactored to cover Amazon Linux 2 + Amazon Linux 2023. We use `%{amzn}` in the `rpm --eval` call so the same instructions work for both. The tabs for AL2/AL2023 have been merged
* We don't build Ubuntu `jammy` packages for 3.0. The installation instructions have been updated to use `bionic` for Kong Gateway 3.0