### PR TITLE
Chore: Add search aliases for plugins

### DIFF
--- a/app/_hub/kong-inc/acme/_metadata.yml
+++ b/app/_hub/kong-inc/acme/_metadata.yml
@@ -1,4 +1,7 @@
 name: ACME
+search_aliases:
+  - let's encrypt
+  - certificates
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/app-dynamics/_metadata.yml
+++ b/app/_hub/kong-inc/app-dynamics/_metadata.yml
@@ -1,4 +1,7 @@
 name: AppDynamics
+search_aliases:
+  - app dynamics
+  - app-dynamics
 publisher: Kong Inc.
 desc: Integrate Kong with the AppDynamics APM Platform
 free: false

--- a/app/_hub/kong-inc/application-registration/_metadata.yml
+++ b/app/_hub/kong-inc/application-registration/_metadata.yml
@@ -1,4 +1,9 @@
 name: Portal Application Registration
+search_aliases:
+  - app reg
+  - portal app reg
+  - dev portal
+  - application-registration
 global: false
 dbless_compatible: 'no'
 free: false

--- a/app/_hub/kong-inc/aws-lambda/_metadata.yml
+++ b/app/_hub/kong-inc/aws-lambda/_metadata.yml
@@ -1,4 +1,6 @@
 name: AWS Lambda
+search_aliases:
+  - aws-lambda
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/azure-functions/_metadata.yml
+++ b/app/_hub/kong-inc/azure-functions/_metadata.yml
@@ -1,4 +1,6 @@
 name: Azure Functions
+search_aliases:
+  - azure-functions
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/basic-auth/_metadata.yml
+++ b/app/_hub/kong-inc/basic-auth/_metadata.yml
@@ -1,4 +1,6 @@
 name: Basic Authentication
+search_aliases:
+  - basic-auth
 dbless_compatible: partially
 dbless_explanation: |
   Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/bot-detection/_metadata.yml
+++ b/app/_hub/kong-inc/bot-detection/_metadata.yml
@@ -1,4 +1,6 @@
 name: Bot Detection
+search_aliases:
+  - bot-detection
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/correlation-id/_metadata.yml
+++ b/app/_hub/kong-inc/correlation-id/_metadata.yml
@@ -1,4 +1,6 @@
 name: Correlation ID
+search_aliases:
+  - correlation-id
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/exit-transformer/_metadata.yml
+++ b/app/_hub/kong-inc/exit-transformer/_metadata.yml
@@ -1,4 +1,6 @@
 name: Exit Transformer
+search_aliases:
+  - exit-transformer
 yaml_examples: false
 dbless_compatible: 'yes'
 free: false

--- a/app/_hub/kong-inc/file-log/_metadata.yml
+++ b/app/_hub/kong-inc/file-log/_metadata.yml
@@ -1,4 +1,7 @@
 name: File Log
+search_aliases:
+  - log file
+  - file-log
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/forward-proxy/_metadata.yml
+++ b/app/_hub/kong-inc/forward-proxy/_metadata.yml
@@ -1,4 +1,6 @@
 name: Forward Proxy Advanced
+search_aliases:
+  - forward-proxy
 dbless_compatible: 'yes'
 free: false
 plus: false

--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata.yml
@@ -1,4 +1,9 @@
 name: GraphQL Proxy Caching Advanced
+search_aliases:
+  - proxy cache
+  - graphql proxy cache
+  - graphql proxy cache advanced
+  - graphql-proxy-cache-advanced
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_metadata.yml
@@ -1,4 +1,6 @@
 name: GraphQL Rate Limiting Advanced
+search_aliases:
+  - graphql-rate-limiting-advanced
 konnect_examples: true
 dbless_compatible: partially
 dbless_explanation: |

--- a/app/_hub/kong-inc/grpc-gateway/_metadata.yml
+++ b/app/_hub/kong-inc/grpc-gateway/_metadata.yml
@@ -1,4 +1,6 @@
 name: gRPC-gateway
+search_aliases:
+  - grpc gateway
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/grpc-web/_metadata.yml
+++ b/app/_hub/kong-inc/grpc-web/_metadata.yml
@@ -1,4 +1,6 @@
 name: gRPC-Web
+search_aliases:
+  - grpc web
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/hmac-auth/_metadata.yml
+++ b/app/_hub/kong-inc/hmac-auth/_metadata.yml
@@ -1,4 +1,7 @@
 name: HMAC Auth
