### PR TITLE
fix: View Organizations

### DIFF
--- a/app/konnect/org-management/org-switcher.md
+++ b/app/konnect/org-management/org-switcher.md
@@ -3,7 +3,7 @@ title: Org Switcher
 content_type: how-to
 ---
 
-The org switcher allows a user with multiple {{site.konnect_short_name}} accounts to seamlessly switch between their organizations. You can navigate to the org switcher by clicking on **Your Org Name** > **Back to Org Switcher**.
+The org switcher allows a user with multiple {{site.konnect_short_name}} accounts to seamlessly switch between their organizations. You can navigate to the org switcher by clicking on **Your Org Name** > **View Organizations**.
 
 From the org switcher, you can:
 - View a list of {{site.konnect_short_name}} organizations to which you have access
@@ -23,7 +23,7 @@ In order to gain access to more organizations, the user may:
 
 ## Switch Organizations
 
-Users can switch organizations while logged in by clicking on the **Org Name** > **Back to Org Switcher**.
+Users can switch organizations while logged in by clicking on the **Org Name** > **View Organizations**.
 The user can login to each organization listed in the org switcher by clicking on the Select  button.
 
 If the organization is configured to be single-sign-on only, then the user will be directed to the configured identity provider to re-authenticate into {{site.konnect_short_name}}.


### PR DESCRIPTION
### Description
To navigate back to the org switcher from Konnect. The button now says "View Organizations" rather than "Back to org switcher".

![image](https://github.com/Kong/docs.konghq.com/assets/1035820/463be71d-88d3-4bfd-8f1a-ed7b13dc9408)

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

