### PR TITLE
Update consumer groups documentation

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_index.md
@@ -6,7 +6,7 @@ The Rate Limiting Advanced plugin offers more functionality than the Kong Gatewa
 * Increased performance: Rate Limiting Advanced has better throughput performance with better accuracy. The plugin allows you to tune performance and accuracy via a configurable synchronization of counter data with the backend storage. This can be controlled by setting the desired value on the `sync_rate` parameter.
 * More limiting algorithms to choose from: These algorithms are more accurate and they enable configuration with more specificity. Learn more about our algorithms in [How to Design a Scalable Rate Limiting Algorithm](https://konghq.com/blog/how-to-design-a-scalable-rate-limiting-algorithm).
 * More control over which requests contribute to incrementing the rate limiting counters via the `disable_penalty` parameter
-{% if_plugin_version lte:3.3.x %}
+{% if_plugin_version gte:3.4.x %}
 * Consumer groups support: Apply different rate limiting configurations to select groups of consumers. Learn more in [Rate limiting for consumer groups](/hub/kong-inc/rate-limiting-advanced/how-to/)
 {% endif_plugin_version %}
 
@@ -99,6 +99,17 @@ When the `redis` strategy is used and a {{site.base_gateway}} node is disconnect
 {{site.base_gateway}} keeps the local counters for rate limiting and syncs with Redis once the connection is re-established.
 {{site.base_gateway}} will still rate limit, but the {{site.base_gateway}} nodes can't sync the counters. As a result, users will be able
 to perform more requests than the limit, but there will still be a limit per node.
+
+{% if_plugin_version gte:3.4.x%}
+## Rate limiting for consumer groups
+
+As of {{site.base_gateway}} 3.4, you can use the [consumer groups entity](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/25d728a0-cfe3-4cf4-8e90-93a5bb15cfd9#/default/post-consumer_groups) to manage custom rate limiting configurations for
+subsets of consumers. This is enabled by default **without** using the `/consumer_groups/:id/overrides` endpoint.
+
+
+You can see an example of this in the [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/) guide.
+
+{% endif_plugin_version %}
 
 {% if_plugin_version gte:2.7.x lte:3.3.x %}
 ## Rate limiting for consumer groups

--- a/app/_src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/app/_src/gateway/kong-enterprise/consumer-groups/index.md
@@ -11,7 +11,7 @@ Consumer groups enable the organization and categorization of consumers (users o
 
 {% if_version gte:3.4.x %}
 
-With consumer groups, you can scope plugins to specificially defined consumer groups, and a new plugin instance will be created for each individual consumer group, making configurations and customizations more flexible and convenient.
+With consumer groups, you can scope plugins to specifically defined consumer groups and a new plugin instance will be created for each individual consumer group, making configurations and customizations more flexible and convenient.
 
 ## Use cases
 

--- a/app/_src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/app/_src/gateway/kong-enterprise/consumer-groups/index.md
@@ -6,10 +6,12 @@ badge: enterprise
 
 Consumer groups enable the organization and categorization of consumers (users or applications) within an API ecosystem. By grouping consumers together, you eliminate the need to manage them individually, providing a scalable, efficient approach to managing configurations. 
 
-With consumer groups, you can scope plugins specifically to defined groups, making configurations and customizations more flexible and convenient. 
+
 
 
 {% if_version gte:3.4.x %}
+
+With consumer groups, you can scope plugins to specificially defined consumer groups, and a new plugin instance will be created for each individual consumer group, making configurations and customizations more flexible and convenient.
 
 ## Use cases
 
@@ -21,7 +23,9 @@ With consumer groups, you can scope plugins specifically to defined groups, maki
 
 * Customizing plugin configurations: With the ability to scope plugins specifically to defined groups, different consumer groups can have distinct plugin configurations based on their requirements. For example, one group may require additional request transformations while another may not need them at all.
 
-Consumer group execution order is deterministic. Consumers can be part of multiple consumer groups, but this does have an implication on the execution logic, so refer to the [precedence](/gateway/latest/key-concepts/plugins/#precedence) chart when assigning multiple consumer groups.
+{:.note}
+> **Note**: Consumer groups plugin scoping is a feature that was added in {{site.base_gateway}} version 3.4. Running a mixed-version {{site.base_gateway}} cluster (3.4 control plane, and <=3.3 data planes) is not supported when using consumer-group scoped plugins. 
+
 
 ## Scope plugins 
 You can scope the following plugins to consumer groups: 
@@ -32,8 +36,8 @@ You can scope the following plugins to consumer groups:
 * [Request Transformer](/hub/kong-inc/request-transformer)
 * [Response Transformer](/hub/kong-inc/response-transformer)
 
-{:note}
-> Consumer groups plugin scoping is a feature that was added in {{site.base_gateway}} version 3.4. Running a mixed-version {{site.base_gateway}} cluster (3.4 control plane, and <=3.3 data planes) is not supported when using consumer-group scoped plugins. 
+{:.note}
+> **Note**: Consumer groups plugin scoping is a feature that was added in {{site.base_gateway}} version 3.4. Running a mixed-version {{site.base_gateway}} cluster (3.4 control plane, and <=3.3 data planes) is not supported when using consumer-group scoped plugins. 
 
 
 
@@ -586,5 +590,6 @@ if you need to cycle the group for a new batch of users.
 
 ## More information
 
+* [Consumer group precedence information](/gateway/latest/key-concepts/plugins/#precedence).
 * [API documentation](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/be79b812-46d5-4cc1-b757-b5270bf4fa60#/consumer_groups/get-consumer_groups)
 * [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/)


### PR DESCRIPTION
* Updated the documentation to include a specific mention of no longer needing the `overrides` endpoint in the rate-limiting plugin doc. 
* Fixed a bullet that should have been written as gte 3.4.x but was written as lte 3.3.x
* Added an explanation of how the new consumer groups endpoint works. 