### PR TITLE
Scaffold KIC 3.0 IA

### DIFF
--- a/app/_data/docs_nav_kic_3.0.x.yml
+++ b/app/_data/docs_nav_kic_3.0.x.yml
@@ -1,0 +1,195 @@
+product: kubernetes-ingress-controller
+release: 3.0.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    items:
+      - text: Overview
+        url: /kubernetes-ingress-controller/3.0.x/
+        absolute_url: true
+      - text: Kubernetes Gateway API
+        url: /gateway-api
+      - text: Version Support Policy
+        url: /support-policy
+      - text: Changelog
+        url: >-
+          https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md
+        absolute_url: true
+        target_blank: true
+  - title: How KIC Works
+    icon: /assets/images/icons/documentation/icn-kubernetes-color.svg
+    items:
+      - text: Architecture
+        url: /concepts/architecture
+      - text: Gateway API
+        url: /concepts/gateway-api
+      - text: Ingress
+        url: /concepts/ingress
+      - text: Custom Resources
+        url: /concepts/custom-resources
+      - text: Using Annotations
+        url: /concepts/annotations
+      - text: Admission Controller
+        url: /concepts/admission-controller
+  - title: Get Started
+    icon: /assets/images/icons/documentation/icn-learning.svg
+    items:
+      - text: Install KIC
+        url: /get-started/
+      - text: Services and Routes
+        url: /get-started/services-and-routes
+      - text: Rate Limiting
+        url: /get-started/rate-limiting
+      - text: Proxy Caching
+        url: /get-started/proxy-caching
+      - text: Key Authentication
+        url: /get-started/key-authentication
+
+  - title: KIC in Production
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    items:
+      - text: Deployment Topologies
+        items:
+          - text: Traditional (sidecar)
+            url: /production/deployment-topologies/sidecar
+          - text: Gateway Discovery
+            url: /production/deployment-topologies/gateway-discovery
+          - text: Database Backed
+            url: /production/deployment-topologies/db-backed
+      - text: Installation Methods
+        items: 
+          - text: Kong Gateway Operator
+            url: /install/gateway-operator
+          - text: Helm
+            url: /install/helm
+      - text: Cloud Deployment
+        items: 
+          - text: Azure
+            url: /install/cloud/aks
+          - text: Amazon
+            url: /install/cloud/eks
+          - text: Google
+            url: /install/cloud/gke
+      - text: Enterprise License
+        url: /license
+      - text: Runtimes
+        items: 
+          - text: Kubernetes
+            url: /runtimes/kubernetes
+          - text: Openshift
+            url: /runtimes/openshift
+      - text: Observability
+        items:
+          - text: Prometheus
+            url: /production/observability/prometheus
+          - text: Kubernetes Events
+            url: /production/observability/events
+      - text: Upgrading
+        items: 
+          - text: Kong Gateway
+            url: /upgrade/gateway
+          - text: Ingress Controller
+            url: /upgrade/kic
+
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: Service Configuration
+        items:
+          - text: TCP Service
+            url: /guides/services/tcp
+          - text: UDP Service
+            url: /guides/services/udp
+          - text: gRPC Service
+            url: /guides/services/grpc
+          - text: Fallback Service
+            url: /guides/services/fallback
+          - text: External Service
+            url: /guides/services/external
+          - text: HTTPS Redirects
+            url: /guides/services/https-redirect
+          - text: Multiple Backend Services
+            url: /guides/services/multiple-backends
+          - text: TLS Termination
+            url: /guides/services/tls-termination
+          - text: TLS Passthrough
+            url: /guides/services/tls-passthrough
+      - text: Request Manipulation
+        items:
+          - text: Rewriting Hosts + Paths
+            url: /guides/requests/rewrite-host
+          - text: Rewrite Annotation
+            url: /guides/requests/rewrite-annotation
+      - text: High Availability
+        items:
+          - text: KIC High Availability
+            url: /guides/high-availability/kic
+          - text: Service Health Checks
+            url: /guides/high-availability/health-checks
+      - text: Security
+        items:
+          - text: KIC <-> Data Plane mTLS
+            url: /guides/security/kic-dp
+          - text: Kong Vaults
+            url: /guides/security/kong-vault
+          - text: Cert Manager
+            url: /guides/security/cert-manager
+          - text: Using Workspaces
+            url: /guides/security/workspaces
+          - text: Preserving Client IP
+            url: /guides/security/client-ip
+      - text: Service Mesh
+        items:
+          - text: Kong Mesh
+            url: /guides/mesh/kong-mesh
+          - text: Kuma
+            url: /guides/mesh/kuma
+          - text: Istio
+            url: /guides/mesh/istio
+
+  - title: Plugins
+    icon: /assets/images/icons/documentation/icn-api-plugins-color.svg
+    items:
+      - text: Custom Plugins
+        url: /plugins/custom
+      - text: Authentication
+        url: /plugins/authentication
+      - text: ACL
+        url: /plugins/acl
+      - text: Rate Limiting
+        url: /plugins/rate-limiting
+      - text: mTLS
+        url: /plugins/mtls
+      - text: OIDC
+        url: /plugins/oidc
+
+  - title: Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    items:
+      - text: Troubleshooting
+        url: /reference/troubleshooting
+      - text: Annotations
+        url: /reference/annotations
+      - text: Feature Gates
+        url: /reference/feature-gates
+      - text: FAQ
+        items:
+          - text: Plugin Compatibility
+            url: /reference/faq/plugin-compatibility
+          - text: Kong Router
+            url: /reference/faq/router
+          - text: Custom nginx.conf
+            url: /reference/faq/nginx.conf
+      - text: Custom Resource Definitions
+        items:
+          - text: KongPlugin / KongClusterPlugin
+            url: /reference/crd/kongplugin
+          - text: KongConsumer
+            url: /reference/crd/kongconsumer
+          - text: KongCredential
+            url: /reference/crd/kongcredential
+          - text: KongIngress
+            url: /reference/crd/kongingress
+      - text: Configuration Options
+        url: /reference/configuration

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -232,6 +232,9 @@
 - release: "2.12.x"
   version: "2.12.0"
   edition: "kubernetes-ingress-controller"
