### PR TITLE
Update KIC EOL dates

### DIFF
--- a/app/_src/kubernetes-ingress-controller/support-policy.md
+++ b/app/_src/kubernetes-ingress-controller/support-policy.md
@@ -74,7 +74,7 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
 
   <tr>
     <td>1.22</td>
-    <td>4.8</td>
+    <td>4.9</td>
     <td>Oct 2022</td>
     <td>2.8 LTS</td>
     <td>2.5 LTS</td>
@@ -82,7 +82,7 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
   </tr>
   <tr>
     <td>1.23</td>
-    <td>4.8</td>
+    <td>4.10</td>
     <td>Feb 2023</td>
     <td>2.8 LTS, 3.x</td>
     <td>{{ latest_kic_release }}</td>
@@ -90,7 +90,7 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
   </tr>
   <tr>
     <td>1.24</td>
-    <td>4.8</td>
+    <td>4.11</td>
     <td>July 2023</td>
     <td>2.8 LTS, 3.x</td>
     <td>{{ latest_kic_release }}</td>
@@ -98,7 +98,7 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
   </tr>
   <tr>
     <td>1.25</td>
-    <td>N/A</td>
+    <td>4.12</td>
     <td>Oct 2023</td>
     <td>2.8 LTS, 3.x</td>
     <td>{{ latest_kic_release }}</td>
@@ -106,7 +106,7 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
   </tr>
   <tr>
     <td>1.26</td>
-    <td>N/A</td>
+    <td>4.13</td>
     <td>Feb 2024</td>
     <td>2.8 LTS, 3.x</td>
     <td>{{ latest_kic_release }}</td>

--- a/app/_src/kubernetes-ingress-controller/support-policy.md
+++ b/app/_src/kubernetes-ingress-controller/support-policy.md
@@ -32,66 +32,17 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
 </thead>
 <tbody>
   <tr>
-    <td>1.17</td>
-    <td>4.4</td>
-    <td>Dec 2020</td>
-    <td>2.8 LTS</td>
-    <td>2.5 LTS</td>
-    <td>March 2025</td>
-  </tr>
-  <tr>
-    <td>1.18</td>
-    <td>4.5</td>
-    <td>June 2021</td>
-    <td>2.8 LTS</td>
-    <td>2.5 LTS</td>
-    <td>March 2025</td>
-  </tr>
-  <tr>
-    <td>1.19</td>
-    <td>4.6</td>
-    <td>Oct 2021</td>
-    <td>2.8 LTS</td>
-    <td>2.5 LTS</td>
-    <td>March 2025</td>
-  </tr>
-  <tr>
-    <td>1.20</td>
-    <td>4.7</td>
-    <td>Feb 2022</td>
-    <td>2.8 LTS</td>
-    <td>2.5 LTS</td>
-    <td>March 2025</td>
-  </tr>
-  <tr>
-    <td>1.21</td>
-    <td>4.8</td>
-    <td>June 2022</td>
-    <td>2.8 LTS</td>
-    <td>2.5 LTS</td>
-    <td>March 2025</td>
-  </tr>
-
-  <tr>
-    <td>1.22</td>
-    <td>4.9</td>
-    <td>Oct 2022</td>
-    <td>2.8 LTS</td>
-    <td>2.5 LTS</td>
-    <td>March 2025</td>
-  </tr>
-  <tr>
-    <td>1.23</td>
-    <td>4.10</td>
-    <td>Feb 2023</td>
+    <td>1.27</td>
+    <td>N/A</td>
+    <td>Jun 2024</td>
     <td>2.8 LTS, 3.x</td>
     <td>{{ latest_kic_release }}</td>
     <td>{{ latest_kic_eol }}</td>
   </tr>
   <tr>
-    <td>1.24</td>
-    <td>4.11</td>
-    <td>July 2023</td>
+    <td>1.26</td>
+    <td>4.13</td>
+    <td>Feb 2024</td>
     <td>2.8 LTS, 3.x</td>
     <td>{{ latest_kic_release }}</td>
     <td>{{ latest_kic_eol }}</td>
@@ -105,20 +56,68 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
     <td>{{ latest_kic_eol }}</td>
   </tr>
   <tr>
-    <td>1.26</td>
-    <td>4.13</td>
-    <td>Feb 2024</td>
+    <td>1.24</td>
+    <td>4.11</td>
+    <td>July 2023</td>
     <td>2.8 LTS, 3.x</td>
     <td>{{ latest_kic_release }}</td>
     <td>{{ latest_kic_eol }}</td>
   </tr>
-    <tr>
-    <td>1.27</td>
-    <td>N/A</td>
-    <td>Jun 2024</td>
+  <tr>
+    <td>1.23</td>
+    <td>4.10</td>
+    <td>Feb 2023</td>
     <td>2.8 LTS, 3.x</td>
     <td>{{ latest_kic_release }}</td>
     <td>{{ latest_kic_eol }}</td>
