### PR TITLE
(fix) Remove Docker from RHEL8 in 3.4 matrix

### DIFF
--- a/app/_data/tables/support/gateway/versions/34.yml
+++ b/app/_data/tables/support/gateway/versions/34.yml
@@ -19,7 +19,7 @@ distributions:
     graviton: true
   - *rhel7
   - <<: *rhel8
-    docker: true
+    docker: false
     fips: true
   - <<: *rhel9
     docker: true


### PR DESCRIPTION
### Description

With addition of RHEL9 support, the docker image for RHEL8 is no longer available as of 3.4 


### Testing instructions

Netlify link:  https://deploy-preview-5965--kongdocs.netlify.app/gateway/latest/support-policy/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

