### PR TITLE
Fix link to docker installation

### DIFF
--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -121,7 +121,13 @@ substituting your own license key.
 
 1. Include the license as part of the `docker run` command when starting a {{site.base_gateway}} container:
 
-    {% if_version lte:2.8.x %}
+    {% if_version lte:2.5.x %}
+    {:.note}
+    > **Note:** This is only a snippet. For a full working example, see the instructions to
+    [Install Kong Gateway on Docker](/enterprise/{{page.kong_version}}/deployment/installation/docker/).
+    {% endif_version %}
+
+    {% if_version gte:2.6.x lte:2.8.x %}
     {:.note}
     > **Note:** This is only a snippet. For a full working example, see the instructions to
     [Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install-and-run/docker/).
@@ -154,7 +160,13 @@ Include the license as part of the `docker run` command when starting a
 local filesystem to a directory in the Docker container, making the file visible
 from the container:
 
-{% if_version lte:2.8.x %}
+{% if_version lte:2.5.x %}
+{:.note}
+> **Note:** This is only a snippet. For a full working example, see the instructions to
+[Install Kong Gateway on Docker](/enterprise/{{page.kong_version}}/deployment/installation/docker/).
+{% endif_version %}
+
+{% if_version gte:2.6.x lte:2.8.x %}
 {:.note}
 > **Note:** This is only a snippet. For a full working example, see the instructions to
 [Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install-and-run/docker).

--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -124,19 +124,19 @@ substituting your own license key.
     {% if_version lte:2.5.x %}
     {:.note}
     > **Note:** This is only a snippet. For a full working example, see the instructions to
-    [Install Kong Gateway on Docker](/enterprise/{{page.kong_version}}/deployment/installation/docker/).
+    [Install {{site.base_gateway}} on Docker](/enterprise/{{page.kong_version}}/deployment/installation/docker/).
     {% endif_version %}
 
     {% if_version gte:2.6.x lte:2.8.x %}
     {:.note}
     > **Note:** This is only a snippet. For a full working example, see the instructions to
-    [Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install-and-run/docker/).
+    [Install {{site.base_gateway}} on Docker](/gateway/{{page.kong_version}}/install-and-run/docker/).
 
     {% endif_version %}
     {% if_version gte:3.0.x %}
     {:.note}
     > **Note:** This is only a snippet. For a full working example, see the instructions to
-    [Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install/docker/).
+    [Install {{site.base_gateway}} on Docker](/gateway/{{page.kong_version}}/install/docker/).
 
     {% endif_version %}
 
@@ -163,19 +163,19 @@ from the container:
 {% if_version lte:2.5.x %}
 {:.note}
 > **Note:** This is only a snippet. For a full working example, see the instructions to
-[Install Kong Gateway on Docker](/enterprise/{{page.kong_version}}/deployment/installation/docker/).
+[Install {{site.base_gateway}} on Docker](/enterprise/{{page.kong_version}}/deployment/installation/docker/).
 {% endif_version %}
 
 {% if_version gte:2.6.x lte:2.8.x %}
 {:.note}
 > **Note:** This is only a snippet. For a full working example, see the instructions to
-[Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install-and-run/docker).
+[Install {{site.base_gateway}} on Docker](/gateway/{{page.kong_version}}/install-and-run/docker).
 
 {% endif_version %}
 {% if_version gte:3.0.x %}
 {:.note}
 > **Note:** This is only a snippet. For a full working example, see the instructions to
-[Install Kong Gateway on Docker](/gateway/{{page.kong_version}}/install/docker).
+[Install {{site.base_gateway}} on Docker](/gateway/{{page.kong_version}}/install/docker).
 
 {% endif_version %}
 


### PR DESCRIPTION
### Description

What did you change and why?
 
Fix the following broken link:

```json
  {
    "page": "http://localhost:8888/enterprise/2.5.x/deployment/licenses/deploy-license/",
    "text": "Install Kong Gateway on Docker",
    "target": "http://localhost:8888/gateway/2.5.x/install-and-run/docker",
    "reason": "HTTP_404"
  },
```
For old versions < 2.5.x the link was pointing to the wrong url.

### Testing instructions

https://deploy-preview-5950--kongdocs.netlify.app/enterprise/2.5.x/deployment/licenses/deploy-license/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