+  </tr>
+  <tr>
+    <td>1.22</td>
+    <td>4.9</td>
+    <td>Oct 2022</td>
+    <td>2.8 LTS</td>
+    <td>2.5 LTS</td>
+    <td>March 2025</td>
+  </tr>
+  <tr>
+    <td>1.21</td>
+    <td>4.8</td>
+    <td>June 2022</td>
+    <td>2.8 LTS</td>
+    <td>2.5 LTS</td>
+    <td>March 2025</td>
+  </tr>
+  <tr>
+    <td>1.20</td>
+    <td>4.7</td>
+    <td>Feb 2022</td>
+    <td>2.8 LTS</td>
+    <td>2.5 LTS</td>
+    <td>March 2025</td>
+  </tr>
+  <tr>
+    <td>1.19</td>
+    <td>4.6</td>
+    <td>Oct 2021</td>
+    <td>2.8 LTS</td>
+    <td>2.5 LTS</td>
+    <td>March 2025</td>
+  </tr>
+  <tr>
+    <td>1.18</td>
+    <td>4.5</td>
+    <td>June 2021</td>
+    <td>2.8 LTS</td>
+    <td>2.5 LTS</td>
+    <td>March 2025</td>
+  </tr>
+  <tr>
+    <td>1.17</td>
+    <td>4.4</td>
+    <td>Dec 2020</td>
+    <td>2.8 LTS</td>
+    <td>2.5 LTS</td>
+    <td>March 2025</td>
   </tr>
 </tbody>
 </table>

--- a/app/_src/kubernetes-ingress-controller/support-policy.md
+++ b/app/_src/kubernetes-ingress-controller/support-policy.md
@@ -16,6 +16,9 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
 
 ## Supported versions
 
+{% assign latest_kic_release = site.data.kong_latest_KIC.release %}
+{% assign latest_kic_eol = "August 2024" %}
+
 <table style="display:table" width="100%">
 <thead>
 <tr>
@@ -24,7 +27,7 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
   <th>Upstream K8s EOL</th>
   <th>Supported {{site.base_gateway}} Versions</th>
   <th>Recommended KIC Version</th>
-  <th>EOL</th>
+  <th>KIC EOL</th>
 </tr>
 </thead>
 <tbody>
@@ -73,56 +76,56 @@ LTS versions of {{site.kic_product_name}} are supported for 3 years after releas
     <td>1.22</td>
     <td>4.8</td>
     <td>Oct 2022</td>
-    <td>2.8 LTS, 3.x</td>
+    <td>2.8 LTS</td>
     <td>2.5 LTS</td>
-    <td>Sept 2023</td>
+    <td>March 2025</td>
   </tr>
   <tr>
     <td>1.23</td>
     <td>4.8</td>
     <td>Feb 2023</td>
     <td>2.8 LTS, 3.x</td>
-    <td>{{ site.data.kong_latest_KIC.release }}</td>
-    <td>Sept 2023</td>
+    <td>{{ latest_kic_release }}</td>
+    <td>{{ latest_kic_eol }}</td>
   </tr>
   <tr>
     <td>1.24</td>
     <td>4.8</td>
     <td>July 2023</td>
     <td>2.8 LTS, 3.x</td>
-    <td>{{ site.data.kong_latest_KIC.release }}</td>
-    <td>Sept 2023</td>
+    <td>{{ latest_kic_release }}</td>
+    <td>{{ latest_kic_eol }}</td>
   </tr>
   <tr>
     <td>1.25</td>
     <td>N/A</td>
     <td>Oct 2023</td>
     <td>2.8 LTS, 3.x</td>
-    <td>{{ site.data.kong_latest_KIC.release }}</td>
-    <td>Sept 2023</td>
+    <td>{{ latest_kic_release }}</td>
+    <td>{{ latest_kic_eol }}</td>
   </tr>
   <tr>
     <td>1.26</td>
     <td>N/A</td>
     <td>Feb 2024</td>
     <td>2.8 LTS, 3.x</td>
-    <td>{{ site.data.kong_latest_KIC.release }}</td>
-    <td>Sept 2023</td>
+    <td>{{ latest_kic_release }}</td>
+    <td>{{ latest_kic_eol }}</td>
   </tr>
     <tr>
     <td>1.27</td>
     <td>N/A</td>
     <td>Jun 2024</td>
     <td>2.8 LTS, 3.x</td>
-    <td>{{ site.data.kong_latest_KIC.release }}</td>
-    <td>Sept 2023</td>
+    <td>{{ latest_kic_release }}</td>
+    <td>{{ latest_kic_eol }}</td>
   </tr>
 </tbody>
 </table>
 
 ## {{site.kic_product_name}} versions
 
-| Version  | Released Date | End of Full Support | End of Sunset Support |
+| Version  | Release Date  | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
 |  2.11.x  |  2023-08-09   |     2024-08-09      |      2025-08-09       |
 |  2.10.x  |  2023-06-02   |     2024-06-02      |      2025-06-02       |


### PR DESCRIPTION
### Description

KIC EOL dates were incorrect. Updated to match 2.11 EOL
 
### Testing instructions

Preview link: [/kubernetes-ingress-controller/latest/support-policy/](https://deploy-preview-6117--kongdocs.netlify.app//kubernetes-ingress-controller/latest/support-policy/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
