### PR TITLE
update: Comment out description for changelog [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,13 @@
 
 ### Description
 
-What did you change and why?
+<!-- What did you change and why? -->
  
-Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc.
-
+<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
 
 ### Testing instructions
 
-Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
-
+Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
 
 ### Checklist 
 


### PR DESCRIPTION
### Description

Updating the PR template so that changelog entries won't generate extra text. Many people leave the description in their PRs, including docs team, so this aims to make it easier for us to clean up the generated changelog.

### Testing instructions

No netlify preview.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

