### PR TITLE
Fix full broken link checker.

### DIFF
--- a/tools/broken-link-checker/full.js
+++ b/tools/broken-link-checker/full.js
@@ -48,7 +48,13 @@ const { SiteChecker } = require("broken-link-checker");
       } else {
         const x = info.split("_");
         item.type = lookup[x[0]];
-        item.version = semver.coerce(x[1]).raw;
+
+        // Handle kuma_dev gracefully
+        if (semver.valid(semver.coerce(x[1]))) {
+          item.version = semver.coerce(x[1]).raw;
+        } else {
+          item.version = x[1];
+        }
         item.original_version = x[1];
       }
       return item;
@@ -62,11 +68,13 @@ const { SiteChecker } = require("broken-link-checker");
     const t = nav.type;
     const existing = current[t];
     if (existing) {
-      if (semver.gt(nav.version, existing.version)) {
-        ignored.push(existing);
-        current[t] = nav;
-      } else {
-        ignored.push(nav);
+      if (semver.valid(nav.version)) {
+        if (semver.gt(nav.version, existing.version)) {
+          ignored.push(existing);
+          current[t] = nav;
+        } else {
+          ignored.push(nav);
+        }
       }
     } else {
       current[t] = nav;


### PR DESCRIPTION
### Description

It started to fail after we introduced `app/_data/docs_nav_mesh_dev.yml` because it tried to parse `dev` as a valid version.

![Screenshot 2023-10-13 at 10 05 40](https://github.com/Kong/docs.konghq.com/assets/715229/0fe30493-a898-4d19-90e7-89d14e11cc58)



### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

