### PR TITLE
fix: Partial revert of plugin scopes changes

### DIFF
--- a/app/_plugins/generators/plugin_single_source/plugin/schemas/base.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/schemas/base.rb
@@ -88,10 +88,10 @@ module PluginSingleSource
         end
 
         def enable_on_service?
-          field = fields.detect { |f| f.key?('service.ne') }
+          field = fields.detect { |f| f.key?('service') }
           return true unless field
 
-          !field_no_def?('service.ne', field, NO_SERVICE)
+          !field_no_def?('service', field, NO_SERVICE)
         end
 
         def enable_on_route?


### PR DESCRIPTION
### Description

Partial revert of https://github.com/Kong/docs.konghq.com/pull/6059, undoing the app registration plugin part. That plugin is an exception and needs to be handled that way, and I can't figure out how to do it right. 

Reverting for now to prevent spec tests from failing in every PR. That just brings us back to the initial problem with the app reg plugin, which still needs fixing, but requires more Ruby knowledge than I have at the moment.



### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

