### PR TITLE
Updated Kong Gateway upgrade guide to be the source of truth for future docs updates

### DIFF
--- a/app/_src/gateway/upgrade-v2.md
+++ b/app/_src/gateway/upgrade-v2.md
@@ -118,9 +118,9 @@ The following table outlines various upgrade path scenarios to {{page.kong_versi
 | 3.1.0.x-3.1.1.2 | Hybrid | No | [Upgrade to 3.1.1.3](/gateway/3.1.x/upgrade/#migrate-db), [upgrade to 3.2.x](#migrate-db), [upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
 | 3.1.1.3 | Hybrid | No | [Upgrade to 3.2.x](#migrate-db), [upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
 | 3.1.x | DB less | No | [Upgrade to 3.2.x](#migrate-db), [upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
-| 3.2.x | Traditional | Yes | [Upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
-| 3.2.x | Hybrid | Yes | [Upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
-| 3.2.x | DB less | Yes | [Upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
+| 3.2.x | Traditional | No | [Upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
+| 3.2.x | Hybrid | No | [Upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
+| 3.2.x | DB less | No | [Upgrade to 3.3.x](#migrate-db), and then [upgrade to 3.4.x](#migrate-db). |
 | 3.3.x | Traditional | Yes | [Upgrade to 3.4.x](#migrate-db). |
 | 3.3.x | Hybrid | Yes | [Upgrade to 3.4.x](#migrate-db). |
 | 3.3.x | DB less | Yes | [Upgrade to 3.4.x](#migrate-db). |

--- a/app/_src/gateway/upgrade-v2.md
+++ b/app/_src/gateway/upgrade-v2.md
@@ -18,7 +18,6 @@ Kong adheres to [semantic versioning](https://semver.org/), which makes a
 distinction between major, minor, and patch versions.
 
 The upgrade to {{page.kong_version}} is a **minor** upgrade.
-The lowest version that Kong {{page.kong_version}} supports migrating from **directly** is 3.0.x.
 
 {:.important}
 > **Important**: Blue-green migration in traditional mode for versions below 2.8.2 to 3.0.x is not supported.


### PR DESCRIPTION
### Description

Removed the contradictory line from the upgrade-v2.md file to make the upgrade table the "source of truth" and future doc updates easier to maintain for Kong Gateway version upgrade instructions.

Slack conversation: https://kongstrong.slack.com/archives/CDSTDSG9J/p1692729286950759

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

