### PR TITLE
chore: Standardize the kong hostname as localhost

### DIFF
--- a/app/_hub/kong-inc/acl/_api.md
+++ b/app/_hub/kong-inc/acl/_api.md
@@ -14,7 +14,7 @@ The `/acls` endpoints only appear once the plugin has been enabled.
 Retrieves paginated ACLs.
 
 ```bash
-curl -X GET http://{HOST}:8001/acls
+curl -X GET http://localhost:8001/acls
 ```
 
 Result:
@@ -49,7 +49,7 @@ Result:
 Retrieves ACLs by consumer.
 
 ```bash
-curl -X GET http://{HOST}:8001/consumers/{CONSUMER}/acls
+curl -X GET http://localhost:8001/consumers/{CONSUMER}/acls
 ```
 
 Result:
@@ -74,7 +74,7 @@ Result:
 Retrieves ACL by ID if the ACL belongs to the specified consumer.
 
 ```bash
-curl -X GET http://{HOST}:8001/consumers/{CONSUMER}/acls/{ID}
+curl -X GET http://localhost:8001/consumers/{CONSUMER}/acls/{ID}
 ```
 
 Result:
@@ -97,7 +97,7 @@ Retrieves a consumer associated with an ACL
 using the following request:
 
 ```bash
-curl -X GET http://{HOST}:8001/acls/{ID}/consumer
+curl -X GET http://localhost:8001/acls/{ID}/consumer
 ```
 
 Result:
@@ -116,7 +116,7 @@ Result:
 Update and insert the group name of the ACL by passing a new group name.
 
 ```bash
-curl -X PUT http://{HOST}:8001/consumers/{CONSUMER}/acls/{ID}
+curl -X PUT http://localhost:8001/consumers/{CONSUMER}/acls/{ID}
   --data "group=newgroupname"
 ```
 
@@ -129,7 +129,7 @@ curl -X PUT http://{HOST}:8001/consumers/{CONSUMER}/acls/{ID}
 Updates an ACL group name by passing a new group name.
 
 ```bash
-curl -X POST http://{HOST}:8001/consumers/{CONSUMER}/acls \
+curl -X POST http://localhost:8001/consumers/{CONSUMER}/acls \
     --data "group=group1"
 ```
 
@@ -140,7 +140,7 @@ curl -X POST http://{HOST}:8001/consumers/{CONSUMER}/acls \
 Deletes an ACL group by ID or group name.
 
 ```bash
-curl -X DELETE http://{HOST}:8001/consumers/{CONSUMER}/acls/{ID}
+curl -X DELETE http://localhost:8001/consumers/{CONSUMER}/acls/{ID}
 ```
 
 `ID`: The `id` property of the ACL.  
@@ -148,7 +148,7 @@ curl -X DELETE http://{HOST}:8001/consumers/{CONSUMER}/acls/{ID}
 Deletes an ACL group by group name.
 
 ```bash
-curl -X DELETE http://{HOST}:8001/consumers/{CONSUMER}/acls/{GROUP}
+curl -X DELETE http://localhost:8001/consumers/{CONSUMER}/acls/{GROUP}
 ```
 
 `GROUP`: The `group` property of the ACL.  

