### PR TITLE
Fix: Mobile top nav

### DIFF
--- a/app/_assets/stylesheets/header-v2.less
+++ b/app/_assets/stylesheets/header-v2.less
@@ -576,6 +576,11 @@ header.navbar-v2 {
         background: white;
         padding: 24px 0;
         z-index: -100;
+        max-height: unset;
+
+        > ul {
+          max-height: unset;
+        }
 
         .navbar-items {
           align-self: stretch;


### PR DESCRIPTION
### Description

Unsetting max navbar menu height on mobile. Accidentally broke it when setting a max height for the nav to deal with overlap, didn't account for the menu transformation on mobile.

Broken:
<img width="667" alt="Screenshot 2023-09-22 at 8 54 21 AM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/120a9ec7-96d9-4797-92c4-479770ad7911">


### Testing instructions

Resize any page down to mobile size: https://deploy-preview-6158--kongdocs.netlify.app/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

