### PR TITLE
fix: Rename runtime group id to control plane id

### DIFF
--- a/app/_hub/kong-inc/jq/overview/_index.md
+++ b/app/_hub/kong-inc/jq/overview/_index.md
@@ -21,7 +21,7 @@ The default response status code is `200`.
 > * In the response context the entire body must be buffered to be processed. This requirement also
 implies that the `Content-Length` header will be dropped if present, and the body transferred with chunked encoding.
 > * To use this plugin in Konnect,
-[upgrade your runtimes](/konnect/runtime-manager/upgrade/) to at least
-v2.6.0.0.
+[upgrade your data plane nodes](/konnect/gateway-manager/data-plane-nodes/upgrade/) 
+to at least v2.6.0.0.
 
 See jq's documentation on [Basic filters](https://stedolan.github.io/jq/manual/#Basicfilters) for more information on writing programs with jq.

--- a/app/_plugins/drops/plugins/examples/curl.rb
+++ b/app/_plugins/drops/plugins/examples/curl.rb
@@ -6,11 +6,11 @@ module Jekyll
       module Examples
         class Curl < Base
           URLS = {
-            'consumer' => 'http://localhost:8001/consumers/{CONSUMER_NAME|ID}/plugins',
-            'consumer_group' => 'http://localhost:8001/consumer_groups/{CONSUMER_GROUP_NAME|ID}/plugins',
+            'consumer' => 'http://localhost:8001/consumers/{consumerName|Id}/plugins',
+            'consumer_group' => 'http://localhost:8001/consumer_groups/{consumerGroupName|Id}/plugins',
             'global' => 'http://localhost:8001/plugins/',
-            'route' => 'http://localhost:8001/routes/{ROUTE_NAME|ID}/plugins',
-            'service' => 'http://localhost:8001/services/{SERVICE_NAME|ID}/plugins'
+            'route' => 'http://localhost:8001/routes/{routeName|Id}/plugins',
+            'service' => 'http://localhost:8001/services/{serviceName|Id}/plugins'
           }.freeze
 
           def params

--- a/app/_plugins/drops/plugins/examples/konnect.rb
+++ b/app/_plugins/drops/plugins/examples/konnect.rb
@@ -6,11 +6,11 @@ module Jekyll
       module Examples
         class Konnect < Base
           URLS = {
-            'consumer' => 'https://{us|eu}.api.konghq.com/v2/runtime-groups/{RUNTIME-GROUP-ID}/core-entities/consumers/{CONSUMER_ID}/plugins',
-            'consumer_group' => 'https://{us|eu}.api.konghq.com/v2/runtime-groups/{RUNTIME-GROUP-ID}/core-entities/consumer_groups/{CONSUMER_GROUP_ID}/plugins',
-            'global' => 'https://{us|eu}.api.konghq.com/v2/runtime-groups/{RUNTIME-GROUP-ID}/core-entities/plugins/',
-            'route' => 'https://{us|eu}.api.konghq.com/v2/runtime-groups/{RUNTIME-GROUP-ID}/core-entities/routes/{ROUTE_ID}/plugins',
-            'service' => 'https://{us|eu}.api.konghq.com/v2/runtime-groups/{RUNTIME-GROUP-ID}/core-entities/services/{SERVICE_ID}/plugins'
+            'consumer' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/consumers/{CONSUMER_ID}/plugins',
+            'consumer_group' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/consumer_groups/{CONSUMER_GROUP_ID}/plugins',
+            'global' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/plugins/',
+            'route' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/routes/{ROUTE_ID}/plugins',
+            'service' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/services/{SERVICE_ID}/plugins'
           }.freeze
 
           def params

--- a/app/_plugins/drops/plugins/examples/konnect.rb
+++ b/app/_plugins/drops/plugins/examples/konnect.rb
@@ -6,11 +6,11 @@ module Jekyll
       module Examples
         class Konnect < Base
           URLS = {
-            'consumer' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/consumers/{CONSUMER_ID}/plugins',
-            'consumer_group' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/consumer_groups/{CONSUMER_GROUP_ID}/plugins',
-            'global' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/plugins/',
-            'route' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/routes/{ROUTE_ID}/plugins',
-            'service' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{CONTROL-PLANE-ID}/core-entities/services/{SERVICE_ID}/plugins'
+            'consumer' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/consumers/{consumerId}/plugins',
+            'consumer_group' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/consumer_groups/{consumerGroupId}/plugins',
+            'global' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/plugins/',
+            'route' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/routes/{routeId}/plugins',
+            'service' => 'https://{us|eu}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/services/{serviceId}/plugins'
           }.freeze
 
           def params

--- a/spec/app/_plugins/drops/plugins/examples/curl_spec.rb
+++ b/spec/app/_plugins/drops/plugins/examples/curl_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Jekyll::Drops::Plugins::Examples::Curl do
     context 'type consumer' do
       let(:type) { 'consumer' }
 
-      it { expect(subject.url).to eq('http://localhost:8001/consumers/{CONSUMER_NAME|ID}/plugins') }
+      it { expect(subject.url).to eq('http://localhost:8001/consumers/{consumerName|Id}/plugins') }
     end
 
     context 'type global' do
@@ -36,13 +36,13 @@ RSpec.describe Jekyll::Drops::Plugins::Examples::Curl do
     context 'type route' do
       let(:type) { 'route' }
 
-      it { expect(subject.url).to eq('http://localhost:8001/routes/{ROUTE_NAME|ID}/plugins') }
+      it { expect(subject.url).to eq('http://localhost:8001/routes/{routeName|Id}/plugins') }
     end
 
     context 'type service' do
       let(:type) { 'service' }
 
-      it { expect(subject.url).to eq('http://localhost:8001/services/{SERVICE_NAME|ID}/plugins') }
+      it { expect(subject.url).to eq('http://localhost:8001/services/{serviceName|Id}/plugins') }
     end
   end
 end


### PR DESCRIPTION
### Description

Missed renaming group ID in Konnect API examples in plugins, eg: https://docs.konghq.com/hub/kong-inc/basic-auth/how-to/basic-example/ (switch to konnect api tab).

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