+- release: "3.0.x"
+  version: "3.0.x"
+  edition: "kubernetes-ingress-controller"
 - edition: gateway-operator
   version: 1.0.0
   release: 1.0.x

--- a/app/_src/kubernetes-ingress-controller/concepts/admission-controller.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/admission-controller.md
@@ -1,0 +1,6 @@
+---
+title: Admission Controller
+type: explanation
+purpose: |
+  Help the user understand. What is the KIC Admission Controller? How do I enable it? What does it validate?
+---

--- a/app/_src/kubernetes-ingress-controller/concepts/annotations.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/annotations.md
@@ -1,0 +1,6 @@
+---
+title: Annotations
+type: explanation
+purpose: |
+  Explain what annotations are used for in KIC. List the top X annotations then link to the reference page
+---

--- a/app/_src/kubernetes-ingress-controller/concepts/architecture.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/architecture.md
@@ -1,0 +1,6 @@
+---
+title: Architecture
+type: explanation
+purpose: |
+  How does KIC work? What are it's roles and responsibilities?
+---

--- a/app/_src/kubernetes-ingress-controller/concepts/custom-resources.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/custom-resources.md
@@ -1,0 +1,6 @@
+---
+title: Custom Resources
+type: explanation
+purpose: |
+  @TODO
+---

--- a/app/_src/kubernetes-ingress-controller/concepts/gateway-api.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/gateway-api.md
@@ -1,0 +1,6 @@
+---
+title: Gateway API
+type: reference
+purpose: |
+  Explain how we translate Gateway API concepts to Kong Gateway items
+---

