### PR TITLE
DOCU-3320: Add support for Mesh's `dev` release

### DIFF
--- a/app/_data/docs_nav_mesh_dev.yml
+++ b/app/_data/docs_nav_mesh_dev.yml
@@ -1,0 +1,183 @@
+generate: true
+assume_generated: true
+max_depth: 3
+inherit:
+  path: /.repos/kuma/app/_src
+  nav: ../_src/.repos/kuma/app/_data/docs_nav_kuma_dev.yml
+  patches:
+    - path: [ Introduction ]
+      action: modify
+      icon: /assets/images/icons/documentation/icn-flag.svg
+    - path: [ Introduction, Overview of Kuma ]
+      text: Overview of Kong Mesh
+      url: /
+      src: null
+      action: modify
+    - path: [ Introduction, How Kuma works ]
+      text: How Kong Mesh works
+      url: /introduction/how-kong-mesh-works
+      action: modify
+      items: []
+    - path: [ Introduction, Kuma requirements ]
+      text: Mesh requirements
+      action: modify
+    - path: [ Introduction ]
+      text: Stages of software availability
+      url: /availability-stages/
+      action: insert
+      index: -3
+    - path: [ Introduction ]
+      text: Version support policy
+      url: /support-policy/
+      action: insert
+      index: -3
+    - path: [ Introduction, Release notes]
+      url: /mesh/changelog
+      src: /mesh/changelog
+      action: modify
+    - title: Getting Started
+      action: insert
+      index: 1
+      icon: /assets/images/icons/documentation/icn-quickstart-color.svg
+      url: /gettingstarted
+    - path: [ Kuma in Production ]
+      action: modify
+      title: Kong Mesh in Production
+      icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    - path: [ Kong Mesh in Production, Kuma user interface ]
+      action: modify
+      text: Kong Mesh user interface
+    - path: [ Kong Mesh in Production, Use Kuma ]
+      action: modify
+      text: Use Kong Mesh
+    - path: [ Kong Mesh in Production, Control plane deployment ]
+      action: insert
+      index: 0
+      text: Kong Mesh license
+      url: /production/cp-deployment/license
+    - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
+      action: modify
+      text: Kong Mesh API access control
+    - path: [ Kong Mesh in Production, Secure your deployment ]
+      action: insert
+      index: -1
+      text: Kong Mesh RBAC
+      url: /features/rbac
+    - path: [ Kong Mesh in Production, Secure your deployment ]
+      action: insert
+      index: -1
+      text: FIPS support
+      url: /features/fips-support
+    - path: [ Kong Mesh in Production, Data plane configuration, Configure the Kuma CNI ]
+      action: modify
+      text: Configure the Kong Mesh CNI
+    - path: [ Kong Mesh in Production, Upgrades and tuning, Upgrade Kuma ]
+      action: modify
+      text: Upgrade Kong Mesh
+    - path: [ Deploy ]
+      action: modify
+      icon: /assets/images/icons/documentation/icn-manager-color.svg
+    - path: [ Deploy, Explore Kuma with the Kubernetes demo app ]
+      text: Explore Kong Mesh with the Kubernetes demo app
+      action: modify
+      items: []
+    - path: [ Deploy, Explore Kuma with the Universal demo app ]
+      text: Explore Kong Mesh with the Universal demo app
+      action: modify
+      items: []
+    - path: [ Explore ]
+      action: modify
+      icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    - path: [ Networking ]
+      action: modify
+      icon: /assets/images/icons/documentation/icn-brain-color.svg
+    - path: [ Monitor & manage ]
+      action: modify
+      icon: /assets/images/icons/konnect/icn-analytics-nav.svg
+    - path: [ Policies ]
+      action: modify
+      icon: /assets/images/icons/documentation/icn-documentation-small.svg
+    - path: [ Policies, General notes about Kuma policies ]
+      text: General notes about Kong Mesh policies
+      url: /policies/general-notes-about-kong-mesh-policies
+      action: modify
+    - path: [ Policies, How Kuma chooses the right policy to apply ]
+      text: How Kong Mesh chooses the right policy to apply
+      action: modify
+      url: /policies/how-kong-mesh-chooses-the-right-policy-to-apply
+      items: []
+    - path: [ Policies, Protocol support in Kuma ]
+      text: Protocol support in Kong Mesh
+      action: modify
+      url: /policies/protocol-support-in-kong-mesh
+      items: []
+    - path: [ Policies ]
+      action: insert
+      index: -1
+      text: OPA policy
+      url: /features/opa
+      generate: false
+    - path: [ Policies ]
+      action: insert
+      index: -1
+      text: MeshOPA (beta)
+      url: /features/meshopa
+      generate: false
+    - path: [ Policies ]
+      action: insert
+      index: -1
+      text: MeshGlobalRateLimit (beta)
+      url: /features/meshglobalratelimit
+      generate: false
+    - title: Enterprise Features
+      action: insert
+      index: -3
+      icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
+      items:
+        - text: Overview
+          url: /features/
+        - text: HashiCorp Vault CA
+          url: /features/vault
+        - text: Amazon ACM Private CA
+          url: /features/acmpca
+        - text: cert-manager Private CA
+          url: /features/cert-manager
+        - text: OPA policy support
+          url: /features/opa
+        - text: MeshOPA (beta)
+          url: /features/meshopa
+        - text: Multi-zone authentication
+          url: /features/kds-auth
+        - text: FIPS support
+          url: /features/fips-support
+          generate: false
+        - text: Certificate Authority rotation
+          url: /features/ca-rotation
+        - text: Role-Based Access Control
+          url: /features/rbac
+          generate: false
+        - text: UBI Images
+          url: /features/ubi-images
+        - text: ECS Support
+          url: /installation/ecs
+        - text: Auditing
+          url: /features/access-audit
+        - text: MeshGlobalRateLimit (beta)
+          url: /features/meshglobalratelimit
+    - path: [ Reference ]
+      action: modify
+      icon: /assets/images/icons/documentation/icn-references-color.svg
+    - path: [ Community ]
+      action: modify
+      icon: /assets/images/icons/documentation/icn-references-color.svg
+    - path: [ Community ]
+      action: delete
+      entries: [ License ]
+    - path: [ Community, Contribute to Kuma ]
+      action: modify
+      src: null
+      absolute_url: true
+      url: https://kuma.io/community
+unlisted:
+  - url: /install
+    src: /mesh/install

