### PR TITLE
add a note to FIPS index page

### DIFF
--- a/app/_src/gateway/kong-enterprise/fips-support/index.md
+++ b/app/_src/gateway/kong-enterprise/fips-support/index.md
@@ -11,6 +11,8 @@ The Federal Information Processing Standard (FIPS) 140-2 is a federal standard d
 
 The package replaces OpenSSL, the primary SSL library in {{site.base_gateway}}, with [BoringSSL](https://boringssl.googlesource.com/boringssl/), which at its core uses the FIPS 140-2 validated BoringCrypto for cryptographic operations.
 
+**Note**: FIPS is not supported when running Kong Gateway Enterprise in free mode.
+
 ## FIPS implementation
 ### Password hashing
 

--- a/app/_src/gateway/kong-enterprise/fips-support/index.md
+++ b/app/_src/gateway/kong-enterprise/fips-support/index.md
@@ -11,7 +11,8 @@ The Federal Information Processing Standard (FIPS) 140-2 is a federal standard d
 
 The package replaces OpenSSL, the primary SSL library in {{site.base_gateway}}, with [BoringSSL](https://boringssl.googlesource.com/boringssl/), which at its core uses the FIPS 140-2 validated BoringCrypto for cryptographic operations.
 
-**Note**: FIPS is not supported when running Kong Gateway Enterprise in free mode.
+{:.note}
+> **Note**: FIPS is not supported when running {{site.ee_product_name}} in free mode.
 
 ## FIPS implementation
 ### Password hashing


### PR DESCRIPTION
Add a not to FIPS index page indicating that `FIPS is not supported when running kong gateway enterprise in free mode`.

KAG-2803