### PR TITLE
chore: Vale cleanup for konnect rename branch

### DIFF
--- a/.github/styles/kong/Terms.yml
+++ b/.github/styles/kong/Terms.yml
@@ -14,7 +14,6 @@ swap:
   multizone: multi-zone
   pg: PostgreSQL
   'postgres$': PostgreSQL
-  'self(?:-| )hosted': self-managed
   redhat: Red Hat
   timezone: time zone
   utilize: use

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -276,6 +276,7 @@ prepending
 prepends
 prepopulated
 preread
+printf
 productize
 productized
 productizing

--- a/app/konnect/api/identity-management/identity-integration.md
+++ b/app/konnect/api/identity-management/identity-integration.md
@@ -10,7 +10,8 @@ Custom teams serve as a primary way for organizations to provision access of use
 
 You must authenticate with the API, for information about authentication read the [API authentication](/konnect/api/index/#authentication) instructions.
 Create a custom team by sending a `POST` request containing the `name` and `description` of your team in the response body: 
-```
+
+```sh
 curl --request POST \
   --url https://global.api.konghq.com/v3/teams \
   --header 'Content-Type: application/json' \
@@ -21,7 +22,7 @@ curl --request POST \
 
 You will receive a `201` response code, and a response body containing information about your team: 
 
-```
+```json
 {
 "id": "a1d5c35a-3c71-4d95-ae4b-438fa9bd1059",
 "name": "IDM - Developers",
@@ -40,44 +41,48 @@ Save the `id` value, so that you can reference this team throughout the guide.
 You must assign roles to a custom team to use the team. Roles define a set of permissions or actions that a user is allowed to perform on a {{site.konnect_short_name}} entity. All custom teams start with no roles and each role must be added to the team for members of the team to inherit the roles. 
 
 1. Obtain a list of available roles by issuing a `GET` request:
-
-        curl --request GET \
-        --url https://global.api.konghq.com/v3/roles
-
+    
+    ```sh
+    curl --request GET \
+      --url https://global.api.konghq.com/v3/roles
+    ```
    The response body will contain a list of available roles: 
 
-    ```
-{
+    ```json
+    {
       "control_planes": {
-        "name": "Control Planes",
+          "name": "Control Planes",
         "roles": {
-          "admin": {
+        "admin": {
             "name": "Admin",
             "description": "This role grants full write access to all entities within a control plane."
-          },
-          "certificate_admin": {
+        },
+        "certificate_admin": {
             "name": "Certificate Admin",
             "description": "This role grants full write access to administer certificates."
-          },
-          ...
+        },
+        ...
         }
-	}
+      }
+    }
     ```
 
 2. Assign a role to a team by issuing  a `POST` request:
     
     The request must contain a `TEAM_ID` parameter in the URL. This request requires a JSON body that contains `role_name`, `entity_id`, `entity_type_name`, and `entity_region`. 
-
-        curl --request POST \
-             --url https://global.api.konghq.com/v3/teams/{teamId}/assigned-roles \
-             --header 'Content-Type: application/json' \
-             --data '{
-             "role_name": "Admin",
-             "entity_id": "e67490ce-44dc-4cbd-b65e-b52c746fc26a",
-             "entity_type_name": "Control Planes",
-             "entity_region": "eu"
-             }'
-         If the information in the request was correct, the response will return a `200` and the `id` of the new assigned role. 
+    
+    ```sh
+    curl --request POST \
+        --url https://global.api.konghq.com/v3/teams/{teamId}/assigned-roles \
+        --header 'Content-Type: application/json' \
+        --data '{
+        "role_name": "Admin",
+        "entity_id": "e67490ce-44dc-4cbd-b65e-b52c746fc26a",
+        "entity_type_name": "Control Planes",
+        "entity_region": "eu"
+        }'
+    ```
+    If the information in the request was correct, the response will return a `200` and the `id` of the new assigned role. 
 
     {:.note}
     > `entity_id` can be found in the {{site.konnect_short_name}} in the **Data Plane Nodes** section. 
@@ -87,39 +92,47 @@ You must assign roles to a custom team to use the team. Roles define a set of pe
 For a user to access the roles assigned to a custom team, the user must become a member of the team. A user may be a part of multiple teams and will inherit all of the roles from the teams they belong to.
 
 1. Obtain a list of users by issuing a `GET` request:
-
-        curl --request GET \
-        --url https://global.api.konghq.com/v2/users
     
+    ```sh
+    curl --request GET \
+    --url https://global.api.konghq.com/v2/users
+    ```
+
     The response body will contain a list of users:
     
+    ```json
+    {
+      "meta": {
+        "page": {
+            "number": 1,
+            "size": 10,
+            "total": 22
+        }
+      },
+      "data": [
         {
-        "meta": {
-            "page": {
-                "number": 1,
-                "size": 10,
-                "total": 22
-            }
-        },
-        "data": [
-            {
-                "id": "69c60945-d42a-4757-a0b2-c18500493949",
-                "email": "user.email@konghq.com",
-                "full_name": "user",
-                "preferred_name": "User2",
-                "active": true,
-                "created_at": "2022-10-12T16:22:53Z",
-                "updated_at": "2022-10-19T15:18:11Z"
-        },
+            "id": "69c60945-d42a-4757-a0b2-c18500493949",
+            "email": "user.email@konghq.com",
+            "full_name": "user",
+            "preferred_name": "User2",
+            "active": true,
+            "created_at": "2022-10-12T16:22:53Z",
+            "updated_at": "2022-10-19T15:18:11Z"
+        }
+        ...
+      ] 
+    }
 
 2. Using the `id` field from the desired user and the `id` field from the team construct and issue a `POST` request: 
-
-        curl --request POST \
-        --url https://global.api.konghq.com/v3/teams/{teamId}/users \
-        --header 'Content-Type: application/json' \
-        --data '{
-        "id": "USER_ID"
-        }'
+    
+    ```sh
+    curl --request POST \
+      --url https://global.api.konghq.com/v3/teams/{teamId}/users \
+      --header 'Content-Type: application/json' \
+      --data '{
+      "id": "USER_ID"
+      }'
+    ```
 
 You will receive a `201` with no response body confirming that the user was added to the custom team. 
 
