### PR TITLE
Don't run lighthouse on `dev`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,35 +13,68 @@
   autoLaunch = false
   targetPort = 4000
 
-[[plugins]]
+[[context.deploy-preview.plugins]]
   package = "@netlify/plugin-lighthouse"
 
-  [plugins.inputs.settings]
+  [context.deploy-preview.plugins.inputs.settings]
     preset = "desktop"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
     path = "hub"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
     path = "hub/kong-inc/jwt-signer/"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
     path = "hub/kong-inc/jwt-signer/configuration/"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
     path = "gateway/latest/"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
     path = "konnect"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
     path = "mesh/latest/"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
     path = "deck/latest/"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
     path = "kubernetes-ingress-controller/latest/"
 
-  [[plugins.inputs.audits]]
+  [[context.deploy-preview.plugins.inputs.audits]]
+    path = "konnect/analytics/use-cases/"
+
+[[context.production.plugins]]
+  package = "@netlify/plugin-lighthouse"
+
+  [context.production.plugins.inputs.settings]
+    preset = "desktop"
+
+  [[context.production.plugins.inputs.audits]]
+    path = "hub"
+
+  [[context.production.plugins.inputs.audits]]
+    path = "hub/kong-inc/jwt-signer/"
+
+  [[context.production.plugins.inputs.audits]]
+    path = "hub/kong-inc/jwt-signer/configuration/"
+
+  [[context.production.plugins.inputs.audits]]
+    path = "gateway/latest/"
+
+  [[context.production.plugins.inputs.audits]]
+    path = "konnect"
+
+  [[context.production.plugins.inputs.audits]]
+    path = "mesh/latest/"
+
+  [[context.production.plugins.inputs.audits]]
+    path = "deck/latest/"
+
+  [[context.production.plugins.inputs.audits]]
+    path = "kubernetes-ingress-controller/latest/"
+
+  [[context.production.plugins.inputs.audits]]
     path = "konnect/analytics/use-cases/"


### PR DESCRIPTION
### Description

Prevent lighthouse from running on `dev`, it was causing issues locally because the plugin requires an older node version

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

