### PR TITLE
(Fix) Cross-ref CP-DP communication through forward proxy in Konnect docs

### DIFF
--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -13,6 +13,9 @@ The {{site.konnect_saas}} control plane uses the following ports:
 
 Kong's hosted control plane expects traffic on these ports, so they can't be customized. 
 
+{:.note}
+> **Note**: If you are unable to make outbound connections through 443, you can use an existing proxy in your network. See [Control Plane and Data Plane Communication through a Forward Proxy](/gateway/latest/production/networking/cp-dp-proxy/) for details. 
+
 ## Runtime instance ports
 
 By default, {{site.base_gateway}} listens on the following ports:

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -14,7 +14,7 @@ The {{site.konnect_saas}} control plane uses the following ports:
 Kong's hosted control plane expects traffic on these ports, so they can't be customized. 
 
 {:.note}
-> **Note**: If you are unable to make outbound connections through 443, you can use an existing proxy in your network. See [Control Plane and Data Plane Communication through a Forward Proxy](/gateway/latest/production/networking/cp-dp-proxy/) for details. 
+> **Note**: If you are unable to make outbound connections using port `443`, you can use an existing proxy in your network to make the connection. See [Control Plane and Data Plane Communication through a Forward Proxy](/gateway/latest/production/networking/cp-dp-proxy/) for details. 
 
 ## Runtime instance ports
 


### PR DESCRIPTION
You can now find cross-reference to the "Control Plane and Data Plane Communication through a Forward Proxy" page in the "Konnect Ports and Networking Requirements" page.

Updated based on Slack feedback [here](https://kongstrong.slack.com/archives/C02CWN8C7DK/p1693260752247129). 

Netlify link: https://deploy-preview-6028--kongdocs.netlify.app/konnect/network/


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

