### PR TITLE
chore: Minor adjustments to changelog generator [skip ci]

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          title: Automated Changelog update
+          title: Automated Changelog update [skip ci]
           body: |
             This is a scheduled pull request to update the changelog.
           labels: skip-changelog,review:copyedit

--- a/tools/changelog-generator/changelog.js
+++ b/tools/changelog-generator/changelog.js
@@ -92,7 +92,7 @@ const earliestDate = subDays(now, 7);
   prsWithFiles = groupBy(prsWithFiles, "week");
 
   // Write the changelog
-  let changelogContent = `# Changelog\n\n`;
+  let changelogContent = `# Changelog\n\n<!--vale off-->\n\n`;
 
   for (let week of Object.keys(prsWithFiles).reverse()) {
     changelogContent += `## Week ${week}\n\n`;
@@ -145,7 +145,7 @@ const earliestDate = subDays(now, 7);
   }
 
   changelogContent = `${changelogContent}\n\n${existingChangelog.replace(
-    "# Changelog\n\n",
+    "# Changelog\n\n<!--vale off-->\n\n",
     "",
   )}`;
   await fs.writeFile(changelogFile, changelogContent);


### PR DESCRIPTION
### Description

Two minor changes:
- Let the title of the generated PR include `[skip ci]` so that Netlify doesn't build any previews, since the changelog is not published on the docs site
- Set `vale off` so that vale doesn't run every time the action triggers, since the changelog is not generally spellchecked or heavily formatted.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