--- a/app/_hub/kong-inc/acl/how-to/_index.md
+++ b/app/_hub/kong-inc/acl/how-to/_index.md
@@ -27,7 +27,7 @@ created your [consumers](/gateway/latest/admin-api/#consumer-object), you can no
 associate a group to a consumer using the following request:
 
 ```bash
-curl -X POST http://{HOST}:8001/consumers/{CONSUMER}/acls \
+curl -X POST http://localhost:8001/consumers/{CONSUMER}/acls \
     --data "group=group1" \
     --data "tags[]=tag1" \
     --data "tags[]=tag2"

--- a/app/_hub/kong-inc/aws-lambda/overview/_index.md
+++ b/app/_hub/kong-inc/aws-lambda/overview/_index.md
@@ -126,7 +126,7 @@ to invoke the function.
 Create the route:
 
 ```bash
-curl -i -X POST http://<kong_hostname>:8001/routes \
+curl -i -X POST http://localhost:8001/routes \
 --data 'name=lambda1' \
 --data 'paths[1]=/lambda1'
 ```
@@ -134,7 +134,7 @@ curl -i -X POST http://<kong_hostname>:8001/routes \
 Add the plugin:
 
 ```bash
-curl -i -X POST http://<kong_hostname>:8001/routes/lambda1/plugins \
+curl -i -X POST http://localhost:8001/routes/lambda1/plugins \
 --data 'name=aws-lambda' \
 --data-urlencode 'config.aws_key={KongInvoker user key}' \
 --data-urlencode 'config.aws_secret={KongInvoker user secret}' \

--- a/app/_hub/kong-inc/basic-auth/overview/_index.md
+++ b/app/_hub/kong-inc/basic-auth/overview/_index.md
@@ -20,7 +20,7 @@ A Consumer can have many credentials.
 To create a Consumer, you can execute the following request:
 
 ```bash
-curl -d "username={USER123}&custom_id={SOME_CUSTOM_ID}" http://kong:8001/consumers/
+curl -d "username={USER123}&custom_id={SOME_CUSTOM_ID}" http://localhost:8001/consumers/
 ```
 {% endnavtab %}
 {% navtab Without a Database %}
@@ -53,7 +53,7 @@ service, you must add the new consumer to the allowed group. See
 You can provision new username/password credentials by making the following HTTP request:
 
 ```bash
-curl -X POST http://kong:8001/consumers/{CONSUMER}/basic-auth \
+curl -X POST http://localhost:8001/consumers/{CONSUMER}/basic-auth \
   --data "username=Aladdin" \
   --data "password=OpenSesame"
 ```
@@ -118,7 +118,7 @@ following request:
 {% navtabs codeblock %}
 {% navtab Request %}
 ```bash
-curl -X GET http://kong:8001/basic-auths
+curl -X GET http://localhost:8001/basic-auths
 ```
 {% endnavtab %}
 {% navtab Response %}
@@ -158,7 +158,7 @@ You can filter the list by Consumer with the following endpoint:
 {% navtabs codeblock %}
 {% navtab Request %}
 ```bash
-curl -X GET http://kong:8001/consumers/{USERNAME_OR_ID}/basic-auth
+curl -X GET http://localhost:8001/consumers/{USERNAME_OR_ID}/basic-auth
 ```
 {% endnavtab %}
 {% navtab Response %}
@@ -190,7 +190,7 @@ basic-auth Credential using the following request:
 {% navtabs codeblock %}
 {% navtab Request %}
 ```bash
-curl -X GET http://kong:8001/basic-auths/{USERNAME_OR_ID}/consumer
+curl -X GET http://localhost:8001/basic-auths/{USERNAME_OR_ID}/consumer
 ```
 {% endnavtab %}
 {% navtab Response %}

--- a/app/_hub/kong-inc/exit-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/overview/_index.md
@@ -175,7 +175,7 @@ end
 1. Create a service in Kong:
 
     ```bash
-    curl -i -X POST http://<admin-hostname>:8001/services \
+    curl -i -X POST http://localhost:8001/services \
       --data name=example.com \
       --data url='http://mockbin.org'
     ```
@@ -183,7 +183,7 @@ end
 2. Create a route in Kong:
 
     ```bash
-    curl -i -X POST http://<admin-hostname>:8001/services/example.com/routes \
+    curl -i -X POST http://localhost:8001/services/example.com/routes \
       --data 'hosts[]=example.com'
     ```
 
@@ -210,7 +210,7 @@ end
 1. Configure the `exit-transformer` plugin with `transform.lua`.
 
     ```bash
-    curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+    curl -X POST http://localhost:8001/services/example.com/plugins \
       -F "name=exit-transformer"  \
       -F "config.functions=@transform.lua"
     ```
@@ -219,7 +219,7 @@ end
 response in the following step:
 
     ```bash
-    curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+    curl -X POST http://localhost:8001/services/example.com/plugins \
       --data "name=key-auth"
     ```
 
@@ -252,7 +252,7 @@ response in the following step:
 The plugin can also be applied globally:
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/plugins/ \
+curl -X POST http://localhost:8001/plugins/ \
   -F "name=exit-transformer"  \
   -F "config.handle_unknown=true" \
   -F "config.functions=@transform.lua"
@@ -342,7 +342,7 @@ end
 Configure the `exit-transformer` plugin with `custom-errors-by-mimetype.lua`:
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/services/example.com/plugins \
+curl -X POST http://localhost:8001/services/example.com/plugins \
   -F "name=exit-transformer"  \
   -F "config.handle_unknown=true" \
   -F "config.handle_unexpected=true" \

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_api.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_api.md
@@ -222,20 +222,20 @@ Add a cost to a service schema.
 Example requests:
 
 ```sh
-curl -X POST http://kong:8001/services/example-service/graphql-rate-limiting-advanced/costs \
+curl -X POST http://localhost:8001/services/example-service/graphql-rate-limiting-advanced/costs \
   --data type_path="Query.allPeople" \
   --data mul_arguments="first"
 
-curl -X POST http://kong:8001/services/example-service/graphql-rate-limiting-advanced/costs \
+curl -X POST http://localhost:8001/services/example-service/graphql-rate-limiting-advanced/costs \
   --data type_path="Person.vehicleConnection" \
   --data mul_arguments="first"
   --data add_constant=42
 
-curl -X POST http://kong:8001/services/example-service/graphql-rate-limiting-advanced/costs \
+curl -X POST http://localhost:8001/services/example-service/graphql-rate-limiting-advanced/costs \
   --data type_path="Vehicle.filmConnection" \
   --data mul_arguments="first"
 
-curl -X POST http://kong:8001/services/example-service/graphql-rate-limiting-advanced/costs \
+curl -X POST http://localhost:8001/services/example-service/graphql-rate-limiting-advanced/costs \
   --data type_path="Film.characterConnection" \
   --data mul_arguments="first"
 ```

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/how-to/_costs.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/how-to/_costs.md
@@ -12,12 +12,12 @@ See the [Costs API reference](/hub/kong-inc/graphql-rate-limiting-advanced/api/)
 ### Add a GraphQL service and route
 
 ```sh
-curl -X POST http://kong:8001/services \
+curl -X POST http://localhost:8001/services \
   --data "name=example" \
   --data "host=mockbin.org" \
   --data "port=443" \
   --data "protocol=https"
-curl -X POST http://kong:8001/services/example/routes \
+curl -X POST http://localhost:8001/services/example/routes \
   --data "hosts=example.com"
 ```
 
@@ -26,7 +26,7 @@ curl -X POST http://kong:8001/services/example/routes \
 Example using a single time window:
 
 ```sh
-curl -i -X POST http://kong:8001/services/example/plugins \
+curl -i -X POST http://localhost:8001/services/example/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100 \
   --data config.window_size=60 \
@@ -36,7 +36,7 @@ curl -i -X POST http://kong:8001/services/example/plugins \
 Example using multiple time windows:
 
 ```sh
-curl -i -X POST --url http://kong:8001/services/example/plugins \
+curl -i -X POST --url http://localhost:8001/services/example/plugins \
   --data 'name=graphql-rate-limiting-advanced' \
   --data 'config.window_size[]=60' \
   --data 'config.window_size[]=3600' \
@@ -48,7 +48,7 @@ curl -i -X POST --url http://kong:8001/services/example/plugins \
 ### Changing the default strategy
 
 ```sh
-curl -X POST http://kong:8001/services/example/plugins \
+curl -X POST http://localhost:8001/services/example/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100 \
   --data config.limit=10000 \
@@ -59,7 +59,7 @@ curl -X POST http://kong:8001/services/example/plugins \
 ```
 
 ```sh
-curl -i -X PATCH http://kong:8001/plugins/{plugin_id} \
+curl -i -X PATCH http://localhost:8001/plugins/{plugin_id} \
   --data config.cost_strategy=node_quantifier
 ```
 
@@ -73,7 +73,7 @@ a cost higher than our set `max_cost`. By default it's set to 0, which means
 no limit.
 
 ```sh
-curl -X POST http://kong:8001/services/example/plugins \
+curl -X POST http://localhost:8001/services/example/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100 \
   --data config.limit=10000 \
@@ -86,7 +86,7 @@ curl -X POST http://kong:8001/services/example/plugins \
 To update `max_cost`:
 
 ```sh
-curl -X PATCH http://kong:8001/plugins/{plugin_id} \
+curl -X PATCH http://localhost:8001/plugins/{plugin_id} \
   --data config.max_cost=10000
 ```
 
@@ -102,7 +102,7 @@ For example, a `score_factor` of `0.01` will divide the costs by 100, meaning
 every cost unit represents 100 nodes.
 
 ```sh
-curl -X POST http://kong:8001/services/example/plugins \
+curl -X POST http://localhost:8001/services/example/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100 \
   --data config.limit=10000 \
@@ -116,7 +116,7 @@ curl -X POST http://kong:8001/services/example/plugins \
 To update `score_factor`:
 
 ```sh
-curl -i -X PATCH http://kong:8001/plugins/{plugin_id} \
+curl -i -X PATCH http://localhost:8001/plugins/{plugin_id} \
   --data config.score_factor=1
 ```
 

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/how-to/_index.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/how-to/_index.md
@@ -40,7 +40,7 @@ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate limiting strategy.
 
 ```sh
-curl -i -X POST http://kong:8001/services/example-service/plugins \
+curl -i -X POST http://localhost:8001/services/example-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/_hub/kong-inc/hmac-auth/overview/_index.md
+++ b/app/_hub/kong-inc/hmac-auth/overview/_index.md
@@ -33,7 +33,7 @@ A Consumer can have many credentials.
 To create a Consumer, you can execute the following request:
 
 ```bash
-curl -d "username=user123&custom_id=SOME_CUSTOM_ID" http://kong:8001/consumers/
+curl -d "username=user123&custom_id=SOME_CUSTOM_ID" http://localhost:8001/consumers/
 ```
 {% endnavtab %}
 {% navtab Without a Database %}
@@ -64,7 +64,7 @@ You can provision new username/password credentials by making the following
 HTTP request:
 
 ```bash
-curl -X POST http://kong:8001/consumers/{consumer}/hmac-auth \
+curl -X POST http://localhost:8001/consumers/{consumer}/hmac-auth \
   --data "username=bob" \
   --data "secret=secret456"
 ```
@@ -317,7 +317,7 @@ Paginate through the `hmac-auth` Credentials for all Consumers using the
 following request:
 
 ```bash
-curl -X GET http://kong:8001/hmac-auths
+curl -X GET http://localhost:8001/hmac-auths
 ```
 
 Example output:
@@ -353,7 +353,7 @@ Example output:
 You can filter the list by consumer by using this other path:
 
 ```bash
-curl -X GET http://kong:8001/consumers/{username or id}/hmac-auth
+curl -X GET http://localhost:8001/consumers/{username or id}/hmac-auth
 ```
 
 Example output:
@@ -380,7 +380,7 @@ It is possible to retrieve a [Consumer][consumer-object] associated with an
 HMAC Credential using the following request:
 
 ```bash
-curl -X GET http://kong:8001/hmac-auths/{hmac username or id}/consumer
+curl -X GET http://localhost:8001/hmac-auths/{hmac username or id}/consumer
 ```
 
 Example output:

--- a/app/_hub/kong-inc/ip-restriction/overview/_index.md
+++ b/app/_hub/kong-inc/ip-restriction/overview/_index.md
@@ -22,7 +22,7 @@ An `allow` list provides a positive security model, in which the configured CIDR
 You can configure the plugin with both `allow` and `deny` configurations. An interesting use case of this flexibility is to allow a CIDR range, but deny an IP address on that CIDR range:
 
 ```bash
-curl -X POST http://kong:8001/services/{service}/plugins \
+curl -X POST http://localhost:8001/services/{service}/plugins \
   --data "name=ip-restriction" \
   --data "config.allow=127.0.0.0/24" \
   --data "config.deny=127.0.0.1"

--- a/app/_hub/kong-inc/jwt-signer/overview/_index.md
+++ b/app/_hub/kong-inc/jwt-signer/overview/_index.md
@@ -94,13 +94,13 @@ and published without revealing their secrets.
 View all of the public keys that Kong has loaded or generated:
 
 ```http
-GET kong:8001/jwt-signer/jwks
+GET localhost:8001/jwt-signer/jwks
 ```
 
 Example:
 
 ```bash
-curl -X GET http://<kong>:8001/jwt-signer/jwks
+curl -X GET http://localhost:8001/jwt-signer/jwks
 ```
 ```json
 {
@@ -173,13 +173,13 @@ curl -X GET http://<kong>:8001/jwt-signer/jwks
 A particular key set can be accessed in another endpoint:
 
 ```http
-GET kong:8001/jwt-signer/jwks/<name-or-id>
+GET localhost:8001/jwt-signer/jwks/<name-or-id>
 ```
 
 Example:
 
 ```bash
-curl -X GET http://<kong>:8001/jwt-signer/jwks/kong
+curl -X GET http://localhost:8001/jwt-signer/jwks/kong
 ```
 ```json
 {
@@ -205,7 +205,7 @@ curl -X GET http://<kong>:8001/jwt-signer/jwks/kong
 }
 ```
 
-The `http://<kong>:8001/jwt-signer/jwks/kong` is the URL that you can give to your
+The `http://localhost:8001/jwt-signer/jwks/kong` is the URL that you can give to your
 upstream services for them to verify Kong-issued tokens. The response is a standard
 JWKS endpoint response. The `kong` suffix in the URI is the one that you can specify
 with `config.access_token_issuer` or `config.channel_token_issuer`.
@@ -217,13 +217,13 @@ if that is needed.
 You can also `DELETE` a key set by issuing following:
 
 ```http
-DELETE kong:8001/jwt-signer/jwks/<name-or-id>
+DELETE localhost:8001/jwt-signer/jwks/<name-or-id>
 ```
 
 Example:
 
 ```bash
-curl -X DELETE http://<kong>:8001/jwt-signer/jwks/kong
+curl -X DELETE http://localhost:8001/jwt-signer/jwks/kong
 ```
 
 The plugin automatically reloads or regenerates missing JWKS if it cannot
@@ -246,13 +246,13 @@ an external URI.
 To rotate keys, send a `POST` request:
 
 ```http
-POST kong:8001/jwt-signer/jwks/<name-or-id>/rotate
+POST localhost:8001/jwt-signer/jwks/<name-or-id>/rotate
 ```
 
 Example:
 
 ```bash
-curl -X POST http://<kong>:8001/jwt-signer/jwks/kong/rotate
+curl -X POST http://localhost:8001/jwt-signer/jwks/kong/rotate
 ```
 Response:
 

--- a/app/_hub/kong-inc/kafka-upstream/overview/_index.md
+++ b/app/_hub/kong-inc/kafka-upstream/overview/_index.md
@@ -12,7 +12,7 @@ See [Kafka Log](/hub/kong-inc/kafka-log/).
 ## Enable on a service-less route
 
 ```bash
-curl -X POST http://kong:8001/routes/my-route/plugins \
+curl -X POST http://localhost:8001/routes/my-route/plugins \
     --data "name=kafka-upstream" \
     --data "config.bootstrap_servers[1].host=localhost" \
     --data "config.bootstrap_servers[1].port=9092" \

--- a/app/_hub/kong-inc/key-auth-enc/overview/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/overview/_index.md
@@ -273,7 +273,7 @@ Response:
 Filter the list by consumer by using a different endpoint:
 
 ```bash
-curl -X GET http://kong:8001/consumers/{USERNAME_OR_ID}/key-auth-enc
+curl -X GET http://localhost:8001/consumers/{USERNAME_OR_ID}/key-auth-enc
 ```
 
 `{USERNAME_OR_ID}`: The username or ID of the consumer whose credentials need to be listed.
@@ -305,7 +305,7 @@ Retrieve a [consumer][consumer-object] associated with an API
 key by making the following request:
 
 ```bash
-curl -X GET http://kong:8001/key-auths-enc/{key or id}/consumer
+curl -X GET http://localhost:8001/key-auths-enc/{key or id}/consumer
 ```
 
 `key or id`: The `id` or `key` property of the API key for which to get the

--- a/app/_hub/kong-inc/mocking/overview/_index.md
+++ b/app/_hub/kong-inc/mocking/overview/_index.md
@@ -326,7 +326,7 @@ This example creates a service named `Stock-Service`.
 
 
 ```bash
-curl -i -X POST http://<admin-hostname>:8001/services \
+curl -i -X POST http://localhost:8001/services \
   --data name=Stock-Service \
   --data url='http://httpbin.org/anything'
 ```
@@ -429,7 +429,7 @@ vary: Origin
 This example enables the Mocking plugin on the `getStockQuote` route.
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/routes/getStockQuote/plugins \
+curl -X POST http://localhost:8001/routes/getStockQuote/plugins \
     --data "name=mocking"  \
     --data "config.api_specification_filename=stock-0.1.json"
 ```
@@ -437,7 +437,7 @@ curl -X POST http://<admin-hostname>:8001/routes/getStockQuote/plugins \
 Optional configuration for random simulated delay:
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/routes/getStockQuote/plugins \
+curl -X POST http://localhost:8001/routes/getStockQuote/plugins \
     --data "name=mocking"  \
     --data "config.api_specification_filename=stock-0.1.json" \
     --data "config.random_delay=true" \
@@ -448,7 +448,7 @@ curl -X POST http://<admin-hostname>:8001/routes/getStockQuote/plugins \
 DB-less or hybrid mode configuration must use `config.api_specification`:
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/routes/getStockQuote/plugins \
+curl -X POST http://localhost:8001/routes/getStockQuote/plugins \
     --data "name=mocking"  \
     --data "config.api_specification=<spec_contents>"
 ```
@@ -458,7 +458,7 @@ a spec:
 
 ```bash
 mock_ex=$(cat example.yaml); \
-curl -X POST http://<admin-hostname>:8001/routes/<route_id>/plugins \
+curl -X POST http://localhost:8001/routes/<route_id>/plugins \
   --data name=mocking \
   --data config.api_specification="$mock_ex"
 ```
@@ -558,7 +558,7 @@ Cross-origin resource sharing (CORS) is disabled by default for security reasons
 from the Dev Portal, enable the [CORS plugin](/hub/kong-inc/cors/) on the `getStockQuote` route.
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/routes/getStockQuote/plugins \
+curl -X POST http://localhost:8001/routes/getStockQuote/plugins \
     --data "name=cors"  \
     --data "config.origins=*"
 ```

--- a/app/_hub/kong-inc/mtls-auth/overview/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/overview/_index.md
@@ -55,7 +55,7 @@ and POST it to `/ca_certificates`:
 {% navtabs %}
 {% navtab Kong Admin API %}
 ```bash
-curl -sX POST https://kong:8001/ca_certificates -F cert=@cert.pem
+curl -sX POST https://localhost:8001/ca_certificates -F cert=@cert.pem
 {
   "tags": null,
   "created_at": 1566597621,
@@ -139,7 +139,7 @@ Common Name (CN). CN is only used if the SAN extension does not exist.
 Create a mapping:
 
 ```bash
-curl -X POST http://kong:8001/consumers/{consumer}/mtls-auth \
+curl -X POST http://localhost:8001/consumers/{consumer}/mtls-auth \
     -d 'subject_name=test@example.com'
 ```
 

--- a/app/_hub/kong-inc/oas-validation/overview/_index.md
+++ b/app/_hub/kong-inc/oas-validation/overview/_index.md
@@ -30,7 +30,7 @@ This example tutorial steps you through ensuring an API request conforms to the 
 1. Create a service called `Petstore-Service`:
 
     ```bash
-    curl -X POST http://<admin-hostname>:8001/services/ \
+    curl -X POST http://localhost:8001/services/ \
         --data name='Petstore-Service' \
         --data url='https://petstore.swagger.io/v2'
     ```
@@ -38,7 +38,7 @@ This example tutorial steps you through ensuring an API request conforms to the 
 2. Create a wildcard route called `Petstore-Route`:
 
     ```bash
-    curl -X POST http://<admin-hostname>:8001/services/Petstore-Service/routes \
+    curl -X POST http://localhost:8001/services/Petstore-Service/routes \
         --data name='Petstore-Route' \
         --data paths='/.*'
     ```
@@ -46,7 +46,7 @@ This example tutorial steps you through ensuring an API request conforms to the 
 3. Enable the Validation plugin on the service you configured:
 
     ```bash
-    curl -X POST http://<admin-hostname>:8001/services/Petstore-Service/plugins \
+    curl -X POST http://localhost:8001/services/Petstore-Service/plugins \
         --data name='oas-validation' \
         --data config.api_spec='<copy contents of https://petstore.swagger.io/v2/swagger.json here>' \
         --data config.verbose_response=true

--- a/app/_hub/kong-inc/oauth2/overview/_index.md
+++ b/app/_hub/kong-inc/oauth2/overview/_index.md
@@ -46,7 +46,7 @@ The clients trying to authorize and request access tokens must use these endpoin
 You need to associate a credential to an existing [Consumer][consumer-object] object. To create a Consumer, you can execute the following request:
 
 ```bash
-curl -X POST http://kong:8001/consumers/ \
+curl -X POST http://localhost:8001/consumers/ \
   --data "username=user123" \
   --data "custom_id=SOME_CUSTOM_ID"
 ```
@@ -63,7 +63,7 @@ A [Consumer][consumer-object] can have many credentials.
 Then you can finally provision new OAuth 2.0 credentials (also called "OAuth applications") by making the following HTTP request:
 
 ```bash
-curl -X POST http://kong:8001/consumers/{consumer_id}/oauth2 \
+curl -X POST http://localhost:8001/consumers/{consumer_id}/oauth2 \
   --data "name=Test%20Application" \
   --data "client_id=SOME-CLIENT-ID" \
   --data "client_secret=SOME-CLIENT-SECRET" \
@@ -89,7 +89,7 @@ If you are migrating your existing OAuth 2.0 applications and access tokens over
 * Migrate access tokens using the `/oauth2_tokens` endpoints in the Kong's Admin API. For example:
 
 ```bash
-curl -X POST http://kong:8001/oauth2_tokens \
+curl -X POST http://localhost:8001/oauth2_tokens \
   --data 'credential.id=KONG-APPLICATION-ID' \
   --data "token_type=bearer" \
   --data "access_token=SOME-TOKEN" \
@@ -112,7 +112,7 @@ form parameter                        | default | description
 Active tokens can be listed and modified using the Admin API. A GET on the `/oauth2_tokens` endpoint returns the following:
 
 ```bash
-curl -sX GET http://kong:8001/oauth2_tokens/
+curl -sX GET http://localhost:8001/oauth2_tokens/
 ```
 
 Response:
@@ -144,11 +144,11 @@ Response:
 }
 ```
 
-`credential_id` is the ID of the OAuth application at `kong:8001/consumers/{consumer_id}/oauth2` and `service_id` is the API or service that the token is valid for.
+`credential_id` is the ID of the OAuth application at `localhost:8001/consumers/{consumer_id}/oauth2` and `service_id` is the API or service that the token is valid for.
 
 Note that `expires_in` is static and does not decrement based on elapsed time: you must add it to `created_at` to calculate when the token will expire.
 
-`DELETE http://kong:8001/oauth2_tokens/<token ID>` allows you to immediately invalidate a token if needed.
+`DELETE http://localhost:8001/oauth2_tokens/<token ID>` allows you to immediately invalidate a token if needed.
 
 ## Upstream Headers
 
