### PR TITLE
fix: Replace Gateway API spec characters causing errors

### DIFF
--- a/api-specs/Gateway-EE/3.4/kong-ee-3.4.yaml
+++ b/api-specs/Gateway-EE/3.4/kong-ee-3.4.yaml
@@ -2803,7 +2803,7 @@ components:
               name:
                 type: string
                 description: |
-                  The name of the route. Route names must be unique, and they are case sensitive. For example, there can be two different routes named “test” and “Test”.
+                  The name of the route. Route names must be unique, and they are case sensitive. For example, there can be two different routes named "test" and "Test".
               protocols:
                 type: array
                 description: An array of the protocols this route should allow
@@ -2892,7 +2892,7 @@ components:
               sources:
                 type: array
                 description: |
-                  A list of IP sources of incoming connections that match this route when using stream routing. Each entry is an object with fields “ip” (optionally in CIDR range notation) and/or “port”.
+                  A list of IP sources of incoming connections that match this route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
                 items:
                   type: object
                   properties:
@@ -2905,7 +2905,7 @@ components:
               destinations:
                 type: array
                 description: |
-                  A list of IP destinations of incoming connections that match this route when using stream routing. Each entry is an object with fields “ip” (optionally in CIDR range notation) and/or “port”.
+                  A list of IP destinations of incoming connections that match this route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
                 items:
                   type: object
                   properties:
@@ -2922,7 +2922,7 @@ components:
                   type: string
               service:
                 type: object
-                description: The service this route is associated to. This is where the route proxies traffic to. With form-encoded, the notation is service.id=<service id> or service.name=<service name>. With JSON, use “`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
+                description: The service this route is associated to. This is where the route proxies traffic to. With form-encoded, the notation is service.id=<service id> or service.name=<service name>. With JSON, use `"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
                 nullable: true
                 properties:
                   id:
@@ -2990,7 +2990,7 @@ components:
             properties:
               set:
                 type: object
-                description: The id (an UUID) of the key-set with which to associate the key .With form-encoded, the notation is `set.id=<set id>` or `set.name=<set name>`. With JSON, use `“"set":{"id":"<set id>"}` or `"set":{"name":"<set name>"}.`
+                description: The id (an UUID) of the key-set with which to associate the key .With form-encoded, the notation is `set.id=<set id>` or `set.name=<set name>`. With JSON, use `"set":{"id":"<set id>"}` or `"set":{"name":"<set name>"}.`
                 properties:
                   id:
                     type: string
@@ -3224,7 +3224,7 @@ components:
                   example: '["user-level", "low-priority"]'
               certificate:
                 type: object
-                description: The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use `“certificate":{"id":"<certificate id>”}`.
+                description: The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use `"certificate":{"id":"<certificate id>"}`.
                 properties:
                   id:
                     type: string

--- a/api-specs/Gateway-EE/3.4/kong-ee-3.4.yaml
+++ b/api-specs/Gateway-EE/3.4/kong-ee-3.4.yaml
@@ -62,7 +62,7 @@ components:
           - error
           - crit
         example: warn
-      description: Log levels are set in Kong’s configuration. Log levels increase in order of their severity
+      description: Log levels are set in Kong's configuration. Log levels increase in order of their severity
     target_id_or_target:
       name: target_id_or_target
       in: path
@@ -193,7 +193,7 @@ components:
       schema:
         type: string
         example: 30b4edb7-0847-4f65-af90-efbed8b0161f
-      description: The license’s unique ID.
+      description: The license's unique ID.
     workspace_id_or_name:
       name: workspace_id_or_name
       in: path
@@ -1299,7 +1299,7 @@ components:
                 type: string
               name:
                 type: string
-                description: The name of the plugin that’s going to be added. Currently, the plugin must be installed in every Kong instance separately.
+                description: The name of the plugin that's going to be added. Currently, the plugin must be installed in every Kong instance separately.
                 example: rate-limiting
               created_at:
                 type: integer
@@ -1356,10 +1356,10 @@ components:
                   type: string
               ordering:
                 type: object
-                description: |-
+                description: |
                   Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  –`before`: The plugin will be executed before a specified plugin or list of plugins.
-                  – `after`: The plugin will be executed after a specified plugin or list of plugins.
+                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
+                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
                 properties:
                   before:
                     type: array
@@ -2001,7 +2001,7 @@ components:
               name:
                 type: string
                 description: |
-                  The name of the Vault that’s going to be added. Currently, the Vault implementation must be installed in every Kong instance.
+                  The name of the Vault that's going to be added. Currently, the Vault implementation must be installed in every Kong instance.
                 example: env
               description:
                 type: string
