### PR TITLE
Update changelog generator [skip-ci]

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
+      - name: sync with main
+        run: git pull origin main
       - name: Run changelog script
         working-directory: tools/changelog-generator
         run: |

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
-      - name: sync with main
-        run: git pull origin main
       - name: Run changelog script
         working-directory: tools/changelog-generator
         run: |

--- a/tools/changelog-generator/changelog.js
+++ b/tools/changelog-generator/changelog.js
@@ -51,12 +51,7 @@ const earliestDate = subDays(now, 7);
       pulls.map(async (pr) => {
         const created_at = new Date(pr.merged_at);
 
-        //check for skip-changelog label
-        const hasSkipChangelogLabel = pr.labels.some(label => label.name === 'skip-changelog');
 
-        if (hasSkipChangelogLabel) {
-          return null;
-        }
 
         // Load the files for this PR using the API
         const pr_files = await octokit.paginate(
@@ -93,10 +88,9 @@ const earliestDate = subDays(now, 7);
       }),
     )
   )
-    .filter((pr) => pr !== null) // Remove null entries
+    
     .filter((pr) => pr.affected_files.length > 0)
-    .filter((pr) => !pr.labels.includes("skip-changelog"));
-
+    .filter((pr) => !pr.labels.map(l => l.name).includes("skip-changelog"));
   prsWithFiles = groupBy(prsWithFiles, "week");
 
   // Write the changelog
@@ -149,7 +143,7 @@ const earliestDate = subDays(now, 7);
   try {
     existingChangelog = await fs.readFile("changelog.md", "utf8");
   } catch (e) {
-    // No file to read
+    console.log(e); // for debugging why the file is being overwritten.
   }
 
   changelogContent = `${changelogContent}\n\n${existingChangelog.replace(

--- a/tools/changelog-generator/changelog.js
+++ b/tools/changelog-generator/changelog.js
@@ -51,6 +51,13 @@ const earliestDate = subDays(now, 7);
       pulls.map(async (pr) => {
         const created_at = new Date(pr.merged_at);
 
+        //check for skip-changelog label
+        const hasSkipChangelogLabel = pr.labels.some(label => label.name === 'skip-changelog');
+
+        if (hasSkipChangelogLabel) {
+          return null;
+        }
+
         // Load the files for this PR using the API
         const pr_files = await octokit.paginate(
           octokit.rest.pulls.listFiles,
@@ -86,6 +93,7 @@ const earliestDate = subDays(now, 7);
       }),
     )
   )
+    .filter((pr) => pr !== null) // Remove null entries
     .filter((pr) => pr.affected_files.length > 0)
     .filter((pr) => !pr.labels.includes("skip-changelog"));
 


### PR DESCRIPTION
Updates the changelog generator after seeing that it was no longer recognizing the skip-changelog tag. I also updated the github action to sync with main before creating a new branch, I suspect that that's why it sometimes overwrites the changelog. 