### PR TITLE
fix(docs): Correct the influxdb flush frequency

### DIFF
--- a/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
+++ b/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
@@ -266,7 +266,7 @@ data points are present.
 
 Kong buffers Vitals metrics and writes InfluxDB points in batches to improve
 throughput in InfluxDB and reduce overhead in the Kong proxy path. Each Kong
-worker process flushes its buffer of metrics every 5 seconds or 5000 data points,
+worker process flushes its buffer of metrics every 10 seconds or 5000 data points,
 whichever comes first.
 
 Metrics points are written with microsecond (`u`) precision. To comply with


### PR DESCRIPTION

### Description

<!-- What did you change and why? -->

Based on the code here https://github.com/Kong/kong-ee/blob/master/kong/vitals/influxdb/strategy.lua#L28 the Influxdb flush frequency is every 10 seconds instead of 5 seconds.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

