### PR TITLE
update urls to latest and remove mention of dev portal

### DIFF
--- a/app/_src/gateway/admin-api/index.md
+++ b/app/_src/gateway/admin-api/index.md
@@ -830,10 +830,10 @@ filters_data:
 {:.note .no-icon }
 > <span class="badge beta"></span> **Kong Gateway API specs now available!**
 > 
-| Spec | Developer portal link | Insomnia link |
-|------|-----------------------|---------------|
-| Enterprise beta API spec|[Dev Portal](/gateway/api/admin-ee/3.3.0.x/)   | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F3.4%2Fkong-ee-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>  |
-|  Open source beta API spec | [Dev Portal](/gateway/api/admin-oss/3.3.x/)  | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Open%20Source%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F3.4%2Fkong-oss-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
+| Spec | Insomnia link |
+|-------|---------------|
+| [Enterprise beta API spec](/gateway/api/admin-ee/latest/) |<a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F3.4%2Fkong-ee-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>  |
+|  [Open source beta API spec](/gateway/api/admin-oss/latest/) |  <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Open%20Source%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F3.4%2Fkong-oss-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
 
 
 <!-- vale off -->

--- a/app/konnect/api/index.md
+++ b/app/konnect/api/index.md
@@ -21,9 +21,9 @@ The region-specific endpoints are used to manage {{site.konnect_short_name}} ent
 {:.note .no-icon }
 > <span class="badge beta"></span> **A beta API spec for the runtime group configuration API is now available!**
 >
-| Spec | Developer portal link | Insomnia link |
-|------|-----------------------|---------------|
-| Konnect runtime group configuration beta API spec |[Developer Portal](/konnect/api/runtime-groups-configuration/v2/)  | <a href="https://insomnia.rest/run/?label=Runtime%20Groups%20Configuration%20API&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FKonnect%2Fv2%2Fjson%2Fkonnect-2.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
+| Spec | Insomnia link |
+|------|---------------|
+| [Konnect runtime group configuration beta API spec](/konnect/api/runtime-groups-configuration/v2/) | <a href="https://insomnia.rest/run/?label=Runtime%20Groups%20Configuration%20API&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FKonnect%2Fv2%2Fjson%2Fkonnect-2.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
 
 ## Authentication
 


### PR DESCRIPTION
Update urls to latest for gateway apis

Remove mention of dev portal from API announcement banner.