### PR TITLE
docs(mesh): adjust external ca verification docs since 2.4.0

### DIFF
--- a/app/_src/mesh/features/acmpca.md
+++ b/app/_src/mesh/features/acmpca.md
@@ -141,7 +141,9 @@ If you're running in Universal mode, you can also use the [HTTP API][http-api] t
 
 In a multi-zone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane can communicate with ACM Private CA. This is because certificates for data plane proxies are requested from ACM Private CA by the zone control plane, not the global control plane.
 
+{% if_version lte:2.3.x %}
 You must also make sure the global control plane can communicate with ACM Private CA. When a new `acmpca` backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate. In a multi-zone environment, validation is performed on the global control plane.
+{% endif_version %}
 
 <!-- links -->
 {% if_version gte:2.0.x %}

--- a/app/_src/mesh/features/cert-manager.md
+++ b/app/_src/mesh/features/cert-manager.md
@@ -105,9 +105,11 @@ resource with the `issuerRef`  specified in the `Mesh` `certmanager` backend spe
 Also, because the backend is `Mesh` scoped configuration and `certmanager` backend is limited to the Kubernetes environment,
 Universal and Kubernetes cannot be used together in a multi-zone environment which includes a `certmanager` mTLS backend.
 
+{% if_version lte:2.3.x %}
 You must also ensure the global control plan can access cert-manager.
 When a new `certmanager`backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate.
 In a multi-zone environment, validation is performed on the global control plane.
+{% endif_version %}
 
 <!-- links -->
 {% if_version gte:2.0.x %}

--- a/app/_src/mesh/features/vault.md
+++ b/app/_src/mesh/features/vault.md
@@ -311,7 +311,9 @@ You can also use the `replace` function to replace `_` with `-`. For example, `{
 
 In a multi-zone environment, the global control plane provides the `Mesh` to the zone control planes. However, you must make sure that each zone control plane communicates with Vault over the same address. This is because certificates for data plane proxies are issued from the zone control plane, not from the global control plane.
 
+{% if_version lte:2.3.x %}
 You must also make sure the global control plane communicates with Vault. When a new Vault backend is configured, {{site.mesh_product_name}} validates the connection by issuing a test certificate. In a multi-zone environment, validation is performed on the global control plane.
+{% endif_version %}
 
 <!-- links -->
 {% if_version gte:2.0.x %}


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->

The docs wrong since 2.4.0 - we changed the implementation.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

