### PR TITLE
feat: Kong Manager forced workspace deletion

### DIFF
--- a/app/_src/gateway/kong-manager/workspaces.md
+++ b/app/_src/gateway/kong-manager/workspaces.md
@@ -76,6 +76,7 @@ navigate to the new Workspace's dashboard.
 {% if_version lte:3.4.x %}
 ## Delete a workspace
 
+
 {:.important}
 > **Caution**: The following steps will also delete **all entities in the workspace**. Make sure that this is something you want to do before proceeding.
 

--- a/app/_src/gateway/kong-manager/workspaces.md
+++ b/app/_src/gateway/kong-manager/workspaces.md
@@ -73,6 +73,7 @@ navigate to the new Workspace's dashboard.
 
 1. Click **Update Workspace** to save.
 
+{% if_version lte:3.4.x %}
 ## Delete a workspace
 
 {:.important}
@@ -82,7 +83,6 @@ Choose one of the following methods.
 
 {% navtabs %}
 {% navtab Kong Manager %}
-{% if_version lte:3.4.x %}
 1.  Manually delete all files via **Dev Portal** > **Editor**. You cannot delete folders at this time, but deleting
 all files from a folder will remove the folder.
 1. Turn off the Dev Portal. Go to Dev Portal **Settings** > **Advanced** > **Turn Off**.
@@ -96,20 +96,6 @@ all files from a folder will remove the folder.
 1. Click the **Settings** button to open the **Edit Workspace** page.
 1. Click **Delete**.
     The deletion will fail if you have any data in your workspace.
-{% endif_version %}
-
-{% if_version gte:3.5.x %}
-Using Kong Manager, complete the following:
-
-1. Go to **Workspaces** and select the workspace you want to delete.
-
-1. Click **Settings** and then **Delete**.
-
-1. In the **Delete Workspace** dialog, enter the name of the workspace, select **Confirm: delete all associated resources**, and then click **Delete**. 
-
-This will automatically delete all entities (teams, roles, services, and routes, for example) associated with the workspace as well as the workspace itself.
-{% endif_version %}
-
 {% endnavtab %}
 {% navtab Admin API %}
 
@@ -159,9 +145,9 @@ If it is successful, you should see the following response:
 HTTP 204 No Content
 ```
 {% endif_version %}
+
 {% endnavtab %}
 {% navtab Portal CLI %}
-{% if_version lte:3.4.x %}
 1. Delete all Dev Portal files associated with the workspace:
     ```sh
     portal wipe WORKSPACE_NAME
@@ -177,34 +163,47 @@ step 3.
 4. Delete the workspace. You can't complete this step using the
 Portal CLI, so switch to either the *Kong Manager* or *Admin API* tab and complete
 step 4.
+{% endnavtab %}
+{% endnavtabs %}
 {% endif_version %}
+
 {% if_version gte:3.5.x %}
-1. Delete all Dev Portal files associated with the workspace:
+## Delete a workspace
 
-    ```sh
-    portal wipe WORKSPACE_NAME
-    ```
+{:.important}
+> **Caution**: The following steps will also delete **all entities in the workspace**. Make sure that this is something you want to do before proceeding.
 
-1. Turn off the Dev Portal for the workspace:
+Choose one of the following methods.
 
-    ```sh
-    portal disable WORKSPACE_NAME
-    ```
+{% navtabs %}
+{% navtab Kong Manager %}
+Using Kong Manager, complete the following:
 
-1. Delete each role from the workspace. You can't complete this step using the
-Portal CLI, so you must use the Admin API:
+1. Go to **Workspaces** and select the workspace you want to delete.
 
-    ```bash
-    curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}/rbac/roles/{ROLE_NAME|ROLE_ID}
-    ```
+1. Click **Settings** and then **Delete**.
 
