### PR TITLE
Rename: deprecated API specs section

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -275,13 +275,6 @@
           absolute_url: true
           generate: false
           target_blank: true
-    - text: Deprecated - Runtime Groups API
-      items:
-        - text: API Spec
-          url: /konnect/api/runtime-groups/latest/
-          absolute_url: true
-          generate: false
-          target_blank: true
     - text: Portal RBAC API
       items:
         - text: API Spec
@@ -293,13 +286,6 @@
       items:
         - text: API Documentation
           url: /konnect/api/control-plane-configuration/latest/
-          absolute_url: true
-          generate: false
-          target_blank: true
-    - text: (Deprecated) - Runtime Configuration API
-      items:
-        - text: API Spec
-          url: /konnect/api/runtime-groups-configuration/latest/
           absolute_url: true
           generate: false
           target_blank: true
@@ -323,6 +309,18 @@
       items:
         - text: API Spec
           url: /konnect/api/api-products/latest/
+          absolute_url: true
+          generate: false
+          target_blank: true
+    - text: Deprecated APIs
+      items:
+        - text: (Deprecated) - Runtime Configuration API
+          url: /konnect/api/runtime-groups-configuration/latest/
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: (Deprecated) - Runtime Configuration API
+          url: /konnect/api/runtime-groups-configuration/latest/
           absolute_url: true
           generate: false
           target_blank: true

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -314,12 +314,12 @@
           target_blank: true
     - text: Deprecated APIs
       items:
-        - text: (Deprecated) - Runtime Configuration API
+        - text: (Deprecated) Runtime Configuration API
           url: /konnect/api/runtime-groups-configuration/latest/
           absolute_url: true
           generate: false
           target_blank: true
-        - text: (Deprecated) - Runtime Groups API
+        - text: (Deprecated) Runtime Groups API
           url: /konnect/api/runtime-groups/latest/
           absolute_url: true
           generate: false

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -319,8 +319,8 @@
           absolute_url: true
           generate: false
           target_blank: true
-        - text: (Deprecated) - Runtime Configuration API
-          url: /konnect/api/runtime-groups-configuration/latest/
+        - text: (Deprecated) - Runtime Groups API
+          url: /konnect/api/runtime-groups/latest/
           absolute_url: true
           generate: false
           target_blank: true


### PR DESCRIPTION
Adds a deprecated subsection to the API section. 