### PR TITLE
Sectioned cluster_fallback configs + added WebAssembly text to Wasm section

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -4196,26 +4196,6 @@ and valid UUID. When empty, node ID is automatically generated.
 ## Cluster Fallback Configuration section
 
 
-### cluster_fallback_config_export
-{:.badge .enterprise}
-
-Enable fallback configuration exports.
-
-**Default:** `off`
-
-
-### cluster_fallback_config_export_delay
-{:.badge .enterprise}
-
-The fallback configuration export interval.
-
-If it's set to 60 and configuration A is exported and there're new
-configurations B, C and D in the next 60 seconds, it will wait until 60 seconds
-passed and export D, skipping B and C.
-
-**Default:** `60`
-
-
 ### cluster_fallback_config_import
 {:.badge .enterprise}
 
@@ -4247,6 +4227,26 @@ The credentials for GCP is provided via the environment variable
 `GCP_SERVICE_ACCOUNT`
 
 **Default:** none
+
+
+### cluster_fallback_config_export
+{:.badge .enterprise}
+
+Enable fallback configuration exports.
+
+**Default:** `off`
+
+
+### cluster_fallback_config_export_delay
+{:.badge .enterprise}
+
+The fallback configuration export interval.
+
+If it's set to 60 and configuration A is exported and there're new
+configurations B, C and D in the next 60 seconds, it will wait until 60 seconds
+passed and export D, skipping B and C.
+
+**Default:** `60`
 
 
 ---

--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -4191,12 +4191,37 @@ and valid UUID. When empty, node ID is automatically generated.
 
 **Default:** none
 
+---
+
+## Cluster Fallback Configuration section
+
+
+### cluster_fallback_config_export
+{:.badge .enterprise}
+
+Enable fallback configuration exports.
+
+**Default:** `off`
+
+
+### cluster_fallback_config_export_delay
+{:.badge .enterprise}
+
+The fallback configuration export interval.
+
+If it's set to 60 and configuration A is exported and there're new
+configurations B, C and D in the next 60 seconds, it will wait until 60 seconds
+passed and export D, skipping B and C.
+
+**Default:** `60`
+
+
 ### cluster_fallback_config_import
 {:.badge .enterprise}
 
 Enable fallback configuration imports
 
-This should only be enabled for data plane
+This should only be enabled for the data plane.
 
 **Default:** `off`
 
@@ -4224,29 +4249,9 @@ The credentials for GCP is provided via the environment variable
 **Default:** none
 
 
-### cluster_fallback_config_export
-{:.badge .enterprise}
-
-Enable fallback configuration exports.
-
-**Default:** `off`
-
-
-### cluster_fallback_config_export_delay
-{:.badge .enterprise}
-
-The fallback configuration export interval.
-
-If it's set to 60 and configuration A is exported and there're new
-configurations B, C and D in the next 60 seconds, it will wait until 60 seconds
-passed and export D, skipping B and C.
-
-**Default:** `60`
-
-
 ---
 
-## Wasm section
+## WebAssembly (Wasm) section
 
 ### wasm
 

--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -4191,17 +4191,16 @@ and valid UUID. When empty, node ID is automatically generated.
 
 **Default:** none
 
----
+----
 
 ## Cluster Fallback Configuration section
-
 
 ### cluster_fallback_config_import
 {:.badge .enterprise}
 
-Enable fallback configuration imports
+Enable fallback configuration imports.
 
-This should only be enabled for the data plane.
+This should only be enabled for data planes.
 
 **Default:** `off`
 
@@ -4210,21 +4209,24 @@ This should only be enabled for the data plane.
 {:.badge .enterprise}
 
 Storage definition used by `cluster_fallback_config_import` and
-`cluster_fallback_config_export`
+`cluster_fallback_config_export`.
 
-Currently supported storage type: S3-like storages and GCP storage service.
+Supported storage types:
+
+- S3-like storages
+- GCP storage service
 
 To use S3 with a bucket named b and place all configs to with a key prefix
-named p, set it to: s3://b/p To use GCP for the same bucket and prefix, set it
-to: gcs://b/p
+named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it
+to: `gcs://b/p`
 
-The credentials (and endpoint URL for S3-like) for S3 are passing with
-environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and
+The credentials (and the endpoint URL for S3-like) for S3 are passed with
+environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
 `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT`
 is the endpoint that hosts S3-like storage.
 
-The credentials for GCP is provided via the environment variable
-`GCP_SERVICE_ACCOUNT`
+The credentials for GCP are provided via the environment variable
+`GCP_SERVICE_ACCOUNT`.
 
 **Default:** none
 
@@ -4242,12 +4244,11 @@ Enable fallback configuration exports.
 
 The fallback configuration export interval.
 
-If it's set to 60 and configuration A is exported and there're new
-configurations B, C and D in the next 60 seconds, it will wait until 60 seconds
+If the interval is set to 60 and configuration A is exported and there are new
+configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds
 passed and export D, skipping B and C.
 
 **Default:** `60`
-
 
 ---
 

--- a/autodoc-conf-ee/run.lua
+++ b/autodoc-conf-ee/run.lua
@@ -199,7 +199,7 @@ for _, section in ipairs(parsed) do
         string.match(var.name, "cluster_fallback") or
         string.match(var.name, "rbac") or
         string.match(var.name, "event_hooks") or
-        string.match(var.name, "keyring") or
+        string.match(var.name, "keyring")
       then
         write("{:.badge .enterprise}")
 


### PR DESCRIPTION
### Description

Moved the DP Resilience feature (Cluster Fallback) properties to their own section for better organization and linking. Loosely related to https://github.com/Kong/docs.konghq.com/pull/6064.

Also noticed our Wasm section had no reference to the text 'WebAssembly' which resulted in it not being found easily. Added that to the title of that section to allow for better searchability.


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)