### PR TITLE
Update: Add link to routing reference from Request Transformer Advanced

### DIFF
--- a/app/_hub/kong-inc/request-transformer-advanced/how-to/_templates.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/how-to/_templates.md
@@ -87,40 +87,44 @@ above).
 
 ### Examples using template as value
 
-Add a Service named `test` which routes requests to the mockbin.com upstream service:
+1. Add a service named `test` which routes requests to the mockbin.com upstream service:
 
-```bash
-curl -X POST http://localhost:8001/services \
-    --data 'name=test' \
-    --data 'url=http://mockbin.com/requests'
-```
+    ```bash
+    curl -X POST http://localhost:8001/services \
+        --data 'name=test' \
+        --data 'url=http://mockbin.com/requests'
+    ```
 
-Create a route for the `test` service, capturing a `user_id` field from the third segment of the request path:
+2. Create a route for the `test` service, capturing a `user_id` field from the 
+third segment of the request path using a regex:
 
-{:.note}
-> **Kubernetes users:** Version `v1beta1` of the Ingress
-  specification does not allow the use of named regex capture groups in paths.
-  If you use the ingress controller, you should use unnamed groups, e.g.
-  `(\w+)/`instead of `(?&lt;user_id&gt;\w+)`. You can access
-  these based on their order in the URL path. For example `$(uri_captures[1])`
-  obtains the value of the first capture group.
+    {:.note}
+    > **Kubernetes users:** Version `v1beta1` of the Ingress
+      specification does not allow the use of named regex capture groups in paths.
+      If you use the ingress controller, you should use unnamed groups, e.g.
+      `(\w+)/`instead of `(?&lt;user_id&gt;\w+)`. You can access
+      these based on their order in the URL path. For example `$(uri_captures[1])`
+      obtains the value of the first capture group.
 
-```bash
-curl -X POST http://localhost:8001/services/test/routes --data "name=test_user" \
-    --data-urlencode 'paths=~/requests/user/(?<user_id>\w+)'
-```
+    ```bash
+    curl -X POST http://localhost:8001/services/test/routes --data "name=test_user" \
+        --data-urlencode 'paths=~/requests/user/(?<user_id>\w+)'
+    ```
 
-Enable the `request-transformer-advanced` plugin to add a new header, `x-user-id`,
+    You can learn more about using regexes in paths in the {{site.base_gateway}} 
+    [traffic routing reference](/gateway/latest/how-kong-works/routing-traffic/#using-regex-in-paths).
+
+3. Enable the `request-transformer-advanced` plugin to add a new header, `x-user-id`,
 whose value is being set from the captured group in the route path specified above:
 
-```bash
-curl -XPOST http://localhost:8001/routes/test_user/plugins --data "name=request-transformer-advanced" --data "config.add.headers=x-user-id:\$(uri_captures['user_id'])"
-```
+    ```bash
+    curl -XPOST http://localhost:8001/routes/test_user/plugins --data "name=request-transformer-advanced" --data "config.add.headers=x-user-id:\$(uri_captures['user_id'])"
+    ```
 
-Now send a request with a user id in the route path:
+4. Now send a request with a user id in the route path:
 
-```bash
-curl -i -X GET localhost:8000/requests/user/foo
-```
+    ```bash
+    curl -i -X GET localhost:8000/requests/user/foo
+    ```
 
-You should notice in the response that the `x-user-id` header has been added with a value of `foo`.
+    You should notice in the response that the `x-user-id` header has been added with a value of `foo`.


### PR DESCRIPTION
### Description

From ticket:

> The documentation would be more helpful if there was a link back to the using-regexes-in-paths to capture uri from the request transform doc to show how this is actually done. 
> This would provide the additional context of how to initially implement this functionality.

Adding the requested link + minor formatting edits to arrange the steps into an ordered list.

https://konghq.atlassian.net/browse/DOCU-156

### Testing instructions

Preview link: https://deploy-preview-6198--kongdocs.netlify.app/hub/kong-inc/request-transformer-advanced/how-to/templates/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

