### PR TITLE
Update: OIDC plugin example for using an access token

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -58,6 +58,8 @@ Luarocks
 Mockbin
 Moesif
 MongoDB
+NAT
+NATs
 Netcat
 Netlify
 Nginx

--- a/app/_hub/kong-inc/openid-connect/overview/_index.md
+++ b/app/_hub/kong-inc/openid-connect/overview/_index.md
@@ -90,6 +90,7 @@ The plugin supports several types of credentials and grants:
 
 The plugin has been tested with several OpenID Connect providers:
 
+<!--vale off-->
 - [Auth0][auth0] ([Kong Integration Guide](/gateway/latest/configure/auth/oidc-auth0/))
 - [Amazon AWS Cognito][cognito] ([Kong Integration Guide](/gateway/latest/configure/auth/oidc-cognito/))
 - [Connect2id][connect2id]
@@ -140,6 +141,7 @@ want your provider to be tested and added to the list.
 [salesforce]: https://help.salesforce.com/articleView?id=sf.sso_provider_openid_connect.htm&type=5
 [wso2]: https://is.docs.wso2.com/en/latest/guides/identity-federation/configure-oauth2-openid-connect/
 [yahoo]: https://developer.yahoo.com/oauth2/guide/openid_connect/
+<!--vale on-->
 
 Once applied, any user with a valid credential can access the service.
 

--- a/app/_hub/kong-inc/openid-connect/overview/_index.md
+++ b/app/_hub/kong-inc/openid-connect/overview/_index.md
@@ -942,11 +942,10 @@ curl -i -X PATCH http://localhost:8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f
 ```
 
 Test out the token by accessing the Kong proxy:
-```bash
-curl -i -X GET http://localhost:8000 \
-  -H "Authorization: Bearer <access-token>"
-```
 
+```bash
+curl http://localhost:8000?access_token=<token>
+```
 
 ### Introspection Authentication
 

--- a/app/_hub/kong-inc/openid-connect/overview/_index.md
+++ b/app/_hub/kong-inc/openid-connect/overview/_index.md
@@ -932,17 +932,19 @@ We can use the output in `Authorization` header.
    
 #### Test the JWT Access Token Authentication with access token in query string 
 
-To specify the bearer token as a query string parameter 
+To specify the bearer token as a query string parameter:
 
 ```bash
-http -f patch :8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f4f9 \
-  config.bearer_token_param_type=query                          \
-  config.auth_methods=bearer                                     \
-  config.auth_methods=password # only enabled for demoing purposes
+curl -i -X PATCH http://localhost:8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f4f9  \
+  --data "config.bearer_token_param_type=query"                 \
+  --data "config.auth_methods=bearer"                           \
+  --data "config.auth_methods=password" # only enabled for demoing purposes
 ```
-  
-  ```bash
-  http -v :8000 access_token==<access-token>
+
+Test out the token by accessing the Kong proxy:
+```bash
+curl -i -X GET http://localhost:8000 \
+  -H "Authorization: Bearer <access-token>"
 ```
 
 

--- a/app/_hub/kong-inc/openid-connect/overview/_index.md
+++ b/app/_hub/kong-inc/openid-connect/overview/_index.md
@@ -927,6 +927,22 @@ We can use the output in `Authorization` header.
    }
    ```
 2. Done.
+   
+#### Test the JWT Access Token Authentication with access token in query string 
+
+To specify the bearer token as a query string parameter 
+
+```bash
+http -f patch :8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f4f9 \
+  config.bearer_token_param_type=query                          \
+  config.auth_methods=bearer                                     \
+  config.auth_methods=password # only enabled for demoing purposes
+```
+  
+  ```bash
+  http -v :8000 access_token==<access-token>
+```
+
 
 ### Introspection Authentication
 


### PR DESCRIPTION
Based on questions in slack, the example in docs does not mention how the plugin works with the access token specified as query string. The plugin uses `access_token` as the default query string parameter name. This is not specified anywhere. Hence this example shows how to use the plugin with the query string param as option instead of header


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