-1. Delete the workspace. You can't complete this step using the
-Portal CLI, so switch to either the *Kong Manager* or *Admin API* tab and complete
-step 4.
-{% endif_version %}
+1. In the **Delete Workspace** dialog, enter the name of the workspace, select **Confirm: delete all associated resources**, and then click **Delete**. 
+
+This will automatically delete all entities (teams, roles, services, and routes, for example) associated with the workspace as well as the workspace itself.
+
+{% endnavtab %}
+{% navtab Admin API %}
+Delete the workspace and [all entities associated with the workspace](/gateway/{{page.kong_version}}/admin-api/workspaces/reference/#delete-a-workspace):
+
+```bash
+curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}?cascade=true
+```
+
+If it is successful, you should see the following response:
+
+```
+HTTP 204 No Content
+```
 
 {% endnavtab %}
 {% endnavtabs %}
+{% endif_version %}
 
 ## Workspace Access
 

--- a/app/_src/gateway/kong-manager/workspaces.md
+++ b/app/_src/gateway/kong-manager/workspaces.md
@@ -75,7 +75,9 @@ navigate to the new Workspace's dashboard.
 
 ## Delete a workspace
 
-To delete a workspace, *all data* must first be deleted from the workspace.
+{:.important}
+> **Caution**: The following steps will also delete **all entities in the workspace**. Make sure that this is something you want to do before proceeding.
+
 Choose one of the following methods.
 
 {% navtabs %}
@@ -93,7 +95,7 @@ This will automatically delete all entities (teams and roles) associated with th
 {% endnavtab %}
 {% navtab Admin API %}
 
-1. Delete the workspace and [all entities associated with the workspace](/gateway/{{page.kong_version}}/admin-api/workspaces/reference/#delete-a-workspace):
+Delete the workspace and [all entities associated with the workspace](/gateway/{{page.kong_version}}/admin-api/workspaces/reference/#delete-a-workspace):
 
     ```bash
     curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}?cascade=true

--- a/app/_src/gateway/kong-manager/workspaces.md
+++ b/app/_src/gateway/kong-manager/workspaces.md
@@ -90,22 +90,22 @@ Using Kong Manager, complete the following:
 
 1. In the **Delete Workspace** dialog, enter the name of the workspace, select **Confirm: delete all associated resources**, and then click **Delete**. 
 
-This will automatically delete all entities (teams and roles) associated with the workspace as well as the workspace itself.
+This will automatically delete all entities (teams, roles, services, and routes, for example) associated with the workspace as well as the workspace itself.
 
 {% endnavtab %}
 {% navtab Admin API %}
 
 Delete the workspace and [all entities associated with the workspace](/gateway/{{page.kong_version}}/admin-api/workspaces/reference/#delete-a-workspace):
 
-    ```bash
-    curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}?cascade=true
-    ```
+```bash
+curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}?cascade=true
+```
 
-    If it is successful, you should see the following response:
+If it is successful, you should see the following response:
 
-    ```
-    HTTP 204 No Content
-    ```
+```
+HTTP 204 No Content
+```
 {% endnavtab %}
 {% navtab Portal CLI %}
 

--- a/app/_src/gateway/kong-manager/workspaces.md
+++ b/app/_src/gateway/kong-manager/workspaces.md
@@ -82,6 +82,23 @@ Choose one of the following methods.
 
 {% navtabs %}
 {% navtab Kong Manager %}
+{% if_version lte:3.4.x %}
+1.  Manually delete all files via **Dev Portal** > **Editor**. You cannot delete folders at this time, but deleting
+all files from a folder will remove the folder.
+1. Turn off the Dev Portal. Go to Dev Portal **Settings** > **Advanced** > **Turn Off**.
+1. Remove all roles from the workspace:
+     1. Go to the **Teams** tab.
+     1. Navigate to the **Roles** tab.
+     1. Click **View** on the workspace you want to delete.
+     1. Go to each role entry and click **Edit**.
+     1. In the entry detail page, click **Delete Role**. A confirmation modal will appear. Click **Delete Role** again.
+1. In the workspace you want to delete, navigate to the **Dashboard** page.
+1. Click the **Settings** button to open the **Edit Workspace** page.
+1. Click **Delete**.
+    The deletion will fail if you have any data in your workspace.
+{% endif_version %}
+
+{% if_version gte:3.5.x %}
 Using Kong Manager, complete the following:
 
 1. Go to **Workspaces** and select the workspace you want to delete.
@@ -91,10 +108,45 @@ Using Kong Manager, complete the following:
 1. In the **Delete Workspace** dialog, enter the name of the workspace, select **Confirm: delete all associated resources**, and then click **Delete**. 
 
 This will automatically delete all entities (teams, roles, services, and routes, for example) associated with the workspace as well as the workspace itself.
+{% endif_version %}
 
 {% endnavtab %}
 {% navtab Admin API %}
 
+{% if_version lte:3.3.x %}
+1. Delete all Dev Portal files associated with the workspace:
+
+    ```bash
+    curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}/files
+    ```
+
+1. Turn off the Dev Portal for the workspace:
+
+   ```bash
+   curl -X PATCH http://localhost:8001/workspaces/{WORKSPACE_NAME}  \
+    --data "config.portal=false"
+   ```
+
+1. [Delete each role](/gateway/{{page.kong_version}}/admin-api/rbac/reference/#delete-a-role)
+from the workspace:
+
+    ```bash
+    curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}/rbac/roles/{ROLE_NAME|ROLE_ID}
+    ```
+
+1. Send a `DELETE` request to the Kong Admin API:
+    ```sh
+    curl -i -X DELETE http://localhost/workspaces/{WORKSPACE_NAME|WORKSPACE_ID}
+    ```
+    The deletion will fail if you have any data in your workspace.
+    
+    If it is successful, you should see the following response:
+    ```
+    HTTP 204 No Content
+    ```
+{% endif_version %}
+
+{% if_version gte:3.4.x %}
 Delete the workspace and [all entities associated with the workspace](/gateway/{{page.kong_version}}/admin-api/workspaces/reference/#delete-a-workspace):
 
 ```bash
