### PR TITLE
Fix: Konnect nav duplicate entry

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -20,7 +20,8 @@
         - text: Control Plane Upgrades FAQ
           url: /upgrade-faq/
         - text: Supported Installation Options
-          url: /gateway-manager/data-plane-nodes/
+          url: /support/data-plane-nodes/
+          generate: false
 
 - title: Get Started
   icon: /assets/images/icons/documentation/icn-quickstart-color.svg

--- a/app/_redirects
+++ b/app/_redirects
@@ -2,6 +2,13 @@
 # Newer, more relevant redirects should appear at the top of the file.
 # More general/sweeping redirects should be at the bottom.
 
+######################################################################
+
+# Evergreen redirects for nav files; do not delete unless you're removing the nav entry
+/konnect/support/data-plane-nodes/  /konnect/gateway-manager/data-plane-nodes/
+/gateway/latest/production/breaking-changes/     /gateway/latest/breaking-changes/
+/gateway/:version/production/breaking-changes/   /gateway/:version/breaking-changes/
+
 # Konnect rename
 
 /konnect/runtime-manager/runtime-instances/verify-instance/ /konnect/gateway-manager/data-plane-nodes/verify-node/
@@ -22,8 +29,6 @@
 # 3.3
 
 /gateway/latest/upgrade/#upgrade-considerations-and-breaking-changes    /gateway/latest/breaking-changes/
-/gateway/latest/production/breaking-changes/     /gateway/latest/breaking-changes/
-/gateway/:version/production/breaking-changes/   /gateway/:version/breaking-changes/
 
 # 3.2
 


### PR DESCRIPTION
### Description

There was an  issue with the "Supported installation options" link opening two nav entries. If you clicked on one, two different entries would be highlighted as active.

Fixing it in the rename branch since that link has to change for rename also.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

