### PR TITLE
changed the incorrect port number given in the docs for kic/using-external-service

### DIFF
--- a/app/_includes/md/kic/http-test-routing-resource.md
+++ b/app/_includes/md/kic/http-test-routing-resource.md
@@ -2,6 +2,7 @@
 {%- assign hostname = include.hostname | default: 'kong.example' %}
 {%- assign name = include.name | default: 'echo' %}
 {%- assign service = include.service | default: 'echo' %}
+{%- assign port = include.port | default: '1027' %}
 {% navtabs api %}
 {% navtab Ingress %}
 ```bash
@@ -24,7 +25,7 @@ spec:
           service:
             name: {{ service }}
             port:
-              number: 1027
+              number: {{ port }}
 " | kubectl apply -f -
 ```
 The results should look like this:
@@ -54,7 +55,7 @@ spec:
     backendRefs:
     - name: {{ service }}
       kind: Service
-      port: 1027
+      port: {{ port }}
 " | kubectl apply -f -
 ```
 The results should look like this:

--- a/app/_src/kubernetes-ingress-controller/guides/using-external-service.md
+++ b/app/_src/kubernetes-ingress-controller/guides/using-external-service.md
@@ -33,7 +33,7 @@ service/echo created
 
 ## Create an Ingress to expose the service at the path `/httpbin`
 
-{% include_cached /md/kic/http-test-routing-resource.md kong_version=page.kong_version path='/httpbin' name='proxy-from-k8s-to-httpbin' service='proxy-to-httpbin' %}
+{% include_cached /md/kic/http-test-routing-resource.md kong_version=page.kong_version path='/httpbin' name='proxy-from-k8s-to-httpbin' service='proxy-to-httpbin' port='80' %}
 
 ## Test the Service
 


### PR DESCRIPTION
### Description

Page on KIC exposing external service was having incorrect port number. 

https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-external-service/
 
Port number was defaulting to 1027 which should be 80 in case of httpbin service
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

