### PR TITLE
Update: Add cache names to mem_cache_size

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -923,7 +923,7 @@ See http://nginx.org/en/docs/ngx_core_module.html#daemon.
 ### mem_cache_size
 
 Size of each of the two shared memory caches for traditional mode database
-entities and runtime data.
+entities and runtime data, `kong_core_cache` and `kong_cache`.
 
 The accepted units are `k` and `m`, with a minimum recommended value of a few
 MBs.

--- a/app/gateway/2.8.x/reference/configuration.md
+++ b/app/gateway/2.8.x/reference/configuration.md
@@ -1111,8 +1111,10 @@ See http://nginx.org/en/docs/ngx_core_module.html#daemon.
 
 #### mem_cache_size
 
-Size of each of the two in-memory caches for database entities. The accepted
-units are `k` and `m`, with a minimum recommended value of a few MBs.
+Size of each of the two shared memory caches for traditional mode database
+entities and runtime data, `kong_core_cache` and `kong_cache`.
+
+The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.
 
 **Note**: As this option controls the size of two different cache entries, the
 total memory Kong uses to cache entities might be double this value.


### PR DESCRIPTION
### Description

The mem_cache_size parameter in kong.conf mentions that it controls the size of two caches, but doesn't say what the names of the caches are.
According to our [changelog](https://github.com/Kong/kong/blob/master/CHANGELOG-OLD.md#core-32), these two in-memory caches are kong_core_cache and kong_cache.

Resolves doc ticket https://konghq.atlassian.net/browse/DOCU-1878.

Parallel PR to https://github.com/Kong/kong/pull/11680.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

