### PR TITLE
fix: Broken step indents in Mesh license guide

### DIFF
--- a/app/_src/mesh/production/cp-deployment/license.md
+++ b/app/_src/mesh/production/cp-deployment/license.md
@@ -106,7 +106,7 @@ To install a valid license via Helm:
   * `kong-mesh-system` is the namespace where Kong Mesh control plane is installed
   * `/path/to/license.json` is the path to a valid license file. The filename should be `license.json` unless otherwise specified in `values.yaml`.
 
-1. Modify the `values.yaml` file to point to the secret. For example:
+2. Modify the `values.yaml` file to point to the secret. For example:
 
   ```yaml
   kuma:

--- a/app/_src/mesh/production/cp-deployment/license.md
+++ b/app/_src/mesh/production/cp-deployment/license.md
@@ -97,25 +97,25 @@ To install a valid license via Helm:
 
 1. Create a secret named `kong-mesh-license` in the same namespace where Kong Mesh is being installed. For example:
 
-  ```sh
-  $ kubectl create namespace kong-mesh-system
-  $ kubectl create secret generic kong-mesh-license -n kong-mesh-system --from-file=/path/to/license.json
-  ```
+   ```sh
+   $ kubectl create namespace kong-mesh-system
+   $ kubectl create secret generic kong-mesh-license -n kong-mesh-system --from-file=/path/to/license.json
+   ```
 
-  Where:
-  * `kong-mesh-system` is the namespace where Kong Mesh control plane is installed
-  * `/path/to/license.json` is the path to a valid license file. The filename should be `license.json` unless otherwise specified in `values.yaml`.
+   Where:
+   * `kong-mesh-system` is the namespace where Kong Mesh control plane is installed
+   * `/path/to/license.json` is the path to a valid license file. The filename should be `license.json` unless otherwise specified in `values.yaml`.
 
-2. Modify the `values.yaml` file to point to the secret. For example:
+1. Modify the `values.yaml` file to point to the secret. For example:
 
-  ```yaml
-  kuma:
-    controlPlane:
-      secrets:
-        - Env: "KMESH_LICENSE_INLINE"
-          Secret: "kong-mesh-license"
-          Key: "license.json"
-  ```
+   ```yaml
+   kuma:
+     controlPlane:
+       secrets:
+         - Env: "KMESH_LICENSE_INLINE"
+           Secret: "kong-mesh-license"
+           Key: "license.json"
+   ```
 
 ### Universal
 


### PR DESCRIPTION
### Description

Fixed step indentation in the Kong Mesh license doc.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

