### PR TITLE
fix: Proxy TCP request

### DIFF
--- a/app/_includes/md/kic/prerequisites.md
+++ b/app/_includes/md/kic/prerequisites.md
@@ -38,6 +38,7 @@ Kubernetes exposes the proxy through a Kubernetes service. Run the following com
     ```bash
     HOST=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     PORT=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.spec.ports[0].port}')
+    export HOST=${HOST}
     export PROXY_IP=${HOST}:${PORT}
     echo $PROXY_IP   
     ```

--- a/app/_includes/md/kic/prerequisites.md
+++ b/app/_includes/md/kic/prerequisites.md
@@ -1,18 +1,60 @@
 <details markdown="1">
 <summary>
 <blockquote class="note">
-  <p style="cursor: pointer">Before you begin ensure that you have <u>Installed {{site.kic_product_name}} </u> in your Kubernetes cluster and are able to connect to Kong.</p>
+  <p style="cursor: pointer">Before you begin ensure that you have <u>Installed {{site.kic_product_name}}</u> {% unless include.disable_gateway_api %}with Gateway API support {% endunless %}in your Kubernetes cluster and are able to connect to Kong.</p>
 </blockquote>
 </summary>
 
-{% unless include.disable_gateway_api %}
-## Install the Gateway APIs
+## Prerequisites
 
-If you wish to use the Gateway APIs examples, ensure that you enable support for [
-Gateway APIs in KIC](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/install-gateway-apis).
+{% unless include.disable_gateway_api %}
+### Install the Gateway APIs
+
+Install the Gateway API CRDs before installing {{ site.kic_product_name }}:
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.1/standard-install.yaml
+```
+
+{% if include.gateway_api_experimental %}
+
+You will also need the experimental Gateway API CRDs to test this feature:
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.1/experimental-install.yaml
+```
+{% endif %}
+
+Finally, create a `Gateway` and `GatewayClass` instance to use:
+
+```bash
+echo "
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: kong
+  annotations:
+    konghq.com/gatewayclass-unmanaged: 'true'
+
+spec:
+  controllerName: konghq.com/kic-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: kong
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: proxy
+    port: 80
+    protocol: HTTP
+" | kubectl apply -f -
+```
+
 {% endunless %}
 
