### PR TITLE
Fix: Kong Gateway support matrix

### DIFF
--- a/app/_data/tables/support/gateway/packages.yml
+++ b/app/_data/tables/support/gateway/packages.yml
@@ -13,6 +13,7 @@ _packages:
     arm: false
     fips: false
     graviton: false
+    eol: December 2020
   amazonlinux2: &amazonlinux2
     os: Amazon Linux
     version: 2
@@ -48,6 +49,7 @@ _packages:
     arm: false
     fips: false
     graviton: false
+    eol: June 2020
   debian9: &debian9
     os: Debian
     version: 9
@@ -55,6 +57,7 @@ _packages:
     arm: false
     fips: false
     graviton: false
+    eol: June 2022
   debian10: &debian10
     os: Debian
     version: 10

--- a/app/_data/tables/support/gateway/third-party.yml
+++ b/app/_data/tables/support/gateway/third-party.yml
@@ -6,9 +6,6 @@ _third_party:
       - 14
       - 13
       - 12
-      - 11
-      - 10
-      - 9
       - Amazon RDS
     icon: postgresql.svg
   cassandra: &cassandra

--- a/app/_data/tables/support/gateway/versions/28.yml
+++ b/app/_data/tables/support/gateway/versions/28.yml
@@ -9,19 +9,24 @@ distributions:
   - <<: *rhel7
     docker: true
     eol: June 2024
-  - *rhel8
-  - *amazonlinux2
+  - <<: *rhel8
+    docker: true
+  - <<: *amazonlinux2
+    docker: true
   - <<: *centos7
     docker: true
     eol: June 2024
-  - *centos8
+  - <<: *centos8
+    eol: December 2021
   - <<: *debian10
+    docker: true
     eol: June 2024
   - *debian11
   - <<: *ubuntu1804
     eol: April 2023
   - *ubuntu2004
-  - *ubuntu2204
+  - <<: *ubuntu2204
+    docker: true
 
 third-party:
   datastore:

--- a/app/_data/tables/support/gateway/versions/31.yml
+++ b/app/_data/tables/support/gateway/versions/31.yml
@@ -8,9 +8,12 @@ distributions:
   - <<: *rhel7
     docker: true
   - <<: *rhel8
+    docker: true
     fips: true
-  - *amazonlinux2
-  - *amazonlinux2023
+  - <<: *amazonlinux2
+    docker: true
+  - <<: *amazonlinux2023
+    docker: true
   - <<: *debian10
     docker: true
   - *debian11
@@ -20,6 +23,7 @@ distributions:
     fips: true
   - <<: *ubuntu2204
     fips: true
+    docker: true
 
 third-party:
   datastore:

--- a/app/_data/tables/support/gateway/versions/33.yml
+++ b/app/_data/tables/support/gateway/versions/33.yml
@@ -43,9 +43,6 @@ third-party:
         - 14
         - 13
         - 12
-        - 11
-        - 10
-        - 9
         - Amazon RDS
         - Amazon Aurora
     - *cassandra

--- a/app/_data/tables/support/gateway/versions/34.yml
+++ b/app/_data/tables/support/gateway/versions/34.yml
@@ -8,15 +8,18 @@ distributions:
     docker: true
     arm: true
     graviton: true
+    eol: June 2025
   - <<: *amazonlinux2023
     docker: true
     arm: true
     graviton: true
-  - *debian10
+  - <<: *debian10
+    eol: June 2024
   - <<: *debian11
     docker: true
     arm: true
     graviton: true
+    eol: June 2026
   - *rhel7
   - <<: *rhel8
     docker: false
@@ -29,6 +32,7 @@ distributions:
     arm: false
     docker: false
     fips: true
+    eol: May 2025
   - <<: *ubuntu2204
     arm: true
     graviton: true
@@ -43,9 +47,6 @@ third-party:
         - 14
         - 13
         - 12
-        - 11
-        - 10
-        - 9
         - Amazon RDS
         - Amazon Aurora
     - *redis

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1096,7 +1096,7 @@ configuration property to `kong.conf` to constrain the `Kong-Debug` header for d
       
 ### Features
 
-* The base OS for our convenience Docker tags (for example, `latest`, `3.2.1.0`, `3.2`) has switched from Debian to Ubuntu.
+* The base operating system (OS) for our convenience Docker tags (for example, `latest`, `3.2.1.0`, `3.2`) has switched from Debian to Ubuntu.
 
 #### Core
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1096,6 +1096,8 @@ configuration property to `kong.conf` to constrain the `Kong-Debug` header for d
       
 ### Features
 
+* The base OS for our convenience Docker tags (for example, `latest`, `3.2.1.0`, `3.2`) has switched from Debian to Ubuntu.
+
 #### Core
 
 * When `router_flavor` is set to`traditional_compatible`, Kong Gateway verifies routes created 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1096,7 +1096,7 @@ configuration property to `kong.conf` to constrain the `Kong-Debug` header for d
       
 ### Features
 
-* The base operating system (OS) for our convenience Docker tags (for example, `latest`, `3.2.1.0`, `3.2`) has switched from Debian to Ubuntu.
+* Changed the underlying operating system (OS) for our convenience Docker tags (for example, `latest`, `3.2.1.0`, `3.2`) from Debian to Ubuntu.
 
 #### Core
 


### PR DESCRIPTION
### Description

Fixing the following issues with the [Kong Gateway support matrix](https://docs.konghq.com/gateway/latest/support-policy/):
* PostgreSQL 9 and 10 are no longer supported by upstream but our docs claim to support them. Also, PostgreSQL 11 is also going out of support in 3 weeks
* Our support policy doc incorrectly stated the EOLs of many OSes. We have this statement (adjusted for dates/versions) at the top of every version's support table:

  " Kong Gateway 2.8 LTS supports the following deployment targets until March 2025, unless otherwise noted by an earlier OS vendor end of life (EOL) date." 

  However, our support tables aren't listing the accurate "earlier OS vendor end of life (EOL) dates".

* The support table inaccurately lists available Docker images. We have many new Docker images available now that weren't listed (especially for 2.8 LTS).
  
  As I was trying to figure out which versions we have images for, I also noticed that the base OS for our convenience images changed once again in 3.2.1.0. It originally switched from Alpine to Debian in 3.0.0.0, which is already in the changelog, but we were unaware of the switch to Ubuntu later. Added a changelog entry for that.

https://konghq.atlassian.net/browse/DOCU-3541

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

