### PR TITLE
update: Remove Gateway 3.0 from supported versions and move to older versions table

### DIFF
--- a/app/_src/gateway/support/browser.md
+++ b/app/_src/gateway/support/browser.md
@@ -20,9 +20,6 @@ Kong supports N-1 versions of Edge, Chrome, Firefox and Safari on desktop plus a
   {% navtab 3.1 %}
     {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.31 %}
   {% endnavtab %}
-  {% navtab 3.0 %}
-    {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.30 %}
-  {% endnavtab %}
   {% navtab 2.8 LTS %}
     {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.28 %}
   {% endnavtab %}

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -59,9 +59,6 @@ Kong supports the following versions of {{site.ee_product_name}}:
   {% navtab 3.1 %}
     {% include_cached gateway-support.html version="3.1" data=site.data.tables.support.gateway.versions.31 eol="Dec 2023" %}
   {% endnavtab %}
-  {% navtab 3.0 %}
-    {% include_cached gateway-support.html version="3.0" data=site.data.tables.support.gateway.versions.30 eol="Sept 2023" %}
-  {% endnavtab %}
   {% navtab 2.8 LTS %}
     {% include_cached gateway-support.html version="2.8 LTS" data=site.data.tables.support.gateway.versions.28  eol="March 2025" %}
   {% endnavtab %}
@@ -73,6 +70,7 @@ These versions have reached the end of full support.
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  3.0.x.x |  2022-09-09   |     2023-09-09      |      2024-09-09       |
 |  2.7.x.x |  2021-12-16   |     2023-02-24      |      2024-08-24       |
 |  2.6.x.x |  2021-10-14   |     2023-02-24      |      2024-08-24       |
 |  2.5.x.x |  2021-08-03   |     2022-08-24      |      2023-08-24       |

--- a/app/_src/gateway/support/third-party.md
+++ b/app/_src/gateway/support/third-party.md
@@ -23,9 +23,6 @@ Unless otherwise noted, Kong supports the last 2 versions any third party tool, 
   {% navtab 3.1 %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.31 %}
   {% endnavtab %}
-  {% navtab 3.0 %}
-    {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.30 %}
-  {% endnavtab %}
   {% navtab 2.8 LTS %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.28 %}
   {% endnavtab %}


### PR DESCRIPTION
### Description

Support for Gateway 3.0 was removed in September, so we needed to update our support version docs to reflect that.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3519
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

