### PR TITLE
fix: Stop indexing duplicate plugin URLs in search

### DIFF
--- a/algolia/config-full-docs.json
+++ b/algolia/config-full-docs.json
@@ -33,7 +33,7 @@
     "https://docs.konghq.com/sitemap.xml"
   ],
   "stop_urls": [
-    "https://docs.konghq.com/hub/.*?/.*?/.*?html"
+    "https://docs.konghq.com/hub/.*?/.*?/[0-9].[0-9].x/"
   ],
 
   "selectors": {


### PR DESCRIPTION
### Description

The Algolia search indexer was picking up all versioned URLs, so that search results would contain many duplicates. The search result would look like this, where each URL would go to a different version of the same page: 

<img width="450" alt="Screenshot 2023-08-29 at 5 36 00 PM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/ed1dd54e-2db3-4e8d-a987-72ffa2c4fc5f">

Post-fix, it only picks up the latest version of a plugin's docs:

<img width="450" alt="Screenshot 2023-08-29 at 5 36 00 PM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/1ce60578-dbab-4ae5-bbb6-5c73ab7910a0">

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