--- a/app/_src/kubernetes-ingress-controller/concepts/ingress.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/ingress.md
@@ -1,0 +1,6 @@
+---
+title: Ingress
+type: reference
+purpose: |
+  Explain the Ingress resource, highlight that Gateway API is now preferred. State that we'll continue to support Ingress for the foreseeable future. Provide an Ingress definition example + talk about IngressClass
+---

--- a/app/_src/kubernetes-ingress-controller/gateway-api.md
+++ b/app/_src/kubernetes-ingress-controller/gateway-api.md
@@ -1,0 +1,6 @@
+---
+title: Gateway API
+type: explanation
+purpose: |
+  Introduce the Kubernetes Gateway API as our preferred configuration method. Explain Gateway, GatewayClass and provide a simple HTTPRoute example
+---

--- a/app/_src/kubernetes-ingress-controller/get-started/index.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/index.md
@@ -1,0 +1,8 @@
+---
+title: Install KIC
+book: kic-get-started
+chapter: 1
+type: tutorial
+purpose: |
+  Install KIC using the Kong Gateway Operator
+---

--- a/app/_src/kubernetes-ingress-controller/get-started/key-authentication.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/key-authentication.md
@@ -1,0 +1,8 @@
+---
+title: Key Authentication
+book: kic-get-started
+chapter: 5
+type: tutorial
+purpose: |
+  Show how to enable Key Authentication with KIC, including creating a consumer and a credential
+---

--- a/app/_src/kubernetes-ingress-controller/get-started/proxy-caching.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/proxy-caching.md
@@ -1,0 +1,8 @@
+---
+title: Proxy Caching
+book: kic-get-started
+chapter: 4
+type: tutorial
+purpose: |
+  Using the Proxy Cache plugin to cache response content using Redis
+---

--- a/app/_src/kubernetes-ingress-controller/get-started/rate-limiting.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/rate-limiting.md
@@ -1,0 +1,8 @@
+---
+title: Rate Limiting
+book: kic-get-started
+chapter: 3
+type: tutorial
+purpose: |
+  How to configure rate limiting with Redis
+---

--- a/app/_src/kubernetes-ingress-controller/get-started/services-and-routes.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/services-and-routes.md
@@ -1,0 +1,8 @@
+---
+title: Services and Routes
+book: kic-get-started
+chapter: 2
+type: tutorial
+purpose: |
+  Use the Gateway API and HTTPRoute to configure a service and a route. Explain how the HTTPRoute translates to Kong Gateway entities.
+---

--- a/app/_src/kubernetes-ingress-controller/guides/high-availability/health-checks.md
+++ b/app/_src/kubernetes-ingress-controller/guides/high-availability/health-checks.md
@@ -1,0 +1,6 @@
+---
+title: Health Checks
+type: how-to
+purpose: |
+  How to enable passive and active health checks for upstream services
+---

--- a/app/_src/kubernetes-ingress-controller/guides/high-availability/kic.md
+++ b/app/_src/kubernetes-ingress-controller/guides/high-availability/kic.md
@@ -1,0 +1,6 @@
+---
+title: KIC
+type: how-to
+purpose: |
+  How to run multiple KIC instances with leader election
+---

--- a/app/_src/kubernetes-ingress-controller/guides/mesh/istio.md
+++ b/app/_src/kubernetes-ingress-controller/guides/mesh/istio.md
@@ -1,0 +1,6 @@
+---
+title: Istio
+type: how-to
+purpose: |
+  How to use KIC when Istio is installed in a cluster
+---

--- a/app/_src/kubernetes-ingress-controller/guides/mesh/kong-mesh.md
+++ b/app/_src/kubernetes-ingress-controller/guides/mesh/kong-mesh.md
@@ -1,0 +1,6 @@
+---
+title: Kong Mesh
+type: how-to
+purpose: |
+  How to use KIC when Kong Mesh is installed in a cluster
+---

