### PR TITLE
Add `consumer_group` section to the plugin schemas

### DIFF
--- a/app/_includes/plugins/schema.html
+++ b/app/_includes/plugins/schema.html
@@ -103,7 +103,7 @@
         <p class="field-description">
           The name or ID of the consumer group the plugin targets.
           If set, the plugin will activate only for requests where the specified group has been authenticated <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          Not required if using  the <code>/consumer_groups/{CONSUMER_GROUP_NAME|ID}/plugins</code> endpoint.
+          Not required if using <code>/consumer_groups/{CONSUMER_GROUP_NAME|ID}/plugins</code>.
         </p>
       </div>
     </li>

--- a/app/_includes/plugins/schema.html
+++ b/app/_includes/plugins/schema.html
@@ -102,8 +102,8 @@
       <div class="field-description-and-children">
         <p class="field-description">
           The name or ID of the consumer group the plugin targets.
-          Set one of these parameters if adding the plugin to a consumer group through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          Not required if using <code>/consumer_groups/{CONSUMER_GROUP_NAME|ID}/plugins</code>.
+          If set, the plugin will activate only for requests where the specified group has been authenticated <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
+          Not required if using  the <code>/consumer_groups/{CONSUMER_GROUP_NAME|ID}/plugins</code> endpoint.
         </p>
       </div>
     </li>

--- a/app/_includes/plugins/schema.html
+++ b/app/_includes/plugins/schema.html
@@ -103,7 +103,7 @@
         <p class="field-description">
           The name or ID of the consumer group the plugin targets.
           Set one of these parameters if adding the plugin to a consumer group through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          Not required if using <code>/consumer_groups/CONSUMER_GROUP_NAME|CONSUMER_GROUP_ID/plugins</code>.
+          Not required if using <code>/consumer_groups/{CONSUMER_GROUP_NAME|ID}/plugins</code>.
         </p>
       </div>
     </li>

--- a/app/_includes/plugins/schema.html
+++ b/app/_includes/plugins/schema.html
@@ -91,6 +91,24 @@
     </li>
   {% endif %}
 
+  {% if schema.enable_on_consumer_group? %}
+    <li class="field">
+      <div class="field-overview">
+        <h4 id="consumer-group">consumer_group.name or consumer_group.id</h4>
+      </div>
+      <div class="field-attributes">
+        <span><strong>string</strong></span>
+      </div>
+      <div class="field-description-and-children">
+        <p class="field-description">
+          The name or ID of the consumer group the plugin targets.
+          Set one of these parameters if adding the plugin to a consumer group through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
+          Not required if using <code>/consumer_groups/CONSUMER_GROUP_NAME|CONSUMER_GROUP_ID/plugins</code>.
+        </p>
+      </div>
+    </li>
+  {% endif %}
+
   <li class="field">
     <div class="field-overview">
       <h4 id="enabled">enabled</h4>


### PR DESCRIPTION
### Description

What did you change and why?

Add `consumer_group` section to plugin schemas.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