+search_aliases:
+  - hmac authentication
+  - hmac-auth
 dbless_compatible: partially
 dbless_explanation: |
   Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/http-log/_metadata.yml
+++ b/app/_hub/kong-inc/http-log/_metadata.yml
@@ -1,4 +1,6 @@
 name: HTTP Log
+search_aliases:
+  - http-log
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/ip-restriction/_metadata.yml
+++ b/app/_hub/kong-inc/ip-restriction/_metadata.yml
@@ -1,4 +1,6 @@
 name: IP Restriction
+search_aliases:
+  - ip-restriction
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/jwe-decrypt/_metadata.yml
+++ b/app/_hub/kong-inc/jwe-decrypt/_metadata.yml
@@ -1,4 +1,6 @@
 name: JWE Decrypt
+search_aliases:
+  - jwe-decrypt
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/jwt-signer/_metadata.yml
+++ b/app/_hub/kong-inc/jwt-signer/_metadata.yml
@@ -1,4 +1,7 @@
 name: Kong JWT Signer
+search_aliases:
+  - json web tokens
+  - jwt-signer
 dbless_compatible: 'yes'
 free: false
 

--- a/app/_hub/kong-inc/jwt/_metadata.yml
+++ b/app/_hub/kong-inc/jwt/_metadata.yml
@@ -1,4 +1,6 @@
 name: JWT
+search_aliases:
+  - json web tokens
 dbless_compatible: partially
 dbless_explanation: |
   Consumers and JWT secrets can be created with declarative configuration.

--- a/app/_hub/kong-inc/kafka-log/_metadata.yml
+++ b/app/_hub/kong-inc/kafka-log/_metadata.yml
@@ -1,4 +1,6 @@
 name: Kafka Log
+search_aliases:
+  - kafka-log
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/kafka-upstream/_metadata.yml
+++ b/app/_hub/kong-inc/kafka-upstream/_metadata.yml
@@ -1,4 +1,6 @@
 name: Kafka Upstream
+search_aliases:
+  - kafka-upstream
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/key-auth-enc/_metadata.yml
+++ b/app/_hub/kong-inc/key-auth-enc/_metadata.yml
@@ -1,4 +1,10 @@
 name: Key Authentication - Encrypted
+search_aliases:
+  - key auth encrypted
+  - key authentication encrypted
+  - key auth advanced
+  - key authentication advanced
+  - key-auth-enc
 dbless_compatible: partially
 dbless_explanation: |
   Consumers and credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/key-auth/_metadata.yml
+++ b/app/_hub/kong-inc/key-auth/_metadata.yml
@@ -1,4 +1,7 @@
 name: Key Auth
+search_aliases:
+  - key authentication
+  - key-auth
 dbless_compatible: partially
 dbless_explanation: |
   Consumers and Credentials can be created with declarative configuration.

--- a/app/_hub/kong-inc/ldap-auth-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_metadata.yml
@@ -1,4 +1,7 @@
 name: LDAP Authentication Advanced
+search_aliases:
+  - ldap-auth-advanced
+  - ldap auth advanced
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/ldap-auth/_metadata.yml
+++ b/app/_hub/kong-inc/ldap-auth/_metadata.yml
@@ -1,4 +1,6 @@
 name: LDAP Authentication
+search_aliases:
+  - ldap-auth
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/mtls-auth/_metadata.yml
+++ b/app/_hub/kong-inc/mtls-auth/_metadata.yml
@@ -1,4 +1,9 @@
 name: Mutual TLS Authentication
+search_aliases:
+  - mtls
+  - mtls authentication
+  - mtls-auth
+  - certificates
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/oas-validation/_metadata.yml
+++ b/app/_hub/kong-inc/oas-validation/_metadata.yml
@@ -3,6 +3,7 @@ search_aliases:
   - specification
   - openapi
   - swagger
+  - oas-validation
 dbless_compatible: 'yes'
 konnect_examples: true
 free: false

--- a/app/_hub/kong-inc/oauth2-introspection/_metadata.yml
+++ b/app/_hub/kong-inc/oauth2-introspection/_metadata.yml
@@ -1,4 +1,6 @@
 name: OAuth 2.0 Introspection
+search_aliases:
+  - oauth2-introspection
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/opa/_metadata.yml
+++ b/app/_hub/kong-inc/opa/_metadata.yml
@@ -1,4 +1,6 @@
 name: OPA