--- a/app/_src/kubernetes-ingress-controller/guides/mesh/kuma.md
+++ b/app/_src/kubernetes-ingress-controller/guides/mesh/kuma.md
@@ -1,0 +1,6 @@
+---
+title: Kuma
+type: how-to
+purpose: |
+   How to use KIC when Kuma is installed in a cluster
+---

--- a/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-annotation.md
+++ b/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-annotation.md
@@ -1,0 +1,6 @@
+---
+title: Rewrite Annotation
+type: explanation
+purpose: |
+  What is the rewrite annotation and how does it work?
+---

--- a/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-host.md
+++ b/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-host.md
@@ -1,0 +1,6 @@
+---
+title: Rewrite Host
+type: how-to
+purpose: |
+  Rewrite the host header for incoming requests
+---

--- a/app/_src/kubernetes-ingress-controller/guides/security/cert-manager.md
+++ b/app/_src/kubernetes-ingress-controller/guides/security/cert-manager.md
@@ -1,0 +1,6 @@
+---
+title: Cert Manager
+type: how-to
+purpose: |
+  How to use Cert Manager to generate KIC/DP certificates
+---

--- a/app/_src/kubernetes-ingress-controller/guides/security/client-ip.md
+++ b/app/_src/kubernetes-ingress-controller/guides/security/client-ip.md
@@ -1,0 +1,6 @@
+---
+title: Preserve Client IP
+type: how-to
+purpose: |
+  How to pass the client IP through Gateway to the upstream service
+---

--- a/app/_src/kubernetes-ingress-controller/guides/security/kic-dp.md
+++ b/app/_src/kubernetes-ingress-controller/guides/security/kic-dp.md
@@ -1,0 +1,6 @@
+---
+title: Securing KIC<->Gateway Traffic
+type: how-to
+purpose: |
+  How to use mTLS to secure traffic between KIC and Kong Gateway
+---

--- a/app/_src/kubernetes-ingress-controller/guides/security/kong-vault.md
+++ b/app/_src/kubernetes-ingress-controller/guides/security/kong-vault.md
@@ -1,0 +1,6 @@
+---
+title: Kong Vault
+type: how-to
+purpose: |
+  How to configure Kong Vault using environment variables
+---

--- a/app/_src/kubernetes-ingress-controller/guides/security/workspaces.md
+++ b/app/_src/kubernetes-ingress-controller/guides/security/workspaces.md
@@ -1,0 +1,6 @@
+---
+title: Workspaces
+type: tutorial
+purpose: |
+  How to use KIC to sync resources to a specific Kong Gateway workspace. Deploy multiple namespaces and use the --watch-namespace flag with a workspace.
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/external.md
@@ -1,0 +1,6 @@
+---
+title: External Service
+type: how-to
+purpose: |
+  How to proxy traffic to an external service
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/fallback.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/fallback.md
@@ -1,0 +1,6 @@
+---
+title: Fallback Service
+type: how-to
+purpose: |
+  How to specify a fallback service if no routing rules match
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
@@ -1,0 +1,6 @@
+---
+title: gRPC
+type: how-to
+purpose: |
+  How to proxy gRPC requests
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/https-redirect.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/https-redirect.md
@@ -1,0 +1,6 @@
+---
+title: HTTPS Rediect
+type: how-to
+purpose: |
+  Force HTTP requests to use a HTTPS endpoint
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/multiple-backends.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/multiple-backends.md
@@ -1,0 +1,6 @@
+---
+title: Multiple Backends
+type: how-to
+purpose: |
+  @TODO
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/tcp.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tcp.md
@@ -1,0 +1,6 @@
+---
+title: TCP
+type: how-to
+purpose: |
+  How to proxy TCP requests
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/tls-passthrough.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tls-passthrough.md
@@ -1,0 +1,6 @@
+---
+title: TLS Passthrough
+type: how-to
+purpose: |
+  How to pass the request through Kong Gateway without terminating TLS
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/tls-termination.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tls-termination.md
@@ -1,0 +1,6 @@
+---
+title: TLS Termination
+type: how-to
+purpose: |
+  Using Kong Gateway to terminate TLS
+---

