### PR TITLE
Update: Add latency units to JSON log format reference for logging plugins

### DIFF
--- a/app/_includes/md/plugins-hub/json-object-log.md
+++ b/app/_includes/md/plugins-hub/json-object-log.md
@@ -5,7 +5,7 @@
 * `request`: Properties about the request sent by the client.
 * `response`: Properties about the response sent to the client.
 * `latencies`: Latency data.
-  * `kong`: The internal {{site.base_gateway}} latency that it takes to process the request. It varies based on the actual processing flow. Generally, it consists of three parts:
+  * `kong`: The internal {{site.base_gateway}} latency, in milliseconds, that it takes to process the request. It varies based on the actual processing flow. Generally, it consists of three parts:
     * The time it took to find the right upstream.
     * The time it took to receive the whole response from upstream.
     * The time it took to run all plugins executed before the log phase.


### PR DESCRIPTION
### Description

There are no units specified for the `kong` latency value so this leads to confusion.

Found the units here: https://github.com/Kong/kong-ee/blob/master/kong/analytics/init.lua#L279-L282

https://konghq.atlassian.net/browse/DOCU-1614

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

