### PR TITLE
fix: More runtime group stragglers

### DIFF
--- a/app/konnect/dev-portal/access-and-approval/manage-teams.md
+++ b/app/konnect/dev-portal/access-and-approval/manage-teams.md
@@ -74,7 +74,7 @@ The {{site.konnect_short_name}} API uses [Personal Access Token (PAT)](/konnect/
       }'
     ```
   
-    You can get the `runtimeGroupId`, by using the [list control planes endpoint](https://developer.konghq.com/spec/cd849478-4628-4bc2-abcd-5d8a83d3b5f2/24c1f98b-ea51-4277-9178-ca28a6aa85d9#/Runtime%20Groups/list-runtime-groups) to list all control planes and their IDs.
+    You can get the `controlPlaneId` by using the [list control planes endpoint](/konnect/api/control-planes/latest/#/Control%20Planes/list-control-planes) to list all control planes and their IDs.
 
     You should get a `201` response like the following:
     ```json

--- a/app/konnect/gateway-manager/control-plane-groups/how-to.md
+++ b/app/konnect/gateway-manager/control-plane-groups/how-to.md
@@ -41,7 +41,7 @@ Create some standard control planes.
 1. Create control plane `CP1`:
 
     ```sh
-    curl -i -X POST https://<region>.api.konghq.com/v2/runtime-groups \
+    curl -i -X POST https://<region>.api.konghq.com/v2/control-planes \
         -H "Authorization: Bearer <your_KPAT>" \
         --data "name=CP1" \
         --data "cluster_type=CLUSTER_TYPE_HYBRID"
@@ -50,7 +50,7 @@ Create some standard control planes.
 1. Create control plane `CP2`:
 
     ```sh
-    curl -i -X POST https://<region>.api.konghq.com/v2/runtime-groups \
+    curl -i -X POST https://<region>.api.konghq.com/v2/control-planes \
         -H "Authorization: Bearer <your_KPAT>" \
         --data "name=CP2" \
         --data "cluster_type=CLUSTER_TYPE_HYBRID"
@@ -82,7 +82,7 @@ Next, create a control plane group with the control planes `CP1` and `CP2` as it
 1. Create a control plane group:
 
     ```sh
-    curl -i -X POST https://<region>.api.konghq.com/v2/runtime-groups \
+    curl -i -X POST https://<region>.api.konghq.com/v2/control-planes \
         -H "Authorization: Bearer <your_KPAT>" \
         --data "name=CPG" \
         --data "cluster_type=CLUSTER_TYPE_COMPOSITE"

--- a/app/konnect/gateway-manager/control-plane-groups/migrate.md
+++ b/app/konnect/gateway-manager/control-plane-groups/migrate.md
@@ -24,7 +24,7 @@ Therefore, when migrating, you will need at least two new groups: a control plan
 1. Create a control plane group:
 
     ```sh
-    curl -i -X POST https://<region>.api.konghq.com/v2/runtime-groups \
+    curl -i -X POST https://<region>.api.konghq.com/v2/control-planes \
         -H "Authorization: Bearer <your_KPAT>" \
         --data name=CPG \
         --data cluster_type=CLUSTER_TYPE_COMPOSITE
@@ -33,7 +33,7 @@ Therefore, when migrating, you will need at least two new groups: a control plan
 1. Create a new standard control plane:
 
     ```sh
-    curl -i -X POST https://<region>.api.konghq.com/v2/runtime-groups \
+    curl -i -X POST https://<region>.api.konghq.com/v2/control-planes \
         -H "Authorization: Bearer <your_KPAT>" \
         --data name=CP1 \
         --data cluster_type=CLUSTER_TYPE_HYBRID

--- a/app/konnect/gateway-manager/data-plane-nodes/custom-dp-labels.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/custom-dp-labels.md
@@ -9,7 +9,7 @@ Labels are commonly used for metadata information. Set anything that you need to
 
 Using labels makes it easier to manage data plane nodes at scale since you're able to identify all of this information at a glance. For example, debugging and troubleshooting become much easier when you're able to attribute a data plane node to a specific region or team.
 
-Any labels you set on a data plane node are visible from the control plane via the [`/nodes`](/konnect/api/runtime-groups-config/#nodes) {{site.konnect_short_name}} API endpoint.
+Any labels you set on a data plane node are visible from the control plane via the [`/nodes`](/konnect/api/control-plane-configuration/latest/#/DP%20Nodes) {{site.konnect_short_name}} API endpoint.
 
 ## Set labels on a data plane node
 

--- a/app/konnect/gateway-manager/data-plane-nodes/renew-certificates.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/renew-certificates.md
@@ -61,7 +61,7 @@ You can generate a new data plane certificate from the {% konnect_icon runtimes 
 
 {% navtab Konnect API %}
 
-You can generate a certificate locally and use the [pin data plane client certificate](/konnect/api/runtime-groups-configuration/v2/#/DP%20Certificates/post-dp-client-certificates) endpoint to add it to {{site.konnect_short_name}}.
+You can generate a certificate locally and use the [pin data plane client certificate](/konnect/api/control-plane-configuration/latest/#/DP%20Certificates/post-dp-client-certificates) endpoint to add it to {{site.konnect_short_name}}.
 
 1.  Generate a new certificate and key:
 

--- a/app/konnect/gateway-manager/index.md
+++ b/app/konnect/gateway-manager/index.md
@@ -130,7 +130,7 @@ nodes in the control plane the have been accounted for.
 
 To delete a control plane, you can use the Gateway Manager or the 
 {{site.konnect_short_name}} 
-[Control Plane API](/konnect/api/runtime-groups/v2/).
+[Control Plane API](/konnect/api/control-planes/v2/).
 
 When a control plane is deleted, all associated entities are also deleted.
 This includes all entities configured in the Gateway Manager for this control plane.

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -69,7 +69,7 @@ You can find the configuration and telemetry hostnames through the Gateway Manag
 
 {% navtab Kong Ingress Controller %}
 
-{{site.kic_product_name}} initiates the connection to the {{site.konnect_short_name}} [Control Planes Configuration API](/konnect/api/runtime-groups-config/) to:
+{{site.kic_product_name}} initiates the connection to the {{site.konnect_short_name}} [Control Planes Configuration API](/konnect/api/control-plane-configuration/latest/) to:
 
 * Synchronize the configuration of the {{site.base_gateway}} instances with {{site.konnect_short_name}}
 * Register data plane nodes

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -32,6 +32,10 @@ services. [Try it today!](https://cloud.konghq.com/quick-start)
 * decK command flag: `--konnect-runtime-group-name` to `--konnect-control-plane-name`
 * decK state file attribute: `_konnect.runtime_group_name`  to` _konnect.control_plane_name`
 
+: Authorization logs:
+* `Authz.runtimegroups` to `Authz.control-planes`
+* `Authz.services` to `Authz.api-products`
+
 **Gateway Manager redesigns**
 : The Gateway Manager Landing Page is now updated to nudge customers to create a control plane if none are present. In addition, the control plane creation workflow has been revamped to make it more intuitive and easier to follow.
 


### PR DESCRIPTION
### Description

Ran into some API examples and links to the old API docs that still use `runtime-groups`, so fixing that.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

