### PR TITLE
Fix(plugin scopes): Consumer groups scope and application registration plugin

### DIFF
--- a/app/_plugins/generators/plugin_single_source/plugin/schemas/base.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/schemas/base.rb
@@ -88,10 +88,10 @@ module PluginSingleSource
         end
 
         def enable_on_service?
-          field = fields.detect { |f| f.key?('service') }
+          field = fields.detect { |f| f.key?('service.ne') }
           return true unless field
 
-          !field_no_def?('service', field, NO_SERVICE)
+          !field_no_def?('service.ne', field, NO_SERVICE)
         end
 
         def enable_on_route?

--- a/app/hub/plugins/compatibility/index.md
+++ b/app/hub/plugins/compatibility/index.md
@@ -225,6 +225,7 @@ See the following table for plugins and their compatible scopes:
       <th style="text-align: center">Service</th>
       <th style="text-align: center">Route</th>
       <th style="text-align: center">Consumer</th>
+      <th style="text-align: center">Consumer group</th>
       <th style="text-align: center">Global</th>
   </thead>
   <tbody>
@@ -249,6 +250,13 @@ See the following table for plugins and their compatible scopes:
         </td>
         <td style="text-align: center"> 
           {% if extn.schema.enable_on_consumer? %}
+            <i class="fa fa-check"></i>
+          {% else %}
+            <i class="fa fa-times"></i>
+          {% endif %}
+        </td>
+        <td style="text-align: center"> 
+          {% if extn.schema.enable_on_consumer_group? %}
             <i class="fa fa-check"></i>
           {% else %}
             <i class="fa fa-times"></i>


### PR DESCRIPTION
### Description

The [scopes compatibility table](https://docs.konghq.com/hub/plugins/compatibility/#scopes) was missing a column for consumer groups. This PR enables generating the column and all entries from the plugins' schemas.

Additionally, the Application Registration plugin was listed as incompatible with all scopes, which is wrong - it's compatible with services only. Turns out we were selecting for the wrong key. Fixing this also fixes the display of the plugin's [config](https://docs.konghq.com/hub/kong-inc/application-registration/configuration/) and [basic examples](https://docs.konghq.com/hub/kong-inc/application-registration/how-to/basic-example/), which were both missing services.

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