@@ -2011,7 +2011,7 @@ components:
               config:
                 type: object
                 description: |
-                  The configuration properties for the Vault which can be found on the vaults’ documentation page.
+                  The configuration properties for the Vault which can be found on the vaults' documentation page.
                 properties:
                   prefix:
                     type: string
@@ -2462,10 +2462,10 @@ components:
                         default: /
                       https_sni:
                         type: string
-                        description: The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the target host’s certificate can be verified with the proper SNI.
+                        description: The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the target host's certificate can be verified with the proper SNI.
                   threshold:
                     type: integer
-                    description: The minimum percentage of the upstream’s targets’ weight that must be available for the whole upstream to be considered healthy.
+                    description: The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy.
                     minimum: 0
                     maximum: 100
                     default: 0
@@ -2707,13 +2707,13 @@ components:
               tls_verify_depth:
                 type: string
                 description: |
-                  Maximum depth of chain while verifying Upstream server’s TLS certificate. If set to null, then the Nginx default is respected. Default: null.
+                  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to null, then the Nginx default is respected. Default: null.
                 example: respected
                 default: null
                 nullable: true
               ca_certificates:
                 type: array
-                description: Array of CA Certificate object UUIDs that are used to build the trust store while verifying upstream server’s TLS certificate. If set to null when Nginx default is respected. With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
+                description: Array of CA Certificate object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to null when Nginx default is respected. With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
                 items:
                   type: string
                   example: 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
@@ -2871,7 +2871,7 @@ components:
                 example: v0
               preserve_host:
                 type: boolean
-                description: When matching a route via one of the `hosts` domain names, use the request `host` header in the upstream request headers. If set to `false`, the upstream Host header will be that of the service’s host.
+                description: When matching a route via one of the `hosts` domain names, use the request `host` header in the upstream request headers. If set to `false`, the upstream Host header will be that of the service's host.
                 default: true
               request_buffering:
                 type: boolean
@@ -3081,7 +3081,7 @@ components:
             properties:
               name:
                 type: string
-                description: The name of the plugin that’s going to be added. Currently, the plugin must be installed in every Kong instance separately.
+                description: The name of the plugin that's going to be added. Currently, the plugin must be installed in every Kong instance separately.
                 example: rate-limiting
               route:
                 type: string
@@ -3135,10 +3135,10 @@ components:
                   type: string
               ordering:
                 type: object
-                description: |-
+                description: |
                   Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  –`before`: The plugin will be executed before a specified plugin or list of plugins.
-                  – `after`: The plugin will be executed after a specified plugin or list of plugins.
+                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
+                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
                 properties:
                   before:
                     type: array
@@ -7475,7 +7475,7 @@ paths:
 
         If you add a consumer to multiple groups:
 
-        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group's settings will apply.
         Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
       requestBody:
         content:
@@ -7528,7 +7528,7 @@ paths:
 
         If you add a consumer to multiple groups:
 
-        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group's settings will apply.
         Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
       requestBody:
         content:
@@ -7871,9 +7871,9 @@ paths:
         '405':
           description: Method Not Allowed
       description: |-
-        When using `PUT`, if the request payload does not contain an entity’s primary key (`id` for licenses), the license will be added and assigned the given ID.
+        When using `PUT`, if the request payload does not contain an entity's primary key (`id` for licenses), the license will be added and assigned the given ID.
 
-        If the request payload does contain an entity’s primary key (id for Licenses), the license will be replaced with the given payload attribute. If the ID is not a valid UUID, a `400 BAD REQUEST` will be returned. If the ID is omitted, a `405 NOT ALLOWED` will be returned.
+        If the request payload does contain an entity's primary key (id for Licenses), the license will be replaced with the given payload attribute. If the ID is not a valid UUID, a `400 BAD REQUEST` will be returned. If the ID is omitted, a `405 NOT ALLOWED` will be returned.
       requestBody:
         $ref: '#/components/requestBodies/license-request'
     patch:
@@ -7883,9 +7883,9 @@ paths:
         '200':
           $ref: '#/components/responses/license-response'
       description: |-
-        When using `PATCH`, if the request payload does contain an entity’s primary key (`id` for licenses), the license will be replaced with the given payload attribute.
+        When using `PATCH`, if the request payload does contain an entity's primary key (`id` for licenses), the license will be replaced with the given payload attribute.
 
