### PR TITLE
chore: Update kong versions with Mesh 2.4.x as latest

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -293,13 +293,15 @@
 - edition: mesh
   version: 2.3.2
   release: 2.3.x
-  latest: true
   releaseDate: "2023-06-26"
   endOfLifeDate: "2024-06-26"
   branch: release-2.3
 - edition: mesh
   version: 2.4.0
   release: 2.4.x
+  latest: true
+  releaseDate: "2023-08-29"
+  endOfLifeDate: "2024-08-29"
   branch: release-2.4
 - edition: mesh
   version: preview


### PR DESCRIPTION
### Description

What did you change and why?
- We released Mesh 2.4.x yesterday and our docs site was still showing 2.3.x as the latest version because the GitHub action to update the docs doesn't also update the kong version file.
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
N/A

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
- Just verify that 2.4.x is latest for Mesh and that's the version you go to when you navigate to the Mesh docs.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

