### PR TITLE
fix: Update OSS install instructions for Kong Manager

### DIFF
--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -186,7 +186,7 @@ If you're running {{site.base_gateway}} with a database (either in traditional
 or hybrid mode), you can enable {{site.base_gateway}}'s graphical user interface
 (GUI), Kong Manager.
 
-See the [Kong Manager setup guide](/gateway/{{page.kong_version}}/kong-manager/enable/) for more information.
+See the [Kong Manager setup guide](/gateway/{{page.kong_version}}/kong-manager/enable/){% if_version gte:3.4.x %} or the [Kong Manager OSS guide](/gateway/{{page.kong_version}}/kong-manager-oss){% endif_version %} for more information.
 
 {% endif_version %}
 {% if_version lte:2.8.x %}

--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -177,8 +177,13 @@ $ scp license.json /etc/kong/license.json
 {% endnavtab %}
 {% endnavtabs %}
 
+{% if_version lte:3.3.x %}
 ### Enable Kong Manager
 {:.badge .free}
+{% endif_version %}
+{% if_version gte:3.4.x %}
+### Enable Kong Manager
+{% endif_version %}
 
 {% if_version gte:3.0.x %}
 

--- a/app/_src/gateway/install/docker/index.md
+++ b/app/_src/gateway/install/docker/index.md
@@ -235,8 +235,7 @@ docker run -d --name kong-gateway \
     the example to  print messages and errors to `stdout` and `stderr`.
     * [`KONG_ADMIN_LISTEN`](/gateway/{{page.kong_version}}/reference/configuration/#admin_listen):
     The port that the Kong Admin API listens on for requests.
-    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
-    (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
+    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url): The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
     * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it
     as an environment variable, this parameter pulls the license from your environment.
@@ -251,7 +250,7 @@ docker run -d --name kong-gateway \
 
     You should receive a `200` status code.
 <!-- vale on -->
-1. (Not available in OSS) Verify that Kong Manager is running by accessing it
+1. Verify that Kong Manager is running by accessing it
 using the URL specified in `KONG_ADMIN_GUI_URL`:
 
     ```
@@ -423,8 +422,7 @@ docker run -d --name kong-dbless \
     the example to  print messages and errors to `stdout` and `stderr`.
     * [`KONG_ADMIN_LISTEN`](/gateway/{{page.kong_version}}/reference/configuration/#admin_listen):
     The port that the Kong Admin API listens on for requests.
-    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url):
-    (Enterprise only) The URL for accessing Kong Manager, preceded by a protocol
+    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url): The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
     * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it
     as an environment variable, this parameter pulls the license from your environment.

--- a/app/_src/gateway/install/docker/index.md
+++ b/app/_src/gateway/install/docker/index.md
@@ -206,6 +206,7 @@ docker run -d --name kong-gateway \
  -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
  -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
+ -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
  -p 8000:8000 \
  -p 8443:8443 \
  -p 127.0.0.1:8001:8001 \
@@ -235,7 +236,7 @@ docker run -d --name kong-gateway \
     the example to  print messages and errors to `stdout` and `stderr`.
     * [`KONG_ADMIN_LISTEN`](/gateway/{{page.kong_version}}/reference/configuration/#admin_listen):
     The port that the Kong Admin API listens on for requests.
-    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url): The URL for accessing Kong Manager, preceded by a protocol
+    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url): {% if_version lte:3.3.x %}(Not available in OSS) {% endif_version %}The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
     * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it
     as an environment variable, this parameter pulls the license from your environment.
@@ -250,13 +251,22 @@ docker run -d --name kong-gateway \
 
     You should receive a `200` status code.
 <!-- vale on -->
+{% if_version lte:3.3.x %}
+1. (Not available in OSS) Verify that Kong Manager is running by accessing it
+using the URL specified in `KONG_ADMIN_GUI_URL`:
+
+    ```
+    http://localhost:8002
+    ```
+{% endif_version %}
+{% if_version gte:3.4.x %}
 1. Verify that Kong Manager is running by accessing it
 using the URL specified in `KONG_ADMIN_GUI_URL`:
 
     ```
     http://localhost:8002
     ```
-
+{% endif_version %}
 ### Get started with {{site.base_gateway}}
 
 Now that you have a running Gateway instance, Kong provides a series of
@@ -383,6 +393,7 @@ docker run -d --name kong-dbless \
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
+{% if_version lte:3.3.x %}
 ```sh
 docker run -d --name kong-dbless \
  --network=kong-net \
@@ -400,6 +411,27 @@ docker run -d --name kong-dbless \
  -p 127.0.0.1:8444:8444 \
  kong:{{page.versions.ce}}
  ```
+{% endif_version %}
+{% if_version gte:3.4.x %}
+```sh
+docker run -d --name kong-dbless \
+ --network=kong-net \
+ -v "$(pwd):/kong/declarative/" \
+ -e "KONG_DATABASE=off" \
+ -e "KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml" \
+ -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
+ -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
+ -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
+ -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
+ -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
+ -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
+ -p 8000:8000 \
+ -p 8443:8443 \
+ -p 127.0.0.1:8001:8001 \
+ -p 127.0.0.1:8444:8444 \
+ kong:{{page.versions.ce}}
+ ```
+{% endif_version %}
 {% endnavtab %}
 {% endnavtabs_ee %}
 {% endcapture %}
@@ -422,7 +454,7 @@ docker run -d --name kong-dbless \
     the example to  print messages and errors to `stdout` and `stderr`.
     * [`KONG_ADMIN_LISTEN`](/gateway/{{page.kong_version}}/reference/configuration/#admin_listen):
     The port that the Kong Admin API listens on for requests.
-    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url): The URL for accessing Kong Manager, preceded by a protocol
+    * [`KONG_ADMIN_GUI_URL`](/gateway/{{page.kong_version}}/reference/configuration/#admin_gui_url): {% if_version lte:3.3.x %}(Not available in OSS) {% endif_version %}The URL for accessing Kong Manager, preceded by a protocol
     (for example, `http://`).
     * `KONG_LICENSE_DATA`: (Enterprise only) If you have a license file and have saved it
     as an environment variable, this parameter pulls the license from your environment.


### PR DESCRIPTION
### Description

What did you change and why?
- Our OSS install instructions (specifically Docker and I found some Linux ones as well) that still said that KM wasn't for OSS even though it is. I fixed those spots.
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
DOCU-3445

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