-## Prerequisites
 
 ### Install Kong
 You can install Kong in your Kubernetes cluster using [Helm](https://helm.sh/).
@@ -29,6 +71,14 @@ You can install Kong in your Kubernetes cluster using [Helm](https://helm.sh/).
     helm install kong kong/ingress -n kong --create-namespace
     ```
 
+{% if include.gateway_api_experimental %}
+1. Enable the Gateway API Alpha feature gate:
+
+    ```bash
+    kubectl set env -n kong deployment/kong-controller CONTROLLER_FEATURE_GATES="GatewayAlpha=true" -c ingress-controller
+    ```
+{% endif %}
+
 ### Test connectivity to Kong
 
 Kubernetes exposes the proxy through a Kubernetes service. Run the following commands to store the load balancer IP address in a variable named `PROXY_IP`:
@@ -38,8 +88,7 @@ Kubernetes exposes the proxy through a Kubernetes service. Run the following com
     ```bash
     HOST=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     PORT=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpath='{.spec.ports[0].port}')
-    export HOST=${HOST}
-    export PROXY_IP=${HOST}:${PORT}
+    export PROXY_IP=${HOST}
     echo $PROXY_IP   
     ```
 

--- a/app/_src/kubernetes-ingress-controller/guides/services/tcp.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tcp.md
@@ -1,6 +1,353 @@
 ---
-title: TCP
+title: Proxy TCP request
 type: how-to
 purpose: |
   How to proxy TCP requests
 ---
+## Overview
+
+Create TCP routing configuration for {{site.base_gateway}} in Kubernetes using either the `TCPIngress` custom resource or `TCPRoute` and `TLSRoute` Gateway APIs resource.
+
+TCP-based Ingress means that {{site.base_gateway}} forwards the TCP stream to a Pod of a Service that's running inside Kubernetes. {{site.base_gateway}} does not perform any sort of transformations.
+
+There are two modes available:
+- **Port based routing**: {{site.base_gateway}} simply proxies all traffic it receives on a specific port to the Kubernetes Service. TCP connections are load balanced across all the available Pods of the Service.
+- **SNI based routing**: {site.base_gateway}} accepts a TLS-encrypted stream at the specified port and can route traffic to different services based on the `SNI` present in the TLS handshake. {{site.base_gateway}} also terminates the TLS handshake and forward the TCP stream to the Kubernetes Service.
+
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false%}
+
+### Install OpenSSL
+### 
+
+## Expose additional ports
+
+{{site.base_gateway}} does not include any TCP listen configuration by default. To expose TCP listens, update the Deployment's environment variables and port configuration.
+
+1. Update the Deployment.
+    ```bash
+    kubectl patch deploy -n kong kong-gateway --patch '{
+      "spec": {
+        "template": {
+          "spec": {
+            "containers": [
+              {
+                "name": "proxy",
+                "env": [
+                  {
+                    "name": "KONG_STREAM_LISTEN",
+                    "value": "0.0.0.0:9000, 0.0.0.0:9443 ssl"
+                  }
+                ],
+                "ports": [
+                  {
+                    "containerPort": 9000,
+                    "name": "stream9000",
+                    "protocol": "TCP"
+                  },
+                  {
+                    "containerPort": 9443,
+                    "name": "stream9443",
+                    "protocol": "TCP"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }'
+    ```
+    The results should look like this:
+    ```text
+    deployment.apps/kong-gateway patched
+    ```
+
+    The `ssl` parameter after the 9443 listen instructs {{site.base_gateway}} to expect TLS-encrypted TCP traffic on that port. The 9000 listen has no parameters, and expects plain TCP traffic.
+
+1.  Update the proxy Service to indicate the new ports.
+
+    ```bash
+    kubectl patch service -n kong kong-gateway-proxy --patch '{
+      "spec": {
+        "ports": [
+          {
+            "name": "stream9000",
+            "port": 9000,
+            "protocol": "TCP",
+            "targetPort": 9000
+          },
+          {
+            "name": "stream9443",
+            "port": 9443,
+            "protocol": "TCP",
+            "targetPort": 9443
+          }
+        ]
+      }
+    }'
+    ```
+    The results should look like this:
+    ```text
+    service/kong-gateway-proxy patched
+    ```
+1.  Configure TCPRoute (Gateway API Only)
+
+    {:.note}
+    > If you are using the Gateway APIs (TCPRoute), your Gateway needs additional configuration under `listeners`. 
+
+    ```bash
+    kubectl patch --type=json gateway kong -p='[
+        {
+            "op":"add",
+            "path":"/spec/listeners/-",
+            "value":{
+                "name":"stream9000",
+                "port":9000,
+                "protocol":"TCP"
+            }
+        },
+        {
+            "op":"add",
+            "path":"/spec/listeners/-",
+            "value":{
+                "name":"stream9443",
+                "port":9443,
+                "protocol":"TLS",
+                "hostname":"tls9443.kong.example",
+                "tls": {
+                    "certificateRefs":[{
+                        "group":"",
+                        "kind":"Secret",
+                        "name":"tls9443.kong.example"
+                     }]
+                }
+            }
+        }
+    ]'
+    ```
+    The results should look like this:
+    ```text
+    gateway.gateway.networking.k8s.io/kong patched
+    ```
+
+## Install TCP echo service
+
+Install an example TCP service:
+
+```bash
+kubectl apply -f {{site.links.web}}/assets/kubernetes-ingress-controller/examples/echo-service.yaml
+```
+The results should look like this:
+```text
+service/echo created
+deployment.apps/echo created
+```
+
+## Route based on ports
+
+To expose the service to the outside world, create a TCPRoute resource for Gateway APIs or a TCPIngress resource for Ingress.
+
+{% navtabs api %}
+{% navtab Gateway APIs %}
+```bash
+echo "apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: echo-plaintext
+spec:
+  parentRefs:
+  - name: kong
+  rules:
+  - backendRefs:
+    - name: echo
+      port: 1025
+" | kubectl apply -f -
+```
+
+{:.note}
+> v1alpha2 TCPRoutes do not support separate proxy and upstream ports. Traffic
+> is redirected to `1025` upstream via Service configuration.
+
+The results should look like this:
+```text
+tcproute.gateway.networking.k8s.io/echo-plaintext created
+```
+{% endnavtab %}
+{% navtab Ingress %}
+```bash
+echo "apiVersion: configuration.konghq.com/v1beta1
+kind: TCPIngress
+metadata:
+  name: echo-plaintext
+  annotations:
+    kubernetes.io/ingress.class: kong
+spec:
+  rules:
+  - port: 9000
+    backend:
+      serviceName: echo
+      servicePort: 1025
+" | kubectl apply -f -
+```
+The results should look like this:
+```text
+tcpingress.configuration.konghq.com/echo-plaintext created
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+This configuration instructs {{site.base_gateway}} to forward all traffic it
+receives on port 9000 to `echo` service on port 1025.
+
+### Test the configuration
+
+1. Check if the Service is ready on the route.
+    {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Gateway APIs%}
+```bash
+kubectl get tcproute echo-plaintext -ojsonpath='{.status.parents[0].conditions[?(@.reason=="Accepted")]}'
+```
+{% endnavtab %}
+{% navtab Ingress %}
+```bash
+kubectl get tcpingress
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+    The results should look like this:
+
+    {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Gateway APIs %}
+```text
+{"lastTransitionTime":"2022-11-14T19:48:51Z","message":"","observedGeneration":2,"reason":"Accepted","status":"True","type":"Accepted"}
+
+```
+{% endnavtab %}
+{% navtab Ingress %}
+```text
+NAME             ADDRESS        AGE
+echo-plaintext   192.0.2.3   3m18s
+
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+1. Connect to this service using `telnet`.
+    ```shell
+    $ telnet $HOST 9000
+    ```
+
+    After you  connect, type some text that you want as a response from the echo Service. 
+    ```
+    Trying 192.0.2.3...
+    Connected to 192.0.2.3.
+    Escape character is '^]'.
+    Welcome, you are connected to node gke-harry-k8s-dev-pool-1-e9ebab5e-c4gw.
+    Running on Pod echo-844545646c-gvmkd.
+    In namespace default.
+    With IP address 192.0.2.7.
+    This text will be echoed back.
+    This text will be echoed back.
+    ^]
+    telnet> Connection closed.
+    ```
+    To exit, press `ctrl+]` then `ctrl+d`.
+
+    The `echo` Service is now available outside the Kubernetes cluster through {{site.base_gateway}}.
+
+## Route based on SNI
+
+{% include_cached /md/kic/add-certificate.md hostname='tls9443.kong.example' kong_version=page.kong_version %}
+
+1. Create the TCPIngress resource to route TLS-encrypted traffic to the `echo` service.
+  {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Gateway APIs%}
+```bash
+echo "apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: echo-tls
+spec:
+  parentRefs:
+  - name: kong
+  hostnames:
+  - tls9443.kong.example
+  rules:
+  - backendRefs:
+    - name: echo
+      port: 9443
+" | kubectl apply -f -
+```
+{% endnavtab %}
+{% navtab Ingress %}
+```bash
+echo "apiVersion: configuration.konghq.com/v1beta1
+kind: TCPIngress
+metadata:
+  name: echo-tls
+  annotations:
+    kubernetes.io/ingress.class: kong
+spec:
+  tls:
+  - hosts:
+    - tls9443.kong.example
+    secretName: tls9443.kong.example
+  rules:
+  - host: tls9443.kong.example
+    port: 9443
+    backend:
+      serviceName: echo
+      servicePort: 1025
+" | kubectl apply -f -
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+    The results should look like this:
+
+    {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Gateway APIs %}
+```text
+tcproute.gateway.networking.k8s.io/echo-tls created
+```
+{% endnavtab %}
+{% navtab Ingress %}
+```text
+tcpingress.configuration.konghq.com/echo-tls created
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+
+### Test the configuration
+
+You can now access the `echo` service on port 9443 with SNI `tls9443.kong.example`.
+
+In real-world usage, you would create a DNS record for `tls9443.kong.example`pointing to your proxy Service's public IP address, which causes TLS clients to add SNI automatically. For this demo, add it manually using the OpenSSL CLI.
+
+```bash
+echo "hello" | openssl s_client -connect $HOST:9443 -servername tls9443.kong.example -quiet 2>/dev/null 
+```
+Press Ctrl+C to exit.
+
+The results should look like this:
+```text
+Welcome, you are connected to node kind-control-plane.
+Running on Pod echo-5f44d4c6f9-krnhk.
+In namespace default.
+With IP address 10.244.0.26.
+hello
+```

--- a/app/_src/kubernetes-ingress-controller/guides/services/tcp.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tcp.md
@@ -16,9 +16,6 @@ There are two modes available:
 
 {% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false%}
 
-### Install OpenSSL
-### 
-
 ## Expose additional ports
 
 {{site.base_gateway}} does not include any TCP listen configuration by default. To expose TCP listens, update the Deployment's environment variables and port configuration.

--- a/app/_src/kubernetes-ingress-controller/guides/services/tcp.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tcp.md
@@ -1,13 +1,11 @@
 ---
-title: Proxy TCP request
+title: Proxy TCP requests
 type: how-to
 purpose: |
   How to proxy TCP requests
 ---
-## Overview
 
 Create TCP routing configuration for {{site.base_gateway}} in Kubernetes using either the `TCPIngress` custom resource or `TCPRoute` and `TLSRoute` Gateway APIs resource.
-
 TCP-based Ingress means that {{site.base_gateway}} forwards the TCP stream to a Pod of a Service that's running inside Kubernetes. {{site.base_gateway}} does not perform any sort of transformations.
 
 There are two modes available:


### PR DESCRIPTION
### Description

- port the TCP guide to 3.0
- tested and validated for ingress
- installed Gateway API and tested however, there is an error that reads: "Error from server (NotFound): gateways.gateway.networking.k8s.io "kong" not found"  step3 of **Expose additional ports** section
 steps to reproduce: start the cluster, install the CRD "kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.8.1/experimental-install.yaml", then enable the feature " kubectl set env -n kong deployment/ingress-kong CONTROLLER_FEATURE_GATES="GatewayAlpha=true" -c ingress-controller" only change the <deployment > is 'kong-controller'

- set $HOST as a variable in the prerequisite because the steps use Host and not  PROXY_IP
- made GatewayAPI the default tab in the steps.
[tcpingressworking3.txt](https://github.com/Kong/docs.konghq.com/files/12871965/tcpingressworking3.txt)



 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

