### PR TITLE
Fix kic broken link

### DIFF
--- a/app/_includes/md/kic/crd-ref/kong_consumer_group_description.md
+++ b/app/_includes/md/kic/crd-ref/kong_consumer_group_description.md
@@ -1,1 +1,1 @@
-KongConsumerGroup resources create [consumer group](gateway/latest/kong-enterprise/consumer-groups/) resources.
+KongConsumerGroup resources create [consumer group](/gateway/latest/kong-enterprise/consumer-groups/) resources.


### PR DESCRIPTION
### Description

What did you change and why?
 
Add missing `/` to kic link.


### Testing instructions

/kubernetes-ingress-controller/latest/references/custom-resources/

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

