### PR TITLE
Add info about how IP address is determined for IP Restriction plugin

### DIFF
--- a/app/_hub/kong-inc/ip-restriction/_index.md
+++ b/app/_hub/kong-inc/ip-restriction/_index.md
@@ -26,6 +26,8 @@ curl -X POST http://kong:8001/services/{service}/plugins \
 
 ### IP Addresses
 
-It is important to understand how the IP address is determined in order to use this plugin effectively. The IP address is determined by the request header sent to Kong from downstream. In most cases, the header has a name of ```X-Real-IP``` or ```X-Forwarded-For```. By default, Kong will use the header name ```X-Real-IP```, however if a different header name is required then this will need to be defined using the [real_ip_header](https://docs.konghq.com/gateway/latest/reference/configuration/#real_ip_header) Nginx property. Depending on the environmental network setup, the [trusted_ips](https://docs.konghq.com/gateway/latest/reference/configuration/#trusted_ips) Nginx property may also need to be configured to include the load balancer IP address.
+It is important to understand how the IP address is determined. The IP address is determined by the request header sent to Kong from downstream. In most cases, the header has a name of `X-Real-IP` or `X-Forwarded-For`.
+
+By default, Kong uses the header name `X-Real-IP`. If a different header name is required, it needs to be defined using the [real_ip_header](https://docs.konghq.com/gateway/latest/reference/configuration/#real_ip_header) Nginx property. Depending on the environmental network setup, the [trusted_ips](https://docs.konghq.com/gateway/latest/reference/configuration/#trusted_ips) Nginx property may also need to be configured to include the load balancer IP address.
 
 ---

--- a/app/_hub/kong-inc/ip-restriction/_index.md
+++ b/app/_hub/kong-inc/ip-restriction/_index.md
@@ -28,6 +28,6 @@ curl -X POST http://kong:8001/services/{service}/plugins \
 
 It is important to understand how the IP address is determined. The IP address is determined by the request header sent to Kong from downstream. In most cases, the header has a name of `X-Real-IP` or `X-Forwarded-For`.
 
-By default, Kong uses the header name `X-Real-IP`. If a different header name is required, it needs to be defined using the [real_ip_header](https://docs.konghq.com/gateway/latest/reference/configuration/#real_ip_header) Nginx property. Depending on the environmental network setup, the [trusted_ips](https://docs.konghq.com/gateway/latest/reference/configuration/#trusted_ips) Nginx property may also need to be configured to include the load balancer IP address.
+By default, Kong uses the header name `X-Real-IP`. If a different header name is required, it needs to be defined using the [real_ip_header](/gateway/latest/reference/configuration/#real_ip_header) Nginx property. Depending on the environmental network setup, the [trusted_ips](/gateway/latest/reference/configuration/#trusted_ips) Nginx property may also need to be configured to include the load balancer IP address.
 
 ---

--- a/app/_hub/kong-inc/ip-restriction/_index.md
+++ b/app/_hub/kong-inc/ip-restriction/_index.md
@@ -24,4 +24,8 @@ curl -X POST http://kong:8001/services/{service}/plugins \
   --data "config.deny=127.0.0.1"
 ```
 
+### IP Addresses
+
+It is important to understand how the IP address is determined in order to use this plugin effectively. The IP address is determined by the request header sent to Kong from downstream. In most cases, the header has a name of ```X-Real-IP``` or ```X-Forwarded-For```. By default, Kong will use the header name ```X-Real-IP```, however if a different header name is required then this will need to be defined using the [real_ip_header](https://docs.konghq.com/gateway/latest/reference/configuration/#real_ip_header) Nginx property. Depending on the environmental network setup, the [trusted_ips](https://docs.konghq.com/gateway/latest/reference/configuration/#trusted_ips) Nginx property may also need to be configured to include the load balancer IP address.
+
 ---


### PR DESCRIPTION
### Description

Added a blurb about how the IP Address is determined when using the IP Restriction plugin, as this was confusing customers who were unaware of the appropriate settings that needed to be tweaked for their environment so the IP could be determined accurately.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)