### PR TITLE
Set concurrency.cancel-in-progress for PRs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -2,6 +2,9 @@ name: Broken Links
 on:
   pull_request:
     types: [synchronize, ready_for_review, opened, labeled, unlabeled]
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,7 +2,9 @@ name: Linting
 on:
   pull_request:
     types: [synchronize, ready_for_review, opened]
-
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,9 @@ on:
      - main
   pull_request:
     types: [synchronize, ready_for_review, opened]
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 env:
   VITE_PORTAL_API_URL: ${{ vars.VITE_PORTAL_API_URL }}

--- a/.github/workflows/scheduled-broken-link-checker.yml
+++ b/.github/workflows/scheduled-broken-link-checker.yml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: '0 0 * * 0'
 
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}
+
 env:
   VITE_PORTAL_API_URL: ${{ vars.VITE_PORTAL_API_URL }}
 


### PR DESCRIPTION
### Description

We're spending a lot of (free, but still) build minutes testing commits that are out of date. This PR cancels old builds when new commits are pushed

### Testing instructions

Preview link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
