### PR TITLE
chore: CE patch version 2.8.4 bump

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -30,7 +30,7 @@
   lua_doc: true
 - release: "2.8.x"
   ee-version: "2.8.4.3"
-  ce-version: "2.8.3"
+  ce-version: "2.8.4"
   edition: "gateway"
   luarocks_version: "2.5.1-0"
   dependencies:


### PR DESCRIPTION
### Description

Bumping CE version to 2.8.4, DOCU-3482/KAG-2394

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

