### PR TITLE
Prevent link checker from running if `[skip ci]` is present in the PR's title

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -23,7 +23,7 @@ jobs:
       result: ${{ steps.labels.outputs.result }}
   build:
     needs: [check]
-    if: needs.check.outputs.result == 'false'
+    if: needs.check.outputs.result == 'false' && !contains(github.event.pull_request.title, "[skip ci]")
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
### Description

The broken link checker depends on the netfliy build and adding `[skip ci]` to a PR's title skips netlify from building the preview-app causing the link checker to fail.
Now we also prevent the link-checker from running if `[skip ci]` is present in the PR's title.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

