### PR TITLE
fix: Kong for Kubernetes

### DIFF
--- a/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
@@ -41,7 +41,7 @@ For a production setup with Kong support, use the [Helm chart](https://github.co
 1. Install Kong for Kubernetes using Kustomize:
 
     ```bash
-    kustomize build github.com/kong/kubernetes-ingress-controller/config/base
+    kubectl apply -k github.com/kong/kubernetes-ingress-controller/config/base
     ```
     You can use the above URL as a base kustomization and build on top of it
     to make it suite better for your cluster and use-case.

--- a/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
@@ -5,76 +5,61 @@ title: Kong for Kubernetes
 Kong for Kubernetes is an Ingress Controller based on the
 Open-Source {{site.base_gateway}}. It consists of two components:
 
-- **Kong**: the Open-Source Gateway
-- **Controller**: a daemon process that integrates with the
-  Kubernetes platform and configures Kong.
+- **Kong** the Open-Source Gateway
+- **Controller** a daemon process that integrates with the Kubernetes platform and configures Kong.
 
 ## Installers
 
 Kong for Kubernetes can be installed using an installer of
-your choice.
+your choice. After the installation is complete, see the [getting started](/kubernetes-ingress-controller/{{page.kong_version}}/guides/getting-started) tutorial to learn more.
 
-Once you've installed Kong for Kubernetes,
-jump to the [next section](#using-kong-for-kubernetes)
-on using it.
+{% navtabs %}
+{% navtab YAML manifests %}
 
-### YAML manifests
-
-Please pick one of the following guides depending on your platform:
+You can install using YAML manifest files in these platforms:
 
 - [Minikube](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/minikube/)
 - [Google Kubernetes Engine(GKE) by Google](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/gke/)
 - [Elastic Kubernetes Service(EKS) by Amazon](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/eks/)
 - [Azure Kubernetes Service(AKS) by Microsoft](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/aks/)
 
-
-### Kustomize
+{% endnavtab %}
+{% navtab Kustomize %}
 
 {:.important}
 > Kustomize manifests are provided for illustration purposes only and are not officially supported by Kong.
 There is no guarantee of backwards compatibility or upgrade capabilities for our Kustomize manifests.
 For a production setup with Kong support, use the [Helm chart](https://github.com/kong/charts).
 
-Use Kustomize to install Kong for Kubernetes:
+1. Install Kong for Kubernetes using Kustomize:
 
-```
-kustomize build github.com/kong/kubernetes-ingress-controller/config/base
-```
+    ```bash
+    kustomize build github.com/kong/kubernetes-ingress-controller/deploy/manifests/base
+    ```
+    You can use the above URL as a base kustomization and build on top of it
+    to make it suite better for your cluster and use-case.
+1. Set the environment variable $PROXY_IP with the External IP address of the `kong-proxy` service in `kong` namespace:
 
-You can use the above URL as a base kustomization and build on top of it
-to make it suite better for your cluster and use-case.
+    ```bash
+    export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
+    ```
+{% endnavtab %}
+{% navtab Helm %}
 
-Once installed, set an environment variable, $PROXY_IP with the External IP address of
-the `kong-proxy` service in `kong` namespace:
+1. Install {{site.kic_product_name}} and {{ site.base_gateway }} with Helm:
 
-```
-export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
-```
+    ```
+    $ helm repo add kong https://charts.konghq.com
+    $ helm repo update
+    $ helm install kong kong/ingress -n kong --create-namespace
+    ```
+1. Kubernetes exposes the proxy through a Kubernetes service. Run the following commands to store the load balancer IP address in a variable named `PROXY_IP`:
 
-### Helm
-
-You can use Helm to install Kong via the official Helm chart:
-
-```
-$ helm repo add kong https://charts.konghq.com
-$ helm repo update
-
-
-# Helm 3
-$ helm install kong/kong --generate-name --set ingressController.installCRDs=false -n kong --create-namespace
-```
-
-Once installed, set an environment variable, $PROXY_IP with the External IP address of
-the `demo-kong-proxy` service in `kong` namespace:
-
-```
-export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong demo-kong-proxy)
-```
-
-{:.note}
-> **Note:** Alternatively, you can also specify `ingress[0].hostname` depending on your environment.
-
-## Using Kong for Kubernetes
-
-Once you've installed Kong for Kubernetes, please follow our
-[getting started](/kubernetes-ingress-controller/{{page.kong_version}}/guides/getting-started) tutorial to learn more.
+    ```
+    HOST=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    PORT=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.spec.ports[0].port}')
+    export PROXY_IP=${HOST}:${PORT}
+    echo $PROXY_IP   
+    ```
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
@@ -16,7 +16,14 @@ your choice. After the installation is complete, see the [getting started](/kube
 {% navtabs %}
 {% navtab YAML manifests %}
 
-You can install using YAML manifest files in these platforms:
+
+You can install {{ site.kic_product_name }} with a single `kubectl apply` for testing purposes:
+
+```bash
+$ kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{ page.release }}/deploy/single/all-in-one-dbless.yaml
+```
+
+There are additional instructions for the following platforms:
 
 - [Minikube](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/minikube/)
 - [Google Kubernetes Engine(GKE) by Google](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/gke/)

--- a/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
@@ -48,8 +48,8 @@ For a production setup with Kong support, use the [Helm chart](https://github.co
 1. Kubernetes exposes the proxy through a Kubernetes service. Run the following commands to store the load balancer IP address in a variable named `PROXY_IP`:
 
     ```bash
-    HOST=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    PORT=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.spec.ports[0].port}')
+    HOST=$(kubectl get svc --namespace kong kong-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    PORT=$(kubectl get svc --namespace kong kong-proxy -o jsonpath='{.spec.ports[0].port}')
     export PROXY_IP=${HOST}:${PORT}
     echo $PROXY_IP  
     ```

--- a/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
+++ b/app/_src/kubernetes-ingress-controller/deployment/k4k8s.md
@@ -34,14 +34,17 @@ For a production setup with Kong support, use the [Helm chart](https://github.co
 1. Install Kong for Kubernetes using Kustomize:
 
     ```bash
-    kustomize build github.com/kong/kubernetes-ingress-controller/deploy/manifests/base
+    kustomize build github.com/kong/kubernetes-ingress-controller/config/base
     ```
     You can use the above URL as a base kustomization and build on top of it
     to make it suite better for your cluster and use-case.
-1. Set the environment variable $PROXY_IP with the External IP address of the `kong-proxy` service in `kong` namespace:
+1. Kubernetes exposes the proxy through a Kubernetes service. Run the following commands to store the load balancer IP address in a variable named `PROXY_IP`:
 
     ```bash
-    export PROXY_IP=$(kubectl get -o jsonpath="{.status.loadBalancer.ingress[0].ip}" service -n kong kong-proxy)
+    HOST=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    PORT=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.spec.ports[0].port}')
+    export PROXY_IP=${HOST}:${PORT}
+    echo $PROXY_IP  
     ```
 {% endnavtab %}
 {% navtab Helm %}


### PR DESCRIPTION
### Description

Tested and validated [Kong for Kubernetes](http://localhost:8888/kubernetes-ingress-controller/2.12.x/deployment/k4k8s/) guide.

Not sure if the title should be Kong Ingress Controller for Kubernetes.

 


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