@@ -230,7 +230,7 @@ A diagram representing this flow:
 3. The client application will send the `client_id` in the query string, from which the web application can retrieve both the OAuth 2.0 application name, and developer name, by making the following request to Kong:
 
     ```bash
-    curl kong:8001/oauth2?client_id=XXX
+    curl localhost:8001/oauth2?client_id=XXX
     ```
 
 4. If the end user authorized the application, the form will submit the data to your backend with a `POST` request, sending the `client_id`, `response_type` and `scope` parameters that were placed in `<input type="hidden" .. />` fields.

--- a/app/_hub/kong-inc/opa/overview/_index.md
+++ b/app/_hub/kong-inc/opa/overview/_index.md
@@ -65,7 +65,7 @@ setup.
 Set up a Route and Service in {{site.base_gateway}} and then enable the plugin:
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/routes/<route>/plugins \
+curl -X POST http://localhost:8001/routes/<route>/plugins \
     --data "name=opa"  \
     --data "config.opa_path=/v1/data/example/allowBoolean" \
     --data "config.opa_host=<host-where-opa is running>"

--- a/app/_hub/kong-inc/opentelemetry/overview/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/overview/_index.md
@@ -130,7 +130,7 @@ See the [OpenTelemetry Collector documentation](https://opentelemetry.io/docs/co
 Enable the plugin:
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/plugins \
+curl -X POST http://localhost:8001/plugins \
     --data "name=opentelemetry"  \
     --data "config.endpoint=http://<opentelemetry-backend>:4318/v1/traces" \
     --data "config.resource_attributes.service.name=kong-dev"
@@ -216,7 +216,7 @@ The following is an example for adding a custom span using {{site.base_gateway}}
 2. Apply the Lua code using the `post-function` plugin using a cURL file upload:
 
     ```bash
-    curl -i -X POST http://<admin-hostname>:8001/plugins \
+    curl -i -X POST http://localhost:8001/plugins \
       -F "name=post-function" \
       -F "config.access[1]=@custom-span.lua"
 

--- a/app/_hub/kong-inc/request-validator/overview/_index.md
+++ b/app/_hub/kong-inc/request-validator/overview/_index.md
@@ -19,7 +19,7 @@ before being proxied.
 Use a request like this:
 
 ``` bash
-curl -i -X POST http://kong:8001/services/{service}/plugins \
+curl -i -X POST http://localhost:8001/services/{service}/plugins \
   --data "name=request-validator" \
   --data "config.version=kong" \
   --data 'config.body_schema=[{\"name\":{\"type\": \"string\", \"required\": true}}]'
@@ -275,7 +275,7 @@ In this example, use the plugin to validate a request's path parameter.
 1.  Add a Service to Kong:
 
     ```
-    curl -i -X POST http://kong:8001/services \
+    curl -i -X POST http://localhost:8001/services \
       --data name=httpbin \
       --data url=http://httpbin.org
 
@@ -301,7 +301,7 @@ In this example, use the plugin to validate a request's path parameter.
 2.  Add a Route with [named capture group](/gateway/latest/how-kong-works/routing-traffic/#capturing-groups):
 
     ```
-    curl -i -X POST http://kong:8001/services/httpbin/routes \
+    curl -i -X POST http://localhost:8001/services/httpbin/routes \
       --data paths="~/status/(?<status_code>\d%+)" \
       --data strip_path=false
 
@@ -337,7 +337,7 @@ In this example, use the plugin to validate a request's path parameter.
 3. Enable `request-validator` plugin to validate body and parameter:
 
     ```
-    curl -i -X POST http://kong:8001/services/httpbin/plugins \
+    curl -i -X POST http://localhost:8001/services/httpbin/plugins \
       --header "Content-Type: application/json" \
       --data @parameter_schema.json
 

--- a/app/_hub/kong-inc/route-by-header/overview/_index.md
+++ b/app/_hub/kong-inc/route-by-header/overview/_index.md
@@ -31,7 +31,7 @@ a Kong service `serviceA`, which routes all the requests to upstream `default.do
 Add an upstream object and a target:
 
 ```bash
-curl -i -X POST http://kong:8001/upstreams -d name=default.domain.com
+curl -i -X POST http://localhost:8001/upstreams -d name=default.domain.com
 ```
 
 Response:
@@ -42,7 +42,7 @@ HTTP/1.1 201 Created
 ```
 
 ```bash
-curl -i -X POST http://kong:8001/upstreams/default.domain.com/targets --data target="default.host.com:9000"
+curl -i -X POST http://localhost:8001/upstreams/default.domain.com/targets --data target="default.host.com:9000"
 ```
 
 Response:
@@ -55,7 +55,7 @@ HTTP/1.1 201 Created
 Now we will add a `service` and a `route` object, using the upstream `default.domain.com` we just created:
 
 ```bash
-curl -i -X POST http://kong:8001/services --data protocol=http --data host=default.domain.com --data name=serviceA
+curl -i -X POST http://localhost:8001/services --data protocol=http --data host=default.domain.com --data name=serviceA
 ```
 
 Response:
@@ -66,7 +66,7 @@ HTTP/1.1 201 Created
 ```
 
 ```bash
-curl -i -X POST http://kong:8001/routes  --data "paths[]=/" --data service.id=6e7f5274-62da-469e-bdd5-03c4a212c15b
+curl -i -X POST http://localhost:8001/routes  --data "paths[]=/" --data service.id=6e7f5274-62da-469e-bdd5-03c4a212c15b
 ```
 
 Response:
@@ -98,7 +98,7 @@ HTTP/1.1 201 Created
 ```
 
 ```bash
-curl -i -X POST http://kong:8001/upstreams/east.domain.com/targets --data target="east.host.com:9001"
+curl -i -X POST http://localhost:8001/upstreams/east.domain.com/targets --data target="east.host.com:9001"
 ```
 
 Response:
@@ -120,7 +120,7 @@ HTTP/1.1 201 Created
 ```
 
 ```bash
-curl -i -X POST http://kong:8001/upstreams/west.domain.com/targets --data target="west.host.com:9002"
+curl -i -X POST http://localhost:8001/upstreams/west.domain.com/targets --data target="west.host.com:9002"
 ```
 
 Response:
@@ -133,7 +133,7 @@ HTTP/1.1 201 Created
 Enable plugin on service `serviceA`:
 
 ```bash
-curl -i -X POST http://kong:8001/services/serviceA/plugins \
+curl -i -X POST http://localhost:8001/services/serviceA/plugins \
   -H 'Content-Type: application/json' \
   --data '{"name": "route-by-header", "config": {"rules":[{"condition": {"location":"us-east"}, "upstream_name": "east.domain.com"}, {"condition": {"location":"us-west"}, "upstream_name": "west.domain.com"}]}}'
 ```
@@ -156,7 +156,7 @@ on the provided headers in the `condition` field of each rule.
 Let's patch above plugin to add one more rule with multiple headers:
 
 ```bash
-curl -i -X PATCH http://kong:8001/plugins/0df16085-76b2-4a50-ac30-c8a1eade389a \
+curl -i -X PATCH http://localhost:8001/plugins/0df16085-76b2-4a50-ac30-c8a1eade389a \
   -H 'Content-Type: application/json' \
   --data '{"name": "route-by-header", "config": {"rules":[{"condition": {"location":"us-east"}, "upstream_name": "east.domain.com"}, {"condition": {"location":"us-west"}, "upstream_name": "west.domain.com"},  {"condition": {"location":"us-south", "region": "US"}, "upstream_name": "south.domain.com"}]}}'
 ```

--- a/app/_hub/kong-inc/vault-auth/_0.3.0/overview/_index.md
+++ b/app/_hub/kong-inc/vault-auth/_0.3.0/overview/_index.md
@@ -16,7 +16,7 @@ In order to use the plugin, you first need to create a Consumer to associate one
 You need to associate a credential to an existing [consumer](/gateway/api/admin-ee/latest/#/Consumers) object. To create a Consumer, you can execute the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/consumers/ \
+$ curl -X POST http://localhost:8001/consumers/ \
     --data "username=<USERNAME>" \
     --data "custom_id=<CUSTOM_ID>"
 HTTP/1.1 201 Created
@@ -82,7 +82,7 @@ This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a versi
 Token pairs can be managed either via the Kong Admin API, or independently via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/vaults/{vault}/credentials/{consumer}
+$ curl -X POST http://localhost:8001/vaults/{vault}/credentials/{consumer}
 HTTP/1.1 201 Created
 
 {
@@ -105,7 +105,7 @@ When the `access_token` or `secret_token` values are not provided, token values 
 Vault objects are treated as foreign references in plugin configs, creating a seamless lifecycle relationship between Vault instances and plugins with which they're associated. `vault-auth` plugins require an association with a Vault object, which can be defined with the following HTTP request during plugin creation:
 
 ```bash
-$ curl -X POST http://kong:8001/plugins \
+$ curl -X POST http://localhost:8001/plugins \
   --data name=vault-auth \
   --data config.vault.id=<uuid>
 HTTP/1.1 201 Created
@@ -157,7 +157,7 @@ $ curl http://kong:8000/{proxy path} \
 Existing Vault credentials can be removed from the Vault server via the following API:
 
 ```bash
-$ curl -X DELETE http://kong:8001/vaults/{vault}/credentials/token/{access token}
+$ curl -X DELETE http://localhost:8001/vaults/{vault}/credentials/token/{access token}
 
 HTTP/1.1 204 No Content
 ```

--- a/app/_hub/kong-inc/vault-auth/overview/_index.md
+++ b/app/_hub/kong-inc/vault-auth/overview/_index.md
@@ -21,7 +21,7 @@ You need to associate a credential to an existing [consumer](/gateway/api/admin-
 To create a consumer, execute the following request:
 
 ```bash
-curl -X POST http://kong:8001/consumers/ \
+curl -X POST http://localhost:8001/consumers/ \
   --data "username=<USERNAME>" \
   --data "custom_id=<CUSTOM_ID>"
 ```
@@ -147,7 +147,7 @@ This assumes a Vault server is accessible via `127.0.0.1:8200`, and that a versi
 Token pairs can be managed either via the Kong Admin API, or independently via direct access with Vault. Token pairs must be associated with an existing Kong Consumer. Creating a token pair with the Kong Admin API can be done via the following request:
 
 ```bash
-curl -X POST http://kong:8001/vault-auth/{vault}/credentials/{consumer}
+curl -X POST http://localhost:8001/vault-auth/{vault}/credentials/{consumer}
 ```
 
 Response:
@@ -174,7 +174,7 @@ When the `access_token` or `secret_token` values are not provided, token values 
 Vault objects are treated as foreign references in plugin configs, creating a seamless lifecycle relationship between Vault instances and plugins with which they're associated. `vault-auth` plugins require an association with a Vault object, which can be defined with the following HTTP request during plugin creation:
 
 ```bash
-curl -X POST http://kong:8001/plugins \
+curl -X POST http://localhost:8001/plugins \
   --data name=vault-auth \
   --data config.vault.id=<uuid>
 ```
@@ -230,7 +230,7 @@ curl http://kong:8000/{proxy path} \
 Existing Vault credentials can be removed from the Vault server via the following API:
 
 ```bash
-curl -X DELETE http://kong:8001/vault-auth/{vault}/credentials/token/{access token}
+curl -X DELETE http://localhost:8001/vault-auth/{vault}/credentials/token/{access token}
 ```
 
 Response:

--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -45,7 +45,7 @@ following format, but provide your own content.
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-$ curl -i -X POST http://<hostname>:8001/licenses \
+$ curl -i -X POST http://localhost:8001/licenses \
   -d payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
 {% endnavtab %}

--- a/app/_includes/md/gateway/admin-api-workspaces.md
+++ b/app/_includes/md/gateway/admin-api-workspaces.md
@@ -4,7 +4,7 @@ Any requests that don't specify a workspace target the `default` workspace.
 To target a different workspace, prefix any endpoint with the workspace name or ID:
 
 ```sh
-http://<HOSTNAME>:8001/<WORKSPACE_NAME|ID>/<ENDPOINT>
+http://localhost:8001/<WORKSPACE_NAME|ID>/<ENDPOINT>
 ```
 
 For example, if you don't specify a workspace,

--- a/app/_src/gateway/admin-api/workspaces/reference.md
+++ b/app/_src/gateway/admin-api/workspaces/reference.md
@@ -383,7 +383,7 @@ Can be used with any request method.
 Target entities within a specified workspace by adding the workspace name or ID prefix before any entity endpoint.
 
 ```sh
-http://<ADMIN_API_HOSTNAME>:8001/<WORKSPACE_NAME|WORKSPACE_ID>/<ENDPOINT>
+http://localhost:8001/<WORKSPACE_NAME|WORKSPACE_ID>/<ENDPOINT>
 ```
 
 For example, to target `services` in the workspace `SRE`:

--- a/app/_src/gateway/kong-enterprise/dev-portal/authentication/azure-oidc-config.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/authentication/azure-oidc-config.md
@@ -25,14 +25,14 @@ for use with the Kong OIDC and Portal Application Registration plugins.
 ## Create a service in Kong
 
 ```bash
-curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure \
+curl -i -X PUT http://localhost:8001/services/httpbin-service-azure \
   --data 'url=https://httpbin.org/anything'
 ```
 
 ## Create a route in Kong
 
 ```bash
-curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
+curl -i -X PUT http://localhost:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
   --data 'paths=/httpbin-azure'
 ```
 
@@ -44,7 +44,7 @@ The plugins must be applied to a Service to work properly.
 1. Configure the OIDC plugin for the service:
 
     ```bash
-    curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+    curl -X POST http://localhost:8001/services/httpbin-service-azure/plugins \
       --data name=openid-connect \
       --data config.issuer="https://login.microsoftonline.com/<your_tenant_id>/v2.0" \
       --data config.display_errors="true" \
@@ -63,7 +63,7 @@ The plugins must be applied to a Service to work properly.
 2. Configure the Application Registration plugin for the service:
 
     ```bash
-    curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+    curl -X POST http://localhost:8001/services/httpbin-service-azure/plugins \
       --data "name=application-registration"  \
       --data "config.auto_approve=true" \
       --data "config.description=Uses consumer claim with various values (sub, aud, etc.) as registration id to support different flows and use cases." \

--- a/app/_src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/app/_src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -23,7 +23,7 @@ Call the Admin API on port `8001` and enable the
 `rate-limiting` plugin, configuring it to run before `key-auth`:
 
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=rate-limiting \
   --data config.minute=5 \
   --data config.policy=local \
@@ -160,7 +160,7 @@ Call the Admin API on port `8001` and enable the
 `basic-auth` plugin, configuring it to run after `request-transformer`:
 
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=basic-auth \
   --data ordering.after.access=request-transformer
 ```

--- a/app/_src/gateway/kong-plugins/authentication/oidc/auth0.md
+++ b/app/_src/gateway/kong-plugins/authentication/oidc/auth0.md
@@ -26,7 +26,7 @@ If you have not done so already, [create a **Service**][add-service] to protect.
 Add an OpenID plugin configuration using the parameters in the example below using an HTTP client or Kong Manager. Auth0's token endpoint [requires passing the API identifier in the `audience` parameter][audience-required], which must be added as a custom argument:
 
 ```bash
-curl -i -X POST http://kong:8001/kong-admin/services/{SERVICE_NAME}/plugins \
+curl -i -X POST http://localhost:8001/kong-admin/services/{SERVICE_NAME}/plugins \
   --data name="openid-connect" \
   --data config.auth_methods="client_credentials" \
   --data config.issuer="https://<auth0 API name>.auth0.com/.well-known/openid-configuration" \

--- a/app/_src/gateway/kong-plugins/authentication/oidc/curity.md
+++ b/app/_src/gateway/kong-plugins/authentication/oidc/curity.md
@@ -29,7 +29,7 @@ If access is granted, the JWT from the introspection response is added to a head
 Create a service that can be used to test the integration.
 
 ```bash
-curl -i -X POST http://kong:8001/services/ \
+curl -i -X POST http://localhost:8001/services/ \
   --data name="httpbin" \
   --data protocol="http" \
   --data url="http://httpbin.org"
@@ -40,7 +40,7 @@ curl -i -X POST http://kong:8001/services/ \
 Add a route to the service.
 
 ```bash
-curl -i -X POST http://kong:8001/services/httpbin/routes \
+curl -i -X POST http://localhost:8001/services/httpbin/routes \
   --data "paths[]=/httpbin"
 ```
 
@@ -49,7 +49,7 @@ curl -i -X POST http://kong:8001/services/httpbin/routes \
 The Kong OpenID Connect plugin is enabled for the previously created service. In the example below, the `openid` scope is required in order for access to be granted. As noted by the `config.upstream_headers_claims` configuration, the plugin looks for the `JWT` (the phantom token) claim in the introspection response. The `config.upstream_headers_names` configuration extracts the `JWT` from the introspection response and adds it to a `phantom_token` header in the call to the upstream API.
 
 ```bash
-curl -X POST http://kong:8001/services/httpbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
 --data name="openid-connect" \
 --data config.issuer="https://idsvr.example.com/oauth/v2/oauth-anonymous" \
 --data config.client_id="gateway-client" \

--- a/app/_src/gateway/kong-plugins/authentication/oidc/google.md
+++ b/app/_src/gateway/kong-plugins/authentication/oidc/google.md
@@ -25,7 +25,7 @@ If you have not yet [added a **Service**][add-service], go ahead and do so. Agai
 Add a plugin with the configuration below to your Service using an HTTP client or Kong Manager. Make sure to use the same redirect URI as configured earlier:
 
 ```bash
-curl -i -X POST http://kong:8001/services/{SERVICE_NAME}/plugins \
+curl -i -X POST http://localhost:8001/services/{SERVICE_NAME}/plugins \
   --data name="openid-connect" \
   --data config.issuer="https://accounts.google.com/.well-known/openid-configuration" \
   --data config.client_id="YOUR_CLIENT_ID" \
@@ -44,11 +44,11 @@ Depending on your needs, it may not be necessary to associate clients with a con
 If you need to interact with other Kong plugins using consumer information, you must add configuration that maps account data received from the identity provider to a Kong consumer. For this example, we'll map the user's Google account email by setting a `custom_id` on their consumer, e.g.
 
 ```bash
-curl -i -X POST http://kong:8001/consumers/ \
+curl -i -X POST http://localhost:8001/consumers/ \
   --data username="Yoda" \
   --data custom_id="user@example.com"
 
-curl -i -X PATCH http://kong:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
+curl -i -X PATCH http://localhost:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
   --data config.consumer_by="custom_id" \
   --data config.consumer_claim="email"
 ```

--- a/app/_src/gateway/plugin-development/configuration.md
+++ b/app/_src/gateway/plugin-development/configuration.md
@@ -22,7 +22,7 @@ Service, Route, or Consumer.
 For example, a user performs the following request:
 
 ```bash
-curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+curl -X POST http://localhost:8001/services/<service-name-or-id>/plugins \
   -d "name=my-custom-plugin" \
   -d "config.foo=bar"
 ```
@@ -343,7 +343,7 @@ Such a configuration will allow a user to post the configuration to your plugin
 as follows:
 
 ```bash
-curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+curl -X POST http://localhost:8001/services/<service-name-or-id>/plugins \
   -d "name=my-custom-plugin" \
   -d "config.environment=development" \
   -d "config.server.host=http://localhost"

--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
@@ -591,7 +591,7 @@ To check whether the CP and DP nodes you just brought up are connected, run the
 following on a control plane:
 
 ```bash
-curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://localhost:8001/clustering/data-planes
 ```
 
 The output shows all of the connected data plane instances in the cluster:

--- a/app/gateway/2.6.x/configure/auth/oidc-auth0.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-auth0.md
@@ -26,7 +26,7 @@ If you have not done so already, [create a **Service**][add-service] to protect.
 Add an OpenID plugin configuration using the parameters in the example below using an HTTP client or Kong Manager. Auth0's token endpoint [requires passing the API identifier in the `audience` parameter][audience-required], which must be added as a custom argument:
 
 ```bash
-curl -i -X POST http://kong:8001/kong-admin/services/{SERVICE_NAME}/plugins \
+curl -i -X POST http://localhost:8001/kong-admin/services/{SERVICE_NAME}/plugins \
   --data name="openid-connect" \
   --data config.auth_methods="client_credentials" \
   --data config.issuer="https://<auth0 API name>.auth0.com/.well-known/openid-configuration" \

--- a/app/gateway/2.6.x/configure/auth/oidc-curity.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-curity.md
@@ -29,7 +29,7 @@ If access is granted, the JWT from the introspection response is added to a head
 Create a service that can be used to test the integration.
 
 ```bash
-curl -i -X POST http://kong:8001/services/ \
+curl -i -X POST http://localhost:8001/services/ \
   --data name="httpbin" \
   --data protocol="http" \
   --data url="http://httpbin.org"
@@ -40,7 +40,7 @@ curl -i -X POST http://kong:8001/services/ \
 Add a route to the service.
 
 ```bash
-curl -i -X POST http://kong:8001/services/httpbin/routes \
+curl -i -X POST http://localhost:8001/services/httpbin/routes \
   --data "paths[]=/httpbin"
 ```
 
@@ -49,7 +49,7 @@ curl -i -X POST http://kong:8001/services/httpbin/routes \
 The Kong OpenID Connect plugin is enabled for the previously created service. In the example below, the `openid` scope is required in order for access to be granted. As noted by the `config.upstream_headers_claims` configuration, the plugin looks for the `JWT` (the phantom token) claim in the introspection response. The `config.upstream_headers_names` configuration extracts the `JWT` from the introspection response and adds it to a `phantom_token` header in the call to the upstream API.
 
 ```bash
-curl -X POST http://kong:8001/services/httpbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
 --data name="openid-connect" \
 --data config.issuer="https://idsvr.example.com/oauth/v2/oauth-anonymous" \
 --data config.client_id="gateway-client" \

--- a/app/gateway/2.6.x/configure/auth/oidc-google.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-google.md
@@ -25,7 +25,7 @@ If you have not yet [added a **Service**][add-service], go ahead and do so. Agai
 Add a plugin with the configuration below to your Service using an HTTP client or Kong Manager. Make sure to use the same redirect URI as configured earlier:
 
 ```bash
-curl -i -X POST http://kong:8001/services/{SERVICE_NAME}/plugins \
+curl -i -X POST http://localhost:8001/services/{SERVICE_NAME}/plugins \
   --data name="openid-connect" \
   --data config.issuer="https://accounts.google.com/.well-known/openid-configuration" \
   --data config.client_id="YOUR_CLIENT_ID" \
@@ -44,11 +44,11 @@ Depending on your needs, it may not be necessary to associate clients with a con
 If you need to interact with other Kong plugins using consumer information, you must add configuration that maps account data received from the identity provider to a Kong consumer. For this example, we'll map the user's Google account email by setting a `custom_id` on their consumer, e.g.
 
 ```bash
-curl -i -X POST http://kong:8001/consumers/ \
+curl -i -X POST http://localhost:8001/consumers/ \
   --data username="Yoda" \
   --data custom_id="user@example.com"
 
-curl -i -X PATCH http://kong:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
+curl -i -X PATCH http://localhost:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
   --data config.consumer_by="custom_id" \
   --data config.consumer_claim="email"
 ```

--- a/app/gateway/2.6.x/configure/auth/oidc-mapping.md
+++ b/app/gateway/2.6.x/configure/auth/oidc-mapping.md
@@ -75,7 +75,7 @@ easy for you to identify.
 name:
 
     ```sh
-    $ curl -X POST --url http://<admin-hostname>:8001/groups \
+    $ curl -X POST --url http://localhost:8001/groups \
       --header 'content-type: application/json' \
       --header 'kong-admin-token: <yourtoken>' \
       --data '{
@@ -90,7 +90,7 @@ name:
 2. Assign a role to the group:
 
     ```sh
-    $ curl -X POST --url http://<admin-hostname>:8001/groups/{group-id}/roles \
+    $ curl -X POST --url http://localhost:8001/groups/{group-id}/roles \
       --header 'content-type: application/json' \
       --header 'kong-admin-token: <yourtoken>' \
       --data '{   
@@ -108,7 +108,7 @@ name:
 3. Create an admin for the group:
 
     ```sh
-    $ curl -X POST --url http://<admin-hostname>:8001/admins \
+    $ curl -X POST --url http://localhost:8001/admins \
       --header 'content-type: application/json' \
       --header 'kong-admin-token: <yourtoken>' \
       --data '{

--- a/app/gateway/2.6.x/configure/graphql-quickstart.md
+++ b/app/gateway/2.6.x/configure/graphql-quickstart.md
@@ -44,7 +44,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
+$ curl -i -X POST http://localhost:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/azure-oidc-config.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/azure-oidc-config.md
@@ -32,7 +32,7 @@ for use with the Kong OIDC and Portal Application Registration plugins.
 {% navtab Using cURL %}
 
 ```bash
-$ curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure \
+$ curl -i -X PUT http://localhost:8001/services/httpbin-service-azure \
   --data 'url=https://httpbin.org/anything'
 ```
 
@@ -52,7 +52,7 @@ $ http PUT :8001/services/httpbin-service-azure \
 {% navtab Using cURL %}
 
 ```bash
-$ curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
+$ curl -i -X PUT http://localhost:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
   --data 'paths=/httpbin-azure'
 ```
 {% endnavtab %}
@@ -78,7 +78,7 @@ The plugins must be applied to a Service to work properly.
 {% navtab Using cURL %}
 
  ```bash
-$ curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+$ curl -X POST http://localhost:8001/services/httpbin-service-azure/plugins \
   --data name=openid-connect \
   --data config.issuer="https://login.microsoftonline.com/<your_tenant_id>/v2.0" \
   --data config.display_errors="true" \
@@ -119,7 +119,7 @@ For more information, see [OIDC plugin](/hub/kong-inc/openid-connect/).
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+$ curl -X POST http://localhost:8001/services/httpbin-service-azure/plugins \
   --data "name=application-registration"  \
   --data "config.auto_approve=true" \
   --data "config.description=Uses consumer claim with various values (sub, aud, etc.) as registration id to support different flows and use cases." \

--- a/app/gateway/2.6.x/developer-portal/files-api.md
+++ b/app/gateway/2.6.x/developer-portal/files-api.md
@@ -29,7 +29,7 @@ For more details about content files, see the
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST http://<admin-hostname>:8001/default/files \
+$ curl -X POST http://localhost:8001/default/files \
   -F "path=content/homepage.html" \
   -F "contents=@<file-location>.json"
 ```
@@ -56,7 +56,7 @@ For more details about specification files, see the
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST http://<admin-hostname>:8001/default/files \
+$ curl -X POST http://localhost:8001/default/files \
   -F "path=specs/homepage.json" \
   -F "contents=@<spec-location>.json"
 ```
@@ -83,7 +83,7 @@ For more details about theme files, see the
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X POST http://<admin-hostname>:8001/default/files \
+$ curl -X POST http://localhost:8001/default/files \
   -F "path=themes/base/partials/header.html" \
   -F "contents=@<partial-location>.html"
 ```
@@ -106,7 +106,7 @@ $ http post :8001/default/files  \
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X GET http://<admin-hostname>:8001/default/files/content/index.txt
+$ curl -X GET http://localhost:8001/default/files/content/index.txt
 ```
 
 {% endnavtab %}
@@ -125,7 +125,7 @@ $ http :8001/default/files/content/index.txt
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X PATCH http://<admin-hostname>:8001/default/files/content/index.txt \
+$ curl -X PATCH http://localhost:8001/default/files/content/index.txt \
   -F "contents=@<updated-content-file-location>.txt"
 ```
 
@@ -146,7 +146,7 @@ $ http patch :8001/default/files/content/index.txt \
 {% navtab Using cURL %}
 
 ```bash
-$ curl -X DELETE http://<admin-hostname>:8001/default/files/content/index.txt
+$ curl -X DELETE http://localhost:8001/default/files/content/index.txt
 ```
 
 {% endnavtab %}

--- a/app/gateway/2.6.x/get-started/comprehensive/dev-portal.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/dev-portal.md
@@ -27,13 +27,13 @@ Make sure the Dev Portal is on. You should have enabled it during [installation]
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
+curl -X PATCH http://localhost:8001/workspaces/SecureWorkspace \
   --data config.portal=true
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http -f PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
+http -f PATCH http://localhost:8001/workspaces/SecureWorkspace \
   config.portal=true
 ```
 {% endnavtab %}

--- a/app/gateway/2.6.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/expose-services.md
@@ -71,7 +71,7 @@ The service is created, and the page automatically redirects back to the
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/services \
+curl -i -X POST http://localhost:8001/services \
   --data name=example_service \
   --data url='http://mockbin.org'
 ```
@@ -94,7 +94,7 @@ Verify the service’s endpoint:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i http://<admin-hostname>:8001/services/example_service
+curl -i http://localhost:8001/services/example_service
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -180,7 +180,7 @@ methods must be set for the Route to be matched to the service.
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/services/example_service/routes \
+curl -i -X POST http://localhost:8001/services/example_service/routes \
   --data 'paths[]=/mock' \
   --data name=mocking
 ```

--- a/app/gateway/2.6.x/get-started/comprehensive/improve-performance.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/improve-performance.md
@@ -50,7 +50,7 @@ Call the Admin API on port `8001` and configure plugins to enable in-memory cach
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=proxy-cache \
   --data config.content_type="application/json; charset=utf-8" \
   --data config.cache_ttl=30 \
@@ -179,7 +179,7 @@ To test more rapidly, the cache can be deleted by calling the Admin API:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X DELETE http://<admin-hostname>:8001/proxy-cache
+curl -i -X DELETE http://localhost:8001/proxy-cache
 ```
 {% endnavtab %}
 {% navtab HTTPie %}

--- a/app/gateway/2.6.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/load-balancing.md
@@ -48,7 +48,7 @@ Call the Admin API on port `8001` and create an Upstream named `example_upstream
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/upstreams \
+curl -X POST http://localhost:8001/upstreams \
   --data name=example_upstream
 ```
 {% endnavtab %}
@@ -67,7 +67,7 @@ Update the service you created previously to point to this upstream:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/services/example_service \
+curl -X PATCH http://localhost:8001/services/example_service \
   --data host='example_upstream'
 ```
 {% endnavtab %}
@@ -87,10 +87,10 @@ Add two targets to the upstream, each with port 80: `mockbin.org:80` and
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
+curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='mockbin.org:80'
 
-curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
+curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='httpbin.org:80'
 ```
 {% endnavtab %}

--- a/app/gateway/2.6.x/get-started/comprehensive/manage-teams.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/manage-teams.md
@@ -95,7 +95,7 @@ account’s password in place of `<super-user-token>`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/workspaces \
+curl -X POST http://localhost:8001/workspaces \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=SecureWorkspace'
 ```
@@ -186,7 +186,7 @@ Create a new user named `secureworkspaceadmin` with the RBAC token
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/users \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=secureworkspaceadmin' \
   --data 'user_token=secureadmintoken'
@@ -209,7 +209,7 @@ Create a blank role in the workspace and name it `admin`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/roles \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=admin' \
 ```
@@ -231,7 +231,7 @@ workspace:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'endpoint=*'
   --data 'workspace=SecureWorkspace' \
@@ -256,7 +256,7 @@ Grant the `admin` role to `secureworkspaceadmin`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'role=admin'
 ```
@@ -292,7 +292,7 @@ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
 
     *Using cURL:*
     ```sh
-    curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/default/rbac/users
+    curl -H Kong-Admin-Token:secureadmintoken -X GET http://localhost:8001/default/rbac/users
     ```
     *Or using HTTPie:*
 
@@ -310,7 +310,7 @@ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
 
     *Using cURL:*
     ```sh
-    curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/SecureWorkspace/rbac/users
+    curl -H Kong-Admin-Token:secureadmintoken -X GET http://localhost:8001/SecureWorkspace/rbac/users
     ```
     *Or using HTTPie:*
 

--- a/app/gateway/2.6.x/get-started/comprehensive/prepare.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/prepare.md
@@ -42,12 +42,12 @@ window:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001
+curl -i -X GET http://localhost:8001
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
-http <admin-hostname>:8001
+http localhost:8001
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -113,7 +113,7 @@ Run the following on a Control Plane:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://localhost:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab HTTPie %}

--- a/app/gateway/2.6.x/get-started/comprehensive/protect-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/protect-services.md
@@ -55,7 +55,7 @@ Call the Admin API on port `8001` and configure plugins to enable a limit of fiv
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=rate-limiting \
   --data config.minute=5 \
   --data config.policy=local

--- a/app/gateway/2.6.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/secure-services.md
@@ -61,7 +61,7 @@ created:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
+curl -X POST http://localhost:8001/routes/mocking/plugins \
   --data name=key-auth
 ```
 {% endnavtab %}
@@ -187,7 +187,7 @@ The following creates a new consumer called **consumer**:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/consumers/ \
+curl -i -X POST http://localhost:8001/consumers/ \
   --data username=consumer \
   --data custom_id=consumer
 ```
@@ -209,7 +209,7 @@ created above. For this example, set the key to `apikey`.
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth \
+curl -i -X POST http://localhost:8001/consumers/consumer/key-auth \
   --data key=apikey
 ```
 {% endnavtab %}
@@ -350,7 +350,7 @@ Find the plugin ID and copy it:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X GET http://<admin-hostname>:8001/routes/mocking/plugins/
+curl -X GET http://localhost:8001/routes/mocking/plugins/
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -372,7 +372,7 @@ Disable the plugin:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/routes/mocking/plugins/{<plugin-id>} \
+curl -X PATCH http://localhost:8001/routes/mocking/plugins/{<plugin-id>} \
   --data enabled=false
 ```
 {% endnavtab %}

--- a/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.6.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -586,7 +586,7 @@ following on a Control Plane:
 {% navtabs %}
 {% navtab Using cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://localhost:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab Using HTTPie %}

--- a/app/gateway/2.6.x/plugin-development/plugin-configuration.md
+++ b/app/gateway/2.6.x/plugin-development/plugin-configuration.md
@@ -22,7 +22,7 @@ Service, Route, or Consumer.
 For example, a user performs the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+$ curl -X POST http://localhost:8001/services/<service-name-or-id>/plugins \
     -d "name=my-custom-plugin" \
     -d "config.foo=bar"
 ```
@@ -355,7 +355,7 @@ Such a configuration will allow a user to post the configuration to your plugin
 as follows:
 
 ```bash
-$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+$ curl -X POST http://localhost:8001/services/<service-name-or-id>/plugins \
     -d "name=my-custom-plugin" \
     -d "config.environment=development" \
     -d "config.server.host=http://localhost"

--- a/app/gateway/2.6.x/reference/loadbalancing.md
+++ b/app/gateway/2.6.x/reference/loadbalancing.md
@@ -242,25 +242,25 @@ Set up the "Blue" environment, running version 1 of the address service:
 
 ```bash
 # create an upstream
-$ curl -X POST http://kong:8001/upstreams \
+$ curl -X POST http://localhost:8001/upstreams \
     --data "name=address.v1.service"
 
 # add two targets to the upstream
-$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
     --data "target=192.168.34.15:80"
     --data "weight=100"
-$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
     --data "target=192.168.34.16:80"
     --data "weight=50"
 
 # create a Service targeting the Blue upstream
-$ curl -X POST http://kong:8001/services/ \
+$ curl -X POST http://localhost:8001/services/ \
     --data "name=address-service" \
     --data "host=address.v1.service" \
     --data "path=/address"
 
 # finally, add a Route as an entry-point into the Service
-$ curl -X POST http://kong:8001/services/address-service/routes/ \
+$ curl -X POST http://localhost:8001/services/address-service/routes/ \
     --data "hosts[]=address.mydomain.com"
 ```
 
@@ -274,14 +274,14 @@ environment:
 
 ```bash
 # create a new Green upstream for address service v2
-$ curl -X POST http://kong:8001/upstreams \
+$ curl -X POST http://localhost:8001/upstreams \
     --data "name=address.v2.service"
 
 # add targets to the upstream
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=100"
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=100"
 ```
@@ -290,7 +290,7 @@ To activate the Blue/Green switch, we now only need to update the Service:
 
 ```bash
 # Switch the Service from Blue to Green upstream, v1 -> v2
-$ curl -X PATCH http://kong:8001/services/address-service \
+$ curl -X PATCH http://localhost:8001/services/address-service \
     --data "host=address.v2.service"
 ```
 
@@ -312,12 +312,12 @@ Using a very simple 2 target example:
 
 ```bash
 # first target at 1000
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=1000"
 
 # second target at 0
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=0"
 ```
@@ -327,12 +327,12 @@ slowly be routed towards the other target. For example, set it at 10%:
 
 ```bash
 # first target at 900
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=900"
 
 # second target at 100
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=100"
 ```

--- a/app/gateway/2.7.x/configure/auth/oidc-auth0.md
+++ b/app/gateway/2.7.x/configure/auth/oidc-auth0.md
@@ -26,7 +26,7 @@ If you have not done so already, [create a **Service**][add-service] to protect.
 Add an OpenID plugin configuration using the parameters in the example below using an HTTP client or Kong Manager. Auth0's token endpoint [requires passing the API identifier in the `audience` parameter][audience-required], which must be added as a custom argument:
 
 ```bash
-curl -i -X POST http://kong:8001/kong-admin/services/{SERVICE_NAME}/plugins \
+curl -i -X POST http://localhost:8001/kong-admin/services/{SERVICE_NAME}/plugins \
   --data name="openid-connect" \
   --data config.auth_methods="client_credentials" \
   --data config.issuer="https://<auth0 API name>.auth0.com/.well-known/openid-configuration" \

--- a/app/gateway/2.7.x/configure/auth/oidc-curity.md
+++ b/app/gateway/2.7.x/configure/auth/oidc-curity.md
@@ -29,7 +29,7 @@ If access is granted, the JWT from the introspection response is added to a head
 Create a service that can be used to test the integration.
 
 ```bash
-curl -i -X POST http://kong:8001/services/ \
+curl -i -X POST http://localhost:8001/services/ \
   --data name="httpbin" \
   --data protocol="http" \
   --data url="http://httpbin.org"
@@ -40,7 +40,7 @@ curl -i -X POST http://kong:8001/services/ \
 Add a route to the service.
 
 ```bash
-curl -i -X POST http://kong:8001/services/httpbin/routes \
+curl -i -X POST http://localhost:8001/services/httpbin/routes \
   --data "paths[]=/httpbin"
 ```
 
@@ -49,7 +49,7 @@ curl -i -X POST http://kong:8001/services/httpbin/routes \
 The Kong OpenID Connect plugin is enabled for the previously created service. In the example below, the `openid` scope is required in order for access to be granted. As noted by the `config.upstream_headers_claims` configuration, the plugin looks for the `JWT` (the phantom token) claim in the introspection response. The `config.upstream_headers_names` configuration extracts the `JWT` from the introspection response and adds it to a `phantom_token` header in the call to the upstream API.
 
 ```bash
-curl -X POST http://kong:8001/services/httpbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
 --data name="openid-connect" \
 --data config.issuer="https://idsvr.example.com/oauth/v2/oauth-anonymous" \
 --data config.client_id="gateway-client" \

--- a/app/gateway/2.7.x/configure/auth/oidc-google.md
+++ b/app/gateway/2.7.x/configure/auth/oidc-google.md
@@ -25,7 +25,7 @@ If you have not yet [added a **Service**][add-service], go ahead and do so. Agai
 Add a plugin with the configuration below to your Service using an HTTP client or Kong Manager. Make sure to use the same redirect URI as configured earlier:
 
 ```bash
-curl -i -X POST http://kong:8001/services/{SERVICE_NAME}/plugins \
+curl -i -X POST http://localhost:8001/services/{SERVICE_NAME}/plugins \
   --data name="openid-connect" \
   --data config.issuer="https://accounts.google.com/.well-known/openid-configuration" \
   --data config.client_id="YOUR_CLIENT_ID" \
@@ -44,11 +44,11 @@ Depending on your needs, it may not be necessary to associate clients with a con
 If you need to interact with other Kong plugins using consumer information, you must add configuration that maps account data received from the identity provider to a Kong consumer. For this example, we'll map the user's Google account email by setting a `custom_id` on their consumer, e.g.
 
 ```bash
-curl -i -X POST http://kong:8001/consumers/ \
+curl -i -X POST http://localhost:8001/consumers/ \
   --data username="Yoda" \
   --data custom_id="user@example.com"
 
-curl -i -X PATCH http://kong:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
+curl -i -X PATCH http://localhost:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
   --data config.consumer_by="custom_id" \
   --data config.consumer_claim="email"
 ```

--- a/app/gateway/2.7.x/configure/graphql-quickstart.md
+++ b/app/gateway/2.7.x/configure/graphql-quickstart.md
@@ -44,7 +44,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
+$ curl -i -X POST http://localhost:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/gateway/2.7.x/developer-portal/administration/application-registration/azure-oidc-config.md
+++ b/app/gateway/2.7.x/developer-portal/administration/application-registration/azure-oidc-config.md
@@ -28,7 +28,7 @@ for use with the Kong OIDC and Portal Application Registration plugins.
 {% navtab Using cURL %}
 
 ```bash
-curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure \
+curl -i -X PUT http://localhost:8001/services/httpbin-service-azure \
   --data 'url=https://httpbin.org/anything'
 ```
 
@@ -48,7 +48,7 @@ http PUT :8001/services/httpbin-service-azure \
 {% navtab Using cURL %}
 
 ```bash
-curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
+curl -i -X PUT http://localhost:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
   --data 'paths=/httpbin-azure'
 ```
 {% endnavtab %}
@@ -74,7 +74,7 @@ The plugins must be applied to a Service to work properly.
 {% navtab Using cURL %}
 
  ```bash
-curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+curl -X POST http://localhost:8001/services/httpbin-service-azure/plugins \
   --data name=openid-connect \
   --data config.issuer="https://login.microsoftonline.com/<your_tenant_id>/v2.0" \
   --data config.display_errors="true" \
@@ -115,7 +115,7 @@ For more information, see [OIDC plugin](/hub/kong-inc/openid-connect/).
 {% navtab Using cURL %}
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+curl -X POST http://localhost:8001/services/httpbin-service-azure/plugins \
   --data "name=application-registration"  \
   --data "config.auto_approve=true" \
   --data "config.description=Uses consumer claim with various values (sub, aud, etc.) as registration id to support different flows and use cases." \

--- a/app/gateway/2.7.x/get-started/comprehensive/dev-portal.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/dev-portal.md
@@ -27,13 +27,13 @@ Make sure the Dev Portal is on. You should have enabled it during [installation]
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
+curl -X PATCH http://localhost:8001/workspaces/SecureWorkspace \
   --data config.portal=true
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http -f PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
+http -f PATCH http://localhost:8001/workspaces/SecureWorkspace \
   config.portal=true
 ```
 {% endnavtab %}

--- a/app/gateway/2.7.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/expose-services.md
@@ -71,7 +71,7 @@ The service is created, and the page automatically redirects back to the
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/services \
+curl -i -X POST http://localhost:8001/services \
   --data name=example_service \
   --data url='http://mockbin.org'
 ```
@@ -94,7 +94,7 @@ Verify the service’s endpoint:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i http://<admin-hostname>:8001/services/example_service
+curl -i http://localhost:8001/services/example_service
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -180,7 +180,7 @@ methods must be set for the Route to be matched to the service.
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/services/example_service/routes \
+curl -i -X POST http://localhost:8001/services/example_service/routes \
   --data 'paths[]=/mock' \
   --data name=mocking
 ```

--- a/app/gateway/2.7.x/get-started/comprehensive/improve-performance.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/improve-performance.md
@@ -50,7 +50,7 @@ Call the Admin API on port `8001` and configure plugins to enable in-memory cach
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=proxy-cache \
   --data config.content_type="application/json; charset=utf-8" \
   --data config.cache_ttl=30 \
@@ -179,7 +179,7 @@ To test more rapidly, the cache can be deleted by calling the Admin API:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X DELETE http://<admin-hostname>:8001/proxy-cache
+curl -i -X DELETE http://localhost:8001/proxy-cache
 ```
 {% endnavtab %}
 {% navtab HTTPie %}

--- a/app/gateway/2.7.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/load-balancing.md
@@ -48,7 +48,7 @@ Call the Admin API on port `8001` and create an Upstream named `example_upstream
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/upstreams \
+curl -X POST http://localhost:8001/upstreams \
   --data name=example_upstream
 ```
 {% endnavtab %}
@@ -67,7 +67,7 @@ Update the service you created previously to point to this upstream:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/services/example_service \
+curl -X PATCH http://localhost:8001/services/example_service \
   --data host='example_upstream'
 ```
 {% endnavtab %}
@@ -87,10 +87,10 @@ Add two targets to the upstream, each with port 80: `mockbin.org:80` and
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
+curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='mockbin.org:80'
 
-curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
+curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='httpbin.org:80'
 ```
 {% endnavtab %}

--- a/app/gateway/2.7.x/get-started/comprehensive/manage-teams.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/manage-teams.md
@@ -95,7 +95,7 @@ account’s password in place of `<super-user-token>`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/workspaces \
+curl -X POST http://localhost:8001/workspaces \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=SecureWorkspace'
 ```
@@ -186,7 +186,7 @@ Create a new user named `secureworkspaceadmin` with the RBAC token
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/users \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=secureworkspaceadmin' \
   --data 'user_token=secureadmintoken'
@@ -209,7 +209,7 @@ Create a blank role in the workspace and name it `admin`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/roles \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=admin' \
 ```
@@ -231,7 +231,7 @@ workspace:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'endpoint=*'
   --data 'workspace=SecureWorkspace' \
@@ -256,7 +256,7 @@ Grant the `admin` role to `secureworkspaceadmin`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'role=admin'
 ```
@@ -292,7 +292,7 @@ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
 
     *Using cURL:*
     ```sh
-    curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/default/rbac/users
+    curl -H Kong-Admin-Token:secureadmintoken -X GET http://localhost:8001/default/rbac/users
     ```
     *Or using HTTPie:*
 
@@ -310,7 +310,7 @@ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
 
     *Using cURL:*
     ```sh
-    curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/SecureWorkspace/rbac/users
+    curl -H Kong-Admin-Token:secureadmintoken -X GET http://localhost:8001/SecureWorkspace/rbac/users
     ```
     *Or using HTTPie:*
 

--- a/app/gateway/2.7.x/get-started/comprehensive/prepare.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/prepare.md
@@ -42,12 +42,12 @@ window:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001
+curl -i -X GET http://localhost:8001
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
-http <admin-hostname>:8001
+http localhost:8001
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -113,7 +113,7 @@ Run the following from a control plane:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://localhost:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab HTTPie %}

--- a/app/gateway/2.7.x/get-started/comprehensive/protect-services.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/protect-services.md
@@ -55,7 +55,7 @@ Call the Admin API on port `8001` and configure plugins to enable a limit of fiv
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=rate-limiting \
   --data config.minute=5 \
   --data config.policy=local

--- a/app/gateway/2.7.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/secure-services.md
@@ -61,7 +61,7 @@ created:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
+curl -X POST http://localhost:8001/routes/mocking/plugins \
   --data name=key-auth
 ```
 {% endnavtab %}
@@ -187,7 +187,7 @@ The following creates a new consumer called **consumer**:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/consumers/ \
+curl -i -X POST http://localhost:8001/consumers/ \
   --data username=consumer \
   --data custom_id=consumer
 ```
@@ -209,7 +209,7 @@ created above. For this example, set the key to `apikey`.
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth \
+curl -i -X POST http://localhost:8001/consumers/consumer/key-auth \
   --data key=apikey
 ```
 {% endnavtab %}
@@ -350,7 +350,7 @@ Find the plugin ID and copy it:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X GET http://<admin-hostname>:8001/routes/mocking/plugins/
+curl -X GET http://localhost:8001/routes/mocking/plugins/
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -372,7 +372,7 @@ Disable the plugin:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/routes/mocking/plugins/{<plugin-id>} \
+curl -X PATCH http://localhost:8001/routes/mocking/plugins/{<plugin-id>} \
   --data enabled=false
 ```
 {% endnavtab %}

--- a/app/gateway/2.7.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.7.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -612,7 +612,7 @@ following on a control plane:
 {% navtabs %}
 {% navtab Using cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://localhost:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab Using HTTPie %}

--- a/app/gateway/2.7.x/plugin-development/plugin-configuration.md
+++ b/app/gateway/2.7.x/plugin-development/plugin-configuration.md
@@ -22,7 +22,7 @@ Service, Route, or Consumer.
 For example, a user performs the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+$ curl -X POST http://localhost:8001/services/<service-name-or-id>/plugins \
     -d "name=my-custom-plugin" \
     -d "config.foo=bar"
 ```
@@ -355,7 +355,7 @@ Such a configuration will allow a user to post the configuration to your plugin
 as follows:
 
 ```bash
-$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+$ curl -X POST http://localhost:8001/services/<service-name-or-id>/plugins \
     -d "name=my-custom-plugin" \
     -d "config.environment=development" \
     -d "config.server.host=http://localhost"

--- a/app/gateway/2.7.x/reference/loadbalancing.md
+++ b/app/gateway/2.7.x/reference/loadbalancing.md
@@ -242,25 +242,25 @@ Set up the "Blue" environment, running version 1 of the address service:
 
 ```bash
 # create an upstream
-$ curl -X POST http://kong:8001/upstreams \
+$ curl -X POST http://localhost:8001/upstreams \
     --data "name=address.v1.service"
 
 # add two targets to the upstream
-$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
     --data "target=192.168.34.15:80"
     --data "weight=100"
-$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
     --data "target=192.168.34.16:80"
     --data "weight=50"
 
 # create a Service targeting the Blue upstream
-$ curl -X POST http://kong:8001/services/ \
+$ curl -X POST http://localhost:8001/services/ \
     --data "name=address-service" \
     --data "host=address.v1.service" \
     --data "path=/address"
 
 # finally, add a Route as an entry-point into the Service
-$ curl -X POST http://kong:8001/services/address-service/routes/ \
+$ curl -X POST http://localhost:8001/services/address-service/routes/ \
     --data "hosts[]=address.mydomain.com"
 ```
 
@@ -274,14 +274,14 @@ environment:
 
 ```bash
 # create a new Green upstream for address service v2
-$ curl -X POST http://kong:8001/upstreams \
+$ curl -X POST http://localhost:8001/upstreams \
     --data "name=address.v2.service"
 
 # add targets to the upstream
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=100"
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=100"
 ```
@@ -290,7 +290,7 @@ To activate the Blue/Green switch, we now only need to update the Service:
 
 ```bash
 # Switch the Service from Blue to Green upstream, v1 -> v2
-$ curl -X PATCH http://kong:8001/services/address-service \
+$ curl -X PATCH http://localhost:8001/services/address-service \
     --data "host=address.v2.service"
 ```
 
@@ -312,12 +312,12 @@ Using a very simple 2 target example:
 
 ```bash
 # first target at 1000
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=1000"
 
 # second target at 0
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=0"
 ```
@@ -327,12 +327,12 @@ slowly be routed towards the other target. For example, set it at 10%:
 
 ```bash
 # first target at 900
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=900"
 
 # second target at 100
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=100"
 ```

--- a/app/gateway/2.8.x/admin-api/workspaces/reference.md
+++ b/app/gateway/2.8.x/admin-api/workspaces/reference.md
@@ -364,7 +364,7 @@ Can be used with any request method.
 Target entities within a specified workspace by adding the workspace name or ID prefix before any entity endpoint.
 
 ```sh
-http://<ADMIN_API_HOSTNAME>:8001/<WORKSPACE_NAME|WORKSPACE_ID>/<ENDPOINT>
+http://localhost:8001/<WORKSPACE_NAME|WORKSPACE_ID>/<ENDPOINT>
 ```
 
 For example, to target `services` in the workspace `SRE`:

--- a/app/gateway/2.8.x/configure/auth/oidc-auth0.md
+++ b/app/gateway/2.8.x/configure/auth/oidc-auth0.md
@@ -26,7 +26,7 @@ If you have not done so already, [create a **Service**][add-service] to protect.
 Add an OpenID plugin configuration using the parameters in the example below using an HTTP client or Kong Manager. Auth0's token endpoint [requires passing the API identifier in the `audience` parameter][audience-required], which must be added as a custom argument:
 
 ```bash
-curl -i -X POST http://kong:8001/kong-admin/services/{SERVICE_NAME}/plugins \
+curl -i -X POST http://localhost:8001/kong-admin/services/{SERVICE_NAME}/plugins \
   --data name="openid-connect" \
   --data config.auth_methods="client_credentials" \
   --data config.issuer="https://<auth0 API name>.auth0.com/.well-known/openid-configuration" \

--- a/app/gateway/2.8.x/configure/auth/oidc-curity.md
+++ b/app/gateway/2.8.x/configure/auth/oidc-curity.md
@@ -29,7 +29,7 @@ If access is granted, the JWT from the introspection response is added to a head
 Create a service that can be used to test the integration.
 
 ```bash
-curl -i -X POST http://kong:8001/services/ \
+curl -i -X POST http://localhost:8001/services/ \
   --data name="httpbin" \
   --data protocol="http" \
   --data url="http://httpbin.org"
@@ -40,7 +40,7 @@ curl -i -X POST http://kong:8001/services/ \
 Add a route to the service.
 
 ```bash
-curl -i -X POST http://kong:8001/services/httpbin/routes \
+curl -i -X POST http://localhost:8001/services/httpbin/routes \
   --data "paths[]=/httpbin"
 ```
 
@@ -49,7 +49,7 @@ curl -i -X POST http://kong:8001/services/httpbin/routes \
 The Kong OpenID Connect plugin is enabled for the previously created service. In the example below, the `openid` scope is required in order for access to be granted. As noted by the `config.upstream_headers_claims` configuration, the plugin looks for the `JWT` (the phantom token) claim in the introspection response. The `config.upstream_headers_names` configuration extracts the `JWT` from the introspection response and adds it to a `phantom_token` header in the call to the upstream API.
 
 ```bash
-curl -X POST http://kong:8001/services/httpbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
 --data name="openid-connect" \
 --data config.issuer="https://idsvr.example.com/oauth/v2/oauth-anonymous" \
 --data config.client_id="gateway-client" \

--- a/app/gateway/2.8.x/configure/auth/oidc-google.md
+++ b/app/gateway/2.8.x/configure/auth/oidc-google.md
@@ -25,7 +25,7 @@ If you have not yet [added a **Service**][add-service], go ahead and do so. Agai
 Add a plugin with the configuration below to your Service using an HTTP client or Kong Manager. Make sure to use the same redirect URI as configured earlier:
 
 ```bash
-curl -i -X POST http://kong:8001/services/{SERVICE_NAME}/plugins \
+curl -i -X POST http://localhost:8001/services/{SERVICE_NAME}/plugins \
   --data name="openid-connect" \
   --data config.issuer="https://accounts.google.com/.well-known/openid-configuration" \
   --data config.client_id="YOUR_CLIENT_ID" \
@@ -44,11 +44,11 @@ Depending on your needs, it may not be necessary to associate clients with a con
 If you need to interact with other Kong plugins using consumer information, you must add configuration that maps account data received from the identity provider to a Kong consumer. For this example, we'll map the user's Google account email by setting a `custom_id` on their consumer, e.g.
 
 ```bash
-curl -i -X POST http://kong:8001/consumers/ \
+curl -i -X POST http://localhost:8001/consumers/ \
   --data username="Yoda" \
   --data custom_id="user@example.com"
 
-curl -i -X PATCH http://kong:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
+curl -i -X PATCH http://localhost:8001/services/{SERVICE_NAME}/plugins/{OIDC_PLUGIN_ID} \
   --data config.consumer_by="custom_id" \
   --data config.consumer_claim="email"
 ```

--- a/app/gateway/2.8.x/configure/graphql-quickstart.md
+++ b/app/gateway/2.8.x/configure/graphql-quickstart.md
@@ -44,7 +44,7 @@ $ curl -i -X POST \
 Protect your upstream GraphQL service with rate limiting. By introspecting your schema, it will analyze query costs and provide an enterprise-grade rate-limiting strategy.
 
 ```
-$ curl -i -X POST http://kong:8001/services/graphql-service/plugins \
+$ curl -i -X POST http://localhost:8001/services/graphql-service/plugins \
   --data name=graphql-rate-limiting-advanced \
   --data config.limit=100,10000 \
   --data config.window_size=60,3600 \

--- a/app/gateway/2.8.x/developer-portal/administration/application-registration/azure-oidc-config.md
+++ b/app/gateway/2.8.x/developer-portal/administration/application-registration/azure-oidc-config.md
@@ -28,7 +28,7 @@ for use with the Kong OIDC and Portal Application Registration plugins.
 {% navtab Using cURL %}
 
 ```bash
-curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure \
+curl -i -X PUT http://localhost:8001/services/httpbin-service-azure \
   --data 'url=https://httpbin.org/anything'
 ```
 
@@ -48,7 +48,7 @@ http PUT :8001/services/httpbin-service-azure \
 {% navtab Using cURL %}
 
 ```bash
-curl -i -X PUT http://<admin-server>:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
+curl -i -X PUT http://localhost:8001/services/httpbin-service-azure/routes/httpbin-route-azure \
   --data 'paths=/httpbin-azure'
 ```
 {% endnavtab %}
@@ -74,7 +74,7 @@ The plugins must be applied to a Service to work properly.
 {% navtab Using cURL %}
 
  ```bash
-curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+curl -X POST http://localhost:8001/services/httpbin-service-azure/plugins \
   --data name=openid-connect \
   --data config.issuer="https://login.microsoftonline.com/<your_tenant_id>/v2.0" \
   --data config.display_errors="true" \
@@ -115,7 +115,7 @@ For more information, see [OIDC plugin](/hub/kong-inc/openid-connect/).
 {% navtab Using cURL %}
 
 ```bash
-curl -X POST http://<admin-hostname>:8001/services/httpbin-service-azure/plugins \
+curl -X POST http://localhost:8001/services/httpbin-service-azure/plugins \
   --data "name=application-registration"  \
   --data "config.auto_approve=true" \
   --data "config.description=Uses consumer claim with various values (sub, aud, etc.) as registration id to support different flows and use cases." \

--- a/app/gateway/2.8.x/get-started/comprehensive/dev-portal.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/dev-portal.md
@@ -27,13 +27,13 @@ Make sure the Dev Portal is on. You should have enabled it during [installation]
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
+curl -X PATCH http://localhost:8001/workspaces/SecureWorkspace \
   --data config.portal=true
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http -f PATCH http://<admin-hostname>:8001/workspaces/SecureWorkspace \
+http -f PATCH http://localhost:8001/workspaces/SecureWorkspace \
   config.portal=true
 ```
 {% endnavtab %}

--- a/app/gateway/2.8.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/expose-services.md
@@ -71,14 +71,14 @@ The service is created, and the page automatically redirects back to the
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<kong-admin-host>:8001/services \
+curl -i -X POST http://localhost:8001/services \
   --data name=example_service \
   --data url='http://mockbin.org'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http POST http://<kong-admin-host>:8001/services \
+http POST http://localhost:8001/services \
   name=example_service \
   url='http://mockbin.org'
 ```
@@ -94,12 +94,12 @@ Verify the service’s endpoint:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i http://<admin-hostname>:8001/services/example_service
+curl -i http://localhost:8001/services/example_service
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http http://<kong-admin-host>:8001/services/example_service
+http http://localhost:8001/services/example_service
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -180,7 +180,7 @@ methods must be set for the Route to be matched to the service.
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/services/example_service/routes \
+curl -i -X POST http://localhost:8001/services/example_service/routes \
   --data 'paths[]=/mock' \
   --data name=mocking
 ```

--- a/app/gateway/2.8.x/get-started/comprehensive/improve-performance.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/improve-performance.md
@@ -50,7 +50,7 @@ Call the Admin API on port `8001` and configure plugins to enable in-memory cach
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=proxy-cache \
   --data config.content_type="application/json; charset=utf-8" \
   --data config.cache_ttl=30 \
@@ -179,7 +179,7 @@ To test more rapidly, the cache can be deleted by calling the Admin API:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X DELETE http://<admin-hostname>:8001/proxy-cache
+curl -i -X DELETE http://localhost:8001/proxy-cache
 ```
 {% endnavtab %}
 {% navtab HTTPie %}

--- a/app/gateway/2.8.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/load-balancing.md
@@ -48,7 +48,7 @@ Call the Admin API on port `8001` and create an Upstream named `example_upstream
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/upstreams \
+curl -X POST http://localhost:8001/upstreams \
   --data name=example_upstream
 ```
 {% endnavtab %}
@@ -67,7 +67,7 @@ Update the service you created previously to point to this upstream:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/services/example_service \
+curl -X PATCH http://localhost:8001/services/example_service \
   --data host='example_upstream'
 ```
 {% endnavtab %}
@@ -87,10 +87,10 @@ Add two targets to the upstream, each with port 80: `mockbin.org:80` and
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
+curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='mockbin.org:80'
 
-curl -X POST http://<admin-hostname>:8001/upstreams/example_upstream/targets \
+curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='httpbin.org:80'
 ```
 {% endnavtab %}

--- a/app/gateway/2.8.x/get-started/comprehensive/manage-teams.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/manage-teams.md
@@ -95,7 +95,7 @@ account’s password in place of `<super-user-token>`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/workspaces \
+curl -X POST http://localhost:8001/workspaces \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=SecureWorkspace'
 ```
@@ -186,7 +186,7 @@ Create a new user named `secureworkspaceadmin` with the RBAC token
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/users \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=secureworkspaceadmin' \
   --data 'user_token=secureadmintoken'
@@ -209,7 +209,7 @@ Create a blank role in the workspace and name it `admin`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/roles \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'name=admin' \
 ```
@@ -231,7 +231,7 @@ workspace:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/roles/admin/endpoints/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'endpoint=*'
   --data 'workspace=SecureWorkspace' \
@@ -256,7 +256,7 @@ Grant the `admin` role to `secureworkspaceadmin`:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
+curl -X POST http://localhost:8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
   -H Kong-Admin-Token:<super-user-token> \
   --data 'role=admin'
 ```
@@ -292,7 +292,7 @@ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
 
     *Using cURL:*
     ```sh
-    curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/default/rbac/users
+    curl -H Kong-Admin-Token:secureadmintoken -X GET http://localhost:8001/default/rbac/users
     ```
     *Or using HTTPie:*
 
@@ -310,7 +310,7 @@ http :8001/SecureWorkspace/rbac/users/secureworkspaceadmin/roles/ \
 
     *Using cURL:*
     ```sh
-    curl -H Kong-Admin-Token:secureadmintoken -X GET http://<admin-hostname>:8001/SecureWorkspace/rbac/users
+    curl -H Kong-Admin-Token:secureadmintoken -X GET http://localhost:8001/SecureWorkspace/rbac/users
     ```
     *Or using HTTPie:*
 

--- a/app/gateway/2.8.x/get-started/comprehensive/prepare.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/prepare.md
@@ -42,12 +42,12 @@ window:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001
+curl -i -X GET http://localhost:8001
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```bash
-http <admin-hostname>:8001
+http localhost:8001
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -113,7 +113,7 @@ Run the following from a control plane:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://localhost:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab HTTPie %}

--- a/app/gateway/2.8.x/get-started/comprehensive/protect-services.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/protect-services.md
@@ -55,7 +55,7 @@ Call the Admin API on port `8001` and configure plugins to enable a limit of fiv
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/plugins \
+curl -i -X POST http://localhost:8001/plugins \
   --data name=rate-limiting \
   --data config.minute=5 \
   --data config.policy=local

--- a/app/gateway/2.8.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/secure-services.md
@@ -61,7 +61,7 @@ created:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X POST http://<admin-hostname>:8001/routes/mocking/plugins \
+curl -X POST http://localhost:8001/routes/mocking/plugins \
   --data name=key-auth
 ```
 {% endnavtab %}
@@ -187,7 +187,7 @@ The following creates a new consumer called **consumer**:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/consumers/ \
+curl -i -X POST http://localhost:8001/consumers/ \
   --data username=consumer \
   --data custom_id=consumer
 ```
@@ -209,7 +209,7 @@ created above. For this example, set the key to `apikey`.
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X POST http://<admin-hostname>:8001/consumers/consumer/key-auth \
+curl -i -X POST http://localhost:8001/consumers/consumer/key-auth \
   --data key=apikey
 ```
 {% endnavtab %}
@@ -350,7 +350,7 @@ Find the plugin ID and copy it:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X GET http://<admin-hostname>:8001/routes/mocking/plugins/
+curl -X GET http://localhost:8001/routes/mocking/plugins/
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
@@ -372,7 +372,7 @@ Disable the plugin:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -X PATCH http://<admin-hostname>:8001/routes/mocking/plugins/{<plugin-id>} \
+curl -X PATCH http://localhost:8001/routes/mocking/plugins/{<plugin-id>} \
   --data enabled=false
 ```
 {% endnavtab %}

--- a/app/gateway/2.8.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
+++ b/app/gateway/2.8.x/plan-and-deploy/hybrid-mode/hybrid-mode-setup.md
@@ -612,7 +612,7 @@ following on a control plane:
 {% navtabs %}
 {% navtab Using cURL %}
 ```bash
-curl -i -X GET http://<admin-hostname>:8001/clustering/data-planes
+curl -i -X GET http://localhost:8001/clustering/data-planes
 ```
 {% endnavtab %}
 {% navtab Using HTTPie %}

--- a/app/gateway/2.8.x/plugin-development/plugin-configuration.md
+++ b/app/gateway/2.8.x/plugin-development/plugin-configuration.md
@@ -22,7 +22,7 @@ Service, Route, or Consumer.
 For example, a user performs the following request:
 
 ```bash
-$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+$ curl -X POST http://localhost:8001/services/<service-name-or-id>/plugins \
     -d "name=my-custom-plugin" \
     -d "config.foo=bar"
 ```
@@ -355,7 +355,7 @@ Such a configuration will allow a user to post the configuration to your plugin
 as follows:
 
 ```bash
-$ curl -X POST http://kong:8001/services/<service-name-or-id>/plugins \
+$ curl -X POST http://localhost:8001/services/<service-name-or-id>/plugins \
     -d "name=my-custom-plugin" \
     -d "config.environment=development" \
     -d "config.server.host=http://localhost"

--- a/app/gateway/2.8.x/reference/loadbalancing.md
+++ b/app/gateway/2.8.x/reference/loadbalancing.md
@@ -242,25 +242,25 @@ Set up the "Blue" environment, running version 1 of the address service:
 
 ```bash
 # create an upstream
-$ curl -X POST http://kong:8001/upstreams \
+$ curl -X POST http://localhost:8001/upstreams \
     --data "name=address.v1.service"
 
 # add two targets to the upstream
-$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
     --data "target=192.168.34.15:80"
     --data "weight=100"
-$ curl -X POST http://kong:8001/upstreams/address.v1.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v1.service/targets \
     --data "target=192.168.34.16:80"
     --data "weight=50"
 
 # create a Service targeting the Blue upstream
-$ curl -X POST http://kong:8001/services/ \
+$ curl -X POST http://localhost:8001/services/ \
     --data "name=address-service" \
     --data "host=address.v1.service" \
     --data "path=/address"
 
 # finally, add a Route as an entry-point into the Service
-$ curl -X POST http://kong:8001/services/address-service/routes/ \
+$ curl -X POST http://localhost:8001/services/address-service/routes/ \
     --data "hosts[]=address.mydomain.com"
 ```
 
@@ -274,14 +274,14 @@ environment:
 
 ```bash
 # create a new Green upstream for address service v2
-$ curl -X POST http://kong:8001/upstreams \
+$ curl -X POST http://localhost:8001/upstreams \
     --data "name=address.v2.service"
 
 # add targets to the upstream
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=100"
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=100"
 ```
@@ -290,7 +290,7 @@ To activate the Blue/Green switch, we now only need to update the Service:
 
 ```bash
 # Switch the Service from Blue to Green upstream, v1 -> v2
-$ curl -X PATCH http://kong:8001/services/address-service \
+$ curl -X PATCH http://localhost:8001/services/address-service \
     --data "host=address.v2.service"
 ```
 
@@ -312,12 +312,12 @@ Using a very simple 2 target example:
 
 ```bash
 # first target at 1000
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=1000"
 
 # second target at 0
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=0"
 ```
@@ -327,12 +327,12 @@ slowly be routed towards the other target. For example, set it at 10%:
 
 ```bash
 # first target at 900
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.17:80"
     --data "weight=900"
 
 # second target at 100
-$ curl -X POST http://kong:8001/upstreams/address.v2.service/targets \
+$ curl -X POST http://localhost:8001/upstreams/address.v2.service/targets \
     --data "target=192.168.34.18:80"
     --data "weight=100"
 ```


### PR DESCRIPTION
### Description

Currently, example commands use a variety of terms to express the kong gateway hostname. Since this isn't standard, it can be confusing, because the readers see different placeholders and assume they're supposed to mean different things.

Using `localhost` as this is the placeholder that we already use the most, and it let you copy & paste commands easily.  It's also the model that the gateway quickstart guide follows. 

https://konghq.atlassian.net/browse/DOCU-2370

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

