### PR TITLE
(fix) Add Runtime Groups limit

### DIFF
--- a/app/konnect/runtime-manager/configuration/index.md
+++ b/app/konnect/runtime-manager/configuration/index.md
@@ -153,6 +153,7 @@ The following entity resource limits apply to each runtime group for the configu
 | Mutual Transport Layer Security Authentication | 50,000 |
 | Plugin Configuration | 10,000 |
 | Route | 10,000 |
+| Runtime Groups | 100 |
 | Server Name Indication | 1,000 |
 | Service | 10,000 |
 | Target | 10,000 |


### PR DESCRIPTION
### Description

Configuration Limits table doesn't currently include Runtime Groups. Adding here is a short-term way to address better communication on limits in general. 


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

