### PR TITLE
Feat: PKI Certs for CP/DP authentication

### DIFF
--- a/app/_api/konnect/pki-certs/_index.md
+++ b/app/_api/konnect/pki-certs/_index.md
@@ -1,0 +1,3 @@
+---
+konnect_product_id: dbb7412b-28ed-473a-a6e3-4222e777bdaa
+---

--- a/app/_api/konnect/pki-certs/_index.md
+++ b/app/_api/konnect/pki-certs/_index.md
@@ -1,3 +1,3 @@
 ---
-konnect_product_id: dbb7412b-28ed-473a-a6e3-4222e777bdaa
+konnect_product_id:
 ---

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -313,12 +313,12 @@
           generate: false
           target_blank: true
     - text: PKI Certs API
-      items:
-        - text: API Spec
-          url: /konnect/api/pki-certs/latest/
-          absolute_url: true
-          generate: false
-          target_blank: true
+      items: 
+      - text: API Spec
+        url: /konnect/api/pki-certs/latest/
+        absolute_url: true
+        generate: false
+        target_blank: true
     - text: Deprecated APIs
       items:
         - text: (Deprecated) Runtime Configuration API

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -313,7 +313,7 @@
           generate: false
           target_blank: true
     - text: PKI Certs API
-      items: 
+      items:
         - text: API Spec
           url: /konnect/api/pki-certs/latest/
           absolute_url: true

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -314,11 +314,11 @@
           target_blank: true
     - text: PKI Certs API
       items: 
-      - text: API Spec
-        url: /konnect/api/pki-certs/latest/
-        absolute_url: true
-        generate: false
-        target_blank: true
+        - text: API Spec
+          url: /konnect/api/pki-certs/latest/
+          absolute_url: true
+          generate: false
+          target_blank: true
     - text: Deprecated APIs
       items:
         - text: (Deprecated) Runtime Configuration API

--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -312,6 +312,13 @@
           absolute_url: true
           generate: false
           target_blank: true
+    - text: PKI Certs API
+      items:
+        - text: API Spec
+          url: /konnect/api/pki-certs/latest/
+          absolute_url: true
+          generate: false
+          target_blank: true
     - text: Deprecated APIs
       items:
         - text: (Deprecated) Runtime Configuration API

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -10,7 +10,7 @@ from a single, cloud-based control plane, and provides a catalog of all deployed
 services. [Try it today!](https://cloud.konghq.com/quick-start)
 
 ## September 2023
-**PKI Certificates fir CP/DP Authentication**
+**PKI Certificates for CP/DP Authentication**
 : {{site.konnect_short_name}} now supports pinned PKI certs for CP/DP authentication. This means that Konnect supports digital certificates signed by a trusted CA in Konnect for CP/DP authentication. 
 
 **Renamed {{site.konnect_short_name}} capabilities**

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -10,6 +10,9 @@ from a single, cloud-based control plane, and provides a catalog of all deployed
 services. [Try it today!](https://cloud.konghq.com/quick-start)
 
 ## September 2023
+**PKI Certificates fir CP/DP Authentication**
+: {{site.konnect_short_name}} now supports pinned PKI certs for CP/DP authentication. This means that Konnect supports digital certificates signed by a trusted CA in Konnect for CP/DP authentication. 
+
 **Renamed {{site.konnect_short_name}} capabilities**
 : We have renamed a number of core {{site.konnect_short_name}} capabilities to simplify user understanding:
 


### PR DESCRIPTION
### Description

Konnect now supports pinned PKI certs for CP/DP authentication. This means that Konnect supports digital certificates signed by a trusted CA in Konnect for CP/DP authentication. 

[DOCU-3357 ](https://konghq.atlassian.net/browse/DOCU-3357)

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

