### PR TITLE
chore: Remove link to KIC guide that doesn't exist

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -111,6 +111,8 @@
 
 # KIC GENERAL
 /kubernetes-ingress-controller/:version/guides/using-gateway-api/ /kubernetes-ingress-controller/:version/guides/getting-started/
+/kubernetes-ingress-controller/:version/guides/configuring-custom-entities/ /kubernetes-ingress-controller/latest/guides/overview/
+/kubernetes-ingress-controller/latest/guides/configuring-custom-entities/   /kubernetes-ingress-controller/latest/guides/overview/
 
 # GETTING STARTED GUIDES
 /getting-started-guide/2.6.x/       /gateway/2.6.x/get-started/comprehensive/

--- a/app/_src/kubernetes-ingress-controller/guides/overview.md
+++ b/app/_src/kubernetes-ingress-controller/guides/overview.md
@@ -81,9 +81,6 @@ the {{site.kic_product_name}}:
 - [Using mtls-auth plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-mtls-auth-plugin)
   This guide gives an overview of how to use `mtls-auth` plugin and CA
   certificates to authenticate requests using client certificates.
-- [Configuring custom entities in Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configuring-custom-entities/)
-  This guide gives an overview of how to configure custom entities for
-  deployments of the {{site.kic_product_name}} running without a database.
 - [Using OpenID-connect plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-oidc-plugin/)
   This guide walks through steps necessary to set up OIDC authentication.
 - [Allow Multiple Authentication Plugins](/kubernetes-ingress-controller/{{page.kong_version}}/guides/allowing-multiple-authentication-methods)

--- a/app/kubernetes-ingress-controller/1.0.x/guides/overview.md
+++ b/app/kubernetes-ingress-controller/1.0.x/guides/overview.md
@@ -70,8 +70,5 @@ the {{site.kic_product_name}}:
 - [Using mtls-auth plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-mtls-auth-plugin/)
   This guide gives an overview of how to use `mtls-auth` plugin and CA
   certificates to authenticate requests using client certificates.
-- [Configuring custom entities in Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configuring-custom-entities/)
-  This guide gives an overview of how to configure custom entities for
-  deployments of the {{site.kic_product_name}} running without a database.
 - [Using OpenID-connect plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-oidc-plugin/)
   This guide walks through steps necessary to set up OIDC authentication.

--- a/app/kubernetes-ingress-controller/1.1.x/guides/overview.md
+++ b/app/kubernetes-ingress-controller/1.1.x/guides/overview.md
@@ -70,8 +70,5 @@ the {{site.kic_product_name}}:
 - [Using mtls-auth plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-mtls-auth-plugin/)
   This guide gives an overview of how to use `mtls-auth` plugin and CA
   certificates to authenticate requests using client certificates.
-- [Configuring custom entities in Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configuring-custom-entities/)
-  This guide gives an overview of how to configure custom entities for
-  deployments of the {{site.kic_product_name}} running without a database.
 - [Using OpenID-connect plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-oidc-plugin/)
   This guide walks through steps necessary to set up OIDC authentication.

--- a/app/kubernetes-ingress-controller/1.2.x/guides/overview.md
+++ b/app/kubernetes-ingress-controller/1.2.x/guides/overview.md
@@ -70,8 +70,5 @@ the {{site.kic_product_name}}:
 - [Using mtls-auth plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-mtls-auth-plugin/)
   This guide gives an overview of how to use `mtls-auth` plugin and CA
   certificates to authenticate requests using client certificates.
-- [Configuring custom entities in Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configuring-custom-entities/)
-  This guide gives an overview of how to configure custom entities for
-  deployments of the {{site.kic_product_name}} running without a database.
 - [Using OpenID-connect plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-oidc-plugin/)
   This guide walks through steps necessary to set up OIDC authentication.

--- a/app/kubernetes-ingress-controller/1.3.x/guides/overview.md
+++ b/app/kubernetes-ingress-controller/1.3.x/guides/overview.md
@@ -70,8 +70,5 @@ the {{site.kic_product_name}}:
 - [Using mtls-auth plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-mtls-auth-plugin/)
   This guide gives an overview of how to use `mtls-auth` plugin and CA
   certificates to authenticate requests using client certificates.
-- [Configuring custom entities in Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configuring-custom-entities/)
-  This guide gives an overview of how to configure custom entities for
-  deployments of the {{site.kic_product_name}} running without a database.
 - [Using OpenID-connect plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-oidc-plugin/)
   This guide walks through steps necessary to set up OIDC authentication.

--- a/app/kubernetes-ingress-controller/2.0.x/guides/overview.md
+++ b/app/kubernetes-ingress-controller/2.0.x/guides/overview.md
@@ -70,8 +70,5 @@ the {{site.kic_product_name}}:
 - [Using mtls-auth plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-mtls-auth-plugin/)
   This guide gives an overview of how to use `mtls-auth` plugin and CA
   certificates to authenticate requests using client certificates.
-- [Configuring custom entities in Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configuring-custom-entities/)
-  This guide gives an overview of how to configure custom entities for
-  deployments of the {{site.kic_product_name}} running without a database.
 - [Using OpenID-connect plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-oidc-plugin/)
   This guide walks through steps necessary to set up OIDC authentication.

--- a/app/kubernetes-ingress-controller/2.1.x/guides/overview.md
+++ b/app/kubernetes-ingress-controller/2.1.x/guides/overview.md
@@ -70,8 +70,5 @@ the {{site.kic_product_name}}:
 - [Using mtls-auth plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-mtls-auth-plugin/)
   This guide gives an overview of how to use `mtls-auth` plugin and CA
   certificates to authenticate requests using client certificates.
-- [Configuring custom entities in Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configuring-custom-entities/)
-  This guide gives an overview of how to configure custom entities for
-  deployments of the {{site.kic_product_name}} running without a database.
 - [Using OpenID-connect plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-oidc-plugin/)
   This guide walks through steps necessary to set up OIDC authentication.

--- a/app/kubernetes-ingress-controller/2.2.x/guides/overview.md
+++ b/app/kubernetes-ingress-controller/2.2.x/guides/overview.md
@@ -70,8 +70,5 @@ the {{site.kic_product_name}}:
 - [Using mtls-auth plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-mtls-auth-plugin/)
   This guide gives an overview of how to use `mtls-auth` plugin and CA
   certificates to authenticate requests using client certificates.
-- [Configuring custom entities in Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/configuring-custom-entities/)
-  This guide gives an overview of how to configure custom entities for
-  deployments of the {{site.kic_product_name}} running without a database.
 - [Using OpenID-connect plugin](/kubernetes-ingress-controller/{{page.kong_version}}/guides/using-oidc-plugin/)
   This guide walks through steps necessary to set up OIDC authentication.


### PR DESCRIPTION
### Description

Guide was removed in https://github.com/Kong/docs.konghq.com/pull/6068 but the link to it from the guides overview still remained.

Caught by the broken link checker: https://github.com/Kong/docs.konghq.com/actions/runs/6251198466/job/16971798110#step:12:399

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

