### PR TITLE
fix: Indent in Konnect Getting Started Guide step

### DIFF
--- a/app/konnect/getting-started/deploy-service.md
+++ b/app/konnect/getting-started/deploy-service.md
@@ -25,13 +25,13 @@ In the {% konnect_icon runtimes %} [**Runtime Manager**](https://cloud.konghq.co
     1. Enter a unique name for the Gateway service, or
     specify a Gateway service that doesn't yet have a version connected to it.
 
-      For the purpose of this example, enter `example_gateway_service`.
+       For the purpose of this example, enter `example_gateway_service`.
 
-      The name can be any string containing letters, numbers, or the following
-      characters: `.`, `-`, `_`, `~`, or `:`. Do not use spaces.
+       The name can be any string containing letters, numbers, or the following
+       characters: `.`, `-`, `_`, `~`, or `:`. Do not use spaces.
 
-      For example, you can use `example_service`, `ExampleService`, `Example-Service`.
-      However, `Example Service` is invalid.
+       For example, you can use `example_service`, `ExampleService`, `Example-Service`.
+       However, `Example Service` is invalid.
 
     1. In the **add using upstream URL** field, enter `http://mockbin.org`.
 

--- a/app/konnect/getting-started/deploy-service.md
+++ b/app/konnect/getting-started/deploy-service.md
@@ -2,7 +2,7 @@
 title: Proxy and Test a Service
 ---
 
-Create a {{site.konnect_short_name}} Gateaway service to proxy your APIs. In this guide, you will create, proxy, and test a gateway service using Runtime Manager in {{site.konnect_short_name}}. 
+Create a {{site.konnect_short_name}} Gateway service to proxy your APIs. In this guide, you will create, proxy, and test a gateway service using Runtime Manager in {{site.konnect_short_name}}. 
 
 When you create a service, you also specify the route to it. This route,
 combined with the proxy URL for the service, will lead to the endpoint


### PR DESCRIPTION
### Description

Fixing an indent that was causing the content of the step to break the formatting of the list.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

