### PR TITLE
chore: Rearrange org management section in Konnect nav

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -211,57 +211,55 @@
     - text: Troubleshoot
       url: /analytics/troubleshoot/
 
-- title: Administer
+- title: Org Management
   icon: /assets/images/icons/konnect/icn-organizations-nav.svg
   items:
     - text: Plans and Billing
       url: /account-management/
-    - text: Org Management
+    - text: Authentication and Authorization
       items:
-      - text: Authentication and Authorization
-        items:
-          - text: Overview
-            url: /org-management/auth/
-          - text: Teams
-            items:
-              - text: Overview
-                url: /org-management/teams-and-roles/
-              - text: Manage Teams
-                url: /org-management/teams-and-roles/manage/
-              - text: Teams Reference
-                url: /org-management/teams-and-roles/teams-reference/
-              - text: Roles Reference
-                url: /org-management/teams-and-roles/roles-reference/
-          - text: Manage Users
-            url: /org-management/users/
-          - text: Manage System Accounts
-            url: /org-management/system-accounts/
-          - text: Social Identity Login
-            url: /org-management/social-identity-login/
-          - text: Org Switcher
-            url: /org-management/org-switcher/
-          - text: Set up SSO with OIDC
-            url: /org-management/oidc-idp/
-          - text: Set up SSO with Okta
-            url: /org-management/okta-idp/
-          - text: Login Sessions Reference
-            url: /org-management/sessions-reference/
-          - text: Troubleshoot
-            url: /org-management/troubleshoot/
-      - text: Audit Logging
-        items:
-          - text: Overview
-            url: /org-management/audit-logging/
-          - text: Set up an Audit Log Webhook
-            url: /org-management/audit-logging/webhook/
-          - text: Set up an Audit Log Replay Job
-            url: /org-management/audit-logging/replay-job/
-          - text: Verify Audit Log Signatures
-            url: /org-management/audit-logging/verify-signatures/
-          - text: Log Reference
-            url: /org-management/audit-logging/reference/
-      - text: Account and Org Deactivation
-        url: /org-management/deactivation/
+        - text: Overview
+          url: /org-management/auth/
+        - text: Teams
+          items:
+            - text: Overview
+              url: /org-management/teams-and-roles/
+            - text: Manage Teams
+              url: /org-management/teams-and-roles/manage/
+            - text: Teams Reference
+              url: /org-management/teams-and-roles/teams-reference/
+            - text: Roles Reference
+              url: /org-management/teams-and-roles/roles-reference/
+        - text: Manage Users
+          url: /org-management/users/
+        - text: Manage System Accounts
+          url: /org-management/system-accounts/
+        - text: Social Identity Login
+          url: /org-management/social-identity-login/
+        - text: Org Switcher
+          url: /org-management/org-switcher/
+        - text: Set up SSO with OIDC
+          url: /org-management/oidc-idp/
+        - text: Set up SSO with Okta
+          url: /org-management/okta-idp/
+        - text: Login Sessions Reference
+          url: /org-management/sessions-reference/
+        - text: Troubleshoot
+          url: /org-management/troubleshoot/
+    - text: Audit Logging
+      items:
+        - text: Overview
+          url: /org-management/audit-logging/
+        - text: Set up an Audit Log Webhook
+          url: /org-management/audit-logging/webhook/
+        - text: Set up an Audit Log Replay Job
+          url: /org-management/audit-logging/replay-job/
+        - text: Verify Audit Log Signatures
+          url: /org-management/audit-logging/verify-signatures/
+        - text: Log Reference
+          url: /org-management/audit-logging/reference/
+    - text: Account and Org Deactivation
+      url: /org-management/deactivation/
 
 - title: API
   icon: /assets/images/icons/documentation/icn-admin-api-color.svg


### PR DESCRIPTION
### Description

Moving out the "Org Management" section up one level. The content under it is very buried and we don't need to have that anymore, with Plans and Billing not being its own special section.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