--- a/app/_plugins/generators/seo/index_entry_builder.rb
+++ b/app/_plugins/generators/seo/index_entry_builder.rb
@@ -52,7 +52,7 @@ module SEO
     end
 
     def versioned_page?
-      /^\d+\.\d+\.x$/.match(url_segments[1]) || url_segments[1] == 'latest'
+      /^\d+\.\d+\.x$/.match(url_segments[1]) || url_segments[1] == 'latest' || url_segments[1] == 'dev'
     end
 
     def url_segments

--- a/app/_plugins/generators/utils/version.rb
+++ b/app/_plugins/generators/utils/version.rb
@@ -5,6 +5,9 @@ module Utils
     def self.to_version(input)
       # Latest should always be the top value
       return Gem::Version.new('9999.9.9') if input == 'latest'
+      # XXX: Mesh-only version, will change this when we add support for
+      # unreleased versions for all the products
+      return Gem::Version.new('9999.9.8') if input == 'dev'
 
       Gem::Version.new(input.gsub(/\.x$/, '.0'))
     end

--- a/app/_plugins/generators/versions.rb
+++ b/app/_plugins/generators/versions.rb
@@ -100,7 +100,10 @@ module Jekyll
             page.data['version'] = version_data['version']
             page.data['release'] = version_data['release']
             page.data['version_data'] = version_data
+            page.data['kong_version'] = parts[1]
           end
+
+          page.data['latest_released_version'] = latest_version_mesh['release']
         when 'konnect'
           page.data['edition'] = parts[0]
           page.data['kong_versions'] = konnect_versions

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -229,7 +229,7 @@ mesh_helm_repo_url: https://kong.github.io/kong-mesh-charts
 mesh_helm_repo_name: kong-mesh
 mesh_helm_repo: kong-mesh/kong-mesh
 mesh_helm_install_name: kong-mesh
-mesh_disabled_versions: [dev]
+mesh_disabled_versions: []
 # binary options
 mesh_install_archive_name: kong-mesh
 

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -216,7 +216,7 @@ mesh_helm_repo_url: https://kong.github.io/kong-mesh-charts
 mesh_helm_repo_name: kong-mesh
 mesh_helm_repo: kong-mesh/kong-mesh
 mesh_helm_install_name: kong-mesh
-mesh_disabled_versions: [dev]
+mesh_disabled_versions: []
 # binary options
 mesh_install_archive_name: kong-mesh
 

--- a/spec/app/_plugins/generators/seo/index_entry/versioned_page_spec.rb
+++ b/spec/app/_plugins/generators/seo/index_entry/versioned_page_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe SEO::IndexEntry::VersionedPage do
 
         it_behaves_like 'sets `seo_noindex` to true'
       end
+
+      context 'when the version is not yet released - `dev`' do
+        let(:page) { find_page_by_url('/mesh/dev/') }
+
+        it 'sets the `canonical_url`' do
+          expect(page.data['canonical_url']).to eq('/mesh/latest/')
+        end
+      end
     end
   end
 

--- a/spec/fixtures/app/_data/docs_nav_mesh_dev.yml
+++ b/spec/fixtures/app/_data/docs_nav_mesh_dev.yml
@@ -1,0 +1,10 @@
+product: mesh
+release: dev
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    items:
+      - text: Introduction to Kong Mesh
+        url: /mesh/dev/
+        absolute_url: true

--- a/spec/fixtures/app/_data/kong_versions.yml
+++ b/spec/fixtures/app/_data/kong_versions.yml
@@ -130,6 +130,10 @@
   version: "2.0.0"
   edition: "mesh"
   latest: true
+- release: "dev"
+  version: "preview"
+  edition: "mesh"
+  branch: "master"
 - release: "1.0.x"
   version: "1.0.0"
   edition: "kubernetes-ingress-controller"


### PR DESCRIPTION
### Description

Add a `dev` release for Kong Mesh.
This works as it does in Kuma so the mesh team can start using it for the next release.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