@@ -106,9 +158,27 @@ If it is successful, you should see the following response:
 ```
 HTTP 204 No Content
 ```
+{% endif_version %}
 {% endnavtab %}
 {% navtab Portal CLI %}
+{% if_version lte:3.4.x %}
+1. Delete all Dev Portal files associated with the workspace:
+    ```sh
+    portal wipe WORKSPACE_NAME
+    ```
+2. Turn off the Dev Portal for the workspace:
+    ```sh
+    portal disable WORKSPACE_NAME
+    ```
+3. Delete each role from the workspace. You can't complete this step using the
+Portal CLI, so switch to either the *Kong Manager* or *Admin API* tab and complete
+step 3.
 
+4. Delete the workspace. You can't complete this step using the
+Portal CLI, so switch to either the *Kong Manager* or *Admin API* tab and complete
+step 4.
+{% endif_version %}
+{% if_version gte:3.5.x %}
 1. Delete all Dev Portal files associated with the workspace:
 
     ```sh
@@ -131,6 +201,7 @@ Portal CLI, so you must use the Admin API:
 1. Delete the workspace. You can't complete this step using the
 Portal CLI, so switch to either the *Kong Manager* or *Admin API* tab and complete
 step 4.
+{% endif_version %}
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_src/gateway/kong-manager/workspaces.md
+++ b/app/_src/gateway/kong-manager/workspaces.md
@@ -75,7 +75,6 @@ navigate to the new Workspace's dashboard.
 
 ## Delete a workspace
 
-### Wipe workspace data
 To delete a workspace, *all data* must first be deleted from the workspace.
 Choose one of the following methods.
 
@@ -113,6 +112,20 @@ from the workspace:
     ```bash
     curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}/rbac/roles/{ROLE_NAME|ROLE_ID}
     ```
+
+1. Send a `DELETE` request to the Kong Admin API:
+
+    ```sh
+    curl -i -X DELETE http://localhost/workspaces/{WORKSPACE_NAME|WORKSPACE_ID}
+    ```
+
+    The deletion will fail if you have any data in your workspace.
+
+    If it is successful, you should see the following response:
+
+    ```
+    HTTP 204 No Content
+    ```
 {% endnavtab %}
 {% navtab Portal CLI %}
 
@@ -122,51 +135,19 @@ from the workspace:
     portal wipe WORKSPACE_NAME
     ```
 
-2. Turn off the Dev Portal for the workspace:
+1. Turn off the Dev Portal for the workspace:
 
     ```sh
     portal disable WORKSPACE_NAME
     ```
 
-3. Delete each role from the workspace. You can't complete this step using the
-Portal CLI, so switch to either the *Kong Manager* or *Admin API* tab and complete
+1. Delete each role from the workspace. You can't complete this step using the
+Portal CLI, so switch to the *Admin API* tab and complete
 step 3.
 
