### PR TITLE
fix(docs): correct the influxdb - gateway startup order

### DIFF
--- a/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
+++ b/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
@@ -56,7 +56,7 @@ will work for the purposes of this guide.
 1. Pull the following Docker image.
 
     ```bash
-    docker pull kong/kong-gateway:{{page.versions.ee}}-alpine
+    docker pull kong/kong-gateway:{{page.versions.ee}}
     ```
 
     {:.important}
@@ -70,7 +70,7 @@ will work for the purposes of this guide.
 1. Tag the image.
 
     ```bash
-    docker tag kong/kong-gateway:{{page.versions.ee}}-alpine kong-ee
+    docker tag kong/kong-gateway:{{page.versions.ee}} kong-ee
     ```
 
 

--- a/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
+++ b/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
@@ -29,7 +29,7 @@ with each other.
 1. Start a local InfluxDB instance with Docker.
 
     ```bash
-    docker run -p 8086:8086 \
+    docker run -d -p 8086:8086 \
       --network=kong-ee-net \
       --name influxdb \
       -e INFLUXDB_DB=kong \

--- a/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
+++ b/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
@@ -14,6 +14,35 @@ For information about using Kong Vitals with a database as the backend, refer to
 
 ## Set up Kong Vitals with InfluxDB
 
+### Start an InfluxDB database
+
+Production-ready InfluxDB installations should be deployed as a separate
+effort, but for proof-of-concept testing, running a local InfluxDB instance
+is possible with Docker.
+
+1. Create a custom network to allow the containers to discover and communicate
+with each other.
+
+    ```bash
+    docker network create kong-ee-net
+    ```
+1. Start a local InfluxDB instance with Docker.
+
+    ```bash
+    docker run -p 8086:8086 \
+      --network=kong-ee-net \
+      --name influxdb \
+      -e INFLUXDB_DB=kong \
+      influxdb:1.8.4-alpine
+    ```
+
+    {:.warning}
+    > You **must** use InfluxDB 1.8.4-alpine because
+    InfluxDB 2.0 will **not** work.  
+    
+    Writing Vitals data to InfluxDB requires that the `kong` database is created,
+    this is done using the `INFLUXDB_DB` variable.
+
 ### Install {{site.base_gateway}}
 
 If you already have a {{site.base_gateway}} instance, skip to [deploying a license](#deploy-a-kong-gateway-license).
@@ -22,7 +51,7 @@ If you have not installed {{site.base_gateway}}, a Docker installation
 will work for the purposes of this guide.
 
 
-### Pull the {{site.base_gateway}} Docker image {#pull-image}
+#### Pull the {{site.base_gateway}} Docker image {#pull-image}
 
 1. Pull the following Docker image.
 
@@ -45,14 +74,7 @@ will work for the purposes of this guide.
     ```
 
 
-### Start the database and {{site.base_gateway}} containers
-
-1. Create a custom network to allow the containers to discover and communicate
-with each other.
-
-    ```bash
-    docker network create kong-ee-net
-    ```
+#### Start the database and {{site.base_gateway}} containers
 
 1. Start a PostgreSQL container:
 
@@ -78,7 +100,7 @@ with each other.
     ```
 
 
-1. Start the gateway with Kong Manager:
+1. Start the gateway with Kong Manager and InfluxDB:
 
 {% include_cached /md/admin-listen.md desc='long' kong_version=page.kong_version %}
 
@@ -93,6 +115,8 @@ with each other.
       -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
       -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
       -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
+      -e "KONG_VITALS_STRATEGY=influxdb" \
+      -e "KONG_VITALS_TSDB_ADDRESS=influxdb:8086" \
       -p 8000:8000 \
       -p 8443:8443 \
       -p 8001:8001 \
@@ -112,35 +136,15 @@ with each other.
 ### Deploy a {{site.base_gateway}} license
 
 If you already have a {{site.ee_product_name}} license attached to your {{site.base_gateway}}
-instance, skip to [starting an InfluxDB database](#start-an-influxdb-database).
+instance, skip to [Configure Vitals with InfluxDB](#configure-vitals-with-influxdb).
 
 You will not be able to access the Kong Vitals functionality without a valid
 {{site.ee_product_name}} license attached to your {{site.base_gateway}} instance.
 
 {% include_cached /md/enterprise/deploy-license.md heading="####" kong_version=page.kong_version %}
 
-### Start an InfluxDB database
 
-Production-ready InfluxDB installations should be deployed as a separate
-effort, but for proof-of-concept testing, running a local InfluxDB instance
-is possible with Docker:
-
-```bash
-docker run -p 8086:8086 \
-  --network=<YOUR_NETWORK_NAME> \
-  --name influxdb \
-  -e INFLUXDB_DB=kong \
-  influxdb:1.8.4-alpine
-```
-
-{:.warning}
-> You **must** use InfluxDB 1.8.4-alpine because
-InfluxDB 2.0 will **not** work.  
-
-Writing Vitals data to InfluxDB requires that the `kong` database is created,
-this is done using the `INFLUXDB_DB` variable.
-
-### Configure {{site.base_gateway}}
+### Configure Vitals with InfluxDB {{site.base_gateway}}
 
 {:.note}
 > **Note:** If you used the configuration in

--- a/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
+++ b/app/_src/gateway/kong-enterprise/analytics/influx-strategy.md
@@ -93,8 +93,6 @@ with each other.
       -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
       -e "KONG_ADMIN_LISTEN=0.0.0.0:8001" \
       -e "KONG_ADMIN_GUI_URL=http://localhost:8002" \
-      -e "KONG_VITALS_STRATEGY=influxdb" \
-      -e "KONG_VITALS_TSDB_ADDRESS=influxdb:8086" \
       -p 8000:8000 \
       -p 8443:8443 \
       -p 8001:8001 \


### PR DESCRIPTION
### Description

- Update the startup order and startup InfluxDB before starting up kong-gateway.

- From 3.4.0.0 Kong doesn't release the alpine docker image anymore thus correct the doc.


<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

