### PR TITLE
Adds documentation for the Filter Chain entity available in Kong Gateway 3.4 

### DIFF
--- a/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
+++ b/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
@@ -37,14 +37,14 @@ components:
       required: true
       schema:
         type: string
-        example: 7fca84d6-7d37-4a74-a7b0-93e576089a41"
+        example: 7fca84d6-7d37-4a74-a7b0-93e576089a41
     certificate_id:
       name: certificate_id
       in: path
       required: true
       schema:
         type: string
-        example: 7fca84d6-7d37-4a74-a7b0-93e576089a41"
+        example: 7fca84d6-7d37-4a74-a7b0-93e576089a41
       description: The unique identifier of the Certificate to retrieve.
     certificate_name_or_id:
       name: certificate_name_or_id
@@ -1715,8 +1715,8 @@ components:
               protocol:
                 type: string
                 description: |-
-                  The protocol used to communicate with the upstream. Accepted values are: "`grpc`", "`grpcs`", "`http`", "`https`", "`tcp`", "`tls`", "`tls_passthrough`", "`udp`", "`ws`" 
-                  , "`wss`" 
+                  The protocol used to communicate with the upstream. Accepted values are: "`grpc`", "`grpcs`", "`http`", "`https`", "`tcp`", "`tls`", "`tls_passthrough`", "`udp`", "`ws`"
+                  , "`wss`"
                   . Default: "`http`".
                 default: http
                 enum:
@@ -2941,7 +2941,7 @@ paths:
         - CA Certificates
     patch:
       description: |-
-        Update the specified Certificate Authority (CA) certificate using the provided ca_certificate_id. Use this endpoint to modify an existing CA certificate in the system. The request body should include the fields of the CA certificate that need to be updated. 
+        Update the specified Certificate Authority (CA) certificate using the provided ca_certificate_id. Use this endpoint to modify an existing CA certificate in the system. The request body should include the fields of the CA certificate that need to be updated.
 
         > This API is not available in DB-less mode.
       operationId: update-ca_certificate
@@ -3204,8 +3204,8 @@ paths:
 
 
 
-         Update an existing SNI associated with a certificate in the system using the SNI ID or name. The request body should include the fields of the SNI that need to be updated, such as the name, description, or other properties. If the request body contains valid data, the endpoint will update the SNI and return a success response. 
-         
+         Update an existing SNI associated with a certificate in the system using the SNI ID or name. The request body should include the fields of the SNI that need to be updated, such as the name, description, or other properties. If the request body contains valid data, the endpoint will update the SNI and return a success response.
+
       responses:
         '200':
           content:
@@ -3261,7 +3261,7 @@ paths:
         required: true
         schema:
           type: string
-          example: 7fca84d6-7d37-4a74-a7b0-93e576089a41"
+          example: 7fca84d6-7d37-4a74-a7b0-93e576089a41
         description: The unique identifier of the Certificate to retrieve.
       - name: sni_name_or_id
         in: path
@@ -3365,7 +3365,7 @@ paths:
         $ref: '#/components/requestBodies/consumer-request'
     put:
       description: |-
-        Create or Update Consumer using ID or username. The consumer will be identified via the username or id attribute.If the consumer with the specified ID or username cannot be found, the endpoint will return a 404. 
+        Create or Update Consumer using ID or username. The consumer will be identified via the username or id attribute.If the consumer with the specified ID or username cannot be found, the endpoint will return a 404.
 
         When the username or id attribute has the structure of a UUID, the Consumer being inserted/replaced will be identified by its id. Otherwise it will be identified by its username.
 
@@ -3930,7 +3930,7 @@ paths:
 
         route entities define rules to match client requests. Each route is associated with a service, and a service may have multiple routes associated to it. Every request matching a given route will be proxied to its associated service.
 
-        > Note: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when router_flavor is set to expressions, route.path_handling will be unconfigurable and the path handling behavior will be "v0"; when router_flavor is set to traditional_compatible, the path handling behavior will be "v0" regardless of the value of route.path_handling. Only router_flavor = traditional will support path_handling "v1' behavior.
+        > Note: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when router_flavor is set to expressions, route.path_handling will be unconfigurable and the path handling behavior will be "v0"; when router_flavor is set to traditional_compatible, the path handling behavior will be "v0" regardless of the value of route.path_handling. Only router_flavor = traditional will support path_handling "v1" behavior.
       operationId: list-route
       parameters:
         - $ref: '#/components/parameters/pagination-size'

--- a/app/_data/docs_nav_gateway_3.4.x.yml
+++ b/app/_data/docs_nav_gateway_3.4.x.yml
@@ -585,7 +585,6 @@ items:
     items:
       - text: Overview
         url: /admin-api/
-        src: admin-api/admin-api-3.4.x
       - text: Information Routes
         url: /admin-api/#information-routes
       - text: Health Routes

--- a/app/_data/docs_nav_gateway_3.4.x.yml
+++ b/app/_data/docs_nav_gateway_3.4.x.yml
@@ -585,6 +585,7 @@ items:
     items:
       - text: Overview
         url: /admin-api/
+        src: admin-api/admin-api-3.4.x
       - text: Information Routes
         url: /admin-api/#information-routes
       - text: Health Routes
@@ -615,6 +616,8 @@ items:
         url: /admin-api/#vaults-object
       - text: Keys
         url: /admin-api/#keys-object
+      - text: Filter Chains
+        url: /admin-api/#filter-chain-object
       - text: Licenses
         url: /admin-api/licenses/reference
       - text: Workspaces