--- a/app/_src/kubernetes-ingress-controller/guides/services/udp.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/udp.md
@@ -1,0 +1,6 @@
+---
+title: UDP
+type: how-to
+purpose: |
+  How to proxy UDP requests
+---

--- a/app/_src/kubernetes-ingress-controller/index.md
+++ b/app/_src/kubernetes-ingress-controller/index.md
@@ -1,0 +1,6 @@
+---
+title: Kong Ingress Controller
+type: explanation
+purpose: |
+  Provide an overview of KIC and what it's used for
+---

--- a/app/_src/kubernetes-ingress-controller/install/cloud/aks.md
+++ b/app/_src/kubernetes-ingress-controller/install/cloud/aks.md
@@ -1,0 +1,6 @@
+---
+title: AKS
+type: reference
+purpose: |
+  Additional information needed to install KIC on AKS
+---

--- a/app/_src/kubernetes-ingress-controller/install/cloud/eks.md
+++ b/app/_src/kubernetes-ingress-controller/install/cloud/eks.md
@@ -1,0 +1,6 @@
+---
+title: EKS
+type: reference
+purpose: |
+  Additional information needed to install KIC on EKS
+---

--- a/app/_src/kubernetes-ingress-controller/install/cloud/gke.md
+++ b/app/_src/kubernetes-ingress-controller/install/cloud/gke.md
@@ -1,0 +1,6 @@
+---
+title: GKE
+type: reference
+purpose: |
+  Additional information needed to install KIC on GKE
+---

--- a/app/_src/kubernetes-ingress-controller/install/gateway-operator.md
+++ b/app/_src/kubernetes-ingress-controller/install/gateway-operator.md
@@ -1,0 +1,6 @@
+---
+title: Gateway Operator
+type: how-to
+purpose: |
+  Using KGO to install KIC
+---

--- a/app/_src/kubernetes-ingress-controller/install/helm.md
+++ b/app/_src/kubernetes-ingress-controller/install/helm.md
@@ -1,0 +1,6 @@
+---
+title: Helm
+type: how-to
+purpose: |
+  Using Helm to install KIC
+---

--- a/app/_src/kubernetes-ingress-controller/license.md
+++ b/app/_src/kubernetes-ingress-controller/license.md
@@ -1,0 +1,6 @@
+---
+title: Enterprise License
+type: how-to
+purpose: |
+  How to get your license and apply it to KIC managed Gateways
+---

--- a/app/_src/kubernetes-ingress-controller/plugins/acl.md
+++ b/app/_src/kubernetes-ingress-controller/plugins/acl.md
@@ -1,0 +1,6 @@
+---
+title: ACL
+type: how-to
+purpose: |
+  How to configure the ACL plugin
+---

--- a/app/_src/kubernetes-ingress-controller/plugins/authentication.md
+++ b/app/_src/kubernetes-ingress-controller/plugins/authentication.md
@@ -1,0 +1,6 @@
+---
+title: Authentication
+type: explanation
+purpose: |
+  List available authentication plugins. Explain how consumers/credentials work. Mention how to apply multiple auth plugins with anonymous consumers.
+---

--- a/app/_src/kubernetes-ingress-controller/plugins/custom.md
+++ b/app/_src/kubernetes-ingress-controller/plugins/custom.md
@@ -1,0 +1,6 @@
+---
+title: Custom Plugins
+type: explanation
+purpose: |
+  How to use Custom Plugins with KIC
+---

--- a/app/_src/kubernetes-ingress-controller/plugins/mtls.md
+++ b/app/_src/kubernetes-ingress-controller/plugins/mtls.md
@@ -1,0 +1,6 @@
+---
+title: mTLS
+type: how-to
+purpose: |
+  How to configure the mTLS plugin
+---

