### PR TITLE
Fix fields name in router expression reference

### DIFF
--- a/app/_src/gateway/reference/router-expressions-language.md
+++ b/app/_src/gateway/reference/router-expressions-language.md
@@ -56,8 +56,8 @@ For example, you can not perform string comparisons on a integer type field.
 | `http.headers.header_name` | Value of header `Header-Name`. Header names are converted to lower case, and `-` are replaced to `_`. | String |
 | `net.src.ip` | Source IP address of incoming connection. | IpAddr |
 | `net.src.port` | Source port number of incoming connection. | Int |
-| `dst.src.ip` | Destination IP address of incoming connection. | IpAddr |
-| `dst.src.port` | Destination port number of incoming connection. | Int |
+| `net.dst.ip` | Destination IP address of incoming connection. | IpAddr |
+| `net.dst.port` | Destination port number of incoming connection. | Int |
 
 ## String
 


### PR DESCRIPTION
### Description

Fix the mistake in #5889.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

