### PR TITLE
Konnect rename: Renames the analytics section.

### DIFF
--- a/app/konnect/analytics/index.md
+++ b/app/konnect/analytics/index.md
@@ -6,7 +6,7 @@ title: Introduction to Monitoring Health with Analytics
 You can monitor the health and performance of any API product, route, or application managed by {{site.konnect_saas}}.
 
 Analytics provides traffic reports to help you track the performance and
-behavior of your APIs and runtimes. Use these reports to quickly access key
+behavior of your APIs and data plane nodes. Use these reports to quickly access key
 statistics, monitor vital signs, and pinpoint anomalies in real time.
 
 Depending on your {{site.konnect_saas}} subscription tier, Analytics retains
@@ -15,16 +15,16 @@ historical data for the following lengths of time:
 * **Plus:** 3 months
 * **Enterprise:** 1 year
 
-{:.important}
-> **Important**: Analytics for a composite runtime group are only available at the composite level. 
-Member standard runtime groups have no individual analytics reporting. This means that:
-* In the Runtime Manager, contextual analytics are logged in the composite runtime group only.
-* When creating custom reports, members of a composite runtime group won't show up as individual entities. 
-Reports will only show the composite group.
+{:.note}
+> **Note**:
+Member standard control planes have no individual analytics reporting. This means that:
+* In the Gateway Manager, contextual analytics are logged in the control plane group only.
+* When creating custom reports, control planes won't show up as individual entities. 
+Reports will only show the control plane group.
 
 ## Contextual analytics for services and routes
 
-In the [Runtime Manager](/konnect/runtime-manager/), you can see
+In the [Gateaway Manager](/konnect/runtime-manager/), you can see
 activity graphs for gateway services or routes for the past 30 days.
 For gateway services and routes, the graphs show requests broken down by status codes.
 
@@ -73,7 +73,7 @@ You can view a graph for each category by clicking **Traffic**, **Errors**, or *
 Admins can monitor the latency, investigate where delays are noticed, and optimize performance for APIs.
 
     {:.note}
-    > **Note**: Latency data is only available for requests proxied through runtime instances running {{site.base_gateway}} 3.0.0.0 or later.
+    > **Note**: Latency data is only available for requests proxied through a data plane running {{site.base_gateway}} 3.0.0.0 or later.
 
    ![latency analytics graph](/assets/images/docs/konnect/konnect-analytics-latency.png){:.image-border}
   > _**Figure 4:** Graph showing latency as a percentage over the past 15 minutes._

--- a/app/konnect/analytics/reference.md
+++ b/app/konnect/analytics/reference.md
@@ -33,7 +33,7 @@ Route | Group or filter the data by route.
 Application | Group or filter the data by application.
 Status Code | Group or filter the data by individual response status code. Individual status codes can range from 100 to 599.
 Status Code (grouped) | Group or filter the data by response status code category: 1XX, 2XX, 3XX, 4XX, and 5XX.
-Runtime Group | Group or filter the data by runtime groups.
+Control Plane | Group or filter the data by control plane.
 Gateway Services | Group or filter the data by gateway services.
 
 ### Route entity format
@@ -41,17 +41,17 @@ Gateway Services | Group or filter the data by gateway services.
 In custom reports, the route entity name is composed of the following elements:
 
 ```
-ROUTE_NAME|FIRST_FIVE_UUID_CHARS (RUNTIME_GROUP_NAME)
+ROUTE_NAME|FIRST_FIVE_UUID_CHARS (CONTROL_PLANE_NODE)
 ```
 
 For example, for a route entity named `example_route (default)`:
 * `example_route` is the route name
-* `default` is the runtime group name
+* `default` is the name of the control plane.
 
 Or, if your route doesn't have a name, it might look like this:
 `DA58B (default)`
 
-Where `DA58B` are the first five characters of its UUID and `default` is the runtime group name.
+Where `DA58B` are the first five characters of its UUID and `default` is the name of the control plane.
 
 {:.note}
 > **Note**: If you see a route with `*` and the last five digits of the UUID, like `*DA58B`, this represents the data of a deleted route.
@@ -61,13 +61,13 @@ Where `DA58B` are the first five characters of its UUID and `default` is the run
 The API product version name isn't unique across an organization. To identify the entity you need, the API product version entity name is composed of the following elements:
 
 ```
-KONNECT_API_PRODUCT_NAME - API_PRODUCT_VERSION (RUNTIME_GROUP_NAME)
+KONNECT_API_PRODUCT_NAME - API_PRODUCT_VERSION (CONTROL_PLANE_NAME)
 ```
 
 For example, for an API product version entity named `Account - v1 (dev)`:
 * `Account` is the {{site.konnect_short_name}} API product name
 * `v1` is the API product version
-* `dev` is the runtime group name
+* `dev` is the name of the control plane.
 
 
 ## Time intervals

--- a/app/konnect/analytics/troubleshoot.md
+++ b/app/konnect/analytics/troubleshoot.md
@@ -13,7 +13,7 @@ This issue may be happening for one of the following reasons:
 
 * The {{site.base_gateway}} version is incompatible.
 
-  Latency data is available starting with {{site.base_gateway}} 3.0.0.0. To collect latency information, [upgrade your runtime instances](/konnect/runtime-manager/runtime-instances/upgrade/) to the latest version.
+  Latency data is available starting with {{site.base_gateway}} 3.0.0.0. To collect latency information, [upgrade a data plane node](/konnect/runtime-manager/runtime-instances/upgrade/) to the latest version.
 
 * No requests were proxied in the requested time period.
 

--- a/app/konnect/analytics/use-cases/latency.md
+++ b/app/konnect/analytics/use-cases/latency.md
@@ -26,9 +26,9 @@ For the Kong latency report, Tal configures the following:
 * **Group by**: API Product
 * **Choose Granularity**: Minutely
 
-Then, they add a filter to filter by the individual runtime group:
+Then, they add a filter to filter by the Control Plane
 
-* **Filter by**: Runtime Group
+* **Filter by**: Control Plane
 * **Operator**: In
 * **Value**: prod 
 
@@ -50,9 +50,9 @@ For the Upstream latency report, Tal configures the following:
 * **Group by**: API Product
 * **Choose Granularity**: Minutely
 
-Then they add a filter to filter by the individual Runtime Group 
+Then they add a filter to filter by Control Plane
 
-* **Filter by**: Runtime Group
+* **Filter by**: Control Plane
 * **Operator**: In
 * **Value**: prod 
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-3375

There is a link to the runtime manager section. I left that behind. I think when someone tackles the runtime manager section they should change the link based on what they rename those files to. 