-        If the request payload does not contain an entity’s primary key (`id` for licenses), a `404 NOT FOUND `will be returned or if the request payload contains a invalid licence, a `400 BAD REQUEST` will be returned.
+        If the request payload does not contain an entity's primary key (`id` for licenses), a `404 NOT FOUND `will be returned or if the request payload contains a invalid licence, a `400 BAD REQUEST` will be returned.
       requestBody:
         $ref: '#/components/requestBodies/license-request'
     delete:
@@ -8140,7 +8140,7 @@ paths:
           description: OK
       operationId: get-schemas-plugins-plugin_name
       description: |
-        Retrieve the schema of a plugin’s configuration. This is useful to understand what fields a plugin accepts, and can be used for building third-party integrations to the Kong’s plugin system.
+        Retrieve the schema of a plugin's configuration. This is useful to understand what fields a plugin accepts, and can be used for building third-party integrations to the Kong's plugin system.
   /schemas/plugins/validate:
     post:
       summary: Validate plugin schema

--- a/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
+++ b/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
@@ -150,7 +150,7 @@ components:
           - error
           - crit
         example: warn
-      description: Log levels are set in Kong’s configuration. Log levels increase in order of their severity
+      description: Log levels are set in Kong's configuration. Log levels increase in order of their severity
   schemas:
     CA-Certificate:
       description: A CA certificate object represents a trusted CA. These objects are used by Kong to verify the validity of a client or server certificate. CA Certificates can be both tagged and filtered by tags.
@@ -1285,7 +1285,7 @@ components:
             properties:
               name:
                 type: string
-                description: 'The name of the Plugin that’s going to be added. Currently, the Plugin must be installed in every Kong instance separately.'
+                description: 'The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.'
                 example: rate-limiting
               route:
                 type: string
@@ -1339,10 +1339,10 @@ components:
                   type: string
               ordering:
                 type: object
-                description: |-
+                description: |
                   Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  –`before`: The plugin will be executed before a specified plugin or list of plugins.
-                  – `after`: The plugin will be executed after a specified plugin or list of plugins.
+                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
+                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
                 properties:
                   before:
                     type: array
@@ -1573,7 +1573,7 @@ components:
                 example: v0
               preserve_host:
                 type: boolean
-                description: 'When matching a route via one of the `hosts` domain names, use the request `host` header in the upstream request headers. If set to `false`, the upstream Host header will be that of the service’s host.'
+                description: 'When matching a route via one of the `hosts` domain names, use the request `host` header in the upstream request headers. If set to `false`, the upstream Host header will be that of the service's host.'
                 default: true
               request_buffering:
                 type: boolean
@@ -1786,13 +1786,13 @@ components:
               tls_verify_depth:
                 type: string
                 description: |
-                  Maximum depth of chain while verifying Upstream server’s TLS certificate. If set to null, then the Nginx default is respected. Default: null.
+                  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to null, then the Nginx default is respected. Default: null.
                 example: respected
                 default: null
                 nullable: true
               ca_certificates:
                 type: array
-                description: 'Array of CA Certificate object UUIDs that are used to build the trust store while verifying upstream server’s TLS certificate. If set to null when Nginx default is respected. With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.'
+                description: 'Array of CA Certificate object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to null when Nginx default is respected. With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.'
                 items:
                   type: string
                   example: 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
@@ -2210,10 +2210,10 @@ components:
                         default: /
                       https_sni:
                         type: string
-                        description: 'The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the target host’s certificate can be verified with the proper SNI.'
+                        description: 'The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the target host's certificate can be verified with the proper SNI.'
                   threshold:
                     type: integer
-                    description: The minimum percentage of the upstream’s targets’ weight that must be available for the whole upstream to be considered healthy.
+                    description: The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy.
                     minimum: 0
                     maximum: 100
                     default: 0
@@ -2405,7 +2405,7 @@ components:
               name:
                 type: string
                 description: |
-                  The name of the Vault that’s going to be added. Currently, the Vault implementation must be installed in every Kong instance.
+                  The name of the Vault that's going to be added. Currently, the Vault implementation must be installed in every Kong instance.
                 example: env
               description:
                 type: string
@@ -2415,7 +2415,7 @@ components:
               config:
                 type: object
                 description: |
-                  The configuration properties for the Vault which can be found on the vaults’ documentation page.
+                  The configuration properties for the Vault which can be found on the vaults' documentation page.
                 properties:
                   prefix:
                     type: string
@@ -2609,7 +2609,7 @@ components:
                 type: string
               name:
                 type: string
