### PR TITLE
Generate OAS Overlays

### DIFF
--- a/app/_data/docs_nav_gateway_3.4.x.yml
+++ b/app/_data/docs_nav_gateway_3.4.x.yml
@@ -665,3 +665,9 @@ items:
         url: /reference/wasm
       - text: FAQ
         url: /reference/faq
+
+unlisted:
+  - title: Overlays
+    items:
+      - url: /overlays/expected-config-hash
+      - url: /overlays/certificate.put

--- a/app/_layouts/overlay.html
+++ b/app/_layouts/overlay.html
@@ -1,0 +1,4 @@
+- target: '{{ page.target }}'
+  update:
+    description: |
+{{ content | indent | indent}}

--- a/app/_src/gateway/overlays/certificate.put.md
+++ b/app/_src/gateway/overlays/certificate.put.md
@@ -1,0 +1,10 @@
+---
+layout: overlay
+target: '$.paths["/{runtimeGroupId}/core-entities/certificates/{certificate_id}"].put'
+---
+
+Update details about the specified certificate using the provided path parameter `certificate_id`.
+
+Inserts (or replaces) the certificate under the requested `certificate_id`with the definition specified in the request body. When the `id` attribute has the structure of a UUID, the certificate being inserted/replaced will be identified by its `id`. Otherwise it will be identified by the `name`.
+
+When creating a new Certificate without specifying `id` (neither in the path or the request body), then it will be auto-generated.

--- a/app/_src/gateway/overlays/expected-config-hash.md
+++ b/app/_src/gateway/overlays/expected-config-hash.md
@@ -1,0 +1,6 @@
+---
+layout: overlay
+target: '$.paths["/{runtimeGroupId}/expected-config-hash"].get'
+---
+
+Retrieve the expected config hash for this runtime group. The expected config hash can be used to verify if the config hash of a runtime instance is up to date with the runtime group. The config hash will be the same if they are in sync.

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -1,0 +1,43 @@
+# Generating OAS Overlays
+
+1. Add all the entries to the gateway nav file in the `unlisted` section
+2. Create entries in `app/_src/gateway/overlays` with the following format:
+
+```yaml
+---
+layout: overlay
+target: '$.paths["/{runtimeGroupId}/core-entities/certificates/{certificate_id}"].put'
+---
+
+This is a description.
+
+It can be as long as you like.
+
+{% if_version gte:3.3.x %}
+And even use conditionals
+{% endif_version %}
+```
+
+Build the site with `make run`:
+
+```bash
+export VERSION=3.4.x;
+for i in dist/gateway/$VERSION/overlays/*/index.html; do cat $i >> $VERSION.yaml; echo "" >> $VERSION.yamldone;
+```
+
+`$VERSION.yaml` now contains all overlay items.
+
+It's missing the header:
+
+```
+info:
+  title: Add descriptions
+  version: 1.0.0
+overlay: 1.0.0
+actions:
+```
+
+## Next Steps
+
+1. Build tooling to combine overlays into a single file, including the header
+1. Make sure that the overlays folder isn't published to production


### PR DESCRIPTION
### Description

Proof of concept OAS Overlay generation from source files. This needs more work if we want to explore further, but it shows what the source files look like and how the output file could be generated

**DO NOT MERGE**

## Path to overlay adoption

* Jekyll ignores overlay markdown files
* Ability to apply multiple overlays and generate one file. 
* **Optional** Automatic upload to Dev Portal 
* Define workflow for everything for specs that live in the platform-api repo and the Kong Admin API specs that live in the docs repo. 
    * This is because we currently own the Gateway admin API specs but eventually they will live in another repo, we also need to figure out how we will interact with the specs in platform-api. 



### 

Preview link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