--- a/app/_src/gateway/admin-api/admin-api-3.4.x.md
+++ b/app/_src/gateway/admin-api/admin-api-3.4.x.md
@@ -1,0 +1,6184 @@
+---
+title: Admin API
+toc: false
+disable_image_expand: true
+
+service_body: |
+    Attributes | Description
+    ---:| ---
+    `name`<br>*optional* | The Service name.
+    `retries`<br>*optional* | The number of retries to execute upon failure to proxy. Default: `5`.
+    `protocol` |  The protocol used to communicate with the upstream.  Accepted values are: `"grpc"`, `"grpcs"`, `"http"`, `"https"`, `"tcp"`, `"tls"`, `"tls_passthrough"`, `"udp"`, `"ws"` <span class="badge enterprise"></span>, `"wss"` <span class="badge enterprise"></span>.  Default: `"http"`.
+    `host` | The host of the upstream server. Note that the host value is case sensitive.
+    `port` | The upstream server port. Default: `80`.
+    `path`<br>*optional* | The path to be used in requests to the upstream server.
+    `connect_timeout`<br>*optional* |  The timeout in milliseconds for establishing a connection to the upstream server.  Default: `60000`.
+    `write_timeout`<br>*optional* |  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.  Default: `60000`.
+    `read_timeout`<br>*optional* |  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.  Default: `60000`.
+    `tags`<br>*optional* |  An optional set of strings associated with the Service for grouping and filtering.
+    `client_certificate`<br>*optional* |  Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
+    `tls_verify`<br>*optional* |  Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
+    `tls_verify_depth`<br>*optional* |  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.  Default: `null`.
+    `ca_certificates`<br>*optional* |  Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
+    `enabled` |  Whether the Service is active. If set to `false`, the proxy behavior will be as if any routes attached to it do not exist (404). Default: `true`.
+    `url`<br>*shorthand-attribute* |  Shorthand attribute to set `protocol`, `host`, `port` and `path` at once. This attribute is write-only (the Admin API never returns the URL).
+
+service_json: |
+    {
+        "id": "9748f662-7711-4a90-8186-dc02f10eb0f5",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-service",
+        "retries": 5,
+        "protocol": "http",
+        "host": "example.com",
+        "port": 80,
+        "path": "/some_api",
+        "connect_timeout": 60000,
+        "write_timeout": 60000,
+        "read_timeout": 60000,
+        "tags": ["user-level", "low-priority"],
+        "client_certificate": {"id":"4e3ad2e4-0bc4-4638-8e34-c84a417ba39b"},
+        "tls_verify": true,
+        "tls_verify_depth": null,
+        "ca_certificates": ["4e3ad2e4-0bc4-4638-8e34-c84a417ba39b", "51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515"],
+        "enabled": true
+    }
+
+service_data: |
+    "data": [{
+        "id": "a5fb8d9b-a99d-40e9-9d35-72d42a62d83a",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-service",
+        "retries": 5,
+        "protocol": "http",
+        "host": "example.com",
+        "port": 80,
+        "path": "/some_api",
+        "connect_timeout": 60000,
+        "write_timeout": 60000,
+        "read_timeout": 60000,
+        "tags": ["user-level", "low-priority"],
+        "client_certificate": {"id":"51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515"},
+        "tls_verify": true,
+        "tls_verify_depth": null,
+        "ca_certificates": ["4e3ad2e4-0bc4-4638-8e34-c84a417ba39b", "51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515"],
+        "enabled": true
+    }, {
+        "id": "fc73f2af-890d-4f9b-8363-af8945001f7f",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-service",
+        "retries": 5,
+        "protocol": "http",
+        "host": "example.com",
+        "port": 80,
+        "path": "/another_api",
+        "connect_timeout": 60000,
+        "write_timeout": 60000,
+        "read_timeout": 60000,
+        "tags": ["admin", "high-priority", "critical"],
+        "client_certificate": {"id":"4506673d-c825-444c-a25b-602e3c2ec16e"},
+        "tls_verify": true,
+        "tls_verify_depth": null,
+        "ca_certificates": ["4e3ad2e4-0bc4-4638-8e34-c84a417ba39b", "51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515"],
+        "enabled": true
+    }],
+
+route_body: |
+    Attributes | Description
+    ---:| ---
+    `name`<br>*optional* | The name of the Route. Route names must be unique, and they are case sensitive. For example, there can be two different Routes named "test" and "Test".
+    `protocols` |  An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. When set to only `"https"`, HTTP requests are answered with an upgrade error. When it is set to only `"http"`, this is essentially the same as `["http", "https"]` in that both HTTP and HTTPS requests are allowed. Default: `["http", "https"]`.
+    `methods`<br>*semi-optional* |  A list of HTTP methods that match this Route.
+    `hosts`<br>*semi-optional* |  A list of domain names that match this Route. Note that the hosts value is case sensitive.  With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
+    `paths`<br>*semi-optional* |  A list of paths that match this Route.  With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an array. The path can be a regular expression, or a plain text pattern. The path patterns are matched against a normalized path, with most percent-encoded characters decoded, path folding, and preserved semantics. For more details read [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986#section-6).
+    `headers`<br>*semi-optional* |  One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. When `headers` contains only one value and that value starts with the special prefix `~*`, the value is interpreted as a regular expression.
+    `https_redirect_status_code` |  The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308. Note: This config applies only if the Route is configured to only accept the `https` protocol.  Accepted values are: `426`, `301`, `302`, `307`, `308`.  Default: `426`.
+    `regex_priority`<br>*optional* |  A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).  Default: `0`.
+    `strip_path` |  When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.  Default: `true`.
+    `path_handling`<br>*optional* |  Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.  Accepted values are: `"v0"`, `"v1"`.  Default: `"v0"`.
+    `preserve_host` |  When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
+    `request_buffering` |  Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.  Default: `true`.
+    `response_buffering` |  Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.  Default: `true`.
+    `snis`<br>*semi-optional* |  A list of SNIs that match this Route when using stream routing.
+    `sources`<br>*semi-optional* |  A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `destinations`<br>*semi-optional* |  A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+    `tags`<br>*optional* |  An optional set of strings associated with the Route for grouping and filtering.
+    `service`<br>*optional* |  The Service this Route is associated to. This is where the Route proxies traffic to. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
+
+route_json: |
+    {
+        "id": "d35165e2-d03e-461a-bdeb-dad0a112abfe",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-route",
+        "protocols": ["http", "https"],
+        "methods": ["GET", "POST"],
+        "hosts": ["example.com", "foo.test"],
+        "paths": ["/foo", "/bar"],
+        "headers": {"x-my-header":["foo", "bar"], "x-another-header":["bla"]},
+        "https_redirect_status_code": 426,
+        "regex_priority": 0,
+        "strip_path": true,
+        "path_handling": "v0",
+        "preserve_host": false,
+        "request_buffering": true,
+        "response_buffering": true,
+        "tags": ["user-level", "low-priority"],
+        "service": {"id":"af8330d3-dbdc-48bd-b1be-55b98608834b"}
+    }
+
+route_data: |
+    "data": [{
+        "id": "a9daa3ba-8186-4a0d-96e8-00d80ce7240b",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-route",
+        "protocols": ["http", "https"],
+        "methods": ["GET", "POST"],
+        "hosts": ["example.com", "foo.test"],
+        "paths": ["/foo", "/bar"],
+        "headers": {"x-my-header":["foo", "bar"], "x-another-header":["bla"]},
+        "https_redirect_status_code": 426,
+        "regex_priority": 0,
+        "strip_path": true,
+        "path_handling": "v0",
+        "preserve_host": false,
+        "request_buffering": true,
+        "response_buffering": true,
+        "tags": ["user-level", "low-priority"],
+        "service": {"id":"127dfc88-ed57-45bf-b77a-a9d3a152ad31"}
+    }, {
+        "id": "9aa116fd-ef4a-4efa-89bf-a0b17c4be982",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-route",
+        "protocols": ["tcp", "tls"],
+        "https_redirect_status_code": 426,
+        "regex_priority": 0,
+        "strip_path": true,
+        "path_handling": "v0",
+        "preserve_host": false,
+        "request_buffering": true,
+        "response_buffering": true,
+        "snis": ["foo.test", "example.com"],
+        "sources": [{"ip":"10.1.0.0/16", "port":1234}, {"ip":"10.2.2.2"}, {"port":9123}],
+        "destinations": [{"ip":"10.1.0.0/16", "port":1234}, {"ip":"10.2.2.2"}, {"port":9123}],
+        "tags": ["admin", "high-priority", "critical"],
+        "service": {"id":"ba641b07-e74a-430a-ab46-94b61e5ea66b"}
+    }],
+
+consumer_body: |
+    Attributes | Description
+    ---:| ---
+    `username`<br>*semi-optional* |  The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+    `custom_id`<br>*semi-optional* |  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+    `tags`<br>*optional* |  An optional set of strings associated with the Consumer for grouping and filtering.
+
+consumer_json: |
+    {
+        "id": "ec1a1f6f-2aa4-4e58-93ff-b56368f19b27",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "username": "my-username",
+        "custom_id": "my-custom-id",
+        "tags": ["user-level", "low-priority"]
+    }
+
+consumer_data: |
+    "data": [{
+        "id": "a4407883-c166-43fd-80ca-3ca035b0cdb7",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "username": "my-username",
+        "custom_id": "my-custom-id",
+        "tags": ["user-level", "low-priority"]
+    }, {
+        "id": "01c23299-839c-49a5-a6d5-8864c09184af",
+        "created_at": 1422386534,
+        "username": "my-username",
+        "custom_id": "my-custom-id",
+        "tags": ["admin", "high-priority", "critical"]
+    }],
+
+plugin_body: |
+    Attributes | Description
+    ---:| ---
+    `name` |  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
+    `route`<br>*optional* |  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.  Default: `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
+    `service`<br>*optional* |  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.  Default: `null`.With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
+    `consumer`<br>*optional* |  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.  Default: `null`.With form-encoded, the notation is `consumer.id=<consumer id>` or `consumer.username=<consumer username>`. With JSON, use "`"consumer":{"id":"<consumer id>"}` or `"consumer":{"username":"<consumer username>"}`.
+    `instance_name`<br>*optional* | The Plugin instance name.
+    `config`<br>*optional* |  The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
+    `protocols` |  A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.  Default: `["grpc", "grpcs", "http",`<wbr>` "https"]`.
+    `enabled` | Whether the plugin is applied. Default: `true`.
+    `tags`<br>*optional* |  An optional set of strings associated with the Plugin for grouping and filtering.
+    `ordering`<br>*optional* <span class="badge enterprise"></span> | Describes a dependency to another plugin to determine plugin ordering during the `access` phase. <br> --`before`: The plugin will be executed _before_ a specified plugin or list of plugins. <br> -- `after`: The plugin will be executed _after_ a specified plugin or list of plugins.
+
+plugin_json: |
+    {
+        "id": "ce44eef5-41ed-47f6-baab-f725cecf98c7",
+        "name": "rate-limiting",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "route": null,
+        "service": null,
+        "consumer": null,
+        "instance_name": rate-limiting-foo,
+        "config": {"hour":500, "minute":20},
+        "protocols": ["http", "https"],
+        "enabled": true,
+        "tags": ["user-level", "low-priority"],
+        "ordering": {"before":["plugin-name"]}
+    }
+
+plugin_data: |
+    "data": [{
+        "id": "02621eee-8309-4bf6-b36b-a82017a5393e",
+        "name": "rate-limiting",
+        "instance_name": "rate-limiting-foo",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "route": null,
+        "service": null,
+        "consumer": null,
+        "config": {"hour":500, "minute":20},
+        "protocols": ["http", "https"],
+        "enabled": true,
+        "tags": ["user-level", "low-priority"],
+        "ordering": {"before":["plugin-name"]}
+    }, {
+        "id": "66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4",
+        "name": "rate-limiting",
+        "created_at": 1422386534,
+        "route": null,
+        "service": null,
+        "consumer": null,
+        "config": {"hour":500, "minute":20},
+        "protocols": ["tcp", "tls"],
+        "enabled": true,
+        "tags": ["admin", "high-priority", "critical"],
+        "ordering": {"after":["plugin-name"]}
+    }],
+
+certificate_body: |
+    Attributes | Description
+    ---:| ---
+    `cert` |  PEM-encoded public certificate chain of the SSL key pair. This field is _referenceable_, which means it can be securely stored as a [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started/) in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format/).
+    `key` |  PEM-encoded private key of the SSL key pair. This field is _referenceable_, which means it can be securely stored as a [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started/) in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format/).
+    `cert_alt`<br>*optional* |  PEM-encoded public certificate chain of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. This field is _referenceable_, which means it can be securely stored as a [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started/) in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format/).
+    `key_alt`<br>*optional* | PEM-encoded private key of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. This field is _referenceable_, which means it can be securely stored as a [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started/) in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format/).
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+    `snis`<br>*shorthand-attribute* |  An array of zero or more hostnames to associate with this certificate as SNIs. This is a sugar parameter that will, under the hood, create an SNI object and associate it with this certificate for your convenience. To set this attribute this certificate must have a valid private key associated with it.
+    `passphrase`<br>*optional* (Enterprise only) | To load an encrypted private key into Kong, specify the passphrase using this attribute. Kong will decrypt the private key and store it in its database. To encrypt the private key and other sensitive information in Kong's database, consider using DB encryption.
+
+certificate_json: |
+    {
+        "id": "7fca84d6-7d37-4a74-a7b0-93e576089a41",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "cert": "-----BEGIN CERTIFICATE-----...",
+        "key": "-----BEGIN RSA PRIVATE KEY-----...",
+        "cert_alt": "-----BEGIN CERTIFICATE-----...",
+        "key_alt": "-----BEGIN EC PRIVATE KEY-----...",
+        "tags": ["user-level", "low-priority"]
+    }
+
+certificate_data: |
+    "data": [{
+        "id": "d044b7d4-3dc2-4bbc-8e9f-6b7a69416df6",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "cert": "-----BEGIN CERTIFICATE-----...",
+        "key": "-----BEGIN RSA PRIVATE KEY-----...",
+        "cert_alt": "-----BEGIN CERTIFICATE-----...",
+        "key_alt": "-----BEGIN EC PRIVATE KEY-----...",
+        "tags": ["user-level", "low-priority"]
+    }, {
+        "id": "a9b2107f-a214-47b3-add4-46b942187924",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "cert": "-----BEGIN CERTIFICATE-----...",
+        "key": "-----BEGIN RSA PRIVATE KEY-----...",
+        "cert_alt": "-----BEGIN CERTIFICATE-----...",
+        "key_alt": "-----BEGIN EC PRIVATE KEY-----...",
+        "tags": ["admin", "high-priority", "critical"]
+    }],
+
+ca_certificate_body: |
+    Attributes | Description
+    ---:| ---
+    `cert` | PEM-encoded public certificate of the CA.
+    `cert_digest`<br>*optional* | SHA256 hex digest of the public certificate.
+    `tags`<br>*optional* |  An optional set of strings associated with the Certificate for grouping and filtering.
+
+ca_certificate_json: |
+    {
+        "id": "04fbeacf-a9f1-4a5d-ae4a-b0407445db3f",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "cert": "-----BEGIN CERTIFICATE-----...",
+        "cert_digest": "c641e28d77e93544f2fa87b2cf3f3d51...",
+        "tags": ["user-level", "low-priority"]
+    }
+
+ca_certificate_data: |
+    "data": [{
+        "id": "43429efd-b3a5-4048-94cb-5cc4029909bb",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "cert": "-----BEGIN CERTIFICATE-----...",
+        "cert_digest": "c641e28d77e93544f2fa87b2cf3f3d51...",
+        "tags": ["user-level", "low-priority"]
+    }, {
+        "id": "d26761d5-83a4-4f24-ac6c-cff276f2b79c",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "cert": "-----BEGIN CERTIFICATE-----...",
+        "cert_digest": "c641e28d77e93544f2fa87b2cf3f3d51...",
+        "tags": ["admin", "high-priority", "critical"]
+    }],
+
+sni_body: |
+    Attributes | Description
+    ---:| ---
+    `name` | The SNI name to associate with the given certificate.
+    `tags`<br>*optional* |  An optional set of strings associated with the SNIs for grouping and filtering.
+    `certificate` |  The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use "`"certificate":{"id":"<certificate id>"}`.
+
+sni_json: |
+    {
+        "id": "91020192-062d-416f-a275-9addeeaffaf2",
+        "name": "my-sni",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "tags": ["user-level", "low-priority"],
+        "certificate": {"id":"a2e013e8-7623-4494-a347-6d29108ff68b"}
+    }
+
+sni_data: |
+    "data": [{
+        "id": "147f5ef0-1ed6-4711-b77f-489262f8bff7",
+        "name": "my-sni",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "tags": ["user-level", "low-priority"],
+        "certificate": {"id":"a3ad71a8-6685-4b03-a101-980a953544f6"}
+    }, {
+        "id": "b87eb55d-69a1-41d2-8653-8d706eecefc0",
+        "name": "my-sni",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "tags": ["admin", "high-priority", "critical"],
+        "certificate": {"id":"4e8d95d4-40f2-4818-adcb-30e00c349618"}
+    }],
+
+upstream_body: |
+    Attributes | Description
+    ---:| ---
+    `name` | This is a hostname, which must be equal to the `host` of a Service.
+    `algorithm`<br>*optional* | Which load balancing algorithm to use. Accepted values are: `"consistent-hashing"`, `"least-connections"`, `"round-robin"`, `"latency"`.  Default: `"round-robin"`.
+    `hash_on`<br>*optional* | What to use as hashing input. Using `none` results in a weighted-round-robin scheme with no hashing. Accepted values are: `"none"`, `"consumer"`, `"ip"`, `"header"`, `"cookie"`, `"path"`, `"query_arg"`, `"uri_capture"`.  Default: `"none"`.
+    `hash_fallback`<br>*optional* | What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no Consumer identified). Not available if `hash_on` is set to `cookie`. Accepted values are: `"none"`, `"consumer"`, `"ip"`, `"header"`, `"cookie"`, `"path"`, `"query_arg"`, `"uri_capture"`.  Default: `"none"`.
+    `hash_on_header`<br>*semi-optional* | The header name to take the value from as hash input. Only required when `hash_on` is set to `header`.
+    `hash_fallback_header`<br>*semi-optional* | The header name to take the value from as hash input. Only required when `hash_fallback` is set to `header`.
+    `hash_on_cookie`<br>*semi-optional* | The cookie name to take the value from as hash input. Only required when `hash_on` or `hash_fallback` is set to `cookie`. If the specified cookie is not in the request, Kong will generate a value and set the cookie in the response.
+    `hash_on_cookie_path`<br>*semi-optional* | The cookie path to set in the response headers. Only required when `hash_on` or `hash_fallback` is set to `cookie`. Default: `"/"`.
+    `hash_on_query_arg`<br>*semi-optional* | The name of the query string argument to take the value from as hash input. Only required when `hash_on` is set to `query_arg`.
+    `hash_fallback_query_arg`<br>*semi-optional* | The name of the query string argument to take the value from as hash input. Only required when `hash_fallback` is set to `query_arg`.
+    `hash_on_uri_capture`<br>*semi-optional* | The name of the route URI capture to take the value from as hash input. Only required when `hash_on` is set to `uri_capture`.
+    `hash_fallback_uri_capture`<br>*semi-optional* | The name of the route URI capture to take the value from as hash input. Only required when `hash_fallback` is set to `uri_capture`.
+    `slots`<br>*optional* | The number of slots in the load balancer algorithm. If `algorithm` is set to `round-robin`, this setting determines the maximum number of slots. If `algorithm` is set to `consistent-hashing`, this setting determines the actual number of slots in the algorithm. Accepts an integer in the range `10`-`65536`. Default: `10000`.
+    `healthchecks.passive.`<wbr>`type`<br>*optional* | Whether to perform passive health checks interpreting HTTP/HTTPS statuses, or just check for TCP connection success. In passive checks, `http` and `https` options are equivalent. Accepted values are: `"tcp"`, `"http"`, `"https"`, `"grpc"`, `"grpcs"`.  Default: `"http"`.
+    `healthchecks.passive.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. Default: `[200, 201, 202, 203, 204, 205,`<wbr>` 206, 207, 208, 226, 300, 301,`<wbr>` 302, 303, 304, 305, 306, 307,`<wbr>` 308]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an Array.
+    `healthchecks.passive.`<wbr>`healthy.successes`<br>*optional* | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks. Default: `0`.
+    `healthchecks.passive.`<wbr>`unhealthy.http_statuses`<br>*optional* | An array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks. Default: `[429, 500, 503]`. With form-encoded, the notation is `http_statuses[]=429&http_statuses[]=500`. With JSON, use an Array.
+    `healthchecks.passive.`<wbr>`unhealthy.timeouts`<br>*optional* | Number of timeouts in proxied traffic to consider a target unhealthy, as observed by passive health checks. Default: `0`.
+    `healthchecks.passive.`<wbr>`unhealthy.http_failures`<br>*optional* | Number of HTTP failures in proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`) to consider a target unhealthy, as observed by passive health checks. Default: `0`.
+    `healthchecks.passive.`<wbr>`unhealthy.tcp_failures`<br>*optional* | Number of TCP failures in proxied traffic to consider a target unhealthy, as observed by passive health checks. Default: `0`.
+    `healthchecks.active.`<wbr>`https_verify_certificate` | Whether to check the validity of the SSL certificate of the remote host when performing active health checks using HTTPS. Default: `true`.
+    `healthchecks.active.`<wbr>`healthy.http_statuses`<br>*optional* | An array of HTTP statuses to consider a success, indicating healthiness, when returned by a probe in active health checks. Default: `[200, 302]`. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=302`. With JSON, use an Array.
+    `healthchecks.active.`<wbr>`healthy.successes`<br>*optional* | Number of successes in active probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider a target healthy. Default: `0`.
+    `healthchecks.active.`<wbr>`healthy.interval`<br>*optional* | Interval between active health checks for healthy targets (in seconds). A value of zero indicates that active probes for healthy targets should not be performed. Default: `0`.
+    `healthchecks.active.`<wbr>`unhealthy.http_failures`<br>*optional* | Number of HTTP failures in active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to consider a target unhealthy. Default: `0`.
+    `healthchecks.active.`<wbr>`unhealthy.http_statuses`<br>*optional* | An array of HTTP statuses to consider a failure, indicating unhealthiness, when returned by a probe in active health checks. Default: `[429, 404, 500, 501, 502, 503,`<wbr>` 504, 505]`. With form-encoded, the notation is `http_statuses[]=429&http_statuses[]=404`. With JSON, use an Array.
+    `healthchecks.active.`<wbr>`unhealthy.timeouts`<br>*optional* | Number of timeouts in active probes to consider a target unhealthy. Default: `0`.
+    `healthchecks.active.`<wbr>`unhealthy.tcp_failures`<br>*optional* | Number of TCP failures in active probes to consider a target unhealthy. Default: `0`.
+    `healthchecks.active.`<wbr>`unhealthy.interval`<br>*optional* | Interval between active health checks for unhealthy targets (in seconds). A value of zero indicates that active probes for unhealthy targets should not be performed. Default: `0`.
+    `healthchecks.active.type`<br>*optional* | Whether to perform active health checks using HTTP or HTTPS, or just attempt a TCP connection. Accepted values are: `"tcp"`, `"http"`, `"https"`, `"grpc"`, `"grpcs"`.  Default: `"http"`.
+    `healthchecks.active.`<wbr>`concurrency`<br>*optional* | Number of targets to check concurrently in active health checks. Default: `10`.
+    `healthchecks.active.`<wbr>`headers`<br>*optional* | One or more lists of values indexed by header name to use in GET HTTP request to run as a probe on active health checks. Values must be pre-formatted.
+    `healthchecks.active.`<wbr>`timeout`<br>*optional* | Socket timeout for active health checks (in seconds). Default: `1`.
+    `healthchecks.active.`<wbr>`http_path`<br>*optional* | Path to use in GET HTTP request to run as a probe on active health checks. Default: `"/"`.
+    `healthchecks.active.`<wbr>`https_sni`<br>*optional* | The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the target host's certificate can be verified with the proper SNI.
+    `healthchecks.threshold`<br>*optional* | The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy. Default: `0`.
+    `tags`<br>*optional* |  An optional set of strings associated with the Upstream for grouping and filtering.
+    `host_header`<br>*optional* | The hostname to be used as `Host` header when proxying requests through Kong.
+    `client_certificate`<br>*optional* | If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use "`"client_certificate":{"id":"<client_certificate id>"}`.
+    `use_srv_name`<br>*optional* | If set, the balancer will use SRV hostname(if DNS Answer has SRV record) as the proxy upstream `Host`.
+
+upstream_json: |
+    {
+        "id": "58c8ccbb-eafb-4566-991f-2ed4f678fa70",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-upstream",
+        "algorithm": "round-robin",
+        "hash_on": "none",
+        "hash_fallback": "none",
+        "hash_on_cookie_path": "/",
+        "slots": 10000,
+        "healthchecks": {
+            "passive": {
+                "type": "http",
+                "healthy": {
+                    "http_statuses": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
+                    "successes": 0
+                },
+                "unhealthy": {
+                    "http_statuses": [429, 500, 503],
+                    "timeouts": 0,
+                    "http_failures": 0,
+                    "tcp_failures": 0
+                }
+            },
+            "active": {
+                "https_verify_certificate": true,
+                "healthy": {
+                    "http_statuses": [200, 302],
+                    "successes": 0,
+                    "interval": 0
+                },
+                "unhealthy": {
+                    "http_failures": 0,
+                    "http_statuses": [429, 404, 500, 501, 502, 503, 504, 505],
+                    "timeouts": 0,
+                    "tcp_failures": 0,
+                    "interval": 0
+                },
+                "type": "http",
+                "concurrency": 10,
+                "headers": [{"x-my-header":["foo", "bar"], "x-another-header":["bla"]}],
+                "timeout": 1,
+                "http_path": "/",
+                "https_sni": "example.com"
+            },
+            "threshold": 0
+        },
+        "tags": ["user-level", "low-priority"],
+        "host_header": "example.com",
+        "client_certificate": {"id":"ea29aaa3-3b2d-488c-b90c-56df8e0dd8c6"},
+        "use_srv_name": false
+    }
+
+upstream_data: |
+    "data": [{
+        "id": "4fe14415-73d5-4f00-9fbc-c72a0fccfcb2",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-upstream",
+        "algorithm": "round-robin",
+        "hash_on": "none",
+        "hash_fallback": "none",
+        "hash_on_cookie_path": "/",
+        "slots": 10000,
+        "healthchecks": {
+            "passive": {
+                "type": "http",
+                "healthy": {
+                    "http_statuses": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
+                    "successes": 0
+                },
+                "unhealthy": {
+                    "http_statuses": [429, 500, 503],
+                    "timeouts": 0,
+                    "http_failures": 0,
+                    "tcp_failures": 0
+                }
+            },
+            "active": {
+                "https_verify_certificate": true,
+                "healthy": {
+                    "http_statuses": [200, 302],
+                    "successes": 0,
+                    "interval": 0
+                },
+                "unhealthy": {
+                    "http_failures": 0,
+                    "http_statuses": [429, 404, 500, 501, 502, 503, 504, 505],
+                    "timeouts": 0,
+                    "tcp_failures": 0,
+                    "interval": 0
+                },
+                "type": "http",
+                "concurrency": 10,
+                "headers": [{"x-my-header":["foo", "bar"], "x-another-header":["bla"]}],
+                "timeout": 1,
+                "http_path": "/",
+                "https_sni": "example.com"
+            },
+            "threshold": 0
+        },
+        "tags": ["user-level", "low-priority"],
+        "host_header": "example.com",
+        "client_certificate": {"id":"a3395f66-2af6-4c79-bea2-1b6933764f80"},
+        "use_srv_name": false
+    }, {
+        "id": "885a0392-ef1b-4de3-aacf-af3f1697ce2c",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "name": "my-upstream",
+        "algorithm": "round-robin",
+        "hash_on": "none",
+        "hash_fallback": "none",
+        "hash_on_cookie_path": "/",
+        "slots": 10000,
+        "healthchecks": {
+            "passive": {
+                "type": "http",
+                "healthy": {
+                    "http_statuses": [200, 201, 202, 203, 204, 205, 206, 207, 208, 226, 300, 301, 302, 303, 304, 305, 306, 307, 308],
+                    "successes": 0
+                },
+                "unhealthy": {
+                    "http_statuses": [429, 500, 503],
+                    "timeouts": 0,
+                    "http_failures": 0,
+                    "tcp_failures": 0
+                }
+            },
+            "active": {
+                "https_verify_certificate": true,
+                "healthy": {
+                    "http_statuses": [200, 302],
+                    "successes": 0,
+                    "interval": 0
+                },
+                "unhealthy": {
+                    "http_failures": 0,
+                    "http_statuses": [429, 404, 500, 501, 502, 503, 504, 505],
+                    "timeouts": 0,
+                    "tcp_failures": 0,
+                    "interval": 0
+                },
+                "type": "http",
+                "concurrency": 10,
+                "headers": [{"x-my-header":["foo", "bar"], "x-another-header":["bla"]}],
+                "timeout": 1,
+                "http_path": "/",
+                "https_sni": "example.com"
+            },
+            "threshold": 0
+        },
+        "tags": ["admin", "high-priority", "critical"],
+        "host_header": "example.com",
+        "client_certificate": {"id":"f5a9c0ca-bdbb-490f-8928-2ca95836239a"},
+        "use_srv_name": false
+    }],
+
+target_body: |
+    Attributes | Description
+    ---:| ---
+    `target` |  The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
+    `weight`<br>*optional* |  The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.  Default: `100`.
+    `tags`<br>*optional* |  An optional set of strings associated with the Target for grouping and filtering.
+
+target_json: |
+    {
+        "id": "173a6cee-90d1-40a7-89cf-0329eca780a6",
+        "created_at": 1422386534,
+         "updated_at": 1422386534,
+        "upstream": {"id":"bdab0e47-4e37-4f0b-8fd0-87d95cc4addc"},
+        "target": "example.com:8000",
+        "weight": 100,
+        "tags": ["user-level", "low-priority"]
+    }
+
+target_data: |
+    "data": [{
+        "id": "f00c6da4-3679-4b44-b9fb-36a19bd3ae83",
+        "created_at": 1422386534,
+        "upstream": {"id":"0c61e164-6171-4837-8836-8f5298726d53"},
+        "target": "example.com:8000",
+        "weight": 100,
+        "tags": ["user-level", "low-priority"]
+    }, {
+        "id": "5027BBC1-508C-41F8-87F2-AB1801E9D5C3",
+        "created_at": 1422386534,
+        "upstream": {"id":"68FDB05B-7B08-47E9-9727-AF7F897CFF1A"},
+        "target": "example.com:8000",
+        "weight": 100,
+        "tags": ["admin", "high-priority", "critical"]
+    }],
+
+vault_body: |
+    Attributes | Description
+    ---:| ---
+    `prefix` |  The unique prefix (or identifier) for this Vault configuration. The prefix is used to load the right Vault configuration and implementation when referencing secrets with the other entities.
+    `name` |  The name of the Vault that's going to be added. Currently, the Vault implementation must be installed in every Kong instance.
+    `description`<br>*optional* |  The description of the Vault object.
+    `config`<br>*optional* |  The configuration properties for the Vault which can be found on the vaults' documentation page.
+    `tags`<br>*optional* |  An optional set of strings associated with the Vault for grouping and filtering.
+
+vault_json: |
+    {
+        "id": "B2A30E8F-C542-49CF-8015-FB674987D1A5",
+        "prefix": "env",
+        "name": "env",
+        "description": "This vault is used to retrieve redis database access credentials",
+        "config": {"prefix":"SSL_"},
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "tags": ["database-credentials", "data-plane"]
+    }
+
+vault_data: |
+    "data": [{
+        "id": "518BBE43-2454-4559-99B0-8E7D1CD3E8C8",
+        "prefix": "env",
+        "name": "env",
+        "description": "This vault is used to retrieve redis database access credentials",
+        "config": {"prefix":"SSL_"},
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "tags": ["database-credentials", "data-plane"]
+    }, {
+        "id": "7C4747E9-E831-4ED8-9377-83A6F8A37603",
+        "prefix": "env",
+        "name": "env",
+        "description": "This vault is used to retrieve redis database access credentials",
+        "config": {"prefix":"SSL_"},
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "tags": ["certificates", "critical"]
+    }],
+
+key_body: |
+    Attributes | Description
+    ---:| ---
+    `set`<br>*optional* |  The id (an UUID) of the key-set with which to associate the key. With form-encoded, the notation is `set.id=<set id>` or `set.name=<set name>`. With JSON, use "`"set":{"id":"<set id>"}` or `"set":{"name":"<set name>"}`.
+    `name`<br>*optional* | The name to associate with the given keys.
+    `kid` |  A unique identifier for a key.
+    `jwk`<br>*optional* |  A JSON Web Key represented as a string.
+    `pem`<br>*optional* |  A keypair in PEM format.
+    `tags`<br>*optional* |  An optional set of strings associated with the Key for grouping and filtering.
+
+key_json: |
+    {
+        "id": "24D0DBDA-671C-11ED-BA0B-EF1DCCD3725F",
+        "set": {"id":"46CA83EE-671C-11ED-BFAB-2FE47512C77A"},
+        "name": "my-key",
+        "kid": "42",
+        "jwk": "{\"alg\":\"RSA\",  \"kid\": \"42\",  ...}",
+        "pem": {
+            "private_key": "-----BEGIN",
+            "public_key": "-----BEGIN"
+        },
+        "tags": ["application-a", "public-key-xyz"],
+        "created_at": 1422386534,
+        "updated_at": 1422386534
+    }
+
+key_data: |
+    "data": [{
+        "id": "57532ECE-6720-11ED-9297-279D4320B841",
+        "set": {"id":"68A64404-6720-11ED-8DE1-47A2EE5E214E"},
+        "name": "my-key",
+        "kid": "42",
+        "jwk": "{\"alg\":\"RSA\",  \"kid\": \"42\",  ...}",
+        "pem": {
+            "private_key": "-----BEGIN",
+            "public_key": "-----BEGIN"
+        },
+        "tags": ["application-a", "public-key-xyz"],
+        "created_at": 1422386534,
+        "updated_at": 1422386534
+    }, {
+        "id": "76BF58F0-6720-11ED-9341-BF64C05FB0CB",
+        "set": {"id":"B235B4BA-6720-11ED-A3DD-67F2793BCB9E"},
+        "name": "my-key",
+        "kid": "42",
+        "jwk": "{\"alg\":\"RSA\",  \"kid\": \"42\",  ...}",
+        "pem": {
+            "private_key": "-----BEGIN",
+            "public_key": "-----BEGIN"
+        },
+        "tags": ["RSA", "ECDSA"],
+        "created_at": 1422386534,
+        "updated_at": 1422386534
+    }],
+
+key_set_body: |
+    Attributes | Description
+    ---:| ---
+    `name`<br>*optional* | The name to associate with the given key-set.
+    `tags`<br>*optional* |  An optional set of strings associated with the Key for grouping and filtering.
+
+key_set_json: |
+    {
+        "id": "24D0DBDA-671C-11ED-BA0B-EF1DCCD3725F",
+        "name": "my-key_set",
+        "tags": ["google-keys", "mozilla-keys"],
+        "created_at": 1422386534,
+        "updated_at": 1422386534
+    }
+
+key_set_data: |
+    "data": [{
+        "id": "46CA83EE-671C-11ED-BFAB-2FE47512C77A",
+        "name": "my-key_set",
+        "tags": ["google-keys", "mozilla-keys"],
+        "created_at": 1422386534,
+        "updated_at": 1422386534
+    }, {
+        "id": "57532ECE-6720-11ED-9297-279D4320B841",
+        "name": "my-key_set",
+        "tags": ["production", "staging", "development"],
+        "created_at": 1422386534,
+        "updated_at": 1422386534
+    }],
+
+filter_chain_body: |
+    Attributes | Description
+    ---:| ---
+    `name` |  The name of the filter chain.
+    `enabled` | Whether the filter chain is applied. Default: `true`.
+    `route`<br>*optional* |  The route to which this chain is applied. A filter chain must be applied to either a single route or a single service. Default: `null`. With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
+    `service`<br>*optional* |  The service to which this chain is applied. A filter chain must be applied to either a single route or a single service. Default: `null`. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
+    `filters` |  An array of filter definitions. Each filter is an object containing a mandatory `name`, an optional `config` and a boolean `enabled` setting.
+    `tags`<br>*optional* |  An optional set of strings associated with the filter chain for grouping and filtering.
+
+filter_chain_json: |
+    {
+        "id": "ce44eef5-41ed-47f6-baab-f725cecf98c7",
+        "name": "my-chain",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "enabled": true,
+        "route": null,
+        "service": "20487393-41ed-47f6-93a8-3407cade2002",,
+        "filters": [
+            {
+                "name": "go-rate-limiting",
+                "enabled": true,
+                "config": "{ \"minute\": 30 }"
+            },
+            {
+                "name": "rust-response-transformer",
+                "enabled": true,
+                "config": "{ \"remove_header\": \"X-Example\" }"
+            }
+        ],
+        "tags": ["my-tag"]
+    }
+
+filter_chain_data: |
+    "data": [{
+        "id": "ce44eef5-41ed-47f6-baab-f725cecf98c7",
+        "name": "my-chain",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "enabled": true,
+        "route": null,
+        "service": "20487393-41ed-47f6-93a8-3407cade2002",,
+        "filters": [
+            {
+                "name": "go-rate-limiting",
+                "enabled": true,
+                "config": "{ \"minute\": 30 }"
+            },
+            {
+                "name": "rust-response-transformer",
+                "enabled": true,
+                "config": "{ \"remove_header\": \"X-Example\" }"
+            }
+        ],
+        "tags": ["my-tag"]
+    }]
+
+filters_data:
+    "filters": [
+        {
+            "config": "{\"minute\": 3}",
+            "enabled": true,
+            "filter_chain": {
+                "id": "0385abc3-f8a7-505b-aeec-9375a298d340",
+                "name": null
+            },
+            "from": "service",
+            "name": "go-rate-limiting"
+        },
+        {
+            "config": "{\"remove_header\": \"X-Example\"}",
+            "enabled": true,
+            "filter_chain": {
+                "id": "d8e9a640-f8a7-505b-aeec-e657383940d6",
+                "name": null
+            },
+            "from": "route",
+            "name": "rust-response-transformer"
+        }
+    ]
+
+
+
+---
+
+{:.note .no-icon }
+> <span class="badge beta"></span> **Kong Gateway API specs now available!**
+> 
+| Spec | Developer portal link | Insomnia link |
+|------|-----------------------|---------------|
+| Enterprise beta API spec|[Dev Portal](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/be79b812-46d5-4cc1-b757-b5270bf4fa60)   | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F3.4%2Fkong-ee-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>  |
+|  Open source beta API spec | [Dev Portal](https://developer.konghq.com/spec/680541e5-de6e-46e5-b43d-0bd1b2369453/e2a0ef29-573d-4fc4-86df-216c417f4aa9)  | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Open%20Source%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F3.4%2Fkong-oss-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
+
+
+<!-- vale off -->
+{% unless page.edition == "gateway" %}
+
+The API for configuring Kong Konnect Runtime Groups.
+
+
+
+
+{% assign prefix = "" %}
+{% if page.edition == "konnect" %}
+{% assign prefix = "/core-entities" %}
+{% endif %}
+
+
+| URL                | Description                                                                                                                         |
+| ---------                | -----------                                                                                                                         |
+| `https://us.api.konghq.com/v2/runtime-groups/{runtime_group_id}`                   | US Region Konnect Platform Base URL |
+| `https://eu.api.konghq.com/v2/runtime-groups/{runtime_group_id}` | EU Region Konnect Platform Base URL |
+       
+
+
+
+This API is similar to the [Kong Gateway admin API](/gateway/admin-api/) with a few notable differences:
+
+* `PATCH` methods are not supported
+> `PATCH` methods are not yet available in the Konnect core entities endpoint. Update operations can be performed with the `PUT` method. 
+
+* Updated error responses
+>  Error responses returned in Konnect core entities endpoint are not compatible with the error responses returned by the Kong Admin APIs.
+
+* `POST` methods only support `application/json`
+> The content types `application/x-www-form-urlencoded` and `multipart/form-data` are not supported in the Konnect core entities endpoint. Please use `application/json`.
+
+* Nested endpoints are not supported
+>  Core entities endpoints include only the top level path. For example, to retrieve a route, only `/routes/{route name or id}` is supported. Nested endpoints are not available in Konnect.
+
+
+## Supported Content Types
+
+
+**application/json**
+
+Handy for complex bodies (ex: complex plugin configuration), in that case send
+a JSON representation of the data you want to send. Example:
+
+```json
+{
+    "config": {
+        "limit": 10,
+        "period": "seconds"
+    }
+}
+```
+
+An example adding a Route to a Service named `test-service`:
+
+```
+curl -i -X POST http://https://us.api.konghq.com/v2/runtime-groups/{runtime_group_id}/core-entities/routes \
+     -H "Content-Type: application/json" \
+     -d '{"name": "test-route", "paths": [ "/path/one", "/path/two" ]}'
+```
+
+## More resources
+
+* [Authentication](/konnect/api/)
+* [Kong Gateway API](/gateway/latest/admin-api/)
+* [Identity Management API](https://developer.konghq.com/spec/5175b87f-bfae-40f6-898d-82d224387f9b/d0e13745-db5c-42d5-80ae-ef803104f5ce)
+* [Runtime Groups API](https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9/)
+* [Plugin Hub](/hub/)
+
+## Nodes
+### List Runtime Instance Records
+
+Returns a list of runtime instance records that are associated to this runtime group. A runtime instance record contains all the metadata information of the Kong Gateway dataplane.
+
+**Endpoint**
+
+<div class="endpoint get">/nodes</div>
+
+**Path Parameters**
+
+| Attribute                | Description                                                                                                                         |
+| ---------                | -----------                                                                                                                         |
+| `page.size`                   | The number of items to include in a page.                                                                                                                 |
+| `page.number` | The specific page number in the collection results. |
+       
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+### Fetch Runtime Instance Record
+
+Retrieve a specific runtime instance record associated to this runtime group. A runtime instance record contains all the metadata information of the Kong Gateway dataplane.
+
+**Endpoint**
+
+<div class="endpoint get">/nodes/{node_id}</div>
+
+**Path Parameters**
+
+| Attribute                | Description                                                                                                                         |
+| ---------                | -----------                                                                                                                         |
+| `node_id`                   | The unique identifier for the runtime instance.                                                                                                                 |
+
+
+**Response**
+
+```
+HTTP 204 OK
+```
+
+### Delete Runtime Instance Record
+
+Remove a specific runtime instance record associated to this runtime group. Deleting this record does not prevent the runtime instance from re-connecting to the runtime group.
+
+**Endpoint**
+
+<div class="endpoint post">/nodes/{node_id}</div>
+
+**Path Parameters**
+
+| Attribute                | Description                                                                                                                         |
+| ---------                | -----------                                                                                                                         |
+| `node_id`                   | The unique identifier for the runtime instance.                                                                                                                 |
+
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+### Fetch Expected Config Hash
+
+Retrieve the expected config hash for this runtime group. The expected config hash can be used to verify if the config hash of a runtime instance is up to date with the conrol plane. If they are in sync, the config hash will be the same. If sync in progress or if out of sync, the config hash will be different. The updated_at timestamp indicates when the config was last updated.
+
+**Endpoint**
+
+<div class="endpoint get">/expected-config-hash</div>
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+## Data plane certificates
+### List data plane client certificates
+
+Returns a list of pinned dataplane client certificates that are associated to this runtime group. A pinned dataplane certificate allows dataplanes configured with the certificate and corresponding private key to establish connection with this runtime group.
+
+**Endpoint**
+
+<div class="endpoint get">/dp-client-certificates</div>
+
+
+**Response**
+
+```
+HTTP 200 OK
+```
+
+### Pin new data plane client certificates
+
+Pin a new DP Client Certificate to this runtime group. A pinned dataplane certificate allows dataplanes configured with the certificate and corresponding private key to establish connection with this runtime group.
+
+**Endpoint**
+
+<div class="endpoint post">/dp-client-certificates</div>
+
+**Response**
+
+```
+HTTP 201 Created
+```
+
+### Fetch data plane client certificate
+
+Retrieve a pinned dataplane client certificate associated to this runtime group. A pinned dataplane certificate allows dataplanes configured with the certificate and corresponding private key to establish connection with this runtime group.
+
+**Endpoint**
+
+<div class="endpoint get">/dp-client-certificates/{certificate_id}</div>
+
+**Response**
+
+```
+HTTP 200 Created
+```
+
+### Replace data plane client certificate
+
+Update a pinned dataplane client certificate associated to this runtime group. A pinned dataplane certificate allows dataplanes configured with the certificate and corresponding private key to establish connection with this runtime group.
+**Endpoint**
+
+<div class="endpoint put">/dp-client-certificates/{certificate_id}</div>
+
+
+**Response**
+
+```
+HTTP 200 Created
+```
+
+### Delete DP Client Certificate
+
+Remove a pinned dataplane client certificate associated to this runtime group. Removing a pinned dataplane certificate would invalidate any dataplanes currently connected to this runtime group using this certificate.
+**Endpoint**
+
+<div class="endpoint delete">/dp-client-certificates/{certificate_id}</div>
+
+**Response**
+```
+HTTP 200 Ok
+```
+
+{% endunless %}
+
+{% unless page.edition == "konnect" %}
+
+{{site.base_gateway}} comes with an **internal** RESTful Admin API for administration purposes.
+ Requests to the Admin API can be sent to any node in the cluster, and Kong will
+ keep the configuration consistent across all nodes.
+
+ - `8001` is the default port on which the Admin API listens.
+ - `8444` is the default port for HTTPS traffic to the Admin API.
+
+ This API is designed for internal use and provides full control over Kong, so
+ care should be taken when setting up Kong environments to avoid undue public
+ exposure of this API. See [this document][secure-admin-api] for a discussion
+ of methods to secure the Admin API.
+
+---
+
+
+
+## DB-less Mode
+
+
+In [DB-less mode](/gateway/{{page.kong_version}}/production/deployment-topologies/db-less-and-declarative-config/),
+the Admin API can be used to load a new declarative
+configuration, and for inspecting the current configuration. In DB-less mode,
+the Admin API for each Kong node functions independently, reflecting the memory state
+of that particular Kong node. This is the case because there is no database
+coordination between Kong nodes.
+
+In DB-less mode, you configure {{site.base_gateway}} declaratively.
+Therefore, the Admin API is mostly read-only. The only tasks it can perform are all
+related to handling the declarative config, including:
+
+* [Validating configurations against schemas](#validate-a-configuration-against-a-schema)
+* [Validating plugin configurations against schemas](#validate-a-plugin-configuration-against-the-schema)
+* [Reloading the declarative configuration](#reload-declarative-configuration)
+* [Setting a target's health status in the load balancer](#set-target-as-healthy)
+
+
+---
+
+
+
+## Declarative Configuration
+
+
+Loading the declarative configuration of entities into {{site.base_gateway}}
+can be done in two ways: at start-up, through the `declarative_config`
+property, or at run-time, through the Admin API using the `/config`
+endpoint.
+
+To get started using declarative configuration, you need a file
+(in YAML or JSON format) containing entity definitions. You can
+generate a sample declarative configuration with the command:
+
+```
+kong config init
+```
+
+It generates a file named `kong.yml` in the current directory,
+containing the appropriate structure and examples.
+
+
+### Reload Declarative Configuration
+
+This endpoint allows resetting a DB-less Kong with a new
+declarative configuration data file. All previous contents
+are erased from memory, and the entities specified in the
+given file take their place.
+
+To learn more about the file format, see the
+[declarative configuration](/gateway/{{page.kong_version}}/production/deployment-topologies/db-less-and-declarative-config) documentation.
+
+
+<div class="endpoint post indent">/config</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`config`<br>**required** | The config data (in YAML or JSON format) to be loaded.
+
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`check_hash`<br>*optional* | If set to 1, Kong will compare the hash of the input config data against that of the previous one. If the configuration is identical, it will not reload it and will return HTTP 304.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+``` json
+{
+    {
+        "services": [],
+        "routes": []
+    }
+}
+```
+
+The response contains a list of all the entities that were parsed from the
+input file.
+
+---
+
+
+## Supported Content Types
+
+The Admin API accepts 3 content types on every endpoint:
+
+- **application/json**
+
+Handy for complex bodies (ex: complex plugin configuration), in that case simply send
+a JSON representation of the data you want to send. Example:
+
+```json
+{
+    "config": {
+        "limit": 10,
+        "period": "seconds"
+    }
+}
+```
+
+An example adding a Route to a Service named `test-service`:
+
+```
+curl -i -X POST http://localhost:8001/services/test-service/routes \
+     -H "Content-Type: application/json" \
+     -d '{"name": "test-route", "paths": [ "/path/one", "/path/two" ]}'
+```
+
+- **application/x-www-form-urlencoded**
+
+Simple enough for basic request bodies, you will probably use it most of the time.
+Note that when sending nested values, Kong expects nested objects to be referenced
+with dotted keys. Example:
+
+```
+config.limit=10&config.period=seconds
+```
+
+When specifying arrays, send the values in order, or use square brackets (numbering
+inside the brackets is optional but if provided it must be 1-indexed, and
+consecutive). An example Route added to a Service named `test-service`:
+
+```
+curl -i -X POST http://localhost:8001/services/test-service/routes \
+     -d "name=test-route" \
+     -d "paths[1]=/path/one" \
+     -d "paths[2]=/path/two"
+```
+
+The following two examples are identical to the one above, but less explicit:
+```
+curl -i -X POST http://localhost:8001/services/test-service/routes \
+     -d "name=test-route" \
+     -d "paths[]=/path/one" \
+     -d "paths[]=/path/two"
+
+curl -i -X POST http://localhost:8001/services/test-service/routes \
+    -d "name=test-route" \
+    -d "paths=/path/one" \
+    -d "paths=/path/two"
+```
+
+
+- **multipart/form-data**
+
+Similar to URL-encoded, this content type uses dotted keys to reference nested
+objects. Here is an example of sending a Lua file to the pre-function Kong plugin:
+
+```
+curl -i -X POST http://localhost:8001/services/plugin-testing/plugins \
+     -F "name=pre-function" \
+     -F "config.access=@custom-auth.lua"
+```
+
+When specifying arrays for this content-type, the array indices must be specified.
+An example Route added to a Service named `test-service`:
+
+```
+curl -i -X POST http://localhost:8001/services/test-service/routes \
+     -F "name=test-route" \
+     -F "paths[1]=/path/one" \
+     -F "paths[2]=/path/two"
+```
+
+---
+
+## Using the API in workspaces 
+{:.badge .enterprise}
+
+{% include_cached /md/gateway/admin-api-workspaces.md %}
+
+---
+
+## Information Routes
+
+
+
+### Retrieve Node Information
+{:.badge .dbless}
+
+Retrieve generic details about a node.
+
+<div class="endpoint get">/</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "hostname": "",
+    "node_id": "6a72192c-a3a1-4c8d-95c6-efabae9fb969",
+    "lua_version": "LuaJIT 2.1.0-beta3",
+    "plugins": {
+        "available_on_server": [
+            ...
+        ],
+        "enabled_in_cluster": [
+            ...
+        ]
+    },
+    "configuration": {
+        ...
+    },
+    "tagline": "Welcome to Kong",
+    "version": "0.14.0"
+}
+```
+
+* `node_id`: A UUID representing the running Kong node. This UUID
+  is randomly generated when Kong starts, so the node will have a
+  different `node_id` each time it is restarted.
+* `available_on_server`: Names of plugins that are installed on the node.
+* `enabled_in_cluster`: Names of plugins that are enabled/configured.
+  That is, the plugins configurations currently in the datastore shared
+  by all Kong nodes.
+
+
+---
+
+### Check Endpoint Or Entity Existence
+{:.badge .dbless}
+
+Similar to `HTTP GET`, but does not return the body. Returns `HTTP 200` when the endpoint exits or `HTTP 404` when it does not. Other status codes are possible.
+
+<div class="endpoint head">/&lt;any-endpoint&gt;</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```http
+Access-Control-Allow-Origin: *
+Content-Length: 11389
+Content-Type: application/json; charset=utf-8
+X-Kong-Admin-Latency: 1
+```
+
+
+---
+
+### List Http Methods by Endpoint
+{:.badge .dbless}
+
+List all the supported `HTTP` methods by an endpoint. This can also be used with a `CORS` preflight request.
+
+<div class="endpoint options">/&lt;any-endpoint&gt;</div>
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+```http
+Access-Control-Allow-Headers: Content-Type
+Access-Control-Allow-Methods: GET, HEAD, OPTIONS
+Access-Control-Allow-Origin: *
+Allow: GET, HEAD, OPTIONS
+```
+
+
+---
+
+### List Available Endpoints
+{:.badge .dbless}
+
+List all available endpoints provided by the Admin API.
+
+<div class="endpoint get">/endpoints</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "data": [
+        "/",
+        "/acls",
+        "/acls/{acls}",
+        "/acls/{acls}/consumer",
+        "/basic-auths",
+        "/basic-auths/{basicauth_credentials}",
+        "/basic-auths/{basicauth_credentials}/consumer",
+        "/ca_certificates",
+        "/ca_certificates/{ca_certificates}",
+        "/cache",
+        "/cache/{key}",
+        "..."
+    ]
+}
+```
+
+
+---
+
+
+
+### Validate A Configuration against A Schema
+{:.badge .dbless}
+
+Check validity of a configuration against its entity schema.
+This allows you to test your input before submitting a request
+to the entity endpoints of the Admin API.
+
+Note that this only performs the schema validation checks,
+checking that the input configuration is well-formed.
+A requests to the entity endpoint using the given configuration
+may still fail due to other reasons, such as invalid foreign
+key relationships or uniqueness check failures against the
+contents of the data store.
+
+
+<div class="endpoint post">/schemas/{entity}/validate</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "message": "schema validation successful"
+}
+```
+
+
+
+---
+
+### Retrieve Entity Schema
+{:.badge .dbless}
+
+Retrieve the schema of an entity. This is useful to
+understand what fields an entity accepts, and can be used for building
+third-party integrations to the Kong.
+
+
+<div class="endpoint get">/schemas/{entity name}</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "fields": [
+        {
+            "id": {
+                "auto": true,
+                "type": "string",
+                "uuid": true
+            }
+        },
+        {
+            "created_at": {
+                "auto": true,
+                "timestamp": true,
+                "type": "integer"
+            }
+        },
+        ...
+    ]
+}
+```
+
+
+---
+{% endunless %}
+
+### Retrieve Plugin Schema
+{:.badge .dbless}
+
+Retrieve the schema of a plugin's configuration. This is useful to
+understand what fields a plugin accepts, and can be used for building
+third-party integrations to the Kong's plugin system.
+
+
+<div class="endpoint get">/schemas/plugins/{plugin name}</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "fields": {
+        "hide_credentials": {
+            "default": false,
+            "type": "boolean"
+        },
+        "key_names": {
+            "default": ["apikey"],
+            "required": true,
+            "type": "array"
+        }
+    }
+}
+```
+
+
+---
+{% unless page.edition == "konnect" %}
+### Validate A Plugin Configuration against The Schema
+{:.badge .dbless}
+
+Check validity of a plugin configuration against the plugins entity schema.
+This allows you to test your input before submitting a request
+to the entity endpoints of the Admin API.
+
+Note that this only performs the schema validation checks,
+checking that the input configuration is well-formed.
+A requests to the entity endpoint using the given configuration
+may still fail due to other reasons, such as invalid foreign
+key relationships or uniqueness check failures against the
+contents of the data store.
+
+
+<div class="endpoint post">/schemas/plugins/validate</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "message": "schema validation successful"
+}
+```
+
+
+---
+
+
+
+### Retrieve Runtime Debugging Info of Kong's Timers
+{:.badge .dbless}
+
+Retrieve runtime stats data from [lua-resty-timer-ng](https://github.com/Kong/lua-resty-timer-ng).
+
+
+<div class="endpoint post">/timers</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{   "worker": {
+      "id": 0,
+      "count": 4,
+    },
+    "stats": {
+      "flamegraph": {
+        "running": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0\n",
+        "elapsed_time": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 17\n",
+        "pending": "@./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0\n"
+      },
+      "sys": {
+          "running": 0,
+          "runs": 7,
+          "pending": 0,
+          "waiting": 7,
+          "total": 7
+      },
+      "timers": {
+          "healthcheck-localhost:8080": {
+              "name": "healthcheck-localhost:8080",
+              "meta": {
+                  "name": "@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()",
+                  "callstack": "@./kong/plugins/prometheus/prometheus.lua:673:init_worker();@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()"
+              },
+              "stats": {
+                  "finish": 2,
+                  "runs": 2,
+                  "elapsed_time": {
+                      "min": 0,
+                      "max": 0,
+                      "avg": 0,
+                      "variance": 0
+                  },
+                  "last_err_msg": ""
+              }
+          }
+      }
+    }
+}
+```
+* `worker`:
+  * `id`: The ordinal number of the current Nginx worker processes (starting from number 0).
+  * `count`: The total number of the Nginx worker processes.
+* `stats.flamegraph`: String-encoded timer-related flamegraph data.
+  You can use [brendangregg/FlameGraph](https://github.com/brendangregg/FlameGraph) to generate flamegraph SVGs.
+* `stats.sys`: List the number of different type of timers.
+  * `running`: number of running timers.
+  * `pending`: number of pending timers.
+  * `waiting`: number of unexpired timers.
+  * `total`: running + pending + waiting.
+* `timers.meta`: Program callstack of created timers.
+  * `name`: An automatically generated string that stores the location where the creation timer was created.
+  * `callstack`: Lua call stack string showing where this timer was created.
+* `timers.stats.elapsed_time`: An object that stores the maximum, minimum, average and variance
+  of the time spent on each run of the timer (second).
+* `timers.stats.runs`: Total number of runs.
+* `timers.stats.finish`: Total number of successful runs.
+
+Note: `flamegraph`, `timers.meta` and `timers.stats.elapsed_time` keys are only available when Kong's `log_level` config is set to `debug`.
+Read the [doc of lua-resty-timer-ng](https://github.com/Kong/lua-resty-timer-ng#stats) for more details.
+
+
+---
+
+## Health Routes
+
+
+
+### Retrieve Node Status
+{:.badge .dbless}
+
+Retrieve usage information about a node, with some basic information
+about the connections being processed by the underlying nginx process,
+the status of the database connection, and node's memory usage.
+
+If you want to monitor the Kong process, since Kong is built on top
+of nginx, every existing nginx monitoring tool or agent can be used.
+
+
+<div class="endpoint get">/status</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "database": {
+      "reachable": true
+    },
+    "memory": {
+        "workers_lua_vms": [{
+            "http_allocated_gc": "0.02 MiB",
+            "pid": 18477
+          }, {
+            "http_allocated_gc": "0.02 MiB",
+            "pid": 18478
+        }],
+        "lua_shared_dicts": {
+            "kong": {
+                "allocated_slabs": "0.04 MiB",
+                "capacity": "5.00 MiB"
+            },
+            "kong_db_cache": {
+                "allocated_slabs": "0.80 MiB",
+                "capacity": "128.00 MiB"
+            },
+        }
+    },
+    "server": {
+        "total_requests": 3,
+        "connections_active": 1,
+        "connections_accepted": 1,
+        "connections_handled": 1,
+        "connections_reading": 0,
+        "connections_writing": 1,
+        "connections_waiting": 0
+    },
+    "configuration_hash": "779742c3d7afee2e38f977044d2ed96b"
+}
+```
+
+* `memory`: Metrics about the memory usage.
+    * `workers_lua_vms`: An array with all workers of the Kong node, where each
+      entry contains:
+    * `http_allocated_gc`: HTTP submodule's Lua virtual machine's memory
+      usage information, as reported by `collectgarbage("count")`, for every
+      active worker, i.e. a worker that received a proxy call in the last 10
+      seconds.
+    * `pid`: worker's process identification number.
+    * `lua_shared_dicts`: An array of information about dictionaries that are
+      shared with all workers in a Kong node, where each array node contains how
+      much memory is dedicated for the specific shared dictionary (`capacity`)
+      and how much of said memory is in use (`allocated_slabs`).
+      These shared dictionaries have least recent used (LRU) eviction
+      capabilities, so a full dictionary, where `allocated_slabs == capacity`,
+      will work properly. However for some dictionaries, e.g. cache HIT/MISS
+      shared dictionaries, increasing their size can be beneficial for the
+      overall performance of a Kong node.
+  * The memory usage unit and precision can be changed using the querystring
+    arguments `unit` and `scale`:
+      * `unit`: one of `b/B`, `k/K`, `m/M`, `g/G`, which will return results
+        in bytes, kibibytes, mebibytes, or gibibytes, respectively. When
+        "bytes" are requested, the memory values in the response will have a
+        number type instead of string. Defaults to `m`.
+      * `scale`: the number of digits to the right of the decimal points when
+        values are given in human-readable memory strings (unit other than
+        "bytes"). Defaults to `2`.
+      You can get the shared dictionaries memory usage in kibibytes with 4
+      digits of precision by doing: `GET /status?unit=k&scale=4`
+* `server`: Metrics about the nginx HTTP/S server.
+    * `total_requests`: The total number of client requests.
+    * `connections_active`: The current number of active client
+      connections including Waiting connections.
+    * `connections_accepted`: The total number of accepted client
+      connections.
+    * `connections_handled`: The total number of handled connections.
+      Generally, the parameter value is the same as accepts unless
+      some resource limits have been reached.
+    * `connections_reading`: The current number of connections
+      where Kong is reading the request header.
+    * `connections_writing`: The current number of connections
+      where nginx is writing the response back to the client.
+    * `connections_waiting`: The current number of idle client
+      connections waiting for a request.
+* `database`: Metrics about the database.
+    * `reachable`: A boolean value reflecting the state of the
+      database connection. Please note that this flag **does not**
+      reflect the health of the database itself.
+* `configuration_hash`: The hash of the current configuration. This
+  field is only returned when the Kong node is running in DB-less
+  or data-plane mode. The special return value "00000000000000000000000000000000"
+  means Kong does not currently have a valid configuration loaded.
+
+{% endunless %}
+
+---
+
+{% unless page.edition == "konnect" %}
+
+## Tags
+
+Tags are strings associated to entities in Kong.
+
+Tags can contain almost all UTF-8 characters, with the following exceptions:
+
+- `,` and `/` are reserved for filtering tags with "and" and "or", so they are not allowed in tags.
+- Non-printable ASCII (for example, the space character) is not allowed.
+
+Most core entities can be *tagged* via their `tags` attribute, upon creation or edition.
+
+Tags can be used to filter core entities as well, via the `?tags` querystring parameter.
+
+For example: if you normally get a list of all the Services by doing:
+
+```
+GET /services
+```
+
+You can get the list of all the Services tagged `example` by doing:
+
+```
+GET /services?tags=example
+```
+
+Similarly, if you want to filter Services so that you only get the ones tagged `example` *and*
+`admin`, you can do that like so:
+
+```
+GET /services?tags=example,admin
+```
+
+Finally, if you wanted to filter the Services tagged `example` *or* `admin`, you could use:
+
+```
+GET /services?tags=example/admin
+```
+
+Some notes:
+
+* A maximum of 5 tags can be queried simultaneously in a single request with `,` or `/`
+* Mixing operators is not supported: if you try to mix `,` with `/` in the same querystring,
+  you will receive an error.
+* You may need to quote and/or escape some characters when using them from the
+  command line.
+* Filtering by `tags` is not supported in foreign key relationship endpoints. For example,
+  the `tags` parameter will be ignored in a request such as `GET /services/foo/routes?tags=a,b`
+* `offset` parameters are not guaranteed to work if the `tags` parameter is altered or removed
+
+
+### List All Tags
+{:.badge .dbless}
+
+Returns a paginated list of all the tags in the system.
+
+The list of entities will not be restricted to a single entity type: all the
+entities tagged with tags will be present on this list.
+
+If an entity is tagged with more than one tag, the `entity_id` for that entity
+will appear more than once in the resulting list. Similarly, if several entities
+have been tagged with the same tag, the tag will appear in several items of this list.
+
+
+<div class="endpoint get">/tags</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+``` json
+{
+    {
+      "data": [
+        { "entity_name": "services",
+          "entity_id": "acf60b10-125c-4c1a-bffe-6ed55daefba4",
+          "tag": "s1",
+        },
+        { "entity_name": "services",
+          "entity_id": "acf60b10-125c-4c1a-bffe-6ed55daefba4",
+          "tag": "s2",
+        },
+        { "entity_name": "routes",
+          "entity_id": "60631e85-ba6d-4c59-bd28-e36dd90f6000",
+          "tag": "s1",
+        },
+        ...
+      ],
+      "offset": "c47139f3-d780-483d-8a97-17e9adc5a7ab",
+      "next": "/tags?offset=c47139f3-d780-483d-8a97-17e9adc5a7ab",
+    }
+}
+```
+
+
+---
+
+### List Entity Ids by Tag
+{:.badge .dbless}
+
+Returns the entities that have been tagged with the specified tag.
+
+The list of entities will not be restricted to a single entity type: all the
+entities tagged with tags will be present on this list.
+
+
+<div class="endpoint get">/tags/{tags}</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+``` json
+{
+    {
+      "data": [
+        { "entity_name": "services",
+          "entity_id": "c87440e1-0496-420b-b06f-dac59544bb6c",
+          "tag": "example",
+        },
+        { "entity_name": "routes",
+          "entity_id": "8a99e4b1-d268-446b-ab8b-cd25cff129b1",
+          "tag": "example",
+        },
+        ...
+      ],
+      "offset": "1fb491c4-f4a7-4bca-aeba-7f3bcee4d2f9",
+      "next": "/tags/example?offset=1fb491c4-f4a7-4bca-aeba-7f3bcee4d2f9",
+    }
+}
+```
+
+
+---
+
+## Debug Routes
+
+
+
+### Set Node Log Level of All Control Plane Nodes
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+ Change the log level of all Control Plane nodes deployed in Hybrid
+ (CP/DP) cluster.
+
+ See http://nginx.org/en/docs/ngx_core_module.html#error_log for a
+ list of accepted values.
+
+ Care must be taken when changing the log level of a node to `debug`
+ in a production environment because the disk could fill up
+ quickly. As soon as the debug logging finishes, revert
+ back to a higher level such as `notice`.
+
+ It's currently not possible to change the log level of DP and
+ DB-less nodes.
+
+ If using Kong Gateway Enterprise, this endpoint can be [RBAC-protected](https://docs.konghq.com/gateway/latest/admin-api/rbac/reference/#add-a-role-endpoint-permission)
+
+ If using Kong Gateway Enterprise, changes to the log level will be reflected in the [Audit Logs](https://docs.konghq.com/gateway/latest/kong-enterprise/audit-log/).
+
+ The log level change is propagated to all Nginx workers of a node,
+ including to newly spawned workers.
+
+ Currently, when a user dynamically changes the log level for the
+ entire cluster, if a new node joins the cluster, the new node will
+ run at the previous log level, not at the log level that was
+previously set dynamically for the entire cluster. To work around that, make
+ sure the new node starts with the proper level by setting the
+ startup `kong.conf` setting [KONG_LOG_LEVEL](https://docs.konghq.com/gateway/latest/reference/configuration/#log_level).
+
+
+<div class="endpoint put indent">/debug/cluster/control-planes-nodes/log-level/{log_level}</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "message": "log level changed"
+}
+```
+
+
+---
+
+### Set Node Log Level of All Nodes
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Change the log level of all nodes in a cluster.
+
+See http://nginx.org/en/docs/ngx_core_module.html#error_log for a
+list of accepted values.
+
+Care must be taken when changing the log level of a node to `debug`
+in a production environment because the disk could fill up
+quickly. As soon as the debug logging finishes, ensure to revert
+back to a higher level such as `notice`.
+
+It's currently not possible to change the log level of DP and
+DB-less nodes.
+
+If using Kong Gateway Enterprise, this endpoint can be [RBAC-protected](https://docs.konghq.com/gateway/latest/admin-api/rbac/reference/#add-a-role-endpoint-permission)
+
+If using Kong Gateway Enterprise, changes to the log level will be reflected in the [Audit Logs](https://docs.konghq.com/gateway/latest/kong-enterprise/audit-log/).
+
+The log level change is propagated to all Nginx workers of a node,
+including to newly spawned workers.
+
+Currently, when a user dynamically changes the log level for the
+entire cluster, if a new node joins a cluster the new node will
+run at the previous log level, not at the log level that was
+previously set dynamically for the entire cluster. To work around that, make
+sure the new node starts with the proper level by setting the
+startup `kong.conf` setting [KONG_LOG_LEVEL](https://docs.konghq.com/gateway/latest/reference/configuration/#log_level).
+
+
+<div class="endpoint put indent">/debug/cluster/log-level/{log_level}</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "message": "log level changed"
+}
+```
+
+
+---
+
+### Retrieve Node Log Level of A Node
+{:.badge .dbless}
+
+Retrieve the current log level of a node.
+
+See http://nginx.org/en/docs/ngx_core_module.html#error_log for
+the list of possible return values.
+
+
+<div class="endpoint get">/debug/node/log-level</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "message": "log level: debug"
+}
+```
+
+
+---
+
+### Set Log Level of A Single Node
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Change the log level of a node.
+
+See http://nginx.org/en/docs/ngx_core_module.html#error_log for a
+list of accepted values.
+
+Care must be taken when changing the log level of a node to `debug`
+in a production environment because the disk could fill up
+quickly. As soon as the debug logging finishes, revert
+back to a higher level such as `notice`.
+
+It's currently not possible to change the log level of DP and
+DB-less nodes.
+
+If using Kong Gateway Enterprise, this endpoint can be [RBAC-protected](https://docs.konghq.com/gateway/latest/admin-api/rbac/reference/#add-a-role-endpoint-permission)
+
+If using Kong Gateway Enterprise, changes to the log level will be reflected in the [Audit Logs](https://docs.konghq.com/gateway/latest/kong-enterprise/audit-log/).
+
+The log level change is propagated to all Nginx workers of a node,
+including to newly spawned workers.
+
+
+<div class="endpoint put indent">/debug/node/log-level/{log_level}</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "message": "log level changed"
+}
+```
+
+{% endunless %}
+
+---
+
+
+
+## Service Object
+
+Service entities, as the name implies, are abstractions of each of your own
+upstream services. Examples of Services would be a data transformation
+microservice, a billing API, etc.
+
+The main attribute of a Service is its URL (where Kong should proxy traffic
+to), which can be set as a single string or by specifying its `protocol`,
+`host`, `port` and `path` individually.
+
+Services are associated to Routes (a Service can have many Routes associated
+with it). Routes are entry-points in Kong and define rules to match client
+requests. Once a Route is matched, Kong proxies the request to its associated
+Service. See the [Proxy Reference][proxy-reference] for a detailed explanation
+of how Kong proxies traffic.
+
+Services can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.service_json }}
+```
+
+### Add Service
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Service
+
+<div class="endpoint post indent">{{ prefix }}/services</div>
+
+{% unless page.edition == "konnect" %}
+##### Create Service Associated to a Specific Certificate
+
+<div class="endpoint post indent">/certificates/{certificate name or id}/services</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate that should be associated to the newly-created Service.
+
+{% endunless %}
+#### Request Body
+
+{{ page.service_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.service_json }}
+```
+
+
+---
+
+### List Services
+{:.badge .dbless}
+
+##### List All Services
+
+<div class="endpoint get indent">{{ prefix }}/services</div>
+
+{% unless page.edition == "konnect" %}
+##### List Services Associated to a Specific Certificate
+
+<div class="endpoint get indent">/certificates/{certificate name or id}/services</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate whose Services are to be retrieved. When using this endpoint, only Services associated to the specified Certificate will be listed.
+
+{% endunless %}
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.service_data }}
+    "next": "http://localhost:8001/services?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Service
+{:.badge .dbless}
+
+##### Retrieve Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to retrieve.
+
+{% unless page.edition == "konnect" %}
+##### Retrieve Service Associated to a Specific Certificate
+
+<div class="endpoint get indent">/certificates/{certificate id}/services/{service name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to retrieve.
+
+
+##### Retrieve Service Associated to a Specific Route
+
+<div class="endpoint get indent">/routes/{route name or id}/service</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be retrieved.
+
+
+##### Retrieve Service Associated to a Specific Plugin
+
+<div class="endpoint get indent">/plugins/{plugin id}/service</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be retrieved.
+
+{% endunless %}
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.service_json }}
+```
+
+
+---
+
+### Update Service
+
+{% unless page.edition == "konnect" %}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Service
+
+<div class="endpoint patch indent">/services/{service name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to update.
+
+
+##### Update Service Associated to a Specific Certificate
+
+<div class="endpoint patch indent">/certificates/{certificate id}/services/{service name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to update.
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to update.
+
+
+##### Update Service Associated to a Specific Route
+
+<div class="endpoint patch indent">/routes/{route name or id}/service</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be updated.
+
+
+##### Update Service Associated to a Specific Plugin
+
+<div class="endpoint patch indent">/plugins/{plugin id}/service</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be updated.
+
+
+#### Request Body
+
+{{ page.service_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.service_json }}
+```
+
+
+---
+{% endunless %}
+### Update Or Create Service
+
+
+{% unless page.edition == "konnect" %}
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+{% endunless %}
+##### Create Or Update Service
+
+<div class="endpoint put indent">{{ prefix }}/services/{service name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to create or update.
+
+{% unless page.edition == "konnect" %}
+##### Create Or Update Service Associated to a Specific Certificate
+
+<div class="endpoint put indent">/certificates/{certificate id}/services/{service name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to create or update.
+
+
+##### Create Or Update Service Associated to a Specific Route
+
+<div class="endpoint put indent">/routes/{route name or id}/service</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route associated to the Service to be created or updated.
+
+
+##### Create Or Update Service Associated to a Specific Plugin
+
+<div class="endpoint put indent">/plugins/{plugin id}/service</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Service to be created or updated.
+
+{% endunless %}
+#### Request Body
+
+{{ page.service_body }}
+
+
+Inserts (or replaces) the Service under the requested resource with the
+definition specified in the body. The Service will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Service being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Service without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+
+{% endunless %}
+---
+
+### Delete Service
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Service
+
+<div class="endpoint delete indent">{{ prefix }}/services/{service name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
+
+{% unless page.edition == "konnect" %}
+##### Delete Service Associated to a Specific Certificate
+
+<div class="endpoint delete indent">/certificates/{certificate id}/services/{service name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to delete.
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
+{% endunless %}
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+## Route Object
+
+Route entities define rules to match client requests. Each Route is
+associated with a Service, and a Service may have multiple Routes associated to
+it. Every request matching a given Route will be proxied to its associated
+Service.
+
+The combination of Routes and Services (and the separation of concerns between
+them) offers a powerful routing mechanism with which it is possible to define
+fine-grained entry-points in Kong leading to different upstream services of
+your infrastructure.
+
+You need at least one matching rule that applies to the protocol being matched
+by the Route. Depending on the protocols configured to be matched by the Route
+(as defined with the `protocols` field), this means that at least one of the
+following attributes must be set:
+
+* For `http`, at least one of `methods`, `hosts`, `headers` or `paths`;
+* For `https`, at least one of `methods`, `hosts`, `headers`, `paths` or `snis`;
+* For `tcp`, at least one of `sources` or `destinations`;
+* For `tls`, at least one of `sources`, `destinations` or `snis`;
+* For `tls_passthrough`, set `snis`;
+* For `grpc`, at least one of `hosts`, `headers` or `paths`;
+* For `grpcs`, at least one of `hosts`, `headers`, `paths` or `snis`;
+* For `ws`, at least one of `hosts`, `headers` or `paths`; <span class="badge enterprise"></span>
+* For `wss`, at least one of `hosts`, `headers`, `paths` or `snis`. <span class="badge enterprise"></span>
+
+A route can't have both `tls` and `tls_passthrough` protocols at same time.
+
+The 3.0.x release introduces a new router implementation: `atc-router`.
+The router adds:
+
+* Reduced router rebuild time when changing Kong’s configuration
+* Increased runtime performance when routing requests
+* Reduced P99 latency from 1.5s to 0.1s with 10,000 routes
+
+Learn more about the router:
+
+[Configure routes using expressions](/gateway/{{page.kong_version}}/key-concepts/routes/expressions)
+[Router Expressions language reference](/gateway/{{page.kong_version}}/reference/router-expressions-language/)
+
+
+#### Path handling algorithms
+
+{:.note}
+> **Note**: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when `router_flavor`
+> is set to `expressions`, `route.path_handling` will be unconfigurable and the path handling behavior
+> will be `"v0"`; when `router_flavor` is set to `traditional_compatible`, the path handling behavior
+> will be `"v0"` regardless of the value of `route.path_handling`. Only `router_flavor` = `traditional`
+> will support `path_handling` `"v1'` behavior.
+
+`"v0"` is the behavior used in Kong 0.x, 2.x and 3.x. It treats `service.path`, `route.path` and request path as
+*segments* of a URL. It will always join them via slashes. Given a service path `/s`, route path `/r`
+and request path `/re`, the concatenated path will be `/s/re`. If the resulting path is a single slash,
+no further transformation is done to it. If it's longer, then the trailing slash is removed.
+
+`"v1"` is the behavior used in Kong 1.x. It treats `service.path` as a *prefix*, and ignores the initial
+slashes of the request and route paths. Given service path `/s`, route path `/r` and request path `/re`,
+the concatenated path will be `/sre`.
+
+Both versions of the algorithm detect "double slashes" when combining paths, replacing them by single
+slashes.
+
+The following table shows the possible combinations of path handling version, strip path, and request:
+
+| `service.path` | `route.path` | `request` |`route.strip_path` | `route.path_handling` | request path | upstream path |
+|----------------|--------------|-----------|-------------------|-----------------------|--------------|---------------|
+| `/s`           | `/fv0`       | `req`     | `false`           | `v0`                  |  `/fv0/req`  | `/s/fv0/req`  |
+| `/s`           | `/fv0`       | `blank`   | `false`           | `v0`                  |  `/fv0`      | `/s/fv0`      |
+| `/s`           | `/fv1`       | `req`     | `false`           | `v1`                  |  `/fv1/req`  | `/sfv1/req`   |
+| `/s`           | `/fv1`       | `blank`   | `false`           | `v1`                  |  `/fv1`      | `/sfv1`       |
+| `/s`           | `/tv0`       | `req`     | `true`            | `v0`                  |  `/tv0/req`  | `/s/req`      |
+| `/s`           | `/tv0`       | `blank`   | `true`            | `v0`                  |  `/tv0`      | `/s`          |
+| `/s`           | `/tv1`       | `req`     | `true`            | `v1`                  |  `/tv1/req`  | `/s/req`      |
+| `/s`           | `/tv1`       | `blank`   | `true`            | `v1`                  |  `/tv1`      | `/s`          |
+| `/s`           | `/fv0/`      | `req`     | `false`           | `v0`                  |  `/fv0/req`  | `/s/fv0/req`  |
+| `/s`           | `/fv0/`      | `blank`   | `false`           | `v0`                  |  `/fv0/`     | `/s/fv01/`    |
+| `/s`           | `/fv1/`      | `req`     | `false`           | `v1`                  |  `/fv1/req`  | `/sfv1/req`   |
+| `/s`           | `/fv1/`      | `blank`   | `false`           | `v1`                  |  `/fv1/`     | `/sfv1/`      |
+| `/s`           | `/tv0/`      | `req`     | `true`            | `v0`                  |  `/tv0/req`  | `/s/req`      |
+| `/s`           | `/tv0/`      | `blank`   | `true`            | `v0`                  |  `/tv0/`     | `/s/`         |
+| `/s`           | `/tv1/`      | `req`     | `true`            | `v1`                  |  `/tv1/req`  | `/sreq`       |
+| `/s`           | `/tv1/`      | `blank`   | `true`            | `v1`                  |  `/tv1/`     | `/s`          |
+
+
+Routes can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.route_json }}
+```
+
+### Add Route
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Route
+
+<div class="endpoint post indent">{{ prefix }}/routes</div>
+
+
+##### Create Route Associated to a Specific Service
+
+<div class="endpoint post indent">{{ prefix }}/services/{service name or id}/routes</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service that should be associated to the newly-created Route.
+
+
+#### Request Body
+
+{{ page.route_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.route_json }}
+```
+
+
+---
+
+### List Routes
+{:.badge .dbless}
+
+##### List All Routes
+
+<div class="endpoint get indent">{{ prefix }}/routes</div>
+
+
+##### List Routes Associated to a Specific Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}/routes</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service whose Routes are to be retrieved. When using this endpoint, only Routes associated to the specified Service will be listed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.route_data }}
+    "next": "http://localhost:8001/routes?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Route
+{:.badge .dbless}
+
+##### Retrieve Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to retrieve.
+
+
+##### Retrieve Route Associated to a Specific Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}/routes/{route name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to retrieve.
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to retrieve.
+
+{% unless page.edition == "konnect" %}
+##### Retrieve Route Associated to a Specific Plugin
+
+<div class="endpoint get indent">/plugins/{plugin id}/route</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be retrieved.
+
+{% endunless %}
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.route_json }}
+```
+
+
+---
+{% unless page.edition == "konnect" %}
+### Update Route
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Route
+
+<div class="endpoint patch indent">/routes/{route name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to update.
+
+
+##### Update Route Associated to a Specific Service
+
+<div class="endpoint patch indent">/services/{service name or id}/routes/{route name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to update.
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to update.
+
+
+##### Update Route Associated to a Specific Plugin
+
+<div class="endpoint patch indent">/plugins/{plugin id}/route</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be updated.
+
+
+#### Request Body
+
+{{ page.route_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.route_json }}
+```
+
+
+---
+{% endunless %}
+### Update Or Create Route
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Route
+
+<div class="endpoint put indent">{{ prefix }}/routes/{route name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to create or update.
+
+
+##### Create Or Update Route Associated to a Specific Service
+
+<div class="endpoint put indent">{{ prefix }}/services/{service name or id}/routes/{route name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to create or update.
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to create or update.
+
+{% unless page.edition == "konnect" %}
+##### Create Or Update Route Associated to a Specific Plugin
+
+<div class="endpoint put indent">/plugins/{plugin id}/route</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Route to be created or updated.
+
+{% endunless %}
+#### Request Body
+
+{{ page.route_body }}
+
+
+Inserts (or replaces) the Route under the requested resource with the
+definition specified in the body. The Route will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Route being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Route without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+---
+
+### Delete Route
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Route
+
+<div class="endpoint delete indent">{{ prefix }}/routes/{route name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to delete.
+
+{% unless page.edition == "konnect" %}
+##### Delete Route Associated to a Specific Service
+
+<div class="endpoint delete indent">/services/{service name or id}/routes/{route name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to delete.
+{% endunless %}
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+## Consumer Object
+
+The Consumer object represents a consumer - or a user - of a Service. You can
+either rely on Kong as the primary datastore, or you can map the consumer list
+with your database to keep consistency between Kong and your existing primary
+datastore.
+
+Consumers can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.consumer_json }}
+```
+
+### Add Consumer
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Consumer
+
+<div class="endpoint post indent">{{ prefix }}/consumers</div>
+
+
+#### Request Body
+
+{{ page.consumer_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.consumer_json }}
+```
+
+
+---
+
+### List Consumers
+{:.badge .dbless}
+
+##### List All Consumers
+
+<div class="endpoint get indent">{{ prefix }}/consumers</div>
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.consumer_data }}
+    "next": "http://localhost:8001/consumers?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Consumer
+{:.badge .dbless}
+
+##### Retrieve Consumer
+
+<div class="endpoint get indent">{{ prefix }}/consumers/{consumer username or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer username or id`<br>**required** | The unique identifier **or** the username of the Consumer to retrieve.
+
+{% unless page.edition == "konnect" %}
+##### Retrieve Consumer Associated to a Specific Plugin
+
+<div class="endpoint get indent">/plugins/{plugin id}/consumer</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be retrieved.
+
+{% endunless %}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.consumer_json }}
+```
+
+
+---
+{% unless page.edition == "konnect" %}
+
+### Update Consumer
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Consumer
+
+<div class="endpoint patch indent">/consumers/{consumer username or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer username or id`<br>**required** | The unique identifier **or** the username of the Consumer to update.
+
+
+##### Update Consumer Associated to a Specific Plugin
+
+<div class="endpoint patch indent">/plugins/{plugin id}/consumer</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be updated.
+
+
+#### Request Body
+
+{{ page.consumer_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.consumer_json }}
+```
+
+
+---
+{% endunless %}
+### Update Or Create Consumer
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Consumer
+
+<div class="endpoint put indent">{{ prefix }}/consumers/{consumer username or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer username or id`<br>**required** | The unique identifier **or** the username of the Consumer to create or update.
+
+{% unless page.edition == "konnect" %}
+##### Create Or Update Consumer Associated to a Specific Plugin
+
+<div class="endpoint put indent">/plugins/{plugin id}/consumer</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin associated to the Consumer to be created or updated.
+
+{% endunless %}
+#### Request Body
+
+{{ page.consumer_body }}
+
+
+Inserts (or replaces) the Consumer under the requested resource with the
+definition specified in the body. The Consumer will be identified via the `username
+or id` attribute.
+
+When the `username or id` attribute has the structure of a UUID, the Consumer being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `username`.
+
+When creating a new Consumer without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `username` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+---
+
+### Delete Consumer
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Consumer
+
+<div class="endpoint delete indent">{{ prefix }}/consumers/{consumer username or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer username or id`<br>**required** | The unique identifier **or** the username of the Consumer to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+## Plugin Object
+
+A Plugin entity represents a plugin configuration that will be executed during
+the HTTP request/response lifecycle. It is how you can add functionalities
+to Services that run behind Kong, like Authentication or Rate Limiting for
+example. You can find more information about how to install and what values
+each plugin takes by visiting the [Kong Hub](https://docs.konghq.com/hub/).
+
+When adding a Plugin Configuration to a Service, every request made by a client to
+that Service will run said Plugin. If a Plugin needs to be tuned to different
+values for some specific Consumers, you can do so by creating a separate
+plugin instance that specifies both the Service and the Consumer, through the
+`service` and `consumer` fields.
+
+Plugins can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.plugin_json }}
+```
+
+See the [Precedence](#precedence) section below for more details.
+
+#### Precedence
+
+A plugin will always be run once and only once per request. But the
+configuration with which it will run depends on the entities it has been
+configured for.
+{% unless page.edition == "konnect" %}
+Plugins can be configured for various entities, combination of entities, or
+even globally. This is useful, for example, when you wish to configure a plugin
+a certain way for most requests, but make _authenticated requests_ behave
+slightly differently.
+
+Therefore, there is an order of precedence for running a plugin when it has
+been applied to different entities with different configurations. The amount of entities configured to a specific plugin directly correlate to its priority. The more entities configured to a plugin the higher its order of precedence is. 
+The complete order of precedence for plugins configured to multiple entities is: 
+
+
+{% if_version gte:3.4.x %}
+
+1. Plugins configured on a combination of: a Consumer, a Route, and a Service.
+    (Consumer means the request must be authenticated).
+2. Plugins configured on a combination of a ConsumerGroup, Service, and a Route.
+    (ConsumerGroup means the request must be authenticated).
+3. Plugins configured on a combination of a Consumer and a Route.
+    (Consumer means the request must be authenticated).
+4. Plugins configured on a combination of a Consumer and a Service.
+5. Plugins configured on a ConsumerGroup and Route.
+6. Plugins configured on a ConsumerGroup and Service.
+7. Plugins configured on a Route and Service.
+8. Plugins configured on a Consumer.
+9. Plugins Configured on a ConsumerGroup.
+10. Plugins configured on a Route.
+11. Plugins configured on a Service. 
+12. Plugins configured Globally. 
+
+{% endif_version %}
+
+{% if_version lte:3.3.x %}
+1. Plugins configured on a combination of: a Route, a Service, and a Consumer.
+    (Consumer means the request must be authenticated).
+2. Plugins configured on a combination of a Route and a Consumer.
+    (Consumer means the request must be authenticated).
+3. Plugins configured on a combination of a Service and a Consumer.
+    (Consumer means the request must be authenticated).
+4. Plugins configured on a combination of a Route and a Service.
+5. Plugins configured on a Consumer.
+    (Consumer means the request must be authenticated).
+6. Plugins configured on a Route.
+7. Plugins configured on a Service.
+8. Plugins configured to run globally.
+
+{% endif_version %}
+
+
+{% endunless %}
+
+**Example**: if the `rate-limiting` plugin is applied twice (with different
+configurations): for a Service (Plugin config A), and for a Consumer (Plugin
+config B), then requests authenticating this Consumer will run Plugin config B
+and ignore A. However, requests that do not authenticate this Consumer will
+fallback to running Plugin config A. Note that if config B is disabled
+(its `enabled` flag is set to `false`), config A will apply to requests that
+would have otherwise matched config B.
+
+
+### Add Plugin
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Plugin
+
+<div class="endpoint post indent">{{ prefix }}/plugins</div>
+
+
+##### Create Plugin Associated to a Specific Route
+
+<div class="endpoint post indent">{{ prefix }}/routes/{route name or id}/plugins</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route that should be associated to the newly-created Plugin.
+
+
+##### Create Plugin Associated to a Specific Service
+
+<div class="endpoint post indent">{{ prefix }}/services/{service name or id}/plugins</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service that should be associated to the newly-created Plugin.
+
+
+##### Create Plugin Associated to a Specific Consumer
+
+<div class="endpoint post indent">{{ prefix }}/consumers/{consumer name or id}/plugins</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer name or id`<br>**required** | The unique identifier or the `name` attribute of the Consumer that should be associated to the newly-created Plugin.
+
+
+#### Request Body
+
+{{ page.plugin_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.plugin_json }}
+```
+
+
+---
+
+### List Plugins
+{:.badge .dbless}
+
+##### List All Plugins
+
+<div class="endpoint get indent">{{ prefix }}/plugins</div>
+
+
+##### List Plugins Associated to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/plugins</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose Plugins are to be retrieved. When using this endpoint, only Plugins associated to the specified Route will be listed.
+
+
+##### List Plugins Associated to a Specific Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}/plugins</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service whose Plugins are to be retrieved. When using this endpoint, only Plugins associated to the specified Service will be listed.
+
+
+##### List Plugins Associated to a Specific Consumer
+
+<div class="endpoint get indent">{{ prefix }}/consumers/{consumer name or id}/plugins</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer name or id`<br>**required** | The unique identifier or the `name` attribute of the Consumer whose Plugins are to be retrieved. When using this endpoint, only Plugins associated to the specified Consumer will be listed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.plugin_data }}
+    "next": "http://localhost:8001/plugins?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Plugin
+{:.badge .dbless}
+
+##### Retrieve Plugin
+
+<div class="endpoint get indent">{{ prefix }}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin to retrieve.
+
+
+##### Retrieve Plugin Associated to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to retrieve.
+`plugin id`<br>**required** | The unique identifier of the Plugin to retrieve.
+
+
+##### Retrieve Plugin Associated to a Specific Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to retrieve.
+`plugin id`<br>**required** | The unique identifier of the Plugin to retrieve.
+
+
+##### Retrieve Plugin Associated to a Specific Consumer
+
+<div class="endpoint get indent">{{ prefix }}/consumers/{consumer username or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer username or id`<br>**required** | The unique identifier **or** the username of the Consumer to retrieve.
+`plugin id`<br>**required** | The unique identifier of the Plugin to retrieve.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.plugin_json }}
+```
+
+
+---
+{% unless page.edition == "konnect" %}
+
+### Update Plugin
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Plugin
+
+<div class="endpoint patch indent">/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin to update.
+
+
+##### Update Plugin Associated to a Specific Route
+
+<div class="endpoint patch indent">/routes/{route name or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to update.
+`plugin id`<br>**required** | The unique identifier of the Plugin to update.
+
+
+##### Update Plugin Associated to a Specific Service
+
+<div class="endpoint patch indent">/services/{service name or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to update.
+`plugin id`<br>**required** | The unique identifier of the Plugin to update.
+
+
+##### Update Plugin Associated to a Specific Consumer
+
+<div class="endpoint patch indent">/consumers/{consumer username or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer username or id`<br>**required** | The unique identifier **or** the username of the Consumer to update.
+`plugin id`<br>**required** | The unique identifier of the Plugin to update.
+
+
+#### Request Body
+
+{{ page.plugin_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.plugin_json }}
+```
+
+{% endunless %}
+---
+
+### Update Or Create Plugin
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Plugin
+
+<div class="endpoint put indent">{{ prefix }}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin to create or update.
+
+
+##### Create Or Update Plugin Associated to a Specific Route
+
+<div class="endpoint put indent">{{ prefix }}/routes/{route name or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to create or update.
+`plugin id`<br>**required** | The unique identifier of the Plugin to create or update.
+
+
+##### Create Or Update Plugin Associated to a Specific Service
+
+<div class="endpoint put indent">{{ prefix }}/services/{service name or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to create or update.
+`plugin id`<br>**required** | The unique identifier of the Plugin to create or update.
+
+
+##### Create Or Update Plugin Associated to a Specific Consumer
+
+<div class="endpoint put indent">{{ prefix }}/consumers/{consumer username or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer username or id`<br>**required** | The unique identifier **or** the username of the Consumer to create or update.
+`plugin id`<br>**required** | The unique identifier of the Plugin to create or update.
+
+
+#### Request Body
+
+{{ page.plugin_body }}
+
+
+Inserts (or replaces) the Plugin under the requested resource with the
+definition specified in the body. The Plugin will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Plugin being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Plugin without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+---
+
+### Delete Plugin
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Plugin
+
+<div class="endpoint delete indent">{{ prefix }}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`plugin id`<br>**required** | The unique identifier of the Plugin to delete.
+
+
+##### Delete Plugin Associated to a Specific Route
+
+<div class="endpoint delete indent">{{ prefix }}/routes/{route name or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to delete.
+`plugin id`<br>**required** | The unique identifier of the Plugin to delete.
+
+
+##### Delete Plugin Associated to a Specific Service
+
+<div class="endpoint delete indent">{{ prefix }}/services/{service name or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
+`plugin id`<br>**required** | The unique identifier of the Plugin to delete.
+
+
+##### Delete Plugin Associated to a Specific Consumer
+
+<div class="endpoint delete indent">{{ prefix }}/consumers/{consumer username or id}/plugins/{plugin id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`consumer username or id`<br>**required** | The unique identifier **or** the username of the Consumer to delete.
+`plugin id`<br>**required** | The unique identifier of the Plugin to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+{% unless page.edition == "konnect" %}
+
+### Retrieve Enabled Plugins
+{:.badge .dbless}
+
+Retrieve a list of all installed plugins on the Kong node.
+
+<div class="endpoint get">/plugins/enabled</div>
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "enabled_plugins": [
+        "jwt",
+        "acl",
+        "cors",
+        "oauth2",
+        "tcp-log",
+        "udp-log",
+        "file-log",
+        "http-log",
+        "key-auth",
+        "hmac-auth",
+        "basic-auth",
+        "ip-restriction",
+        "request-transformer",
+        "response-transformer",
+        "request-size-limiting",
+        "rate-limiting",
+        "response-ratelimiting",
+        "aws-lambda",
+        "bot-detection",
+        "correlation-id",
+        "datadog",
+        "galileo",
+        "ldap-auth",
+        "loggly",
+        "statsd",
+        "syslog"
+    ]
+}
+```
+
+
+---
+{% endunless %}
+
+## Certificate Object
+
+A certificate object represents a public certificate, and can be optionally paired with the
+corresponding private key. These objects are used by Kong to handle SSL/TLS termination for
+encrypted requests, or for use as a trusted CA store when validating peer certificate of
+client/service. Certificates are optionally associated with SNI objects to
+tie a cert/key pair to one or more hostnames.
+
+If intermediate certificates are required in addition to the main
+certificate, they should be concatenated together into one string according to
+the following order: main certificate on the top, followed by any intermediates.
+
+Certificates can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.certificate_json }}
+```
+
+### Add Certificate
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Certificate
+
+<div class="endpoint post indent">{{ prefix }}/certificates</div>
+
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.certificate_json }}
+```
+
+
+---
+
+### List Certificates
+{:.badge .dbless}
+
+##### List All Certificates
+
+<div class="endpoint get indent">{{ prefix }}/certificates</div>
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.certificate_data }}
+    "next": "http://localhost:8001/certificates?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Certificate
+{:.badge .dbless}
+
+##### Retrieve Certificate
+
+<div class="endpoint get indent">{{ prefix }}/certificates/{certificate id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
+
+{% unless page.edition == "konnect" %}
+
+##### Retrieve Certificate Associated to a Specific Upstream
+
+<div class="endpoint get indent">/upstreams/{upstream name or id}/client_certificate</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream associated to the Certificate to be retrieved.
+
+{% endunless %}
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.certificate_json }}
+```
+
+
+---
+
+### Update Certificate
+
+
+{% unless page.edition == "konnect" %}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+##### Update Certificate
+
+<div class="endpoint patch indent">/certificates/{certificate id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to update.
+
+
+##### Update Certificate Associated to a Specific Upstream
+
+<div class="endpoint patch indent">/upstreams/{upstream name or id}/client_certificate</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream associated to the Certificate to be updated.
+
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.certificate_json }}
+```
+
+{% endunless %}
+---
+
+### Update Or Create Certificate
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Certificate
+
+<div class="endpoint put indent">{{ prefix }}/certificates/{certificate id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
+
+{% unless page.edition == "konnect" %}
+
+##### Create Or Update Certificate Associated to a Specific Upstream
+
+<div class="endpoint put indent">/upstreams/{upstream name or id}/client_certificate</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream associated to the Certificate to be created or updated.
+{% endunless %}
+
+#### Request Body
+
+{{ page.certificate_body }}
+
+
+Inserts (or replaces) the Certificate under the requested resource with the
+definition specified in the body. The Certificate will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Certificate being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Certificate without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+
+---
+
+### Delete Certificate
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Certificate
+
+<div class="endpoint delete indent">{{ prefix }}/certificates/{certificate id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to delete.
+
+{% unless page.edition == "konnect" %}
+
+##### Delete Certificate Associated to a Specific Upstream
+
+<div class="endpoint delete indent">/upstreams/{upstream name or id}/client_certificate</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream associated to the Certificate to be deleted.
+
+{% endunless %}
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+## CA Certificate Object
+
+A CA certificate object represents a trusted CA. These objects are used by Kong to
+verify the validity of a client or server certificate.
+
+CA Certificates can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.ca_certificate_json }}
+```
+
+### Add CA Certificate
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create CA Certificate
+
+<div class="endpoint post indent">{{ prefix }}/ca_certificates</div>
+
+
+#### Request Body
+
+{{ page.ca_certificate_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.ca_certificate_json }}
+```
+
+
+---
+
+### List CA Certificates
+{:.badge .dbless}
+
+##### List All CA Certificates
+
+<div class="endpoint get indent">{{ prefix }}/ca_certificates</div>
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.ca_certificate_data }}
+    "next": "http://localhost:8001/ca_certificates?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve CA Certificate
+{:.badge .dbless}
+
+##### Retrieve CA Certificate
+
+<div class="endpoint get indent">{{ prefix }}/ca_certificates/{ca_certificate id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`ca_certificate id`<br>**required** | The unique identifier of the CA Certificate to retrieve.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.ca_certificate_json }}
+```
+
+
+---
+
+### Update CA Certificate
+
+
+{% unless page.edition == "konnect" %}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update CA Certificate
+
+<div class="endpoint patch indent">/ca_certificates/{ca_certificate id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`ca_certificate id`<br>**required** | The unique identifier of the CA Certificate to update.
+
+
+#### Request Body
+
+{{ page.ca_certificate_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.ca_certificate_json }}
+```
+
+{% endunless %}
+---
+
+### Update Or Create CA Certificate
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update CA Certificate
+
+<div class="endpoint put indent">{{ prefix }}/ca_certificates/{ca_certificate id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`ca_certificate id`<br>**required** | The unique identifier of the CA Certificate to create or update.
+
+
+#### Request Body
+
+{{ page.ca_certificate_body }}
+
+
+Inserts (or replaces) the CA Certificate under the requested resource with the
+definition specified in the body. The CA Certificate will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the CA Certificate being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new CA Certificate without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+
+---
+
+### Delete CA Certificate
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete CA Certificate
+
+<div class="endpoint delete indent">{{ prefix }}/ca_certificates/{ca_certificate id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`ca_certificate id`<br>**required** | The unique identifier of the CA Certificate to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+## SNI Object
+
+An SNI object represents a many-to-one mapping of hostnames to a certificate.
+That is, a certificate object can have many hostnames associated with it; when
+Kong receives an SSL request, it uses the SNI field in the Client Hello to
+lookup the certificate object based on the SNI associated with the certificate.
+
+SNIs can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.sni_json }}
+```
+
+### Add SNI
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create SNI
+
+<div class="endpoint post indent">{{ prefix }}/snis</div>
+
+
+##### Create SNI Associated to a Specific Certificate
+
+<div class="endpoint post indent">{{ prefix }}/certificates/{certificate name or id}/snis</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate that should be associated to the newly-created SNI.
+
+
+#### Request Body
+
+{{ page.sni_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.sni_json }}
+```
+
+
+---
+
+### List SNIs
+{:.badge .dbless}
+
+##### List All SNIs
+
+<div class="endpoint get indent">{{ prefix }}/snis</div>
+
+
+##### List SNIs Associated to a Specific Certificate
+
+<div class="endpoint get indent">{{ prefix }}/certificates/{certificate name or id}/snis</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate whose SNIs are to be retrieved. When using this endpoint, only SNIs associated to the specified Certificate will be listed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.sni_data }}
+    "next": "http://localhost:8001/snis?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve SNI
+{:.badge .dbless}
+
+##### Retrieve SNI
+
+<div class="endpoint get indent">{{ prefix }}/snis/{sni name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`sni name or id`<br>**required** | The unique identifier **or** the name of the SNI to retrieve.
+
+
+##### Retrieve SNI Associated to a Specific Certificate
+
+<div class="endpoint get indent">{{ prefix }}/certificates/{certificate id}/snis/{sni name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
+`sni name or id`<br>**required** | The unique identifier **or** the name of the SNI to retrieve.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.sni_json }}
+```
+
+
+---
+
+### Update SNI
+
+
+{% unless page.edition == "konnect" %}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+
+##### Update SNI
+
+<div class="endpoint patch indent">/snis/{sni name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`sni name or id`<br>**required** | The unique identifier **or** the name of the SNI to update.
+
+
+##### Update SNI Associated to a Specific Certificate
+
+<div class="endpoint patch indent">/certificates/{certificate id}/snis/{sni name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to update.
+`sni name or id`<br>**required** | The unique identifier **or** the name of the SNI to update.
+
+
+#### Request Body
+
+{{ page.sni_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.sni_json }}
+```
+
+
+---
+{% endunless %}
+
+### Update Or Create SNI
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update SNI
+
+<div class="endpoint put indent">{{ prefix }}/snis/{sni name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`sni name or id`<br>**required** | The unique identifier **or** the name of the SNI to create or update.
+
+
+##### Create Or Update SNI Associated to a Specific Certificate
+
+<div class="endpoint put indent">{{ prefix }}/certificates/{certificate id}/snis/{sni name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
+`sni name or id`<br>**required** | The unique identifier **or** the name of the SNI to create or update.
+
+
+#### Request Body
+
+{{ page.sni_body }}
+
+
+Inserts (or replaces) the SNI under the requested resource with the
+definition specified in the body. The SNI will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the SNI being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new SNI without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+---
+
+### Delete SNI
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete SNI
+
+<div class="endpoint delete indent">{{ prefix }}/snis/{sni name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`sni name or id`<br>**required** | The unique identifier **or** the name of the SNI to delete.
+
+
+##### Delete SNI Associated to a Specific Certificate
+
+<div class="endpoint delete indent">{{ prefix }}/certificates/{certificate id}/snis/{sni name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to delete.
+`sni name or id`<br>**required** | The unique identifier **or** the name of the SNI to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+## Upstream Object
+
+The upstream object represents a virtual hostname and can be used to loadbalance
+incoming requests over multiple services (targets). So for example an upstream
+named `service.v1.xyz` for a Service object whose `host` is `service.v1.xyz`.
+Requests for this Service would be proxied to the targets defined within the upstream.
+
+An upstream also includes a [health checker][healthchecks], which is able to
+enable and disable targets based on their ability or inability to serve
+requests. The configuration for the health checker is stored in the upstream
+object, and applies to all of its targets.
+
+Upstreams can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.upstream_json }}
+```
+
+### Add Upstream
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Upstream
+
+<div class="endpoint post indent">{{ prefix }}/upstreams</div>
+
+{% unless page.edition == "konnect" %}
+
+##### Create Upstream Associated to a Specific Certificate
+
+<div class="endpoint post indent">/certificates/{certificate name or id}/upstreams</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate that should be associated to the newly-created Upstream.
+
+{% endunless %}
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.upstream_json }}
+```
+
+
+---
+
+### List Upstreams
+{:.badge .dbless}
+
+##### List All Upstreams
+
+<div class="endpoint get indent">{{ prefix }}/upstreams</div>
+
+{% unless page.edition == "konnect" %}
+
+##### List Upstreams Associated to a Specific Certificate
+
+<div class="endpoint get indent">/certificates/{certificate name or id}/upstreams</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate name or id`<br>**required** | The unique identifier or the `name` attribute of the Certificate whose Upstreams are to be retrieved. When using this endpoint, only Upstreams associated to the specified Certificate will be listed.
+
+{% endunless %}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.upstream_data }}
+    "next": "http://localhost:8001/upstreams?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Upstream
+{:.badge .dbless}
+
+##### Retrieve Upstream
+
+<div class="endpoint get indent">{{ prefix }}/upstreams/{upstream name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
+
+{% unless page.edition == "konnect" %}
+
+##### Retrieve Upstream Associated to a Specific Certificate
+
+<div class="endpoint get indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to retrieve.
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to retrieve.
+
+{% endunless %}
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
+
+
+---
+
+### Update Upstream
+
+
+{% unless page.edition == "konnect" %}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+
+
+##### Update Upstream
+
+<div class="endpoint patch indent">/upstreams/{upstream name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
+
+
+##### Update Upstream Associated to a Specific Certificate
+
+<div class="endpoint patch indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to update.
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to update.
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.upstream_json }}
+```
+
+
+
+---
+{% endunless %}
+
+### Update Or Create Upstream
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Upstream
+
+<div class="endpoint put indent">{{ prefix }}/upstreams/{upstream name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
+
+{% unless page.edition == "konnect" %}
+
+##### Create Or Update Upstream Associated to a Specific Certificate
+
+<div class="endpoint put indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to create or update.
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to create or update.
+
+{% endunless %}
+
+#### Request Body
+
+{{ page.upstream_body }}
+
+
+Inserts (or replaces) the Upstream under the requested resource with the
+definition specified in the body. The Upstream will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Upstream being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Upstream without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+---
+
+### Delete Upstream
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Upstream
+
+<div class="endpoint delete indent">{{ prefix }}/upstreams/{upstream name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
+
+{% unless page.edition == "konnect" %}
+##### Delete Upstream Associated to a Specific Certificate
+
+<div class="endpoint delete indent">/certificates/{certificate id}/upstreams/{upstream name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`certificate id`<br>**required** | The unique identifier of the Certificate to delete.
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the Upstream to delete.
+
+{% endunless %}
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+{% unless page.edition == "konnect" %}
+
+---
+
+### Show Upstream Health for Node
+{:.badge .dbless}
+
+Displays the health status for all Targets of a given Upstream, or for
+the whole Upstream, according to the perspective of a specific Kong node.
+Note that, being node-specific information, making this same request
+to different nodes of the Kong cluster may produce different results.
+For example, one specific node of the Kong cluster may be experiencing
+network issues, causing it to fail to connect to some Targets: these
+Targets will be marked as unhealthy by that node (directing traffic from
+this node to other Targets that it can successfully reach), but healthy
+to all others Kong nodes (which have no problems using that Target).
+
+The `data` field of the response contains an array of Target objects.
+The health for each Target is returned in its `health` field:
+
+* If a Target fails to be activated in the balancer due to DNS issues,
+  its status displays as `DNS_ERROR`.
+* When [health checks][healthchecks] are not enabled in the Upstream
+  configuration, the health status for active Targets is displayed as
+  `HEALTHCHECKS_OFF`.
+* When health checks are enabled and the Target is determined to be healthy,
+  either automatically or [manually](#set-target-as-healthy),
+  its status is displayed as `HEALTHY`. This means that this Target is
+  currently included in this Upstream's load balancer execution.
+* When a Target has been disabled by either active or passive health checks
+  (circuit breakers) or [manually](#set-target-as-unhealthy),
+  its status is displayed as `UNHEALTHY`. The load balancer is not directing
+  any traffic to this Target via this Upstream.
+
+When the request query parameter `balancer_health` is set to `1`, the
+`data` field of the response refers to the Upstream itself, and its `health`
+attribute is defined by the state of all of Upstream's Targets, according
+to the field `healthchecks.threshold`.
+
+
+<div class="endpoint get indent">/upstreams/{name or id}/health</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the Upstream for which to display Target health.
+
+
+#### Request Querystring Parameters
+
+Attributes | Description
+---:| ---
+`balancer_health`<br>*optional* | If set to 1, Kong will return the health status of the Upstream itself. See the `healthchecks.threshold` property.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "node_id": "cbb297c0-14a9-46bc-ad91-1d0ef9b42df9",
+    "data": [
+        {
+            "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+            "health": "HEALTHY",
+            "data": {
+                "dns": "ttl=0, virtual SRV",
+                "addresses": [
+                    {
+                        "weight": 100,
+                        "ip": "127.0.0.1",
+                        "port": 20000,
+                        "health": "HEALTHY"
+                    }
+                ],
+                "weight": {
+                    "unavailable": 0,
+                    "available": 100,
+                    "total": 100
+                },
+                "port": 20000,
+                "host": "127.0.0.1",
+                "nodeWeight": 100
+            },
+            "weight": 100,
+            "target": "127.0.0.1:20000",
+            "created_at": 1485524883980,
+            "upstream": {
+                "id": "07131005-ba30-4204-a29f-0927d53257b4"
+            },
+            "tags": null
+        },
+        {
+            "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+            "health": "UNHEALTHY",
+            "data": {
+                "dns": "ttl=0, virtual SRV",
+                "addresses": [
+                    {
+                        "weight": 100,
+                        "ip": "127.0.0.1",
+                        "port": 20002,
+                        "health": "UNHEALTHY"
+                    }
+                ],
+                "weight": {
+                    "unavailable": 100,
+                    "available": 0,
+                    "total": 100
+                },
+                "port": 20002,
+                "host": "127.0.0.1",
+                "nodeWeight": 100
+            },
+            "weight": 100,
+            "target": "127.0.0.1:20002",
+            "created_at": 1485524914883,
+            "upstream": {
+                "id": "07131005-ba30-4204-a29f-0927d53257b4"
+            },
+            "tags": null
+        }
+    ]
+}
+```
+
+If `balancer_health=1`:
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "data": {
+        "health": "HEALTHY",
+        "id": "07131005-ba30-4204-a29f-0927d53257b4"
+    },
+    "next": null,
+    "node_id": "cbb297c0-14a9-46bc-ad91-1d0ef9b42df9"
+}
+```
+{% endunless %}
+
+---
+
+## Target Object
+
+A target is an ip address/hostname with a port that identifies an instance of a backend
+service. Every upstream can have many targets, and the targets can be
+dynamically added, modified, or deleted. Changes take effect on the fly.
+
+To disable a target, post a new one with `weight=0`;
+alternatively, use the `DELETE` convenience method to accomplish the same.
+
+The current target object definition is the one with the latest `created_at`.
+
+Targets can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.target_json }}
+```
+
+{% unless page.edition == "konnect" %}
+
+### Update Target
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Update a target.
+
+
+<div class="endpoint patch indent">/upstreams/{upstream name or id}/targets/{host:port or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to update the target.
+`host:port or id`<br>**required** | The host:port combination element of the target to update, or the `id` of an existing target entry.
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+{% endunless %}
+
+---
+
+### Delete Target
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Remove a target from the load balancer.
+
+
+<div class="endpoint delete indent">{{ prefix }}/upstreams/{upstream name or id}/targets/{host:port or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to delete the target.
+`host:port or id`<br>**required** | The host:port combination element of the target to remove, or the `id` of an existing target entry.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+{% unless page.edition == "konnect" %}
+
+### Set Target Address As Healthy
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Set the current health status of an individual address resolved by a target
+in the load balancer to "healthy" in the entire Kong cluster.
+
+This endpoint can be used to manually re-enable an address resolved by a
+target that was previously disabled by the upstream's [health checker][healthchecks].
+Upstreams only forward requests to healthy nodes, so this call tells Kong
+to start using this address again.
+
+This resets the health counters of the health checkers running in all workers
+of the Kong node, and broadcasts a cluster-wide message so that the "healthy"
+status is propagated to the whole Kong cluster.
+
+Note: This API is not available when Kong is running in Hybrid mode.
+
+
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/{address}/healthy</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+`target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
+`address`<br>**required** | The host/port combination element of the address to set as healthy.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+### Set Target Address As Unhealthy
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Set the current health status of an individual address resolved by a target
+in the load balancer to "unhealthy" in the entire Kong cluster.
+
+This endpoint can be used to manually disable an address and have it stop
+responding to requests. Upstreams only forward requests to healthy nodes, so
+this call tells Kong to start skipping this address.
+
+This call resets the health counters of the health checkers running in all
+workers of the Kong node, and broadcasts a cluster-wide message so that the
+"unhealthy" status is propagated to the whole Kong cluster.
+
+[Active health checks][active] continue to execute for unhealthy
+addresses. Note that if active health checks are enabled and the probe detects
+that the address is actually healthy, it will automatically re-enable it again.
+To permanently remove a target from the balancer, you should [delete a
+target](#delete-target) instead.
+
+Note: This API is not available when Kong is running in Hybrid mode.
+
+
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+`target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+### Set Target As Healthy
+{:.badge .dbless}
+
+Set the current health status of a target in the load balancer to "healthy"
+in the entire Kong cluster. This sets the "healthy" status to all addresses
+resolved by this target.
+
+This endpoint can be used to manually re-enable a target that was previously
+disabled by the upstream's [health checker][healthchecks]. Upstreams only
+forward requests to healthy nodes, so this call tells Kong to start using this
+target again.
+
+This resets the health counters of the health checkers running in all workers
+of the Kong node, and broadcasts a cluster-wide message so that the "healthy"
+status is propagated to the whole Kong cluster.
+
+Note: This API is not available when Kong is running in Hybrid mode.
+
+
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/healthy</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+`target or id`<br>**required** | The host/port combination element of the target to set as healthy, or the `id` of an existing target entry.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+### Set Target As Unhealthy
+{:.badge .dbless}
+
+Set the current health status of a target in the load balancer to "unhealthy"
+in the entire Kong cluster. This sets the "unhealthy" status to all addresses
+resolved by this target.
+
+This endpoint can be used to manually disable a target and have it stop
+responding to requests. Upstreams only forward requests to healthy nodes, so
+this call tells Kong to start skipping this target.
+
+This call resets the health counters of the health checkers running in all
+workers of the Kong node, and broadcasts a cluster-wide message so that the
+"unhealthy" status is propagated to the whole Kong cluster.
+
+[Active health checks][active] continue to execute for unhealthy
+targets. Note that if active health checks are enabled and the probe detects
+that the target is actually healthy, it will automatically re-enable it again.
+To permanently remove a target from the balancer, you should [delete a
+target](#delete-target) instead.
+
+Note: This API is not available when Kong is running in Hybrid mode.
+
+
+<div class="endpoint put indent">/upstreams/{upstream name or id}/targets/{target or id}/unhealthy</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`upstream name or id`<br>**required** | The unique identifier **or** the name of the upstream.
+`target or id`<br>**required** | The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+{% endunless %}
+
+### List All Targets
+{:.badge .dbless}
+
+Lists all targets of the upstream. Multiple target objects for the same
+target may be returned, showing the history of changes for a specific target.
+The target object with the latest `created_at` is the current definition.
+
+
+<div class="endpoint get indent">/upstreams/{name or id}/targets/all</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`name or id`<br>**required** | The unique identifier **or** the name of the upstream for which to list the targets.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+    "total": 2,
+    "data": [
+        {
+            "created_at": 1485524883980,
+            "id": "18c0ad90-f942-4098-88db-bbee3e43b27f",
+            "target": "127.0.0.1:20000",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 100
+        },
+        {
+            "created_at": 1485524914883,
+            "id": "6c6f34eb-e6c3-4c1f-ac58-4060e5bca890",
+            "target": "127.0.0.1:20002",
+            "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4",
+            "weight": 200
+        }
+    ]
+}
+```
+
+
+---
+
+
+## Vaults Object
+
+Vault object are used to configure different Vault connectors. Examples of
+Vaults are Environment Variables, Hashicorp Vault and AWS Secrets Manager.
+
+Configuring a Vault allows referencing the secrets with other entities. For
+example a certificate entity can store a reference to a certificate and key,
+stored in a vault, instead of storing the certificate and key within the
+entity. This allows a proper separation of secrets and configuration and
+prevents secret sprawl.
+
+{% if_version gte:3.4.x %}
+Secrets rotation can be managed using [TTLs](/gateway/latest/kong-enterprise/secrets-management/advanced-usage).
+{% endif_version %}
+
+Vaults can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.vault_json }}
+```
+
+### Add Vault
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Vault
+
+<div class="endpoint post indent">{{ prefix }}/vaults</div>
+
+
+#### Request Body
+
+{{ page.vault_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.vault_json }}
+```
+
+
+---
+
+### List Vaults
+{:.badge .dbless}
+
+##### List All Vaults
+
+<div class="endpoint get indent">{{ prefix }}/vaults</div>
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.vault_data }}
+    "next": "http://localhost:8001/vaults?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Vault
+{:.badge .dbless}
+
+##### Retrieve Vault
+
+<div class="endpoint get indent">{{ prefix }}/vaults/{vault prefix or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`vault prefix or id`<br>**required** | The unique identifier **or** the prefix of the Vault to retrieve.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.vault_json }}
+```
+
+
+---
+
+### Update Vault
+
+
+{% unless page.edition == "konnect" %}
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Vault
+
+<div class="endpoint patch indent">/vaults/{vault prefix or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`vault prefix or id`<br>**required** | The unique identifier **or** the prefix of the Vault to update.
+
+
+#### Request Body
+
+{{ page.vault_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.vault_json }}
+```
+
+
+---
+{% endunless %}
+
+### Update Or Create Vault
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Vault
+
+<div class="endpoint put indent">{{ prefix }}/vaults/{vault prefix or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`vault prefix or id`<br>**required** | The unique identifier **or** the prefix of the Vault to create or update.
+
+
+#### Request Body
+
+{{ page.vault_body }}
+
+
+Inserts (or replaces) the Vault under the requested resource with the
+definition specified in the body. The Vault will be identified via the `prefix
+or id` attribute.
+
+When the `prefix or id` attribute has the structure of a UUID, the Vault being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `prefix`.
+
+When creating a new Vault without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `prefix` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+---
+
+### Delete Vault
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Vault
+
+<div class="endpoint delete indent">{{ prefix }}/vaults/{vault prefix or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`vault prefix or id`<br>**required** | The unique identifier **or** the prefix of the Vault to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+{% unless page.edition == "konnect" %}
+## Keys Object
+
+A Key object holds a representation of asymmetric keys in various formats.
+When Kong or a Kong plugin requires a specific public or private key to perform
+certain operations, it can use this entity.
+
+Keys can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.key_json }}
+```
+
+### Add Key
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Key
+
+<div class="endpoint post indent">/keys</div>
+
+
+##### Create Key Associated to a Specific Key Set
+
+<div class="endpoint post indent">/key-sets/{key_set name or id}/keys</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier or the `name` attribute of the Key Set that should be associated to the newly-created Key.
+
+
+#### Request Body
+
+{{ page.key_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.key_json }}
+```
+
+
+---
+
+### List Keys
+{:.badge .dbless}
+
+##### List All Keys
+
+<div class="endpoint get indent">/keys</div>
+
+
+##### List Keys Associated to a Specific Key Set
+
+<div class="endpoint get indent">/key-sets/{key_set name or id}/keys</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier or the `name` attribute of the Key Set whose Keys are to be retrieved. When using this endpoint, only Keys associated to the specified Key Set will be listed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.key_data }}
+    "next": "http://localhost:8001/keys?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Key
+{:.badge .dbless}
+
+##### Retrieve Key
+
+<div class="endpoint get indent">/keys/{key name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key to retrieve.
+
+
+##### Retrieve Key Associated to a Specific Key Set
+
+<div class="endpoint get indent">/key-sets/{key_set name or id}/keys/{key name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier **or** the name of the Key Set to retrieve.
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key to retrieve.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.key_json }}
+```
+
+
+---
+
+### Update Key
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Key
+
+<div class="endpoint patch indent">/keys/{key name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key to update.
+
+
+##### Update Key Associated to a Specific Key Set
+
+<div class="endpoint patch indent">/key-sets/{key_set name or id}/keys/{key name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier **or** the name of the Key Set to update.
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key to update.
+
+
+#### Request Body
+
+{{ page.key_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.key_json }}
+```
+
+
+---
+
+### Update Or Create Key
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Key
+
+<div class="endpoint put indent">/keys/{key name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key to create or update.
+
+
+##### Create Or Update Key Associated to a Specific Key Set
+
+<div class="endpoint put indent">/key-sets/{key_set name or id}/keys/{key name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier **or** the name of the Key Set to create or update.
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key to create or update.
+
+
+#### Request Body
+
+{{ page.key_body }}
+
+
+Inserts (or replaces) the Key under the requested resource with the
+definition specified in the body. The Key will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Key being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Key without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+
+---
+
+### Delete Key
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Key
+
+<div class="endpoint delete indent">/keys/{key name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key to delete.
+
+
+##### Delete Key Associated to a Specific Key Set
+
+<div class="endpoint delete indent">/key-sets/{key_set name or id}/keys/{key name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier **or** the name of the Key Set to delete.
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+## Key Sets Entity
+
+A Key Set object holds a collection of asymmetric key objects.
+This entity allows to logically group keys by their purpose.
+
+Key Sets can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.key_set_json }}
+```
+
+### Add Key Set
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Key Set
+
+<div class="endpoint post indent">/key-sets</div>
+
+
+#### Request Body
+
+{{ page.key_set_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.key_set_json }}
+```
+
+
+---
+
+### List Key Sets
+{:.badge .dbless}
+
+##### List All Key Sets
+
+<div class="endpoint get indent">/key-sets</div>
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.key_set_data }}
+    "next": "http://localhost:8001/key-sets?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"
+}
+```
+
+
+---
+
+### Retrieve Key Set
+{:.badge .dbless}
+
+##### Retrieve Key Set
+
+<div class="endpoint get indent">/key-sets/{key_set name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier **or** the name of the Key Set to retrieve.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.key_set_json }}
+```
+
+
+---
+
+### Update Key Set
+
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Key Set
+
+<div class="endpoint patch indent">/key-sets/{key_set name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier **or** the name of the Key Set to update.
+
+
+#### Request Body
+
+{{ page.key_set_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.key_set_json }}
+```
+
+
+---
+
+### Update Or Create Key Set
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Key Set
+
+<div class="endpoint put indent">/key-sets/{key_set name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier **or** the name of the Key Set to create or update.
+
+
+#### Request Body
+
+{{ page.key_set_body }}
+
+
+Inserts (or replaces) the Key Set under the requested resource with the
+definition specified in the body. The Key Set will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Key Set being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Key Set without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+See POST and PATCH responses.
+
+
+---
+
+### Delete Key Set
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Key Set
+
+<div class="endpoint delete indent">/key-sets/{key_set name or id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key_set name or id`<br>**required** | The unique identifier **or** the name of the Key Set to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+
+---
+
+### List Keys Associated to A Specific Key-set
+{:.badge .dbless}
+
+Lists all keys within the specifified key set.
+
+
+
+##### Retrieve Key Set Associated to a Specific Key
+
+<div class="endpoint get indent">/keys/{key name or id}/set</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key associated to the Key Set to be retrieved.
+
+
+#### Response
+
+ ```
+ HTTP 200 OK
+ ```
+
+ ``` json
+{
+   "data": [
+     {
+       "id": "46CA83EE-671C-11ED-BFAB-2FE47512C77A",
+       "name": "my-key_set",
+       "tags": ["google-keys", "mozilla-keys"],
+       "created_at": 1422386534,
+       "updated_at": 1422386534
+   }, {
+       "id": "57532ECE-6720-11ED-9297-279D4320B841",
+       "name": "my-key_set",
+       "tags": ["production", "staging", "development"],
+       "created_at": 1422386534,
+       "updated_at": 1422386534
+   }]
+ }
+ ```
+
+
+---
+
+### Updates A Key Within A Key-set
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Updates a key within a key-set
+
+
+
+##### Update Key Set Associated to a Specific Key
+
+<div class="endpoint patch indent">/keys/{key name or id}/set</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key associated to the Key Set to be updated.
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+
+---
+
+### Create A Key Within A Key-set
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Creates a key
+
+
+
+##### Create Or Update Key Set Associated to a Specific Key
+
+<div class="endpoint put indent">/keys/{key name or id}/set</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key associated to the Key Set to be created or updated.
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+
+---
+
+### Delete Key Within Key-set
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+Delete a key that is associated with this key-set
+
+
+
+##### Delete Key Set Associated to a Specific Key
+
+<div class="endpoint delete indent">/keys/{key name or id}/set</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`key name or id`<br>**required** | The unique identifier **or** the name of the Key associated to the Key Set to be deleted.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+## Filter Chain Object
+
+A [filter chain] is the database entity representing one or more WebAssembly
+[filters] executed for each request to a particular [service](#services)
+or [route](#routes), each one with its configuration.
+
+Filter chains can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.filter_chain_json }}
+```
+
+See the [WebAssembly section] of the reference documentation for more details.
+
+
+
+### Add Filter Chain
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Filter Chain
+
+<div class="endpoint post indent">{{ prefix }}/filter-chains</div>
+
+
+##### Create Filter Chain Associated to a Specific Route
+
+<div class="endpoint post indent">{{ prefix }}/routes/{route name or id}/filter-chains</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route that should be associated to the newly-created Filter Chain.
+
+
+##### Create Filter Chain Associated to a Specific Service
+
+<div class="endpoint post indent">{{ prefix }}/services/{service name or id}/filter-chains</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service that should be associated to the newly-created Filter Chain.
+
+
+#### Request Body
+
+{{ page.filter_chain_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.filter_chain_json }}
+```
+
+
+---
+
+### List Filter Chains
+{:.badge .dbless}
+
+##### List All Filter Chains
+
+<div class="endpoint get indent">{{ prefix }}/filter-chains</div>
+
+
+##### List Filter Chains Associated to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filter-chains</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose Filter Chains are to be retrieved. When using this endpoint, only Filter Chains associated to the specified Route will be listed.
+
+
+##### List Filter Chains Associated to a Specific Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}/filter-chains</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service whose Filter Chains are to be retrieved. When using this endpoint, only Filter Chains associated to the specified Service will be listed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.filter_chain_data }}
+}
+```
+
+
+---
+
+### Retrieve Filter Chain
+{:.badge .dbless}
+
+##### Retrieve Filter Chain
+
+<div class="endpoint get indent">{{ prefix }}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to retrieve.
+
+
+##### Retrieve Filter Chain Associated to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to retrieve.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to retrieve.
+
+
+##### Retrieve Filter Chain Associated to a Specific Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to retrieve.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to retrieve.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.filter_chain_json }}
+```
+
+
+---
+{% unless page.edition == "konnect" %}
+
+### Update Filter Chain
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Filter Chain
+
+<div class="endpoint patch indent">/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to update.
+
+
+##### Update Filter Chain Associated to a Specific Route
+
+<div class="endpoint patch indent">/routes/{route name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to update.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to update.
+
+
+##### Update Filter Chain Associated to a Specific Service
+
+<div class="endpoint patch indent">/services/{service name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to update.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to update.
+
+
+#### Request Body
+
+{{ page.filter_chain_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.filter_chain_json }}
+```
+
+{% endunless %}
+---
+
+### Update Or Create Filter Chain
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Filter Chain
+
+<div class="endpoint put indent">{{ prefix }}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to create or update.
+
+
+##### Create Or Update Filter Chain Associated to a Specific Route
+
+<div class="endpoint put indent">{{ prefix }}/routes/{route name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to create or update.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to create or update.
+
+
+##### Create Or Update Filter Chain Associated to a Specific Service
+
+<div class="endpoint put indent">{{ prefix }}/services/{service name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to create or update.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to create or update.
+
+
+#### Request Body
+
+{{ page.filter_chain_body }}
+
+
+Inserts (or replaces) the Filter Chain under the requested resource with the
+definition specified in the body. The Filter Chain will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Filter Chain being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Filter Chain without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+---
+
+### Delete Filter Chain
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Filter Chain
+
+<div class="endpoint delete indent">{{ prefix }}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to delete.
+
+
+##### Delete Filter Chain Associated to a Specific Route
+
+<div class="endpoint delete indent">{{ prefix }}/routes/{route name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to delete.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to delete.
+
+
+##### Delete Filter Chain Associated to a Specific Service
+
+<div class="endpoint delete indent">{{ prefix }}/services/{service name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### List Filters Applied to a Route
+{:.badge .dbless}
+
+You can inspect the full filter execution plan for a given route, combining
+the filters applied from the service filter chain and the route filter chain,
+in that order. Since both the chains and individual filters can be enabled
+and disabled individually via the `enabled` boolean attribute, there are
+individual endpoints for listing enabled filters (which is the active
+execution plan), disabled filters, and all filters.
+
+See the reference documentation for [filter execution behavior] for more details.
+
+
+##### List Enabled Filters Applied to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filters/enabled</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose associated filters are to be listed.
+
+
+##### List Disabled Filters Applied to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filters/disabled</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose associated filters are to be listed.
+
+
+##### List All Filters Applied to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filters/all</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose associated filters are to be listed.
+
+
+
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.filters_data }}
+}
+```
+
+
+---
+
+[clustering]: /gateway/{{page.kong_version}}/reference/clustering
+[cli]: /gateway/{{page.kong_version}}/reference/cli
+[active]: /gateway/{{page.kong_version}}/how-kong-works/health-checks/#active-health-checks
+[healthchecks]: /gateway/{{page.kong_version}}/how-kong-works/health-checks
+[secure-admin-api]: /gateway/{{page.kong_version}}/production/running-kong/secure-admin-api
+[proxy-reference]: /gateway/{{page.kong_version}}/how-kong-works/routing-traffic/
+[WebAssembly section]: /gateway/{{page.kong_version}}/reference/wasm/
+[filter execution behavior]: /gateway/{{page.kong_version}}/reference/wasm/#filter_execution_behavior
+[filters]: /gateway/{{page.kong_version}}/reference/wasm/#filter
+[filter chain]: /gateway/{{page.kong_version}}/reference/wasm/#filter_chain
+
+{% endunless %}

--- a/app/_src/gateway/admin-api/index.md
+++ b/app/_src/gateway/admin-api/index.md
@@ -740,6 +740,90 @@ key_set_data: |
         "updated_at": 1422386534
     }],
 