-                description: 'The name of the Plugin that’s going to be added. Currently, the Plugin must be installed in every Kong instance separately.'
+                description: 'The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.'
                 example: rate-limiting
               created_at:
                 type: integer
@@ -2666,10 +2666,10 @@ components:
                   type: string
               ordering:
                 type: object
-                description: |-
+                description: |
                   Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  –`before`: The plugin will be executed before a specified plugin or list of plugins.
-                  – `after`: The plugin will be executed after a specified plugin or list of plugins.
+                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
+                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
                 properties:
                   before:
                     type: array
@@ -6877,7 +6877,7 @@ paths:
           description: OK
       operationId: get-schemas-plugins-plugin_name
       description: |
-        Retrieve the schema of a plugin’s configuration. This is useful to understand what fields a plugin accepts, and can be used for building third-party integrations to the Kong’s plugin system.
+        Retrieve the schema of a plugin's configuration. This is useful to understand what fields a plugin accepts, and can be used for building third-party integrations to the Kong's plugin system.
   /schemas/plugins/validate:
     post:
       summary: Validate plugin schema
@@ -6910,7 +6910,7 @@ paths:
         - Information
   /timers:
     get:
-      summary: Retrieve Runtime Debugging Info of Kong’s Timers
+      summary: Retrieve Runtime Debugging Info of Kong's Timers
       tags:
         - Information
       responses:
@@ -7171,10 +7171,10 @@ paths:
                           properties:
                             http_allocated_gc:
                               type: string
-                              description: 'HTTP submodule’s Lua virtual machine’s memory usage information, as reported by'
+                              description: 'HTTP submodule's Lua virtual machine's memory usage information, as reported by'
                             pid:
                               type: integer
-                              description: worker’s process identification number.
+                              description: worker's process identification number.
                               example: 18478
                   database:
                     type: object
@@ -7306,7 +7306,7 @@ paths:
                       connections_accepted: 15
       operationId: get-status
       description: |-
-        Retrieve usage information about a node, with some basic information about the connections being processed by the underlying nginx process, the status of the database connection, and node’s memory usage.
+        Retrieve usage information about a node, with some basic information about the connections being processed by the underlying nginx process, the status of the database connection, and node's memory usage.
 
         If you want to monitor the Kong process, since Kong is built on top of nginx, every existing nginx monitoring tool or agent can be used.
   /tags:
@@ -7371,7 +7371,7 @@ paths:
 
         Care must be taken when changing the log level of a node to `debug` in a production environment because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level such as notice.
 
-        It’s currently not possible to change the log level of DP and DB-less nodes.
+        It's currently not possible to change the log level of DP and DB-less nodes.
       tags:
         - Debug
   '/debug/cluster/log-level/{log_level}':
@@ -7406,7 +7406,7 @@ paths:
 
         See the [NGINX docs](http://nginx.org/en/docs/ngx_core_module.html#error_log) for a list of accepted values.
 
-        It’s currently not possible to change the log level of DP and DB-less nodes.
+        It's currently not possible to change the log level of DP and DB-less nodes.
 
         Currently, when a user dynamically changes the log level for the entire cluster, if a new node joins a cluster the new node will run at the previous log level, not at the log level that was previously set dynamically for the entire cluster.
       tags:

--- a/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
+++ b/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
@@ -1214,7 +1214,7 @@ components:
                   example: '["user-level", "low-priority"]'
               certificate:
                 type: object
-                description: 'The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use `“certificate":{"id":"<certificate id>”}`.'
+                description: 'The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use `"certificate":{"id":"<certificate id>"}`.'
                 properties:
                   id:
                     type: string
@@ -1285,19 +1285,23 @@ components:
             properties:
               name:
                 type: string
-                description: 'The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.'
+                description: |
+                  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
                 example: rate-limiting
               route:
                 type: string
-                description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used. Default: `null`.With form-encoded, the notation is `route.id=<route id> or route.name=<route name>`. With JSON, use `"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.'
+                description: |
+                  If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used. Default: `null`. With form-encoded, the notation is `route.id=<route id> or route.name=<route name>`. With JSON, use `"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
                 nullable: true
               service:
                 type: string
-                description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified service.'
+                description: |
+                  If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified service.
                 nullable: true
               consumer:
                 type: string
-                description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.)'
+                description: |
+                  If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.)
                 nullable: true
               instance_name:
                 type: string
@@ -1412,7 +1416,7 @@ components:
             properties:
               set:
                 type: object