-{% endnavtab %}
-{% endnavtabs %}
-
-### Delete a clean workspace
-
-If your workspace is clean, you can delete it using the Kong Manager GUI or the
-Kong Admin API. If not, see the previous section to [wipe workspace data](#wipe-workspace-data).
-
-{% navtabs %}
-{% navtab Kong Manager %}
-
-Using Kong Manager, complete the following:
-
-1. Go to **Workspaces** and select the workspace you want to delete.
-
-1. Click **Settings** and then **Delete**.
-
-1. In the **Delete Workspace** dialog, enter the name of the workspace, select **Confirm: delete all associated resources**, and then click **Delete**. 
-
-{% endnavtab %}
-{% navtab Admin API %}
-
-Send a `DELETE` request to the Kong Admin API:
-
-```sh
-curl -i -X DELETE http://localhost/workspaces/{WORKSPACE_NAME|WORKSPACE_ID}
-```
-
-The deletion will fail if you have any data in your workspace.
-
-If it is successful, you should see the following response:
-
-```
-HTTP 204 No Content
-```
+1. Delete the workspace. You can't complete this step using the
+Portal CLI, so switch to either the *Kong Manager* or *Admin API* tab and complete
+step 4.
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_src/gateway/kong-manager/workspaces.md
+++ b/app/_src/gateway/kong-manager/workspaces.md
@@ -93,33 +93,11 @@ This will automatically delete all entities (teams and roles) associated with th
 {% endnavtab %}
 {% navtab Admin API %}
 
-1. Delete all Dev Portal files associated with the workspace:
+1. Delete the workspace and [all entities associated with the workspace](/gateway/{{page.kong_version}}/admin-api/workspaces/reference/#delete-a-workspace):
 
     ```bash
-    curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}/files
+    curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}?cascade=true
     ```
-
-1. Turn off the Dev Portal for the workspace:
-
-   ```bash
-   curl -X PATCH http://localhost:8001/workspaces/{WORKSPACE_NAME}  \
-    --data "config.portal=false"
-   ```
-
-1. [Delete each role](/gateway/{{page.kong_version}}/admin-api/rbac/reference/#delete-a-role)
-from the workspace:
-
-    ```bash
-    curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}/rbac/roles/{ROLE_NAME|ROLE_ID}
-    ```
-
-1. Send a `DELETE` request to the Kong Admin API:
-
-    ```sh
-    curl -i -X DELETE http://localhost/workspaces/{WORKSPACE_NAME|WORKSPACE_ID}
-    ```
-
-    The deletion will fail if you have any data in your workspace.
 
     If it is successful, you should see the following response:
 
@@ -142,8 +120,11 @@ from the workspace:
     ```
 
 1. Delete each role from the workspace. You can't complete this step using the
-Portal CLI, so switch to the *Admin API* tab and complete
-step 3.
+Portal CLI, so you must use the Admin API:
+
+    ```bash
+    curl -i -X DELETE http://localhost:8001/{WORKSPACE_NAME}/rbac/roles/{ROLE_NAME|ROLE_ID}
+    ```
 
 1. Delete the workspace. You can't complete this step using the
 Portal CLI, so switch to either the *Kong Manager* or *Admin API* tab and complete

--- a/app/_src/gateway/kong-manager/workspaces.md
+++ b/app/_src/gateway/kong-manager/workspaces.md
@@ -83,15 +83,13 @@ Choose one of the following methods.
 {% navtab Kong Manager %}
 Using Kong Manager, complete the following:
 
-1.  Manually delete all files via **Dev Portal** > **Editor**. You cannot delete folders at this time, but deleting
-all files from a folder will remove the folder.
-1. Turn off the Dev Portal. Go to Dev Portal **Settings** > **Advanced** > **Turn Off**.
-1. Remove all roles from the workspace:
-     1. Go to the **Teams** tab.
-     1. Navigate to the **Roles** tab.
-     1. Click **View** on the workspace you want to delete.
-     1. Go to each role entry and click **Edit**.
-     1. In the entry detail page, click **Delete Role**. A confirmation modal will appear. Click **Delete Role** again.
+1. Go to **Workspaces** and select the workspace you want to delete.
+
+1. Click **Settings** and then **Delete**.
+
+1. In the **Delete Workspace** dialog, enter the name of the workspace, select **Confirm: delete all associated resources**, and then click **Delete**. 
+
+This will automatically delete all entities (teams and roles) associated with the workspace as well as the workspace itself.
 
 {% endnavtab %}
 {% navtab Admin API %}
@@ -145,13 +143,13 @@ Kong Admin API. If not, see the previous section to [wipe workspace data](#wipe-
 {% navtabs %}
 {% navtab Kong Manager %}
 
-1. In the workspace you want to delete, navigate to the **Dashboard** page.
+Using Kong Manager, complete the following:
 
-1. Click the **Settings** button to open the **Edit Workspace** page.
+1. Go to **Workspaces** and select the workspace you want to delete.
 
-1. Click **Delete**.
+1. Click **Settings** and then **Delete**.
 
-    The deletion will fail if you have any data in your workspace.
+1. In the **Delete Workspace** dialog, enter the name of the workspace, select **Confirm: delete all associated resources**, and then click **Delete**. 
 
 {% endnavtab %}
 {% navtab Admin API %}

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -9,6 +9,7 @@ Changelog for supported Kong Gateway versions.
 
 For product versions that have reached the end of sunset support, see the [changelog archives](https://legacy-gateway--kongdocs.netlify.app/enterprise/changelog/).
 
+<<<<<<< HEAD
 ## 3.4.1.1
 **Release Date** 2023/10/12
 
@@ -28,6 +29,14 @@ This change is in direct response to the identified vulnerability [CVE-2023-4448
 ### Dependencies
 
 * Bumped `libxml2` from 2.10.3 to 2.11.5
+=======
+## 3.5.0
+**Release Date** 2023/11/03
+
+### Kong Manager
+
+You can now force delete a workspace in the Kong Manager UI. Previously, a workspace couldn't be deleted until all the entities associated with it were manually deleted. With forced deletion, you can automatically remove any entities associated with a workspace while you are deleting it. For more information, see [Delete a workspace](/gateway/latest/kong-manager/workspaces/#delete-a-workspace).
+>>>>>>> 02900f0e4 (Update workspace deletion instructions, add changelog entry about forced KM workspace deletion)
 
 ## 3.4.1.0
 **Release Date** 2023/09/28

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -9,7 +9,13 @@ Changelog for supported Kong Gateway versions.
 
 For product versions that have reached the end of sunset support, see the [changelog archives](https://legacy-gateway--kongdocs.netlify.app/enterprise/changelog/).
 
-<<<<<<< HEAD
+## 3.5.0.0
+**Release Date** TBD
+
+### Kong Manager
+
+* You can now force delete a workspace in the Kong Manager UI. Previously, a workspace couldn't be deleted until all the entities associated with it were manually deleted. With forced deletion, you can automatically remove any entities associated with a workspace while you are deleting it. For more information, see [Delete a workspace](/gateway/latest/kong-manager/workspaces/#delete-a-workspace).
+
 ## 3.4.1.1
 **Release Date** 2023/10/12
 
@@ -29,14 +35,6 @@ This change is in direct response to the identified vulnerability [CVE-2023-4448
 ### Dependencies
 
 * Bumped `libxml2` from 2.10.3 to 2.11.5
-=======
-## 3.5.0
-**Release Date** 2023/11/03
-
-### Kong Manager
-
-You can now force delete a workspace in the Kong Manager UI. Previously, a workspace couldn't be deleted until all the entities associated with it were manually deleted. With forced deletion, you can automatically remove any entities associated with a workspace while you are deleting it. For more information, see [Delete a workspace](/gateway/latest/kong-manager/workspaces/#delete-a-workspace).
->>>>>>> 02900f0e4 (Update workspace deletion instructions, add changelog entry about forced KM workspace deletion)
 
 ## 3.4.1.0
 **Release Date** 2023/09/28


### PR DESCRIPTION
### Description

In 3.5, users can now force delete a workspace. Since this allows them to automatically delete entities associated with the workspace instead of doing it manually, our instructions needed to be updated.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3408
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

