### PR TITLE
Changelog: specify which version to write using github labels. 

### DIFF
--- a/tools/changelog-generator/changelog.js
+++ b/tools/changelog-generator/changelog.js
@@ -4,7 +4,7 @@ const groupBy = require("lodash.groupby");
 
 const convertFilePathsToUrls = require("../_utilities/path-to-url");
 const now = startOfDay(new Date());
-const earliestDate = subDays(now, 4);
+const earliestDate = subDays(now, 7);
 
 (async function () {
   // Create an octokit instance


### PR DESCRIPTION
**I don't think this is the right solution for the problem**

This PR adds a function `getVersionFromLabels` that extracts version labels from PRs and uses it to write specific versions to changelog.md. 

Where to go from here: 
* Descending order
* Add a function to check for duplicates. 
* Discussed at end of hackathon: Only print the latest version or potentially latest + lts only. 

