### PR TITLE
fix: Add changelog entry for RHEL 9 support

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -33,6 +33,10 @@ See the new [consumer groups](https://developer.konghq.com/spec/937dcdd7-4485-47
 
 ### Features 
 
+#### Deployment
+
+* Kong Gateway is now available on [RHEL 9](https://cloudsmith.io/~kong/repos/gateway-34/packages/?q=distribution%3Arhel+AND+distribution%3A9).
+
 #### Enterprise
 
 * Introduced the [`cascade`](/gateway/latest/admin-api/workspaces/reference/#delete-a-workspace) option for 


### PR DESCRIPTION
### Description

3.4 supports RHEL 9, but we were missing this entry from the changelog. 
This fix adds the missing entry and links to the available packages.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

