### PR TITLE
fix: `my-secret-value` example letter case in Gateway secrets management docs

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/env.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/env.md
@@ -11,7 +11,7 @@ Storing secrets in environment variables is a common method, as they can be inje
 Define a secret in a environment variable:
 
 ```bash
-export MY_SECRET_VALUE=EXAMPLE_VALUE
+export my-secret-value=EXAMPLE_VALUE
 ```
 
 You can now reference this secret:


### PR DESCRIPTION
The variable was in UPPER CASE and UNDERSCORE, changed it to lowercase and hypen


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

