### PR TITLE
Copy example .env when running make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install: ruby-version-check
 	npm ci
 	bundle install
 	git submodule update --init
+	@if [ ! -f .env ]; then cp .env.example .env; fi
 
 # Using local dependencies, starts a doc site instance on http://localhost:4000.
 run: ruby-version-check


### PR DESCRIPTION
### Description

Improve onboarding experience by using the example `.env` file by default. 

Run `make install` to copy the example to the correct location.

### Testing instructions

Netlify link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)