### PR TITLE
feat: Add note about MinK system accounts

### DIFF
--- a/app/konnect/mesh-manager/service-mesh.md
+++ b/app/konnect/mesh-manager/service-mesh.md
@@ -24,7 +24,7 @@ Creating a fully-functioning {{site.mesh_product_name}} deployment in {{site.kon
 1. Select the control plane you just created, and then click **Zones** in the sidebar.
 1. Click **Create Zone**, configure the fields as needed, and follow the steps in the wizard to connect your zone to {{site.konnect_short_name}}.
     {:.note}
-    > **Note:** Mesh Manager automatically creates a special [managed service account](/konnect/org-management/system-accounts/) that is only used in the zone creation process. This special, read-only managed service account cannot be edited or deleted manually. Instead, it is removed by {{site.konnect_short_name}} after the zone is created.
+    > **Note:** Mesh Manager automatically creates a [managed service account](/konnect/org-management/system-accounts/) that is only used in the zone creation process. This managed system account cannot be edited or deleted manually. Instead, its life cycle is managed by {{site.konnect_short_name}} it is deleted automatically by {{site.konnect_short_name}} and it is deleted automatically when the zone is deleted.
 1. From the {% konnect_icon mesh-manager %} [**Mesh Manager**](https://cloud.konghq.com/mesh-manager) navigation menu, and select the control plane you created in step 2.
 1. Select **Configure kumactl** from the **Control Plane Actions** dropdown menu and follow the steps in the wizard to connect `kumactl` to the control plane.
 

--- a/app/konnect/mesh-manager/service-mesh.md
+++ b/app/konnect/mesh-manager/service-mesh.md
@@ -23,6 +23,8 @@ Creating a fully-functioning {{site.mesh_product_name}} deployment in {{site.kon
 1. Click **New Control Plane** and complete the fields as needed.
 1. Select the control plane you just created, and then click **Zones** in the sidebar.
 1. Click **Create Zone**, configure the fields as needed, and follow the steps in the wizard to connect your zone to {{site.konnect_short_name}}.
+    {:.note}
+    > **Note:** Mesh Manager automatically creates a special [managed service account](/konnect/org-management/system-accounts/) that is only used in the zone creation process. This special, read-only managed service account cannot be edited or deleted manually. Instead, it is removed by {{site.konnect_short_name}} after the zone is created.
 1. From the {% konnect_icon mesh-manager %} [**Mesh Manager**](https://cloud.konghq.com/mesh-manager) navigation menu, and select the control plane you created in step 2.
 1. Select **Configure kumactl** from the **Control Plane Actions** dropdown menu and follow the steps in the wizard to connect `kumactl` to the control plane.
 

--- a/app/konnect/mesh-manager/service-mesh.md
+++ b/app/konnect/mesh-manager/service-mesh.md
@@ -23,8 +23,13 @@ Creating a fully-functioning {{site.mesh_product_name}} deployment in {{site.kon
 1. Click **New Control Plane** and complete the fields as needed.
 1. Select the control plane you just created, and then click **Zones** in the sidebar.
 1. Click **Create Zone**, configure the fields as needed, and follow the steps in the wizard to connect your zone to {{site.konnect_short_name}}.
-    {:.note}
-    > **Note:** Mesh Manager automatically creates a [managed service account](/konnect/org-management/system-accounts/) that is only used in the zone creation process. This managed system account cannot be edited or deleted manually. Instead, its life cycle is managed by {{site.konnect_short_name}} it is deleted automatically by {{site.konnect_short_name}} and it is deleted automatically when the zone is deleted.
+   
+     {:.note}
+    > **Note:** Mesh Manager automatically creates a [managed service account](/konnect/org-management/system-accounts/) that is only used in the zone creation process. 
+    This managed system account can't be edited or deleted manually. 
+    Instead, its life cycle is managed by {{site.konnect_short_name}}. 
+    It is deleted automatically by {{site.konnect_short_name}} when the zone is deleted.
+    
 1. From the {% konnect_icon mesh-manager %} [**Mesh Manager**](https://cloud.konghq.com/mesh-manager) navigation menu, and select the control plane you created in step 2.
 1. Select **Configure kumactl** from the **Control Plane Actions** dropdown menu and follow the steps in the wizard to connect `kumactl` to the control plane.
 

--- a/app/konnect/org-management/system-accounts.md
+++ b/app/konnect/org-management/system-accounts.md
@@ -20,7 +20,7 @@ The system account can use a {{site.konnect_short_name}} personal access token (
 
 Managed system accounts are system accounts whose life cycle is managed by {{site.konnect_short_name}} instead of the user. The `konnect_managed: true` flag in the API denotes this type of system account.
 
-[Mesh Manager](/konnect/mesh-manager/) automatically creates a managed system account that is only used in the zone creation process. This managed system account cannot be edited or deleted manually. Instead, it is deleted automatically by {{site.konnect_short_name}} when the zone is deleted.
+[Mesh Manager](/konnect/mesh-manager/) automatically creates a managed system account that is only used in the zone creation process. This managed system account can't be edited or deleted manually. Instead, it is deleted automatically by {{site.konnect_short_name}} when the zone is deleted.
 
 ## Manage a system account via the UI
 You can create and manage system accounts in your {{site.konnect_short_name}} organization through the {% konnect_icon organizations %} **Organization** > **System Accounts** page.

--- a/app/konnect/org-management/system-accounts.md
+++ b/app/konnect/org-management/system-accounts.md
@@ -18,7 +18,7 @@ The system account can use a {{site.konnect_short_name}} personal access token (
 
 ## Managed system accounts
 
-Managed system accounts are system accounts whose life cycle is managed by {{site.konnect_short_name}} instead of the user. The `blank` flag in the API denotes this type of system account.
+Managed system accounts are system accounts whose life cycle is managed by {{site.konnect_short_name}} instead of the user. The `konnect_managed: true` flag in the API denotes this type of system account.
 
 [Mesh Manager](/konnect/mesh-manager/) automatically creates a managed system account that is only used in the zone creation process. This managed system account cannot be edited or deleted manually. Instead, it is deleted automatically by {{site.konnect_short_name}} when the zone is deleted.
 

--- a/app/konnect/org-management/system-accounts.md
+++ b/app/konnect/org-management/system-accounts.md
@@ -16,7 +16,11 @@ System accounts offer the following benefits over regular user accounts:
 
 The system account can use a {{site.konnect_short_name}} personal access token (PAT) the same way a [regular {{site.konnect_short_name}} user](/konnect/org-management/users/) can. In addition, the system account can be assigned roles directly or inherit the roles of a [team](/konnect/org-management/teams-and-roles/). As such, a PAT created by a system account inherits the roles assigned to the system account.
 
-[Mesh Manager](/konnect/mesh-manager/) automatically creates a special managed service account that is only used in the zone creation process. This special, read-only managed service account cannot be edited or deleted manually. Instead, it is removed by {{site.konnect_short_name}} after the zone is created.
+## Managed system accounts
+
+Managed system accounts are system accounts whose life cycle is managed by {{site.konnect_short_name}} instead of the user. The `blank` flag in the API denotes this type of system account.
+
+[Mesh Manager](/konnect/mesh-manager/) automatically creates a managed system account that is only used in the zone creation process. This managed system account cannot be edited or deleted manually. Instead, it is deleted automatically by {{site.konnect_short_name}} when the zone is deleted.
 
 ## Manage a system account via the UI
 You can create and manage system accounts in your {{site.konnect_short_name}} organization through the {% konnect_icon organizations %} **Organization** > **System Accounts** page.

--- a/app/konnect/org-management/system-accounts.md
+++ b/app/konnect/org-management/system-accounts.md
@@ -16,6 +16,8 @@ System accounts offer the following benefits over regular user accounts:
 
 The system account can use a {{site.konnect_short_name}} personal access token (PAT) the same way a [regular {{site.konnect_short_name}} user](/konnect/org-management/users/) can. In addition, the system account can be assigned roles directly or inherit the roles of a [team](/konnect/org-management/teams-and-roles/). As such, a PAT created by a system account inherits the roles assigned to the system account.
 
+[Mesh Manager](/konnect/mesh-manager/) automatically creates a special managed service account that is only used in the zone creation process. This special, read-only managed service account cannot be edited or deleted manually. Instead, it is removed by {{site.konnect_short_name}} after the zone is created.
+
 ## Manage a system account via the UI
 You can create and manage system accounts in your {{site.konnect_short_name}} organization through the {% konnect_icon organizations %} **Organization** > **System Accounts** page.
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
MinK auto creates a system account for zones. This shows up in the UI but is read only, so we needed to add a note about it so customers know what it does and why it's there. 
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3467
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

