### PR TITLE
fix: Add missing metadata to appdynamics and serverless functions plugins

### DIFF
--- a/app/_hub/kong-inc/app-dynamics/_metadata.yml
+++ b/app/_hub/kong-inc/app-dynamics/_metadata.yml
@@ -3,6 +3,7 @@ publisher: Kong Inc.
 desc: Integrate Kong with the AppDynamics APM Platform
 free: false
 enterprise: true
+network_config_opts: Self-managed traditional, DB-less, and hybrid
 type: plugin
 categories:
   - analytics-monitoring

--- a/app/_hub/kong-inc/serverless-functions/_metadata.yml
+++ b/app/_hub/kong-inc/serverless-functions/_metadata.yml
@@ -7,6 +7,7 @@ categories:
 free: true
 enterprise: true
 konnect: true
+network_config_opts: All
 dbless_compatible: partially
 dbless_explanation: |
   The functions will be executed, but if the configured functions attempt to write to the database, the writes will fail.


### PR DESCRIPTION
### Description

The AppDynamics and Serverless functions plugins were incorrectly listed as being incompatible with all Kong Gateway deployment modes: https://docs.konghq.com/hub/plugins/compatibility/#serverless

Fixing that by adding `network_config_opts` to the metadata files for both plugins. Both plugins can be run in DB-less, traditional, and hybrid modes.

### Testing instructions

Netlify link: https://deploy-preview-5999--kongdocs.netlify.app/hub/plugins/compatibility/#serverless


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

