### PR TITLE
Fix: Rendering issue on clusering reference page.

### DIFF
--- a/app/_src/gateway/production/clustering.md
+++ b/app/_src/gateway/production/clustering.md
@@ -57,7 +57,7 @@ All nodes perform a periodic background job to synchronize with changes that
 may have been triggered by other nodes. The frequency of this job can be
 configured via:
 
-* [`db_update_frequency`][db_update_frequency] (default: 5 seconds)
+* [`db_update_frequency`](/gateway/{{page.kong_version}}/reference/configuration/#db_update_frequency)(default: 5 seconds)
 
 Every `db_update_frequency` seconds, all running Kong nodes will poll the
 database for any update, and will purge the relevant entities from their cache
@@ -163,7 +163,7 @@ experiment with its clustering capabilities while avoiding surprises. As you
 prepare a production setup, you should consider tuning those values to ensure
 that your performance constraints are respected.
 
-### [`db_update_frequency`][db_update_frequency] (default: 5s)
+### db_update_frequency (default: 5s)
 
 This value determines the frequency at which your Kong nodes will be polling
 the database for invalidation events. A lower value means that the polling
@@ -176,7 +176,10 @@ traffic.
 > **Note**: Changes propagate through the cluster in up to `db_update_frequency`
 seconds.
 
-### [`db_update_propagation`][db_update_propagation] (default: 0s)
+View the `db_update_frequency` entry in the configuration [reference documentation](/gateway/{{page.kong_version}}/reference/configuration/#db_update_frequency).
+
+### db_update_propagation (default: 0s)
+
 
 {% if_version lte:3.3.x %}
 If your database itself is eventually consistent (that is, Cassandra), you **must**
@@ -198,7 +201,9 @@ cluster takes to propagate changes.
 > **Note**: When this value is set, changes propagate through the cluster in
 up to `db_update_frequency + db_update_propagation` seconds.
 
-### [`db_cache_ttl`][db_cache_ttl] (default: 0s)
+View the `db_update_propagation` entry in the configuration [reference documentation](/gateway/{{page.kong_version}}/reference/configuration/#db_update_propagation).
+
+### db_cache_ttl (default: 0s)
 
 The time (in seconds) for which Kong will cache database entities (both hits
 and misses). This Time-To-Live value acts as a safeguard in case a Kong node
@@ -213,11 +218,13 @@ node might miss invalidation event for any reason, you should set a TTL. Otherwi
 the node might run with a stale value in its cache for an undefined amount of time
 until the cache is manually purged, or the node is restarted.
 
+View the `db_cache_ttl` entry in the configuration [reference documentation](/gateway/{{page.kong_version}}/reference/configuration/#db_cache_ttl).
+
 {% if_version lte:3.3.x %}
 ### When using Cassandra
 
 If you use Cassandra as your Kong database, you **must** set
-[db_update_propagation][db_update_propagation] to a non-zero value. Since
+`db_update_propagation` to a non-zero value. Since
 Cassandra is eventually consistent by nature, this will ensure that Kong nodes
 do not prematurely invalidate their cache, only to fetch and catch a
 not up-to-date entity again. Kong will present you a warning in logs if you did
@@ -297,6 +304,9 @@ If the node is receiving a lot of traffic, purging its cache at the same time
 will trigger many requests to your database, and could cause a
 [dog-pile effect](https://en.wikipedia.org/wiki/Cache_stampede).
 
-[`db_update_frequency`]: /gateway/{{page.kong_version}}/reference/configuration/#db_update_frequency
-[`db_update_propagation`]: /gateway/{{page.kong_version}}/reference/configuration/#db_update_propagation
-[`db_cache_ttl`]: /gateway/{{page.kong_version}}/reference/configuration/#db_cache_ttl
+
+## Read more
+
+* [`db_update_frequency`](/gateway/{{page.kong_version}}/reference/configuration/#db_update_frequency)
+* [`db_update_propagation`](/gateway/{{page.kong_version}}/reference/configuration/#db_update_propagation)
+* [`db_cache_ttl`](/gateway/{{page.kong_version}}/reference/configuration/#db_cache_ttl)


### PR DESCRIPTION
This is not on the changelog

User reported issues with the rendering in the `/gateway/3.0.x/production/clustering/` doc. The problem was that the headings used code tags and relative linking. Removed that in place of direct linking at the bottom of each section. Made a more info section at the bottom as well.