### PR TITLE
Raise an exception when two or more pages have the same output path

### DIFF
--- a/app/_plugins/hooks/url_conflicts.rb
+++ b/app/_plugins/hooks/url_conflicts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  if Jekyll::Commands::Doctor.conflicting_urls(site)
+    raise "Conflict: Two or more pages have the same output path. Check Jekyll's logs for more info."
+  end
+end


### PR DESCRIPTION
### Description

Based on a Slack conversation.
By default, Jekyll logs a warning whenever two or more pages have the same output path which has caused us problems in the past because we noticed the issue after releasing the changes.
This change introduces a hook that raises whenever a conflict exists.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

