### PR TITLE
Clarify and improve DP Resilience feature notes

### DIFF
--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -103,7 +103,10 @@ kong-dp-exporter:
       KONG_CLUSTER_FALLBACK_CONFIG_EXPORT: "on"
 ```
 
-This node is responsible for writing to the GCP bucket when it receives a new configuration. The file structure will be automatically created inside of the bucket, these should not be created manually. If the node version is `3.2.0.0` using the example above, the key name will be `test-prefix/3.2.0.0/config.json`. Both the control plane and data plane can be configured to export configurations.
+This node is responsible for writing to the GCP bucket when it receives a new configuration. 
+The file structure is automatically created inside of the bucket and should not be created manually. If the node version is `3.2.0.0`, using the example above, the key name will be `test-prefix/3.2.0.0/config.json`. 
+
+Both the control plane and data plane can be configured to export configurations.
 
 
 You can configure new data planes to load a configuration from the GCP cloud storage bucket if the control plane is unreachable using the following environment variables: 

--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -23,7 +23,8 @@ In this setup, you need to designate one backup node.
 The backup node must have read and write access to the S3 bucket, and the data plane nodes that are provisioned must have read access to the same S3 bucket. 
 This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the S3 bucket.
 
-Nodes are initialized with fallback configs via environment variables, including `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`. If associating with an IAM role and if the backup node does not reside on the AWS platform then an additional environment variable `AWS_SESSION_TOKEN` may be necessary. 
+Nodes are initialized with fallback configs via environment variables, including `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`. 
+If associating with an IAM role and if the backup node does not reside on the AWS platform, an additional environment variable `AWS_SESSION_TOKEN` may be necessary. 
 
 A backup node should not be used to proxy traffic. A single backup node is sufficient for all deployments. For more information about the data that is set in the environment variables, review the [AWS environment variable configuration documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
 

--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -46,7 +46,9 @@ kong-exporter:
 
 ```
 
-This node is responsible for writing to the S3 bucket when it receives a new configuration. The file structure will be automatically created inside of the bucket, these should not be created manually. If the node version is `3.2.0.0` using the example above, the key name will be `test-prefix/3.2.0.0/config.json`. Both the control plane and data plane can be configured to export configurations.
+This node is responsible for writing to the S3 bucket when it receives new configuration. The file structure is automatically created inside of the bucket and should not be created manually. If the node version is `3.2.0.0`, using the example above, the key name will be `test-prefix/3.2.0.0/config.json`. 
+
+Both the control plane and data plane can be configured to export configurations.
 
 You can configure new data planes to load a configuration from the S3 bucket if the control plane is unreachable using the following environment variables: 
 

--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -14,7 +14,7 @@ This option is only recommended for customers who have to adhere to strict avail
 ## Prerequisites
  
 * An Amazon S3 bucket
-* Read & write credentials for the bucket
+* Read and write credentials for the bucket
 
 
 ## Configuration

--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -19,7 +19,9 @@ This option is only recommended for customers who have to adhere to strict avail
 
 ## Configuration
 
-In this setup, you will need to designate one backup node. The backup node must have read & write access to the S3 bucket and the data plane nodes that are provisioned must have read access to the same S3 bucket. This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the S3 bucket.
+In this setup, you need to designate one backup node. 
+The backup node must have read and write access to the S3 bucket, and the data plane nodes that are provisioned must have read access to the same S3 bucket. 
+This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the S3 bucket.
 
 Nodes are initialized with fallback configs via environment variables, including `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`. If associating with an IAM role and if the backup node does not reside on the AWS platform then an additional environment variable `AWS_SESSION_TOKEN` may be necessary. 
 

--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -80,7 +80,9 @@ kong-dp-importer:
 
 ## Configuration
 