+filter_chain_body: |
+    Attributes | Description
+    ---:| ---
+    `name` |  The name of the filter chain.
+    `enabled` | Whether the filter chain is applied. Default: `true`.
+    `route`<br>*optional* |  The route to which this chain is applied. A filter chain must be applied to either a single route or a single service. Default: `null`. With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use "`"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
+    `service`<br>*optional* |  The service to which this chain is applied. A filter chain must be applied to either a single route or a single service. Default: `null`. With form-encoded, the notation is `service.id=<service id>` or `service.name=<service name>`. With JSON, use "`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
+    `filters` |  An array of filter definitions. Each filter is an object containing a mandatory `name`, an optional `config` and a boolean `enabled` setting.
+    `tags`<br>*optional* |  An optional set of strings associated with the filter chain for grouping and filtering.
+
+filter_chain_json: |
+    {
+        "id": "ce44eef5-41ed-47f6-baab-f725cecf98c7",
+        "name": "my-chain",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "enabled": true,
+        "route": null,
+        "service": "20487393-41ed-47f6-93a8-3407cade2002",,
+        "filters": [
+            {
+                "name": "go-rate-limiting",
+                "enabled": true,
+                "config": "{ \"minute\": 30 }"
+            },
+            {
+                "name": "rust-response-transformer",
+                "enabled": true,
+                "config": "{ \"remove_header\": \"X-Example\" }"
+            }
+        ],
+        "tags": ["my-tag"]
+    }
+
+filter_chain_data: |
+    "data": [{
+        "id": "ce44eef5-41ed-47f6-baab-f725cecf98c7",
+        "name": "my-chain",
+        "created_at": 1422386534,
+        "updated_at": 1422386534,
+        "enabled": true,
+        "route": null,
+        "service": "20487393-41ed-47f6-93a8-3407cade2002",,
+        "filters": [
+            {
+                "name": "go-rate-limiting",
+                "enabled": true,
+                "config": "{ \"minute\": 30 }"
+            },
+            {
+                "name": "rust-response-transformer",
+                "enabled": true,
+                "config": "{ \"remove_header\": \"X-Example\" }"
+            }
+        ],
+        "tags": ["my-tag"]
+    }]
+
+filters_data:
+    "filters": [
+        {
+            "config": "{\"minute\": 3}",
+            "enabled": true,
+            "filter_chain": {
+                "id": "0385abc3-f8a7-505b-aeec-9375a298d340",
+                "name": null
+            },
+            "from": "service",
+            "name": "go-rate-limiting"
+        },
+        {
+            "config": "{\"remove_header\": \"X-Example\"}",
+            "enabled": true,
+            "filter_chain": {
+                "id": "d8e9a640-f8a7-505b-aeec-e657383940d6",
+                "name": null
+            },
+            "from": "route",
+            "name": "rust-response-transformer"
+        }
+    ]
+
+
+
 
 ---
 
