### PR TITLE
Fix issue with Vale reporting incorrect things as broken

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,13 +84,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v38
+        with:
+          sha: ${{ github.sha }}
+          files: |
+            app/
+            docs/
+          files_ignore: |
+            app/_src/.repos/kuma/**
+          json: true
+          quotepath: false
+          escape_json: false
       - uses: errata-ai/vale-action@reviewdog
         with:
-          #version: 2.24.0
-          # path where vale checks checking only modified files.
           fail_on_error: true
+          files: '${{ steps.changed-files.outputs.all_changed_files }}'
           filter_mode: file
-          vale_flags: "--glob=!app/_src/.repos/kuma/**"
           reporter: github-pr-review
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -94,6 +94,8 @@ jobs:
             docs/
           files_ignore: |
             app/_src/.repos/kuma/**
+            app/gateway/2.7.x/**
+            app/gateway/2.6.x/**
           json: true
           quotepath: false
           escape_json: false

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -98,6 +98,7 @@ jobs:
           quotepath: false
           escape_json: false
       - uses: errata-ai/vale-action@reviewdog
+        if: steps.changed-files.outputs.any_changed == 'true'
         with:
           fail_on_error: true
           files: '${{ steps.changed-files.outputs.all_changed_files }}'


### PR DESCRIPTION
### Description

Update Vale Github Action so that it only runs against added/copied/modified files.
This also prevents Vale from running on `2.6.x` and `2.7.x` Gateway file changes.

### Note

Because of an [API limitation](https://github.com/reviewdog/reviewdog#filter-mode-support-table) two types of `comments` might appear as a result of the check. Excerpt from the docs:
> Note that not all reporters provide full support of filter mode due to API limitation. e.g. github-pr-review reporter uses [GitHub Review API](https://docs.github.com/en/rest/pulls/reviews) and [GitHub Review Comment API](https://docs.github.com/en/rest/pulls/comments) but these APIs don't support posting comment outside diff file, so reviewdog will use [Check annotation](https://docs.github.com/en/rest/checks/runs) as fallback to post those comments [1].

* Github Annotations - for pre-existing errors (not part of the diff) on files, this will no longer appear once we fix all the errors. They look like this
![image (2)](https://github.com/Kong/docs.konghq.com/assets/715229/200c8cd4-4aeb-4e84-b825-c89ab6adc2b6)
* Github Comments - for newly introduced errors. They look like this
<img width="843" alt="Screenshot 2023-10-05 at 17 41 28" src="https://github.com/Kong/docs.konghq.com/assets/715229/3682d4c8-ed60-454e-afac-0c3d9db5e274">