-In this setup, you will need to designate one backup node. The backup node must have read & write access to the GCP cloud storage bucket and the data plane nodes that are provisioned must have read access to the same GCP cloud storage bucket. This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the GCP cloud storage bucket.
+In this setup, you need to designate one backup node. 
+The backup node must have read and write access to the GCP cloud storage bucket and the data plane nodes that are provisioned must have read access to the same GCP cloud storage bucket. 
+This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the GCP cloud storage bucket.
 
 Credentials are passed via the environment variable `GCP_SERVICE_ACCOUNT`. For more information about credentials review the [GCP credentials documentation](https://developers.google.com/workspace/guides/create-credentials).
 

--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -13,15 +13,19 @@ This option is only recommended for customers who have to adhere to strict avail
 {% navtab Amazon S3 %}
 ## Prerequisites
  
-* An Amazon S3 service and bucket.
-* Read/write credentials for the bucket.
+* An Amazon S3 bucket
+* Read & write credentials for the bucket
 
 
-## Configuration 
+## Configuration
 
-In this setup, you will need to designate one backup node. The backup node must have read/write access to the S3 compatible storage volume and the data plane nodes that are provisioned must have read access to the storage volume. This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the storage volume. Nodes are initialized with fallback configs via environment variables, including `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`. A backup node should not be used to proxy traffic. A single backup node is sufficient for all deployments. For more information about the data that is set in the environment variables, review the [AWS environment variable configuration documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
+In this setup, you will need to designate one backup node. The backup node must have read & write access to the S3 bucket and the data plane nodes that are provisioned must have read access to the same S3 bucket. This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the S3 bucket.
 
-Using Docker Compose, you can configure the backup data plane:
+Nodes are initialized with fallback configs via environment variables, including `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`. If associating with an IAM role and if the backup node does not reside on the AWS platform then an additional environment variable `AWS_SESSION_TOKEN` may be necessary. 
+
+A backup node should not be used to proxy traffic. A single backup node is sufficient for all deployments. For more information about the data that is set in the environment variables, review the [AWS environment variable configuration documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
+
+Using Docker Compose, you can configure the backup node:
 
 ```yaml
 kong-exporter:
@@ -39,10 +43,9 @@ kong-exporter:
 
 ```
 
-This node is responsible for writing to the S3 bucket when it receives a new configuration. If the node version is `3.2.0.0`, the key name should be `test-prefix/3.2.0.0/config.json`.
-Both the control plane and data plane can be configured to export configurations.
+This node is responsible for writing to the S3 bucket when it receives a new configuration. The file structure will be automatically created inside of the bucket, these should not be created manually. If the node version is `3.2.0.0` using the example above, the key name will be `test-prefix/3.2.0.0/config.json`. Both the control plane and data plane can be configured to export configurations.
 
-You can configure new data planes to load a configuration from a S3 bucket if the control plane is unreachable using the following environment variables: 
+You can configure new data planes to load a configuration from the S3 bucket if the control plane is unreachable using the following environment variables: 
 
 ```yaml
 kong-dp-importer:
@@ -67,15 +70,18 @@ kong-dp-importer:
 ## Prerequisites
 
 * A GCP cloud storage bucket
-* Read/write credentials for the bucket.
+* Read & write credentials for the bucket
 
 
 ## Configuration
 
-In this setup you will need to designate one backup node. The backup node must have read/write access to the storage volume, and the data plane nodes supposed to be provisioned must have read access to the storage volume. This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the storage volume. A backup node should not be used to proxy traffic. A single backup node is sufficient for all deployments.
+In this setup, you will need to designate one backup node. The backup node must have read & write access to the GCP cloud storage bucket and the data plane nodes that are provisioned must have read access to the same GCP cloud storage bucket. This node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the control plane to the GCP cloud storage bucket.
+
 Credentials are passed via the environment variable `GCP_SERVICE_ACCOUNT`. For more information about credentials review the [GCP credentials documentation](https://developers.google.com/workspace/guides/create-credentials).
 
-Using Docker Compose, configure the node:
+A backup node should not be used to proxy traffic. A single backup node is sufficient for all deployments.
+
+Using Docker Compose, you can configure the backup node:
 
 ```yaml
 kong-dp-exporter:
@@ -85,14 +91,15 @@ kong-dp-exporter:
       - '8443:8443'
     environment:
       <<: *other-kong-envs
-      KONG_CLUSTER_FALLBACK_CONFIG_STORAGE: gcs://test-bucket/
-      KONG_CLUSTER_FALLBACK_CONFIG_EXPORT: "on"
       GCP_SERVICE_ACCOUNT: <GCP_JSON_STRING_WRITE>
+      KONG_CLUSTER_FALLBACK_CONFIG_STORAGE: gcs://test-bucket/test-prefix
+      KONG_CLUSTER_FALLBACK_CONFIG_EXPORT: "on"
 ```
 
-This node will ship backup configurations to the GCP bucket when it receives a new configuration. If the version is `3.2.0.0`, the key name should be `test-prefix/3.2.0.0/config.json`.
+This node is responsible for writing to the GCP bucket when it receives a new configuration. The file structure will be automatically created inside of the bucket, these should not be created manually. If the node version is `3.2.0.0` using the example above, the key name will be `test-prefix/3.2.0.0/config.json`. Both the control plane and data plane can be configured to export configurations.
 
-A new data plane can be configured to load a configuration from GCP bucket if the control plane is not reachable using the following environment variables: 
+
+You can configure new data planes to load a configuration from the GCP cloud storage bucket if the control plane is unreachable using the following environment variables: 
 
 ```yaml
   kong-dp-importer:
@@ -102,9 +109,9 @@ A new data plane can be configured to load a configuration from GCP bucket if th
       - '8443:8443'
     environment:
       <<: *other-kong-envs
-      KONG_CLUSTER_FALLBACK_CONFIG_STORAGE: gcs://test-bucket/
-      KONG_CLUSTER_FALLBACK_CONFIG_IMPORT: "on"
       GCP_SERVICE_ACCOUNT: <GCP_JSON_STRING_READ>
+      KONG_CLUSTER_FALLBACK_CONFIG_STORAGE: gcs://test-bucket/test-prefix
+      KONG_CLUSTER_FALLBACK_CONFIG_IMPORT: "on"
 ```
 
 

--- a/app/_src/gateway/kong-enterprise/cp-outage-handling.md
+++ b/app/_src/gateway/kong-enterprise/cp-outage-handling.md
@@ -75,7 +75,7 @@ kong-dp-importer:
 ## Prerequisites
 
 * A GCP cloud storage bucket
-* Read & write credentials for the bucket
+* Read and write credentials for the bucket
 
 
 ## Configuration


### PR DESCRIPTION
### Description

In troubleshooting a support case, we discovered that there was no mention of the `AWS_SESSION_TOKEN` variable which is needed in certain situations. Added a line in the Configuration section to clarify this for AWS S3.

Some customers were also confused thinking they needed to manually create the file structure including the config.json file in the bucket, so I added a line that confirmed this is created automatically and should not be created manually.

Also aligned some wording between AWS S3 and GCP bucket instructions, just minor tweaks to verbiage. Also modified "read/write" to "read & write" to remove any possible misunderstanding of the forward-slash being seen as an "or" when both are needed on the bucket.
 
Slack threads: https://kongstrong.slack.com/archives/C02DP1KL2DR/p1693931351607979 & https://kongstrong.slack.com/archives/C03CTMSHP6C/p1694016868653509

Tagging with Review:SME too just to double-check my recent learnings which I applied in part to this documentation page (specifically for my understanding of the AWS_SESSION_TOKEN situation).

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)