### PR TITLE
fix: Plugin tiers for konnect-incompatible plugins

### DIFF
--- a/app/_assets/stylesheets/page.less
+++ b/app/_assets/stylesheets/page.less
@@ -613,6 +613,13 @@ Generic Styling for Desktop
       border: none;
     }
 
+    &.compatibility {
+      background-color: @grey-200;
+      color: @grey-600;
+      border-radius: 5px;
+      padding: 10px;
+    }
+
     &.install-banner {
       background-color: @blue-100;
       border: none;

--- a/app/_hub/kong-inc/jwt-signer/_metadata.yml
+++ b/app/_hub/kong-inc/jwt-signer/_metadata.yml
@@ -3,7 +3,6 @@ dbless_compatible: 'yes'
 free: false
 
 enterprise: true
-paid: true
 konnect: false
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/key-auth-enc/_metadata.yml
+++ b/app/_hub/kong-inc/key-auth-enc/_metadata.yml
@@ -7,7 +7,6 @@ dbless_explanation: |
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: false
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 notes: |

--- a/app/_hub/kong-inc/openwhisk/_metadata.yml
+++ b/app/_hub/kong-inc/openwhisk/_metadata.yml
@@ -2,7 +2,6 @@ name: Apache OpenWhisk
 dbless_compatible: 'yes'
 free: true
 enterprise: true
-paid: true
 konnect: false
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 notes: |

--- a/app/_hub/kong-inc/vault-auth/_0.3.0/_metadata.yml
+++ b/app/_hub/kong-inc/vault-auth/_0.3.0/_metadata.yml
@@ -3,7 +3,6 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: false
 publisher: Kong Inc.
 version: 2.1.x-2.7.x

--- a/app/_hub/kong-inc/vault-auth/_metadata.yml
+++ b/app/_hub/kong-inc/vault-auth/_metadata.yml
@@ -3,7 +3,6 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: false
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 notes: --

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -6,6 +6,13 @@ breadcrumbs:
   Hub: '/hub/'
 
 ---
+
+{% unless page.konnect == true %}
+<blockquote class="compatibility">
+  <strong>This plugin is not compatible with Konnect</strong>
+</blockquote>
+{% endunless %}
+
 {% unless page.free %}
   {% if page.paid and page.extn_publisher == "kong-inc" %}
     <blockquote class="note" role="alert">


### PR DESCRIPTION
### Description

Some konnect-incompatible plugins were displaying Konnect Paid or Konnect Premium badges. This was happening because the metadata was incorrectly set to include either `paid: true` or `premium: true` for these plugins.

Fixing that, and adding a banner to konnect-incompatible plugin landing pages to call that out.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

