### PR TITLE
chore: Remove pardot script

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -60,29 +60,6 @@
     ></script>
 
     <script type="text/javascript">
-      piAId = '393112';
-      piCId = '48375';
-
-      (function() {
-        function async_load() {
-          var s = document.createElement('script');
-          s.type = 'text/javascript';
-          s.src =
-            ('https:' == document.location.protocol
-              ? 'https://pi'
-              : 'http://cdn') + '.pardot.com/pd.js';
-          var c = document.getElementsByTagName('script')[0];
-          c.parentNode.insertBefore(s, c);
-        }
-        if (window.attachEvent) {
-          window.attachEvent('onload', async_load);
-        } else {
-          window.addEventListener('load', async_load, false);
-        }
-      })();
-    </script>
-
-    <script type="text/javascript">
       var _vwo_code = (function() {
         var account_id = 125292,
           settings_tolerance = 2000,


### PR DESCRIPTION
### Description

We don't use Pardot anymore, so I'm removing the script (request from PMM).

This may or may not help resolve the issue of the download button not working for specs; we won't know till it's merged.

### Testing instructions

Just check that nothing looks out of place in the preview. 

If you go into dev tools console in chrome > Network tab > filter on `JS`, then reload a page, the `pd.js` file shouldn't be there anymore. 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

