### PR TITLE
Don't prevent default behaviour on enter

### DIFF
--- a/app/_assets/javascripts/navbar.js
+++ b/app/_assets/javascripts/navbar.js
@@ -68,7 +68,6 @@ $(document).ready(function() {
   topNavSubmenus.forEach(function(nav) {
     nav.addEventListener("keydown", function(e) {
       if (e.keyCode == 13) {
-        e.preventDefault();
         toggleNav(nav);
         return false;
       }


### PR DESCRIPTION
### Description

What did you change and why?
 
Fixes submenus on enter.
When using the tabs + enter to open one of the menus in the topnav, hitting tab again would iterate over the menu items but hitting enter on one of them wasn't actually visiting the highlighted link, it was just closing the submenu.
This change fixes the issue, so that it actually visits the corresponding page.

![keyboard](https://github.com/Kong/docs.konghq.com/assets/715229/94ec9865-403a-4278-8995-777f593105ae)



### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

