### PR TITLE
Update _index.md - GraphQL Introspection endpoint related note.

### DIFF
--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
@@ -20,7 +20,7 @@ cost for a given time window.
   * PostgreSQL 9.5+ is required when using the `cluster` strategy with `postgres` as the backing Kong cluster datastore.
   * The `dictionary_name` directive was added to prevent the usage of the `kong` shared dictionary, which could lead to `no memory` errors.
   * The introspection endpoint is generated based on the Kong service path, so the service path should be defined with an actual path instead of appending from the route path.
-    - A known limitation is we cannot have separate paths for query and introspection endpoints.
+    * Known limitation: The query and introspection endpoints _cannot_ have separate paths.
     - Example: While using KIC, if the query and introspection endpoints are at path /graphql, should be configured like this
       - Add `konghq.com/strip-path: "true"` annotation to the ingress resource
       - Add `konghq.com/path: /graphql` annotation to the service resource.

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
@@ -22,7 +22,7 @@ cost for a given time window.
   * The introspection endpoint is generated based on the Kong service path, so the service path should be defined with an actual path instead of appending from the route path.
     * Known limitation: The query and introspection endpoints _cannot_ have separate paths.
     - Example: While using KIC, if the query and introspection endpoints are at path /graphql, should be configured like this
-      - Add `konghq.com/strip-path: "true"` annotation to the ingress resource
+      * Add the `konghq.com/strip-path: "true"` annotation to the ingress resource
       - Add the `konghq.com/path: /graphql` annotation to the service resource
 
 Kong also provides a [GraphQL Proxy Cache Advanced plugin](/hub/kong-inc/graphql-proxy-cache-advanced/).

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
@@ -19,6 +19,11 @@ cost for a given time window.
   * Redis configuration values are ignored if the `cluster` strategy is used.
   * PostgreSQL 9.5+ is required when using the `cluster` strategy with `postgres` as the backing Kong cluster datastore.
   * The `dictionary_name` directive was added to prevent the usage of the `kong` shared dictionary, which could lead to `no memory` errors.
+  * Introspection endpoint is generated based on the Kong service path, hence service path should be defined with actual path instead of appending from the route path.
+    - A known limitation is we cannot have separate paths for query and introspection endpoints.
+    - Example: While using KIC, if the query and introspection endpoints are at path /graphql, should be configured like this
+      - Add `konghq.com/strip-path: "true"` annotation to the ingress resource
+      - Add `konghq.com/path: /graphql` annotation to the service resource.
 
 Kong also provides a [GraphQL Proxy Cache Advanced plugin](/hub/kong-inc/graphql-proxy-cache-advanced/).
 

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
@@ -21,7 +21,7 @@ cost for a given time window.
   * The `dictionary_name` directive was added to prevent the usage of the `kong` shared dictionary, which could lead to `no memory` errors.
   * The introspection endpoint is generated based on the Kong service path, so the service path should be defined with an actual path instead of appending from the route path.
     * Known limitation: The query and introspection endpoints _cannot_ have separate paths.
-    - Example: While using KIC, if the query and introspection endpoints are at path /graphql, should be configured like this
+    * Example: While using KIC, if the query and introspection endpoints are at path `/graphql`, they should be configured like this:
       * Add the `konghq.com/strip-path: "true"` annotation to the ingress resource
       - Add the `konghq.com/path: /graphql` annotation to the service resource
 

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
@@ -19,7 +19,7 @@ cost for a given time window.
   * Redis configuration values are ignored if the `cluster` strategy is used.
   * PostgreSQL 9.5+ is required when using the `cluster` strategy with `postgres` as the backing Kong cluster datastore.
   * The `dictionary_name` directive was added to prevent the usage of the `kong` shared dictionary, which could lead to `no memory` errors.
-  * Introspection endpoint is generated based on the Kong service path, hence service path should be defined with actual path instead of appending from the route path.
+  * The introspection endpoint is generated based on the Kong service path, so the service path should be defined with an actual path instead of appending from the route path.
     - A known limitation is we cannot have separate paths for query and introspection endpoints.
     - Example: While using KIC, if the query and introspection endpoints are at path /graphql, should be configured like this
       - Add `konghq.com/strip-path: "true"` annotation to the ingress resource

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/overview/_index.md
@@ -23,7 +23,7 @@ cost for a given time window.
     * Known limitation: The query and introspection endpoints _cannot_ have separate paths.
     - Example: While using KIC, if the query and introspection endpoints are at path /graphql, should be configured like this
       - Add `konghq.com/strip-path: "true"` annotation to the ingress resource
-      - Add `konghq.com/path: /graphql` annotation to the service resource.
+      - Add the `konghq.com/path: /graphql` annotation to the service resource
 
 Kong also provides a [GraphQL Proxy Cache Advanced plugin](/hub/kong-inc/graphql-proxy-cache-advanced/).
 


### PR DESCRIPTION
GraphQL Introspection endpoint will only be read from the Kong service (`service = ngx.ctx.service`) instead of reading from a specific variable or ingress - local 

Documenting this behavior so consumers are aware of how to configure correctly and know about the limitation


### Description

What did you change and why?
 
Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.


### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

