### PR TITLE
Set repository to ${{ github.event.pull_request.head.repo.full_name }}

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository:  ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### Description

Fixes Vale for forks

See https://github.com/Kong/docs.konghq.com/actions/runs/6493878637/job/17635740287

From the logs:
```
  Warning: Unable to find merge base between X and Y
  Warning: Error checking commit history
  Warning: If this pull request is from a forked repository, please set the checkout action `repository` input to the same repository as the pull request.
  Warning: This can be done by setting actions/checkout `repository` to ${{ github.event.pull_request.head.repo.full_name }}
```

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

