### PR TITLE
kgo: update docs with 1.0.1

### DIFF
--- a/app/_src/gateway-operator/get-started/kic/create-gateway.md
+++ b/app/_src/gateway-operator/get-started/kic/create-gateway.md
@@ -69,10 +69,6 @@ spec:
 ' | kubectl apply -f -
 ```
 
-{:.note}
-> **Note:** There is a known issue where applying a `GatewayConfiguration` without
-> `spec.controlPlaneOptions` would cause the operator to perpetually update the `ControlPlane`.
-
 The results should look like this:
 
 ```text

--- a/app/gateway-operator/changelog.md
+++ b/app/gateway-operator/changelog.md
@@ -5,6 +5,19 @@ no_version: true
 
 Changelog for supported {{ site.kgo_product_name }} versions.
 
+## 1.0.1
+
+**Release Date** 2023/10/02
+
+### Fixes
+
+* Fix flapping of `Gateway` managed `ControlPlane` `spec` field when applied without `controlPlaneOptions` set.
+
+### Changes
+
+* Bump `ControlPlane` default version to `v2.12`.
+* Bump `WebhookCertificateConfigBaseImage` to `v1.3.0`.
+
 ## 1.0.0
 
 **Release Date** 2023/09/27


### PR DESCRIPTION
### Description

Update docs with 1.0.1 release https://github.com/Kong/gateway-operator/releases/tag/v1.0.1

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

