### PR TITLE
fix missing keyword config in curl data

### DIFF
--- a/app/_hub/kong-inc/grpc-web/how-to/_index.md
+++ b/app/_hub/kong-inc/grpc-web/how-to/_index.md
@@ -106,7 +106,7 @@ or via the Admin API:
 ```bash
 curl -X POST localhost:8001/routes/web-service/plugins \
   --data name=grpc-web \
-  --data proto=path/to/hello.proto
+  --data config.proto=path/to/hello.proto
 ```
 
 Upload the Protobuf definition to your Kong Node:


### PR DESCRIPTION
To enable grpc-web plugin via Admin API, the keyworkd `config` in curl data is missing.