### PR TITLE
Add github star button to Kong manager oss page

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -96,14 +96,18 @@ id: documentation
 
           <h1 tabindex="-1" id="main" class="page-content-title"
           >{{page.title | flatify }}
-          {% if page.badge %}
-            <a href="https://konghq.com/pricing" {%
-              if page.badge == 'paid' %}class="badge paid" aria-label="available with Konnect Paid subscription"{% endif %}{%
-              if page.badge == 'premium' %}class="badge premium" aria-label="available with Konnect Premium subscription"{% endif %}{%
-              if page.badge == 'enterprise' %}class="badge enterprise" aria-label="available with Kong Gateway Enterprise subscription"{% endif %}{%
-              if page.badge == 'free' %}class="badge free" aria-label="available in Kong Gateway free mode"{% endif %}{%
-              if page.badge == 'oss' %}class="badge oss" aria-label="open-source only"{% endif %}>
-            </a>
+            {% if page.github_star_button %}
+              {{ page.github_star_button }}
+            {% endif %}
+
+            {% if page.badge %}
+              <a href="https://konghq.com/pricing" {%
+                if page.badge == 'paid' %}class="badge paid" aria-label="available with Konnect Paid subscription"{% endif %}{%
+                if page.badge == 'premium' %}class="badge premium" aria-label="available with Konnect Premium subscription"{% endif %}{%
+                if page.badge == 'enterprise' %}class="badge enterprise" aria-label="available with Kong Gateway Enterprise subscription"{% endif %}{%
+                if page.badge == 'free' %}class="badge free" aria-label="available in Kong Gateway free mode"{% endif %}{%
+                if page.badge == 'oss' %}class="badge oss" aria-label="open-source only"{% endif %}>
+              </a>
             {% endif %}
           </h1>
 

--- a/app/_src/gateway/kong-manager-oss/index.md
+++ b/app/_src/gateway/kong-manager-oss/index.md
@@ -1,6 +1,8 @@
 ---
 title: About Kong Manager Open Source
 badge: oss
+github_star_button: <a class='github-button' href='https://github.com/Kong/kong-manager' data-icon='octicon-star' data-show-count='true' aria-label='Star kong/kong-manager on GitHub'>Star</a>
+
 ---
 
 Kong Manager Open Source (OSS) is the graphical user interface (GUI) for {{site.ce_product_name}}. It uses the Kong Admin API under the hood to administer and control {{site.ce_product_name}}. To access Kong Manager OSS, go to the following URL after installing {{site.ce_product_name}}: [http://localhost:8002](http://localhost:8002)


### PR DESCRIPTION
### Description

Add Github star button with count next to the page title.

### Testing instructions

[Preview link](https://deploy-preview-6267--kongdocs.netlify.app/gateway/latest/kong-manager-oss/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

