### PR TITLE
Fix: Konnect OIDC sign-in & sign-out redirect URIs

### DIFF
--- a/app/konnect/org-management/oidc-idp.md
+++ b/app/konnect/org-management/oidc-idp.md
@@ -17,7 +17,7 @@ using their IdP credentials, without needing a separate login.
 
 ## Set up SSO in {{site.konnect_short_name}}
 
-1. In [{{site.konnect_saas}}](https://cloud.konghq.com), click {% konnect_icon organizations %} **Organization**, and then **Auth Settings**.
+1. In [{{site.konnect_saas}}](https://cloud.konghq.com/login), click {% konnect_icon organizations %} **Organization**, and then **Auth Settings**.
 
 1. Click **Configure provider** for **OIDC**.
 
@@ -45,7 +45,7 @@ using their IdP credentials, without needing a separate login.
 {:.important}
 > **Important:** Keep built-in authentication enabled while you are testing IdP authentication. Only disable built-in authentication after successfully testing IdP authentication.
 
-You can test the SSO configuration by navigating to the login URI based on the organization login path you set earlier. For example: `cloud.konghq.com/login/examplepath`. If your configuration is set up correctly, you will see the IdP sign-in window.
+You can test the SSO configuration by navigating to the login URI based on the organization login path you set earlier. For example: `https://cloud.konghq.com/login/examplepath` where `examplepath` is the unique login path string set in the steps above. If your configuration is set up correctly, you will see the IdP sign-in page.
 
 You can now manage your organization's user permissions entirely from the IdP
 application.

--- a/app/konnect/org-management/oidc-idp.md
+++ b/app/konnect/org-management/oidc-idp.md
@@ -45,7 +45,9 @@ using their IdP credentials, without needing a separate login.
 {:.important}
 > **Important:** Keep built-in authentication enabled while you are testing IdP authentication. Only disable built-in authentication after successfully testing IdP authentication.
 
-You can test the SSO configuration by navigating to the login URI based on the organization login path you set earlier. For example: `https://cloud.konghq.com/login/examplepath` where `examplepath` is the unique login path string set in the steps above. If your configuration is set up correctly, you will see the IdP sign-in page.
+You can test the SSO configuration by navigating to the login URI based on the organization login path you set earlier. For example: `https://cloud.konghq.com/login/examplepath`, where `examplepath` is the unique login path string set in the steps above. 
+
+If your configuration is set up correctly, you will see the IdP sign-in page.
 
 You can now manage your organization's user permissions entirely from the IdP
 application.


### PR DESCRIPTION
### Description

Fixes the reported issue in Jira [DOCU-3311](https://konghq.atlassian.net/browse/DOCU-3311) which was causing confusion with the `examplepath` name in the testing section of the login URL.

### Testing instructions

N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

[DOCU-3311]: https://konghq.atlassian.net/browse/DOCU-3311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