### PR TITLE
Fix Ubuntu 3.4 package install instructions

### DIFF
--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -87,9 +87,9 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 1. Download the Kong package:
 
 {% assign ubuntu_flavor = "jammy" %}
-{% if_version eq:3.0.x %}
+{% if page.release == "3.0.x" %}
 {% assign ubuntu_flavor = "bionic" %}
-{% endif_version %}
+{% endif %}
 
 {% capture download_package %}
 {% navtabs_ee codeblock %}


### PR DESCRIPTION
We no longer build Ubuntu `bionic` packages for Kong Gateway 3.4+.

Update the conditional rendering to use Ubuntu `jammy` for all releases except 3.0, which provides a `bionic` package but no `jammy` package