### PR TITLE
Group renovate updates in to a single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,5 +11,18 @@
   ],
   "labels": [
     "review:tech"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
### Description

Combine all non-major renovate updates into a single PR

### Testing instructions

Preview link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