+search_aliases:
+  - open policy agent
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/openid-connect/_metadata.yml
+++ b/app/_hub/kong-inc/openid-connect/_metadata.yml
@@ -2,6 +2,9 @@ name: OpenID Connect
 search_aliases:
   - oidc
   - oauth2
+  - openid-connect
+  - idp
+  - identity provider
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/opentelemetry/_metadata.yml
+++ b/app/_hub/kong-inc/opentelemetry/_metadata.yml
@@ -1,4 +1,8 @@
 name: OpenTelemetry
+search_aliases:
+  - otlp
+  - otel
+  - open telemetry
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/proxy-cache-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_metadata.yml
@@ -1,4 +1,8 @@
 name: Proxy Caching Advanced
+search_aliases:
+  - proxy cache
+  - proxy cache advanced
+  - proxy-cache-advanced
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/proxy-cache/_metadata.yml
+++ b/app/_hub/kong-inc/proxy-cache/_metadata.yml
@@ -1,4 +1,7 @@
 name: Proxy Cache
+search_aliases:
+  - proxy caching
+  - proxy-cache
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/rate-limiting-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_metadata.yml
@@ -1,4 +1,6 @@
 name: Rate Limiting Advanced
+search_aliases:
+  - rate-limiting-advanced
 dbless_compatible: partially
 dbless_explanation: |
   The cluster strategy is not supported in DB-less and hybrid modes. For Kong

--- a/app/_hub/kong-inc/rate-limiting/_metadata.yml
+++ b/app/_hub/kong-inc/rate-limiting/_metadata.yml
@@ -1,4 +1,6 @@
 name: Rate Limiting
