### PR TITLE
feat: Rename Konnect "runtimes" on the docs homepage

### DIFF
--- a/app/_data/landing_page.yml
+++ b/app/_data/landing_page.yml
@@ -31,13 +31,13 @@ features:
             icon: /assets/images/icons/icn-doc.svg
             url: /gateway/latest/kong-enterprise/analytics/
 
-      - name: Runtime Manager
-        description: Provision and manage Kong Gateway runtimes and services in your environment and platform of choice.
+      - name: Gateway Manager
+        description: Provision and manage Kong Gateway data planes and services in your environment and platform of choice.
         icon:  /assets/images/landing-page/card-icons/runtime.svg
         links:
           - text: Overview
             icon: /assets/images/icons/icn-doc.svg
-            url: /konnect/runtime-manager/
+            url: /konnect/gateway-manager/
 
       - name: API Products
         description: Bundle and manage multiple APIs via API products to document, enable application registration and publish them to a Developer Portal for consumption. 


### PR DESCRIPTION
### Description

What did you change and why?
- Since Konnect is renaming "runtimes", we needed to update the homepage to change "runtimes". 
- I know the homepage on `main` is now the refreshed one and this is the old one, but I wanted to make sure everything was updated. Was there anything I missed?

Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-3380

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

