### PR TITLE
(Fix) RHEL8 Docker Image deprecation

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -30,7 +30,7 @@ See the new [consumer groups](https://developer.konghq.com/spec/937dcdd7-4485-47
 * Renamed the configuration property `admin_api_uri` to `admin_gui_api_url`.
   The old `admin_api_uri` property is considered deprecated and will be
   fully removed in a future version of Kong Gateway.
-* The RHEL8 Docker image provided by Kong is replaced with the RHEL9 Docker image. The RHEL8 package is still avialable. 
+* The RHEL8 Docker image provided by Kong is replaced with the RHEL9 Docker image. The RHEL8 package is still available [here](https://cloudsmith.io/~kong/repos/gateway-34/packages/?q=distribution%3Arhel+AND+distribution%3A8). 
 
 ### Features 
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -30,7 +30,7 @@ See the new [consumer groups](https://developer.konghq.com/spec/937dcdd7-4485-47
 * Renamed the configuration property `admin_api_uri` to `admin_gui_api_url`.
   The old `admin_api_uri` property is considered deprecated and will be
   fully removed in a future version of Kong Gateway.
-* The RHEL8 Docker image provided by Kong is replaced with the RHEL9 Docker image. The RHEL8 package is still available [here](https://cloudsmith.io/~kong/repos/gateway-34/packages/?q=distribution%3Arhel+AND+distribution%3A8). 
+* The RHEL8 Docker image provided by Kong is replaced with the RHEL9 Docker image. The RHEL8 packages are still available [from our package repository](https://cloudsmith.io/~kong/repos/gateway-34/packages/?q=distribution%3Arhel+AND+distribution%3A8). 
 
 ### Features 
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -30,6 +30,7 @@ See the new [consumer groups](https://developer.konghq.com/spec/937dcdd7-4485-47
 * Renamed the configuration property `admin_api_uri` to `admin_gui_api_url`.
   The old `admin_api_uri` property is considered deprecated and will be
   fully removed in a future version of Kong Gateway.
+* The RHEL8 Docker image provided by Kong is replaced with the RHEL9 Docker image. The RHEL8 package is still avialable. 
 
 ### Features 
 


### PR DESCRIPTION
### Description

Adding statement to deprecation section of changelog to make clear the Kong-provided Docker image in this release is RHEL9 not RHEL8. 


### Testing instructions

Netlify link: https://deploy-preview-5967--kongdocs.netlify.app/gateway/changelog/#breaking-changes-and-deprecations


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