@@ -130,10 +143,11 @@ If [single sign on](/konnect/org-management/okta-idp/) is enabled, an organizati
 
 Update the team mappings by issuing a `PUT` request containing `team_ids` in the request body: 
 
-    curl --request PUT \
-    --url https://global.api.konghq.com/v2/identity-provider/team-mappings \
-    --header 'Content-Type: application/json' \
-    --data '{
+```sh
+curl --request PUT \
+  --url https://global.api.konghq.com/v2/identity-provider/team-mappings \
+  --header 'Content-Type: application/json' \
+  --data '{
     "mappings": [
         {
         "group": "team-idm",
@@ -141,18 +155,22 @@ Update the team mappings by issuing a `PUT` request containing `team_ids` in the
             "af91db4c-6e51-403e-a2bf-33d27ae50c0a",
             "bc46c7ca-f300-41fe-a9b6-5dbc1257208e"
         ]
-    }]}
+    }]}'
+```
 
 If you were successful, you will receive a `200` response code, and the response body will contain a `data` object reflecting the new mappings: 
 
-    "data": [
-    {
-        "group": "Service Developers",
-        "team_ids": [
-            "af91db4c-6e51-403e-a2bf-33d27ae50c0a",
-            "bc46c7ca-f300-41fe-a9b6-5dbc1257208e"
-        ]
-    }]}
+```json
+"data": [
+  {
+    "group": "Service Developers",
+    "team_ids": [
+        "af91db4c-6e51-403e-a2bf-33d27ae50c0a",
+        "bc46c7ca-f300-41fe-a9b6-5dbc1257208e"
+    ]
+  }
+]
+```
     
 
 


### PR DESCRIPTION
### Description
Addressing vale comments from https://github.com/Kong/docs.konghq.com/pull/6121.

Removing the rule for "self-hosted -> self-managed" because we now have self-hosted Dev Portal.

`app/konnect/api/identity-management/identity-integration.md` gets a code block cleanup because the code block formatting was a) triggering vale, and b) super inconsistent across the page.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

