### PR TITLE
fix: change go-apiops to deck file in deck_file_remove-tags.md

### DIFF
--- a/app/_src/deck/reference/deck_file_remove-tags.md
+++ b/app/_src/deck/reference/deck_file_remove-tags.md
@@ -19,10 +19,10 @@ deck file remove-tags [command-specific flags] [global flags] tag [...tag]
 
 ```
 # clear tags 'tag1' and 'tag2' from all services in file 'kong.yml'
-cat kong.yml | go-apiops remove-tags --selector='services[*]' tag1 tag2
+cat kong.yml | deck file remove-tags --selector='services[*]' tag1 tag2
 
 # clear all tags except 'tag1' and 'tag2' from the file 'kong.yml'
-cat kong.yml | go-apiops remove-tags --keep-only tag1 tag2
+cat kong.yml | deck file remove-tags --keep-only tag1 tag2
 ```
 
 ## Flags


### PR DESCRIPTION
go-apiops cli is built for testing purposes. End users are encumbered to use this utility through deck file command.


### Description

What did you change and why?

I changed `go-apiops` cli example to `deck file`. As mentioned in [go-apiops repository](https://github.com/Kong/go-apiops)
> Currently, the functionality is released as a library and as part of the [decK](https://github.com/Kong/deck) CLI tool. The 
> repository also contains a CLI named go-apiops **for local testing**. For general CLI usage, prefer the decK tool [docs](https://docs.konghq.com/deck/latest/) tool.

 `go-apiops` is used for testing and deck is encouraged for general usage.

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
