### PR TITLE
feat: MinK zone consumption billing notes

### DIFF
--- a/app/konnect/getting-started/configure-mesh.md
+++ b/app/konnect/getting-started/configure-mesh.md
@@ -34,7 +34,7 @@ You now have a {{site.mesh_product_name}} global control plane. This control pla
 After creating the global control plane, you must add a zone to that control plane. Adding a zone allows you to manage services added to that zone and send and receive configuration changes to the zone. 
 
 {:.important}
-> **Important:** Mesh zones are priced based on consumption. For more information about the pricing and consumption of zones, see the [Pricing and Plans](/konnect/account-management/) documentation and Kong's [Pricing](https://konghq.com/pricing) page.
+> **Important:** Mesh zones are priced based on consumption. For more information about the pricing and consumption of zones, see Kong's [Pricing](https://konghq.com/pricing) page.
 
 1. In {% konnect_icon mesh-manager %} [**Mesh Manager**](https://cloud.konghq.com/mesh-manager), click the `example-cp` control plane you just created, and then click **Zones** in the sidebar.
 1. Click **Create Zone**. 

--- a/app/konnect/getting-started/configure-mesh.md
+++ b/app/konnect/getting-started/configure-mesh.md
@@ -33,6 +33,9 @@ You now have a {{site.mesh_product_name}} global control plane. This control pla
 
 After creating the global control plane, you must add a zone to that control plane. Adding a zone allows you to manage services added to that zone and send and receive configuration changes to the zone. 
 
+{:.important}
+> **Important:** Mesh zones are priced based on consumption. Your Konnect free trial provides enough credits for your first two zones. For more information about the pricing and consumption of additional zones, see the [Pricing and Plans](/konnect/account-management/) documentation and Kong's [Pricing](https://konghq.com/pricing) page.
+
 1. In {% konnect_icon mesh-manager %} [**Mesh Manager**](https://cloud.konghq.com/mesh-manager), click the `example-cp` control plane you just created, and then click **Zones** in the sidebar.
 1. Click **Create Zone**. 
 1. Enter "zone-1" in the **Name** field for the new zone, and then click **Create Zone & generate token**. 

--- a/app/konnect/getting-started/configure-mesh.md
+++ b/app/konnect/getting-started/configure-mesh.md
@@ -34,7 +34,7 @@ You now have a {{site.mesh_product_name}} global control plane. This control pla
 After creating the global control plane, you must add a zone to that control plane. Adding a zone allows you to manage services added to that zone and send and receive configuration changes to the zone. 
 
 {:.important}
-> **Important:** Mesh zones are priced based on consumption. Your Konnect free trial provides enough credits for your first two zones. For more information about the pricing and consumption of additional zones, see the [Pricing and Plans](/konnect/account-management/) documentation and Kong's [Pricing](https://konghq.com/pricing) page.
+> **Important:** Mesh zones are priced based on consumption. For more information about the pricing and consumption of zones, see the [Pricing and Plans](/konnect/account-management/) documentation and Kong's [Pricing](https://konghq.com/pricing) page.
 
 1. In {% konnect_icon mesh-manager %} [**Mesh Manager**](https://cloud.konghq.com/mesh-manager), click the `example-cp` control plane you just created, and then click **Zones** in the sidebar.
 1. Click **Create Zone**. 

--- a/app/konnect/mesh-manager/service-mesh.md
+++ b/app/konnect/mesh-manager/service-mesh.md
@@ -11,6 +11,9 @@ Creating a fully-functioning {{site.mesh_product_name}} deployment in {{site.kon
 1. Configure `kumactl` to connect to your global control plane.
 1. Add services to your mesh.
 
+{:.important}
+> **Important:** Mesh zones are priced based on consumption. For more information about the pricing and consumption of zones, see the [Pricing and Plans](/konnect/account-management/) documentation and Kong's [Pricing](https://konghq.com/pricing) page.
+
 ### Prerequisites
 
 * [A Kubernetes cluster with a load balancer](https://kubernetes.io/docs/setup/)

--- a/app/konnect/mesh-manager/service-mesh.md
+++ b/app/konnect/mesh-manager/service-mesh.md
@@ -12,7 +12,7 @@ Creating a fully-functioning {{site.mesh_product_name}} deployment in {{site.kon
 1. Add services to your mesh.
 
 {:.important}
-> **Important:** Mesh zones are priced based on consumption. For more information about the pricing and consumption of zones, see the [Pricing and Plans](/konnect/account-management/) documentation and Kong's [Pricing](https://konghq.com/pricing) page.
+> **Important:** Mesh zones are priced based on consumption. For more information about the pricing and consumption of zones, see Kong's [Pricing](https://konghq.com/pricing) page.
 
 ### Prerequisites
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
MinK zones will be billed based on consumption. We need to call this out in docs so that customers know when they will be billed for something and how much it will be.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3418
### Testing instructions
Relates to https://github.com/Kong/docs.konghq.com/pull/6099. I chose to branch these changes off of the `mink-beta` branch since the changes needed to happen on the MinK docs. Let me know if you think I missed anything by doing this or if I should branch differently. I figured this is also okay since MinK billing will release at the same as MinK.

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

