### PR TITLE
Fix: curl examples for custom plugins schemas in Konnect

### DIFF
--- a/app/konnect/gateway-manager/plugins/add-custom-plugin.md
+++ b/app/konnect/gateway-manager/plugins/add-custom-plugin.md
@@ -57,10 +57,15 @@ Upload the `schema.lua` file for your plugin using the [`/plugin-schemas`](/konn
 ```sh
 curl -i -X POST \
   https://{region}.api.konghq.com/v2/{controlPlaneId}/core-entities/plugin-schemas \
-  --data lua_schema=@example-schema.lua
+  --header 'Content-Type: application/json' \
+  --data "{\"lua_schema\": <your escaped Lua schema>}"
 ```
 
-This example specifies a file, but you can also include the entire schema in the request as JSON data.
+{:.note}
+> **Tip**: You can use jq to pass your schema directly from the file instead of manually escaping it:
+```sh
+--data "{\"lua_schema\": $(jq -Rs '.' < REPLACE-PATH-TO-SCHEMA-FILE)}"
+```
 
 You should get an `HTTP 201` response. 
 

--- a/app/konnect/gateway-manager/plugins/update-custom-plugin.md
+++ b/app/konnect/gateway-manager/plugins/update-custom-plugin.md
@@ -155,7 +155,14 @@ To update a schema, use a `PUT` request with the [`/plugin-schemas`](/konnect/ap
 ```sh
 curl -i -X PUT \
   https://{region}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/plugin-schemas/{customPluginName} \
-  --data "lua_schema=@example-schema.lua"
+  --header 'Content-Type: application/json' \
+  --data "{\"lua_schema\": "<your escaped Lua schema>"}"
+```
+
+{:.note}
+> **Tip**: You can use jq to pass your schema directly from the file instead of manually escaping it:
+```sh
+--data "{\"lua_schema\": $(jq -Rs '.' < REPLACE-PATH-TO-SCHEMA-FILE)}"
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Description

Turns out that you can't pass a file directly via cURL to our Konnect CP configuration API. The contents of the file don't get escaped correctly. When testing this out originally, I used a mix of cURL and HTTPie, and HTTPie had no issues - but our default cURL instructions have problems here.

Issue was reported on [Slack](https://kongstrong.slack.com/archives/C03NRECFJPM/p1696622470557839).

Updating the doc with Fero's help, tested it all with curl this time around.

The jq instructions are in a "tip", since we can't tell them to use jq if they don't want to or don't have it.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

