### PR TITLE
DOCU-3435: Find in page counts hidden elements in the result

### DIFF
--- a/app/_assets/stylesheets/accordion.less
+++ b/app/_assets/stylesheets/accordion.less
@@ -23,6 +23,7 @@
           + div {
             opacity: 1;
             max-height: 2000vh;
+            visibility: visible;
           }
         }
       }
@@ -77,6 +78,7 @@
 
     div {
       overflow: hidden;
+      visibility: hidden;
       max-height: 0;
       opacity: 0;
       transition: all 0.25s linear;


### PR DESCRIPTION
### Description

This was caused due to the way the sidebar items (accordion items) expanded and collapsed.
When an accordion item was "collapsed", its:
* max-height was set to 0
* opacity was set to 1 so technically even though they were "hidden" to the naked eye, they were still "visible".

This caused Chrome's and Firefox's `find in page` to count the supposedly "hidden" occurrences of the searched text as part of the results.

Setting the visibility to `hidden` when the item is collapsed, and to `visible` when it is expanded fixed the issue.

#### Reported page
Prod:
![Screenshot 2023-08-24 at 9 07 54 AM](https://github.com/Kong/docs.konghq.com/assets/715229/2bdb8853-5cce-4355-84ed-343ab04989d3)

Preview app:
<img width="1759" alt="Screenshot 2023-10-17 at 17 33 35" src="https://github.com/Kong/docs.konghq.com/assets/715229/fb49ea9f-a4cf-4784-9672-d84ce36c1ae8">


### Testing instructions

[Preview link](https://deploy-preview-6325--kongdocs.netlify.app/mesh/latest/introduction/about-service-meshes/)



### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

