### PR TITLE
update: Add generated mesh changelog to vale ignore list

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -98,6 +98,7 @@ jobs:
             app/_src/.repos/kuma/**
             app/gateway/2.7.x/**
             app/gateway/2.6.x/**
+            app/mesh/raw/CHANGELOG.md
           json: true
           quotepath: false
           escape_json: false


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
We keep getting a ton of Vale errors whenever the generated Mesh changelog is updated. All our other changelogs have vale off, but this one doesn't because it's autogenerated and that would wipe it out, so I had to add it to our linting file to ignore.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

