### PR TITLE
update: Add a section about managing key sets to the JWT plugin docs

### DIFF
--- a/app/_hub/kong-inc/jwt-signer/overview/_index.md
+++ b/app/_hub/kong-inc/jwt-signer/overview/_index.md
@@ -24,25 +24,7 @@ specify some options to actually make the plugin work:
 * Also for introspection to work, you need to specify introspection endpoints
 `config.access_token_introspection_endpoint` and/or `config.channel_token_introspection_endpoint`.
 
-## Manage key signing
-
-If you specify `config.access_token_keyset` or `config.channel_token_keyset` with either an
-`http://` or `https://` prefix, it means that token signing keys are externally managed by you.
-In that case, the plugin loads the keys just like it does for `config.access_token_jwks_uri`
-and `config.channel_token_jwks_uri`. If the prefix is not `http://` or `https://`
-(such as `"my-company"` or `"kong"`), Kong autogenerates JWKS for supported algorithms.
-
-External JWKS specified with `config.access_token_keyset` or
-`config.channel_token_keyset` should also contain private keys with supported `alg`,
-either `"RS256"` or `"RS512"` for now. External URLs that contain private keys should
-be protected so that only Kong can access them. Currently, Kong doesn't add any authentication
-headers when it loads the keys from an external endpoint, so you have to do it with network
-level restrictions. If it is a common need to manage private keys externally
-instead of allowing Kong to autogenerate them, we can add another parameter
-for adding an authentication header (possibly similar to
-`config.channel_token_introspection_authorization`).
-
-The key size (the modulo) for RSA keys is currently hard-coded to 2048 bits.
+* If you are using the JWT signer plugin with {{site.konnect_short_name}}, you must externally manage your own signing keys. For more information about how to configure this, see [Manage key signing](/hub/kong-inc/jwt-signer/manage-keys/).
 
 ## Consumer mapping
 

--- a/app/_hub/kong-inc/jwt-signer/overview/manage-keys.md
+++ b/app/_hub/kong-inc/jwt-signer/overview/manage-keys.md
@@ -1,0 +1,59 @@
+---
+nav_title: Manage key signing
+---
+
+What is key signing and why does the JWT plugin require it?
+
+With the JWT signer plugin, you have the option to either use signing keys that are externally managed by you or to use Kong-generated signing keys. If you're using the JWT signer plugin with {{site.konnect_short_name}}, you *must* manage your signing keys externally. If you're using {{site.base_gateway}}, you can either manage your signing keys externally or use Kong-generated keys.
+
+Are there any reasons why someone who is using {{site.base_gateway}} might choose one mode over the other?
+
+## Externally manage signing keys
+
+This section provides instructions that explain how to host key sets using the library of your choice and configure the JWT plugin to load your externally managed keys.
+
+### Prerequisites
+
+* A keys host (for example, a Docker container) for the keys. This host must be accessible from both {{site.base_gateway}} and upstreams with NGINX installed on it
+* An environment where you can generate signing keys
+What does this mean? What do we need in the environment?
+* A TLS certificate to secure the key server
+
+### Host key sets
+
+1. Generate server certificates using your organization's certificate authority (CA).
+
+1. Generate JWKs using any of the [standard libraries](https://jwt.io/libraries) that align with your organization's security requriements. 
+    The key size (the modulo) for RSA keys is currently hard-coded to 2048 bits.
+
+1. Copy the generated keys in a directory on the host machine. Also, copy your server certificate and key to the host machine as well. 
+
+1. Configure your host server with the certificate, certificate key, signing keys, and JSON Web Key Set (JWKS). 
+    
+    {:.note}
+    > **Note:** External URLs that contain private keys should be protected so that only Kong can access them. Currently, Kong doesn't add any authentication headers when it loads the keys from an external endpoint, so you have to do it with network level restrictions. If you commonly need to manage private keys externally instead of allowing Kong to autogenerate them, you can add another parameter for adding an authentication header (possibly similar to `config.channel_token_introspection_authorization`).
+
+### Configure the JWT plugin with your self-hosted key sets
+
+To configure the JWT plugin with your self-hosted key sets, you must specify `config.access_token_keyset` or `config.channel_token_keyset` with either an `http://` or `https://` prefix:
+
+```bash
+curl -X POST \
+https://{us|eu}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/services/{serviceId}/plugins \
+    --header "accept: application/json" \
+    --header "Content-Type: application/json" \
+    --header "Authorization: Bearer TOKEN" \
+    --data '{"name":"jwt-signer","config":{"access_token_keyset":http://keyserverexample.internal/signingkeys}}'
+```
+
+In this case, the plugin loads the keys just like it does for `config.access_token_jwks_uri`
+and `config.channel_token_jwks_uri`.
+
+External JWKS specified with `config.access_token_keyset` or
+`config.channel_token_keyset` should also contain private keys with supported `alg`,
+either `"RS256"` or `"RS512"` for now.
+
+## Generate signing keys with Kong
+
+If you specify `config.access_token_keyset` or `config.channel_token_keyset` without either an
+`http://` or `https://` prefix (such as `"my-company"` or `"kong"`), Kong autogenerates JWKS for supported algorithms.

--- a/app/_redirects
+++ b/app/_redirects
@@ -299,6 +299,7 @@
 /hub/smartparkingtechnology/*                      /hub/
 /hub/bitnami/*                                     /gateway/latest/install/
 /hub/kong-inc/kong-terraform-aws/                  https://github.com/kong/kong-terraform-aws
+/hub/kong-inc/jwt-signer/#manage-key-signing/      /hub/kong-inc/jwt-signer/manage-keys/
 
 # KONNECT
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Konnect users must manage their own keys externally in order for the JWT plugin to work with Konnect. This wasn't described in docs and the content that we did have on managing keys was lacking some info, so I added to it and made it it's own section.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3453
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

