### PR TITLE
Update: SSH access note for instances deployed using Konnect Tech Preview install platforms

### DIFF
--- a/app/konnect/gateway-manager/data-plane-nodes/index.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/index.md
@@ -38,6 +38,7 @@ Advanced setup:
 > * Gateway Manager includes a feature called Control Plane Launcher which can be used with any of AWS, Azure, or GCP. This feature is currently in tech preview.
 > * Kong does not host data plane nodes. You must install and host your own.
 > * Gateway Manager allows users to select the {{site.base_gateway}} version that they want for their Quickstart scripts (except for cloud provider quickstart scripts for AWS, Azure, and GCP). This allows you to leverage official {{site.konnect_short_name}} scripts to start your gateways while reducing the number of errors due to an invalid script for a certain {{site.base_gateway}} version.
+> * SSH access to Konnect data planes must be done using the cloud provider's tools when using [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html), [Azure](https://learn.microsoft.com/en-us/azure/cloud-shell/overview), and [Google Cloud](https://cloud.google.com/compute/docs/instances/ssh) advanced setups. Direct SSH access is not possible as the keys are randomly generated and not exposed.
 
 ### Forward proxy support
 

--- a/app/konnect/gateway-manager/data-plane-nodes/index.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/index.md
@@ -38,7 +38,7 @@ Advanced setup:
 > * Gateway Manager includes a feature called Control Plane Launcher which can be used with any of AWS, Azure, or GCP. This feature is currently in tech preview.
 > * Kong does not host data plane nodes. You must install and host your own.
 > * Gateway Manager allows users to select the {{site.base_gateway}} version that they want for their Quickstart scripts (except for cloud provider quickstart scripts for AWS, Azure, and GCP). This allows you to leverage official {{site.konnect_short_name}} scripts to start your gateways while reducing the number of errors due to an invalid script for a certain {{site.base_gateway}} version.
-> * SSH access to Konnect data planes must be done using the cloud provider's tools when using [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html), [Azure](https://learn.microsoft.com/en-us/azure/cloud-shell/overview), and [Google Cloud](https://cloud.google.com/compute/docs/instances/ssh) advanced setups. Direct SSH access is not possible as the keys are randomly generated and not exposed.
+> * SSH access to Konnect data planes must be done using the cloud provider's tools when using [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html), [Azure](https://learn.microsoft.com/azure/cloud-shell/overview), and [Google Cloud](https://cloud.google.com/compute/docs/instances/ssh) advanced setups. Direct SSH access isn't possible because the keys are randomly generated and not exposed.
 
 ### Forward proxy support
 


### PR DESCRIPTION
### Description

Add a note about SSH access to Konnect data plane nodes when using the AWS, Azure, or GCP deployment styles and how it's not allowed directly but need to use the cloud provider tools.

Raised in Slack: https://kongstrong.slack.com/archives/C03NRECFJPM/p1691689181346589

### Testing instructions

N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)