### PR TITLE
feat: support HTTP query parameters in expression routes.

### DIFF
--- a/app/_src/gateway/reference/router-expressions-language.md
+++ b/app/_src/gateway/reference/router-expressions-language.md
@@ -55,7 +55,7 @@ For example, you can not perform string comparisons on a integer type field.
 | `http.path` | Normalized request path (without query parameters). | String |
 | `http.headers.header_name` | Value of header `Header-Name`. Header names are converted to lower case, and `-` are replaced to `_`. | String |
 
-{% if_version gte:3.4.1.x %}
+{% if_version gte:3.4.x %}
 | `http.queries.query_name` | Value of query parameter `query-name`. | String |
 {% endif_version %}
 

--- a/app/_src/gateway/reference/router-expressions-language.md
+++ b/app/_src/gateway/reference/router-expressions-language.md
@@ -54,6 +54,7 @@ For example, you can not perform string comparisons on a integer type field.
 | `http.host`  | Lists of domains that match a route. | String |
 | `http.path` | Normalized request path (without query parameters). | String |
 | `http.headers.header_name` | Value of header `Header-Name`. Header names are converted to lower case, and `-` are replaced to `_`. | String |
+| `http.queries.query_name` | Value of query parameter `query-name`. | String |
 | `net.src.ip` | Source IP address of incoming connection. | IpAddr |
 | `net.src.port` | Source port number of incoming connection. | Int |
 | `net.dst.ip` | Destination IP address of incoming connection. | IpAddr |

--- a/app/_src/gateway/reference/router-expressions-language.md
+++ b/app/_src/gateway/reference/router-expressions-language.md
@@ -54,7 +54,11 @@ For example, you can not perform string comparisons on a integer type field.
 | `http.host`  | Lists of domains that match a route. | String |
 | `http.path` | Normalized request path (without query parameters). | String |
 | `http.headers.header_name` | Value of header `Header-Name`. Header names are converted to lower case, and `-` are replaced to `_`. | String |
+
+{% if_version gte:3.4.1.x %}
 | `http.queries.query_name` | Value of query parameter `query-name`. | String |
+{% endif_version %}
+
 | `net.src.ip` | Source IP address of incoming connection. | IpAddr |
 | `net.src.port` | Source port number of incoming connection. | Int |
 | `net.dst.ip` | Destination IP address of incoming connection. | IpAddr |


### PR DESCRIPTION
### Description

See: https://github.com/Kong/kong/pull/11348
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-6201--kongdocs.netlify.app/gateway/latest/reference/router-expressions-language/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