@@ -5692,7 +5776,398 @@ Attributes | Description
 ```
 HTTP 204 No Content
 ```
+{% if_version gte:3.4.x %}
+## Filter Chain Object
 
+A [filter chain] is the database entity representing one or more WebAssembly
+[filters] executed for each request to a particular [service](#services)
+or [route](#routes), each one with its configuration.
+
+Filter chains can be both [tagged and filtered by tags](#tags).
+
+
+```json
+{{ page.filter_chain_json }}
+```
+
+See the [WebAssembly section] of the reference documentation for more details.
+
+
+
+### Add Filter Chain
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Filter Chain
+
+<div class="endpoint post indent">{{ prefix }}/filter-chains</div>
+
+
+##### Create Filter Chain Associated to a Specific Route
+
+<div class="endpoint post indent">{{ prefix }}/routes/{route name or id}/filter-chains</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route that should be associated to the newly-created Filter Chain.
+
+
+##### Create Filter Chain Associated to a Specific Service
+
+<div class="endpoint post indent">{{ prefix }}/services/{service name or id}/filter-chains</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service that should be associated to the newly-created Filter Chain.
+
+
+#### Request Body
+
+{{ page.filter_chain_body }}
+
+
+#### Response
+
+```
+HTTP 201 Created
+```
+
+```json
+{{ page.filter_chain_json }}
+```
+
+
+---
+
+### List Filter Chains
+{:.badge .dbless}
+
+##### List All Filter Chains
+
+<div class="endpoint get indent">{{ prefix }}/filter-chains</div>
+
+
+##### List Filter Chains Associated to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filter-chains</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose Filter Chains are to be retrieved. When using this endpoint, only Filter Chains associated to the specified Route will be listed.
+
+
+##### List Filter Chains Associated to a Specific Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}/filter-chains</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier or the `name` attribute of the Service whose Filter Chains are to be retrieved. When using this endpoint, only Filter Chains associated to the specified Service will be listed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.filter_chain_data }}
+}
+```
+
+
+---
+
+### Retrieve Filter Chain
+{:.badge .dbless}
+
+##### Retrieve Filter Chain
+
+<div class="endpoint get indent">{{ prefix }}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to retrieve.
+
+
+##### Retrieve Filter Chain Associated to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to retrieve.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to retrieve.
+
+
+##### Retrieve Filter Chain Associated to a Specific Service
+
+<div class="endpoint get indent">{{ prefix }}/services/{service name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to retrieve.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to retrieve.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.filter_chain_json }}
+```
+
+
+---
+{% unless page.edition == "konnect" %}
+
+### Update Filter Chain
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Update Filter Chain
+
+<div class="endpoint patch indent">/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to update.
+
+
+##### Update Filter Chain Associated to a Specific Route
+
+<div class="endpoint patch indent">/routes/{route name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to update.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to update.
+
+
+##### Update Filter Chain Associated to a Specific Service
+
+<div class="endpoint patch indent">/services/{service name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to update.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to update.
+
+
+#### Request Body
+
+{{ page.filter_chain_body }}
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{{ page.filter_chain_json }}
+```
+
+{% endunless %}
+---
+
+### Update Or Create Filter Chain
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Create Or Update Filter Chain
+
+<div class="endpoint put indent">{{ prefix }}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to create or update.
+
+
+##### Create Or Update Filter Chain Associated to a Specific Route
+
+<div class="endpoint put indent">{{ prefix }}/routes/{route name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to create or update.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to create or update.
+
+
+##### Create Or Update Filter Chain Associated to a Specific Service
+
+<div class="endpoint put indent">{{ prefix }}/services/{service name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to create or update.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to create or update.
+
+
+#### Request Body
+
+{{ page.filter_chain_body }}
+
+
+Inserts (or replaces) the Filter Chain under the requested resource with the
+definition specified in the body. The Filter Chain will be identified via the `name
+or id` attribute.
+
+When the `name or id` attribute has the structure of a UUID, the Filter Chain being
+inserted/replaced will be identified by its `id`. Otherwise it will be
+identified by its `name`.
+
+When creating a new Filter Chain without specifying `id` (neither in the URL nor in
+the body), then it will be auto-generated.
+
+Notice that specifying a `name` in the URL and a different one in the request
+body is not allowed.
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+{% unless page.edition == "konnect" %}
+See POST and PATCH responses.
+{% endunless %}
+
+---
+
+### Delete Filter Chain
+
+
+
+{:.note}
+> **Note**: This API is not available in DB-less mode.
+
+##### Delete Filter Chain
+
+<div class="endpoint delete indent">{{ prefix }}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to delete.
+
+
+##### Delete Filter Chain Associated to a Specific Route
+
+<div class="endpoint delete indent">{{ prefix }}/routes/{route name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier **or** the name of the Route to delete.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to delete.
+
+
+##### Delete Filter Chain Associated to a Specific Service
+
+<div class="endpoint delete indent">{{ prefix }}/services/{service name or id}/filter-chains/{filter chain id}</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`service name or id`<br>**required** | The unique identifier **or** the name of the Service to delete.
+`filter chain id`<br>**required** | The unique identifier of the Filter Chain to delete.
+
+
+#### Response
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### List Filters Applied to a Route
+{:.badge .dbless}
+
+You can inspect the full filter execution plan for a given route, combining
+the filters applied from the service filter chain and the route filter chain,
+in that order. Since both the chains and individual filters can be enabled
+and disabled individually via the `enabled` boolean attribute, there are
+individual endpoints for listing enabled filters (which is the active
+execution plan), disabled filters, and all filters.
+
+See the reference documentation for [filter execution behavior] for more details.
+
+
+##### List Enabled Filters Applied to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filters/enabled</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose associated filters are to be listed.
+
+
+##### List Disabled Filters Applied to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filters/disabled</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose associated filters are to be listed.
+
+
+##### List All Filters Applied to a Specific Route
+
+<div class="endpoint get indent">{{ prefix }}/routes/{route name or id}/filters/all</div>
+
+{:.indent}
+Attributes | Description
+---:| ---
+`route name or id`<br>**required** | The unique identifier or the `name` attribute of the Route whose associated filters are to be listed.
+
+
+
+
+
+#### Response
+
+```
+HTTP 200 OK
+```
+
+```json
+{
+{{ page.filters_data }}
+}
+```
+{% endif_version %}
 
 ---
 
@@ -5702,5 +6177,9 @@ HTTP 204 No Content
 [healthchecks]: /gateway/{{page.kong_version}}/how-kong-works/health-checks
 [secure-admin-api]: /gateway/{{page.kong_version}}/production/running-kong/secure-admin-api
 [proxy-reference]: /gateway/{{page.kong_version}}/how-kong-works/routing-traffic/
+[WebAssembly section]: /gateway/{{page.kong_version}}/reference/wasm/
+[filter execution behavior]: /gateway/{{page.kong_version}}/reference/wasm/#filter_execution_behavior
+[filters]: /gateway/{{page.kong_version}}/reference/wasm/#filter
+[filter chain]: /gateway/{{page.kong_version}}/reference/wasm/#filter_chain
 
 {% endunless %}

--- a/app/_src/gateway/reference/wasm.md
+++ b/app/_src/gateway/reference/wasm.md
@@ -45,7 +45,7 @@ Example:
 
 ```yaml
 ---
-filter-chains:
+filter_chains:
   name: my-filter-chain
   # Filter Chains can be toggled on/off for testing
   enabled: true


### PR DESCRIPTION
### Description

Adds documentation for the Filter Chain entity available in Kong Gateway 3.4 when WebAssembly support is enabled.

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

