### PR TITLE
Rename invalid request to bad request in Konnect errors

### DIFF
--- a/app/_data/konnect_errors.yml
+++ b/app/_data/konnect_errors.yml
@@ -17,8 +17,8 @@
       title: Not Found
       description: The resource requested does not exist, or it is not owned by the organization that the authenticated user belongs to
       resolution: Check the resource ID provided and try again
-    invalid-request:
-      title: Invalid Request
+    bad-request:
+      title: Bad Request
       description: Your request was understood, but can't be processed due to invalid data in the payload
       resolution: See the `invalid_parameters` section of the response for more detailed information
     conflict:


### PR DESCRIPTION
### Description

Rename `Invalid Request` to `Bad Request` as that's what `shared-go` uses as the `type` field

### Testing instructions

Preview link: 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