+search_aliases:
+  - rate-limiting
 dbless_compatible: partially
 dbless_explanation: |
   The plugin will run fine with the `local` policy (which doesn't use the database) or

--- a/app/_hub/kong-inc/request-size-limiting/_metadata.yml
+++ b/app/_hub/kong-inc/request-size-limiting/_metadata.yml
@@ -1,4 +1,6 @@
 name: Request Size Limiting
+search_aliases:
+  - request-size-limiting
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/request-termination/_metadata.yml
+++ b/app/_hub/kong-inc/request-termination/_metadata.yml
@@ -1,4 +1,6 @@
 name: Request Termination
+search_aliases:
+  - request-termination
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/request-transformer-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/request-transformer-advanced/_metadata.yml
@@ -1,4 +1,6 @@
 name: Request Transformer Advanced
+search_aliases:
+  - request-transformer-advanced
 dbless_compatible: 'yes'
 free: false
 plus: false

--- a/app/_hub/kong-inc/request-transformer/_metadata.yml
+++ b/app/_hub/kong-inc/request-transformer/_metadata.yml
@@ -1,4 +1,6 @@
 name: Request Transformer
+search_aliases:
+  - request-transformer
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/request-validator/_metadata.yml
+++ b/app/_hub/kong-inc/request-validator/_metadata.yml
@@ -1,4 +1,6 @@
 name: Request Validator
+search_aliases:
+  - request-validator
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/response-ratelimiting/_metadata.yml
+++ b/app/_hub/kong-inc/response-ratelimiting/_metadata.yml
@@ -1,4 +1,7 @@
 name: Response Rate Limiting
+search_aliases:
+  - ratelimiting
+  - response-ratelimiting
 dbless_compatible: partially
 dbless_explanation: |
   The plugin will run fine with the `local` policy (which doesn't use the database) or

--- a/app/_hub/kong-inc/response-transformer-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/response-transformer-advanced/_metadata.yml
@@ -1,4 +1,6 @@
 name: Response Transformer Advanced
+search_aliases:
+  - response-transformer-advanced
 dbless_compatible: 'yes'
 free: false
 plus: false

--- a/app/_hub/kong-inc/response-transformer/_metadata.yml
+++ b/app/_hub/kong-inc/response-transformer/_metadata.yml
@@ -1,4 +1,6 @@
 name: Response Transformer
+search_aliases:
+  - response-transformer
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/route-by-header/_metadata.yml
+++ b/app/_hub/kong-inc/route-by-header/_metadata.yml
@@ -1,4 +1,7 @@
 name: Route By Header
+search_aliases:
+  - route-by-header
+  - route by request header
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/route-transformer-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/route-transformer-advanced/_metadata.yml
@@ -1,4 +1,6 @@
 name: Route Transformer Advanced
+search_aliases:
+  - route-transformer-advanced
 dbless_compatible: 'yes'
 free: false
 plus: false

--- a/app/_hub/kong-inc/saml/_metadata.yml
+++ b/app/_hub/kong-inc/saml/_metadata.yml
@@ -1,4 +1,7 @@
 name: SAML
+search_aliases:
+  - azure
+  - security assertion markup language
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/session/_metadata.yml
+++ b/app/_hub/kong-inc/session/_metadata.yml
@@ -1,4 +1,6 @@
 name: Session
+search_aliases:
+  - sessions
 dbless_compatible: partially
 dbless_explanation: |
   `config.storage` must be set to `cookie`. The `kong` strategy uses

--- a/app/_hub/kong-inc/statsd/_metadata.yml
+++ b/app/_hub/kong-inc/statsd/_metadata.yml
@@ -1,4 +1,6 @@
 name: StatsD
+search_aliases:
+  - collectd
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/tcp-log/_metadata.yml
+++ b/app/_hub/kong-inc/tcp-log/_metadata.yml
@@ -1,4 +1,6 @@
 name: TCP Log
+search_aliases:
+  - tcp-log
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/tls-handshake-modifier/_metadata.yml
+++ b/app/_hub/kong-inc/tls-handshake-modifier/_metadata.yml
@@ -1,4 +1,7 @@
 name: TLS Handshake Modifier
+search_aliases:
+  - tls-handshake-modifier
+  - certificates
 dbless_compatible: 'yes'
 free: false
 plus: false

--- a/app/_hub/kong-inc/tls-metadata-headers/_metadata.yml
+++ b/app/_hub/kong-inc/tls-metadata-headers/_metadata.yml
@@ -1,4 +1,7 @@
 name: TLS Metadata Headers
+search_aliases:
+  - tls-metadata-headers
+  - certificates
 dbless_compatible: 'yes'
 free: false
 plus: false

--- a/app/_hub/kong-inc/udp-log/_metadata.yml
+++ b/app/_hub/kong-inc/udp-log/_metadata.yml
@@ -1,4 +1,6 @@
 name: UDP Log
+search_aliases:
+  - udp-log
 dbless_compatible: 'yes'
 free: true
 enterprise: true

--- a/app/_hub/kong-inc/upstream-timeout/_metadata.yml
+++ b/app/_hub/kong-inc/upstream-timeout/_metadata.yml
@@ -1,4 +1,6 @@
 name: Upstream Timeout
+search_aliases:
+  - upstream-timeout
 dbless_compatible: yes
 free: false
 plus: false

--- a/app/_hub/kong-inc/vault-auth/_metadata.yml
+++ b/app/_hub/kong-inc/vault-auth/_metadata.yml
@@ -1,4 +1,6 @@
 name: Vault Authentication
+search_aliases:
+  - vault-auth
 dbless_compatible: 'yes'
 free: false
 plus: false

--- a/app/_hub/kong-inc/websocket-size-limit/_metadata.yml
+++ b/app/_hub/kong-inc/websocket-size-limit/_metadata.yml
@@ -1,4 +1,6 @@
 name: WebSocket Size Limit
+search_aliases:
+  - websocket-size-limit
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/websocket-validator/_metadata.yml
+++ b/app/_hub/kong-inc/websocket-validator/_metadata.yml
@@ -1,4 +1,6 @@
 name: WebSocket Validator
+search_aliases:
+  - websocket-validator
 dbless_compatible: 'yes'
 free: false
 enterprise: true

--- a/app/_hub/kong-inc/xml-threat-protection/_metadata.yml
+++ b/app/_hub/kong-inc/xml-threat-protection/_metadata.yml
@@ -1,4 +1,6 @@
 name: XML Threat Protection
+search_aliases:
+  - xml-threat-protection
 dbless_compatible: 'yes'
 free: false
 plus: false


### PR DESCRIPTION
### Description

The search field on the plugin hub homepage relies on the plugin's name and the optional `search_aliases` metadata field.
Adding shortform aliases (eg `mtls`), related terms (eg `certificates`), and plugin literal names in code (eg `mtls-auth`). 

### Testing instructions

If anyone has other search alias ideas, feel free to add. These just cover the basics.

Preview link:  test by searching for these aliases on the /hub/ homepage in the preview.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