--- a/app/_src/kubernetes-ingress-controller/plugins/oidc.md
+++ b/app/_src/kubernetes-ingress-controller/plugins/oidc.md
@@ -1,0 +1,6 @@
+---
+title: OIDC
+type: how-to
+purpose: |
+  How to configure the OIDC plugin
+---

--- a/app/_src/kubernetes-ingress-controller/plugins/rate-limiting.md
+++ b/app/_src/kubernetes-ingress-controller/plugins/rate-limiting.md
@@ -1,0 +1,6 @@
+---
+title: Rate-Limiting
+type: how-to
+purpose: |
+  How to configure the Rate-Limiting plugin
+---

--- a/app/_src/kubernetes-ingress-controller/production/deployment-topologies/db-backed.md
+++ b/app/_src/kubernetes-ingress-controller/production/deployment-topologies/db-backed.md
@@ -1,0 +1,6 @@
+---
+title: DB-backed
+type: explanation
+purpose: |
+  What is a DB-backed deployment and when should it be used?
+---

--- a/app/_src/kubernetes-ingress-controller/production/deployment-topologies/gateway-discovery.md
+++ b/app/_src/kubernetes-ingress-controller/production/deployment-topologies/gateway-discovery.md
@@ -1,0 +1,6 @@
+---
+title: Gateway Discovery
+type: explanation
+purpose: |
+  What is Gateway Discovery?
+---

--- a/app/_src/kubernetes-ingress-controller/production/deployment-topologies/sidecar.md
+++ b/app/_src/kubernetes-ingress-controller/production/deployment-topologies/sidecar.md
@@ -1,0 +1,6 @@
+---
+title: Sidecar
+type: explanation
+purpose: |
+  What is Sidecar Mode? Why is it deprecated?
+---

--- a/app/_src/kubernetes-ingress-controller/production/observability/events.md
+++ b/app/_src/kubernetes-ingress-controller/production/observability/events.md
@@ -1,0 +1,6 @@
+---
+title: Kubernetes Events
+type: explanation
+purpose: |
+  What are events? What events are available? How can they trigger alerts?
+---

--- a/app/_src/kubernetes-ingress-controller/production/observability/prometheus.md
+++ b/app/_src/kubernetes-ingress-controller/production/observability/prometheus.md
@@ -1,0 +1,6 @@
+---
+title: Prometheus
+type: explanation
+purpose: |
+  What metrics are available? What port does it listen on?
+---

--- a/app/_src/kubernetes-ingress-controller/reference/annotations.md
+++ b/app/_src/kubernetes-ingress-controller/reference/annotations.md
@@ -1,0 +1,6 @@
+---
+title: Annotations
+type: reference
+purpose: |
+  What annotatations are available and what do they do?
+---

--- a/app/_src/kubernetes-ingress-controller/reference/configuration.md
+++ b/app/_src/kubernetes-ingress-controller/reference/configuration.md
@@ -1,0 +1,6 @@
+---
+title: Configuration
+type: reference
+purpose: |
+  What configuration options are available? How do I set them in the Helm chart / KGO
+---

--- a/app/_src/kubernetes-ingress-controller/reference/crd/kongconsumer.md
+++ b/app/_src/kubernetes-ingress-controller/reference/crd/kongconsumer.md
@@ -1,0 +1,6 @@
+---
+title: "kongconsumer"
+type: 
+purpose: |
+  ...
+---

--- a/app/_src/kubernetes-ingress-controller/reference/crd/kongcredential.md
+++ b/app/_src/kubernetes-ingress-controller/reference/crd/kongcredential.md
@@ -1,0 +1,6 @@
+---
+title: "kongcredential"
+type: 
+purpose: |
+  ...
+---

--- a/app/_src/kubernetes-ingress-controller/reference/crd/kongingress.md
+++ b/app/_src/kubernetes-ingress-controller/reference/crd/kongingress.md
@@ -1,0 +1,6 @@
+---
+title: "kongingress"
+type: 
+purpose: |
+  ...
+---

