### PR TITLE
fix: External Service

### DIFF
--- a/app/_includes/md/kic/http-test-routing-resource.md
+++ b/app/_includes/md/kic/http-test-routing-resource.md
@@ -5,31 +5,6 @@
 {%- assign port = include.port | default: '1027' %}
   {% capture the_code %}
 {% navtabs api %}
-{% navtab Ingress %}
-```bash
-echo "
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ name }}
-  annotations:
-    konghq.com/strip-path: 'true'
-spec:
-  ingressClassName: kong
-  rules:
-  - host: {{ hostname }}
-    http:
-      paths:
-      - path: {{ path }}
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: {{ service }}
-            port:
-              number: {{ port }}
-" | kubectl apply -f -
-```
-{% endnavtab %}
 {% navtab Gateway APIs %}
 ```bash
 echo "
@@ -56,22 +31,47 @@ spec:
 " | kubectl apply -f -
 ```
 {% endnavtab %}
+{% navtab Ingress %}
+```bash
+echo "
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ name }}
+  annotations:
+    konghq.com/strip-path: 'true'
+spec:
+  ingressClassName: kong
+  rules:
+  - host: {{ hostname }}
+    http:
+      paths:
+      - path: {{ path }}
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ service }}
+            port:
+              number: {{ port }}
+" | kubectl apply -f -
+```
+{% endnavtab %}
 {% endnavtabs %}
 {% endcapture %}
 {{ the_code | indent }}
 
-The results should look like this:
+     The results should look like this:
 
-{% capture the_code %}
+     {% capture the_code %}
 {% navtabs codeblock %}
-{% navtab ingress %}
-```text
-ingress.networking.k8s.io/{{ name }} created
-```
-{% endnavtab %}
 {% navtab Gateway APIs %}
 ```text
 httproute.gateway.networking.k8s.io/{{ name }} created
+```
+{% endnavtab %}
+{% navtab Ingress%}
+```text
+ingress.networking.k8s.io/{{ name }} created
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_includes/md/kic/http-test-routing-resource.md
+++ b/app/_includes/md/kic/http-test-routing-resource.md
@@ -17,9 +17,9 @@ metadata:
 spec:
   parentRefs:
   - name: kong
-  hostnames:
+{% unless include.skip_host %}  hostnames:
   - '{{ hostname }}'
-  rules:
+{% endunless %}  rules:
   - matches:
     - path:
         type: PathPrefix
@@ -43,8 +43,8 @@ metadata:
 spec:
   ingressClassName: kong
   rules:
-  - host: {{ hostname }}
-    http:
+  - {% unless include.skip_host %}host: {{ hostname }}
+    {% endunless %}http:
       paths:
       - path: {{ path }}
         pathType: ImplementationSpecific

--- a/app/_src/kubernetes-ingress-controller/guides/services/external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/external.md
@@ -7,7 +7,7 @@ purpose: |
 
 Expose a service located outside the Kubernetes cluster using an Ingress.
 
-{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false %}
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version %}
 
 ## Create a Kubernetes Service
 
@@ -33,12 +33,12 @@ Expose a service located outside the Kubernetes cluster using an Ingress.
     ```    
 1. Create an Ingress to expose the service at the path `/httpbin`
 
-    {% include_cached /md/kic/http-test-routing-resource.md kong_version=page.kong_version path='/httpbin' name='proxy-from-k8s-to-httpbin' service='proxy-to-httpbin' port='80' %}
+    {% include_cached /md/kic/http-test-routing-resource.md kong_version=page.kong_version path='/httpbin' name='proxy-from-k8s-to-httpbin' service='proxy-to-httpbin' port='80' skip_host=true %}
 
 ## Test the Service
 
 ```bash
-curl -i -H 'Host:kong.example' $PROXY_IP/httpbin/anything
+curl -i $PROXY_IP/httpbin/anything
 ```
 The results should look like this:
 ```

--- a/app/_src/kubernetes-ingress-controller/guides/services/external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/external.md
@@ -4,3 +4,72 @@ type: how-to
 purpose: |
   How to proxy traffic to an external service
 ---
+
+Expose a service located outside the Kubernetes cluster using an Ingress.
+
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=true %}
+
+## Create a Kubernetes Service
+
+1. Deploy a Kubernetes Service [type=ExternalName][0] using the hostname of the application you want to expose.
+
+    ```bash
+    echo "
+    kind: Service
+    apiVersion: v1
+    metadata:
+      name: proxy-to-httpbin
+    spec:
+      ports:
+      - protocol: TCP
+        port: 80
+      type: ExternalName
+      externalName: httpbin.org
+    " | kubectl apply -f -
+    ```
+    The results should look like this:
+    ```
+    service/proxy-to-httpbin created
+    ```    
+1. Create an Ingress to expose the service at the path `/httpbin`
+
+    {% include_cached /md/kic/http-test-routing-resource.md kong_version=page.kong_version path='/httpbin' name='proxy-from-k8s-to-httpbin' service='proxy-to-httpbin' port='80' %}
+
+## Test the Service
+
+```bash
+curl -i -H 'Host:kong.example' $PROXY_IP/httpbin/anything
+```
+The results should look like this:
+```
+HTTP/1.1 200 OK
+Date: Thu, 15 Dec 2022 21:31:47 GMT
+Content-Type: application/json
+Content-Length: 341
+Connection: keep-alive
+Server: gunicorn/19.9.0
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Credentials: true
+X-Kong-Upstream-Latency: 2
+X-Kong-Proxy-Latency: 1
+Via: kong/3.1.1
+
+{
+  "args": {},
+  "data": "",
+  "files": {},
+  "form": {},
+  "headers": {
+    "Accept": "*/*",
+    "Host": "httpbin.org",
+    "User-Agent": "curl/7.86.0",
+    "X-Amzn-Trace-Id": "Root=1-639b9243-7cdb670008b8189a5948d619"
+  },
+  "json": null,
+  "method": "GET",
+  "origin": "136.25.153.9",
+  "url": "http://httpbin.org/anything"
+}
+```
+
+[0]: https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors

--- a/app/_src/kubernetes-ingress-controller/guides/services/external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/external.md
@@ -7,7 +7,7 @@ purpose: |
 
 Expose a service located outside the Kubernetes cluster using an Ingress.
 
-{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=true %}
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false %}
 
 ## Create a Kubernetes Service
 


### PR DESCRIPTION
### Description

tested and validates the guide however, even after installing the CRDs and the Gateway APIs, the [test service](http://localhost:8888/kubernetes-ingress-controller/latest/guides/services/external/#test-the-service) gives 
```
HTTP/1.1 404 Not Found
Date: Thu, 12 Oct 2023 11:23:43 GMT
Content-Type: application/json; charset=utf-8
Connection: keep-alive
Content-Length: 52
X-Kong-Response-Latency: 0
Server: kong/3.4.0

{
  "message":"no Route matched with those values"
}%
```


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

