### PR TITLE
Update: Add info about untrusted_lua param to exit transformer plugin

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/overview/_index.md
@@ -6,6 +6,13 @@ Transform and customize {{site.base_gateway}} response exit messages using Lua f
 The plugin's capabilities range from changing messages, status codes, and headers,
 to completely transforming the structure of {{site.base_gateway}} responses.
 
+{:.note}
+> [`untrusted-lua`](/gateway/latest/reference/configuration/#untrusted_lua)
+must be set to either `on` or `sandbox` in your `kong.conf` file for this plugin 
+to work. The default value is `sandbox`, which means that Lua functions are allowed,
+but will be executed in a sandbox which has limited access to the Kong global
+environment.
+
 ## Transforming 4xx and 5xx Responses
 
 By default, the Exit Transformer is only applied to requests that match its


### PR DESCRIPTION
### Description

The Exit Transformer plugin allows you to execute Lua functions. There is a setting in kong.conf that controls any plugins or other functionality that can do that. There was nothing in the plugin's doc about the setting, so I added that in.

https://konghq.atlassian.net/browse/DOCU-1046

### Testing instructions

Preview link: https://deploy-preview-6199--kongdocs.netlify.app/hub/kong-inc/exit-transformer/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

