### PR TITLE
Update: Request Validator plugin parameter validation info

### DIFF
--- a/app/_hub/kong-inc/request-validator/overview/_index.md
+++ b/app/_hub/kong-inc/request-validator/overview/_index.md
@@ -252,10 +252,17 @@ Such a schema would validate the following request body:
 
 ### Parameter Schema Definition
 
-You can setup definitions for each parameter based on the OpenAPI Specification and
-the plugin will validate each parameter against it. For more information, see the
-[OpenAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameter-object)
-or the [OpenAPI examples](https://swagger.io/docs/specification/serialization/).
+You can set up definitions for each parameter based on the OpenAPI Specification and
+the plugin will validate each parameter against it.
+
+To be able to do parameter validation, the parameter must be deserialized according to [OAS type serialization](https://swagger.io/docs/specification/serialization/).
+The datatype used in the deserialization step (`object`, `array` or `primitive`) is
+derived from the JSON Schema. The top-level type entry is used for this purpose,
+where `object` and `array` types map one-to-one to the deserialization, and any other
+type in the JSON Schema (`string`, `integer`, etc).
+
+For more information, see the
+[OpenAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameter-object).
 
 #### Fixed Fields
 


### PR DESCRIPTION
### Description

To be able to do parameter validation with the Request Validator plugin, the parameter must be deserialized according to the
OAS type serialization (see https://swagger.io/docs/specification/serialization/).

Adding this info to the plugin's docs.

https://konghq.atlassian.net/browse/DOCU-1896

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