--- a/app/_src/kubernetes-ingress-controller/reference/crd/kongplugin.md
+++ b/app/_src/kubernetes-ingress-controller/reference/crd/kongplugin.md
@@ -1,0 +1,6 @@
+---
+title: "kongplugin"
+type: 
+purpose: |
+  ...
+---

--- a/app/_src/kubernetes-ingress-controller/reference/faq/nginx.conf.md
+++ b/app/_src/kubernetes-ingress-controller/reference/faq/nginx.conf.md
@@ -1,0 +1,6 @@
+---
+title: "nginx.conf"
+type: reference
+purpose: |
+  How do I use a custom nginx.conf file?
+---

--- a/app/_src/kubernetes-ingress-controller/reference/faq/plugin-compatibility.md
+++ b/app/_src/kubernetes-ingress-controller/reference/faq/plugin-compatibility.md
@@ -1,0 +1,6 @@
+---
+title: "plugin-compatibility"
+type: reference
+purpose: |
+  @TODO
+---

--- a/app/_src/kubernetes-ingress-controller/reference/faq/router.md
+++ b/app/_src/kubernetes-ingress-controller/reference/faq/router.md
@@ -1,0 +1,6 @@
+---
+title: Router Flavor
+type: reference
+purpose: |
+  What is the router flavor? What's the default? What difference does it make? (Gateway API only possible with expressions).
+---

--- a/app/_src/kubernetes-ingress-controller/reference/feature-gates.md
+++ b/app/_src/kubernetes-ingress-controller/reference/feature-gates.md
@@ -1,0 +1,6 @@
+---
+title: Feature Gates
+type: reference
+purpose: |
+  What feature gates are available? What are the default values? What do they do?
+---

--- a/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
@@ -1,0 +1,6 @@
+---
+title: Troubleshooting
+type: reference
+purpose: |
+  How do I figure out what's going wrong? How do I dump broken config?
+---

--- a/app/_src/kubernetes-ingress-controller/runtimes/kubernetes.md
+++ b/app/_src/kubernetes-ingress-controller/runtimes/kubernetes.md
@@ -1,0 +1,6 @@
+---
+title: Kubernetes
+type: explanation
+purpose: |
+  Supported Kubernetes versions, testing methodology
+---

--- a/app/_src/kubernetes-ingress-controller/runtimes/openshift.md
+++ b/app/_src/kubernetes-ingress-controller/runtimes/openshift.md
@@ -1,0 +1,6 @@
+---
+title: Openshift
+type: explanation
+purpose: |
+  Supported Openshift versions, testing methodology
+---

--- a/app/_src/kubernetes-ingress-controller/support-policy.md
+++ b/app/_src/kubernetes-ingress-controller/support-policy.md
@@ -1,0 +1,6 @@
+---
+title: Support Policy
+type: reference
+purpose: |
+  What versions of KIC are supported, and until when?
+---

--- a/app/_src/kubernetes-ingress-controller/upgrade/gateway.md
+++ b/app/_src/kubernetes-ingress-controller/upgrade/gateway.md
@@ -1,0 +1,6 @@
+---
+title: Upgrading Kong Gateway
+type: how-to
+purpose: |
+  What do I need to know when upgrading Kong Gateway on Kubernetes? DB-backed mode vs DB-less
+---

--- a/app/_src/kubernetes-ingress-controller/upgrade/kic.md
+++ b/app/_src/kubernetes-ingress-controller/upgrade/kic.md
@@ -1,0 +1,6 @@
+---
+title: Upgrading Kong Ingress Controller
+type: how-to
+purpose: |
+  How do I upgrade the Kong Ingress Controller. Are there any pitfalls?
+---


### PR DESCRIPTION
### Description

Scaffold out all pages for the new KIC 3.0 IA.

All pages are empty - followup PRs will populate the content and be reviewed one by one

### Testing instructions

Preview link: /kubernetes-ingress-controller/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
