### PR TITLE
Add 'make kill-ports' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,7 @@ smoke:
 	@npm run test:smoke || true
 	@kill -TERM $$(cat netlify.PID)
 	@rm netlify.PID
+
+kill-ports:
+	@JEKYLL_PROCESS=$$(lsof -ti:4000) && kill -9 $$JEKYLL_PROCESS || true
+	@VITE_PROCESS=$$(lsof -ti:3036) && kill -9 $$VITE_PROCESS || true


### PR DESCRIPTION
### Description

Add a `make kill-ports` command to clear things that are listening on port 4000 (Jekyll) and port 3036 (Vite).

This is useful when you change branch without stopping the server first and the port continues to be used by a zombie process.

### Testing instructions

Preview link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