-                description: 'The id (an UUID) of the key-set with which to associate the key .With form-encoded, the notation is `set.id=<set id>` or `set.name=<set name>`. With JSON, use `“"set":{"id":"<set id>"}` or `"set":{"name":"<set name>"}.`'
+                description: 'The id (an UUID) of the key-set with which to associate the key .With form-encoded, the notation is `set.id=<set id>` or `set.name=<set name>`. With JSON, use `"set":{"id":"<set id>"}` or `"set":{"name":"<set name>"}.`'
                 properties:
                   id:
                     type: string
@@ -1505,7 +1509,7 @@ components:
               name:
                 type: string
                 description: |
-                  The name of the route. Route names must be unique, and they are case sensitive. For example, there can be two different routes named “test” and “Test”.
+                  The name of the route. Route names must be unique, and they are case sensitive. For example, there can be two different routes named "test" and "Test".
               protocols:
                 type: array
                 description: An array of the protocols this route should allow
@@ -1573,7 +1577,8 @@ components:
                 example: v0
               preserve_host:
                 type: boolean
-                description: 'When matching a route via one of the `hosts` domain names, use the request `host` header in the upstream request headers. If set to `false`, the upstream Host header will be that of the service's host.'
+                description: |
+                  When matching a route via one of the `hosts` domain names, use the request `host` header in the upstream request headers. If set to `false`, the upstream Host header will be that of the service's host.
                 default: true
               request_buffering:
                 type: boolean
@@ -1594,7 +1599,7 @@ components:
               sources:
                 type: array
                 description: |
-                  A list of IP sources of incoming connections that match this route when using stream routing. Each entry is an object with fields “ip” (optionally in CIDR range notation) and/or “port”.
+                  A list of IP sources of incoming connections that match this route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
                 items:
                   type: object
                   properties:
@@ -1607,7 +1612,7 @@ components:
               destinations:
                 type: array
                 description: |
-                  A list of IP destinations of incoming connections that match this route when using stream routing. Each entry is an object with fields “ip” (optionally in CIDR range notation) and/or “port”.
+                  A list of IP destinations of incoming connections that match this route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
                 items:
                   type: object
                   properties:
@@ -1624,7 +1629,7 @@ components:
                   type: string
               service:
                 type: object
-                description: 'The service this route is associated to. This is where the route proxies traffic to. With form-encoded, the notation is service.id=<service id> or service.name=<service name>. With JSON, use “`"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.'
+                description: 'The service this route is associated to. This is where the route proxies traffic to. With form-encoded, the notation is service.id=<service id> or service.name=<service name>. With JSON, use `"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.'
                 properties:
                   id:
                     type: string
@@ -1792,14 +1797,17 @@ components:
                 nullable: true
               ca_certificates:
                 type: array
-                description: 'Array of CA Certificate object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to null when Nginx default is respected. With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.'
+                description: |
+                  Array of CA Certificate object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to null when Nginx default is respected. 
+                  With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an Array.
                 items:
                   type: string
                   example: 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
               enabled:
                 type: boolean
                 default: true
-                description: 'Whether the service is active. If set to `false`, the proxy behavior will be as if any routes attached to it do not exist (404). Default: `true`.'
+                description: |
+                  Whether the service is active. If set to `false`, the proxy behavior will be as if any routes attached to it do not exist (404). Default: `true`.
             required:
               - protocol
               - host
@@ -2210,7 +2218,9 @@ components:
                         default: /
                       https_sni:
                         type: string
-                        description: 'The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the target host's certificate can be verified with the proper SNI.'
+                        description: 
+                          The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. 
+                          This is particularly useful when Targets are configured using IPs, so that the target host's certificate can be verified with the proper SNI.
                   threshold:
                     type: integer
                     description: The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy.
@@ -2609,7 +2619,8 @@ components:
                 type: string
               name:
                 type: string
-                description: 'The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.'
+                description: |
+                  The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.
                 example: rate-limiting
               created_at:
                 type: integer
@@ -7171,7 +7182,8 @@ paths:
                           properties:
                             http_allocated_gc:
                               type: string
-                              description: 'HTTP submodule's Lua virtual machine's memory usage information, as reported by'
+                              description: |
+                                HTTP submodule's Lua virtual machine's memory usage information, as reported by
                             pid:
                               type: integer
                               description: worker's process identification number.


### PR DESCRIPTION
### Description

Replacing some characters, as they're throwing errors when the specs are uploaded to Dev Portal.

### Testing instructions

Preview link: Changed already live, this is just syncing the source files:
https://docs.konghq.com/gateway/api/admin-ee/latest/
https://docs.konghq.com/gateway/api/admin-oss/latest/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

