### PR TITLE
Update: Mark the canary plugin as not recommended for use with KIC

### DIFF
--- a/app/_hub/kong-inc/canary/_metadata.yml
+++ b/app/_hub/kong-inc/canary/_metadata.yml
@@ -3,10 +3,15 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
+k8s_examples: false
 premium: true
 konnect: true
 network_config_opts: All
-notes: --
+notes: |
+  The Canary plugin is not designed for a Kubernetes-native philosophy,
+  and shouldn't be used with the Kong Ingress Controller. Instead, use the 
+  <a href="/kubernetes-ingress-controller/latest/concepts/gateway-api/">Gateway API</a> 
+  to manage canary deploys.
 categories:
   - traffic-control
 publisher: Kong Inc.

--- a/app/_hub/kong-inc/canary/overview/_index.md
+++ b/app/_hub/kong-inc/canary/overview/_index.md
@@ -7,6 +7,11 @@ production by slowly rolling out the change to a small subset of users.
 This plugin also enables rolling back to your original upstream service, or shifting 
 all traffic to the new version.
 
+{:.important}
+> **Note**: The Canary plugin is not designed for a Kubernetes-native philosophy,
+and shouldn't be used with the {{site.kic_product_name}}. Instead, use the 
+[Gateway API](/kubernetes-ingress-controller/latest/concepts/gateway-api/) to manage canary deploys.
+
 ## Usage
 
 The Canary Release plugin allows you to route traffic to two separate upstream


### PR DESCRIPTION
### Description

Marking the Canary plugin as not supported for use with KIC.

From ticket:
> It looks like the way the Canary plugin works is not really designed to align with a Kubernetes-native philosophy and it doesn't really make sense to use with KIC.

We now have the Gateway API to cover for this functionality, so linking over to that instead.

https://konghq.atlassian.net/browse/DOCU-869

### Testing instructions

Preview link: 

https://deploy-preview-6221--kongdocs.netlify.app/hub/kong-inc/canary/
https://deploy-preview-6221--kongdocs.netlify.app/hub/kong-inc/canary/how-to/basic-example/
https://deploy-preview-6221--kongdocs.netlify.app/hub/plugins/compatibility/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

