### PR TITLE
fix: Using multiple backend Services

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,4 +188,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.4.10
+   2.4.21

--- a/app/_src/kic-v2/guides/using-multiple-backends.md
+++ b/app/_src/kic-v2/guides/using-multiple-backends.md
@@ -8,109 +8,98 @@ stability_message: |
 
 ## Overview
 
-HTTPRoute supports adding multiple Services under its
-`BackendRefs` field. When you add multiple Services,
-requests through the HTTPRoute are distributed across the Services. This guide
-walks through creating an HTTPRoute with multiple backend Services.
+HTTPRoute supports adding multiple Services under its `BackendRefs` field. When you add multiple Services,
+requests through the HTTPRoute are distributed across the Services. This guide walks through creating an HTTPRoute with multiple backend Services.
 
-{% include /md/kic/installation.md %}
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false %}
 
 {% include /md/kic/class.md %}
 
-## Deploy multiple Services
+## Deploy multiple Services with HTTPRoute
 
-To do so, you can deploy a second echo Service so that you have
-a second `BackendRef` to use for traffic splitting:
-```bash
-kubectl apply -f {{site.links.web}}/assets/kubernetes-ingress-controller/examples/echo-services.yaml
-```
-Response:
-```text
-service/echo created
-deployment.apps/echo created
-service/echo2 created
-deployment.apps/echo2 created
-```
+1. Deploy a second echo Service so that you have a second `BackendRef` to use for traffic splitting:
+    ```bash
+    kubectl apply -f {{site.links.web}}/assets/kubernetes-ingress-controller/examples/echo-services.yaml
+    ```
+    The results should look like this:
+    ```text
+    service/echo created
+    deployment.apps/echo created
+    service/echo2 created
+    deployment.apps/echo2 created
+    ```
 
-## Create a multi-Service HTTPRoute
+1. Deploy an HTTPRoute that sends traffic to both the services. By default, traffic is distributed evenly across all services:
 
-Now that those two Services are deployed, you can now deploy an HTTPRoute that
-sends traffic to both of them. By default, traffic is distributed evenly across
-all Services:
+    ```bash
+   echo 'apiVersion: gateway.networking.k8s.io/v1beta1
+   kind: HTTPRoute
+   metadata:
+     name: echo
+     annotations:
+       konghq.com/strip-path: "true"
+   spec:
+     parentRefs:
+     - name: kong
+     rules:
+     - matches:
+       - path:
+           type: PathPrefix
+           value: /echo
+       backendRefs:
+       - name: echo
+         kind: Service
+         port: 80
+       - name: echo2
+         kind: Service
+         port: 80
+   ' | kubectl apply -f -
+    ```
+    The results should look like this:
+    ```text
+    httproute.gateway.networking.k8s.io/echo created
+    ```
 
-```bash
-echo 'apiVersion: gateway.networking.k8s.io/v1beta1
-kind: HTTPRoute
-metadata:
-  name: echo
-  annotations:
-    konghq.com/strip-path: "true"
-spec:
-  parentRefs:
-  - name: kong
-  rules:
-  - matches:
-    - path:
-        type: PathPrefix
-        value: /echo
-    backendRefs:
-    - name: echo
-      kind: Service
-      port: 80
-    - name: echo2
-      kind: Service
-      port: 80
-' | kubectl apply -f -
-```
-Response:
-```text
-httproute.gateway.networking.k8s.io/echo created
-```
-
-Sending many requests through this route and tabulating the results will show
-an even distribution of requests across the Services:
-```bash
-curl -s 192.168.96.0/echo/hostname?iteration=[1-200] -w "\n" | sort | uniq -c
-```
-Response:
-```text
-100 echo2-7cb798f47-gv6hs
-100 echo-658c5ff5ff-tv275
-```
+1. Send multiple requests through this route and tabulating the results to check an even distribution of requests across the Services:
+    ```bash
+    curl -s "$PROXY_IP/echo/hostname?iteration="{1..200} -w "\n" | sort | uniq -c
+    ```
+    The results should look like this:
+    ```text
+    100 echo2-7cb798f47-gv6hs
+    100 echo-658c5ff5ff-tv275
+    ```
 
 ## Add Service weights
 
-The `weight` field overrides the default distribution of requests across
-Services. Each Service instead receives `weight / sum(all Service weights)`
-percent of the requests. Add weights to the Services in the HTTPRoute's
-backend list:
+The `weight` field overrides the default distribution of requests across Services. Each Service instead receives `weight / sum(all Service weights)` percent of the requests. 
+1. Add weights to the Services in the HTTPRoute's backend list.
 
-```bash
-kubectl patch --type json httproute echo -p='[
-    {
-	    "op":"add",
-		"path":"/spec/rules/0/backendRefs/0/weight",
-		"value":200
-    },
-    {   "op":"add",
-	    "path":"/spec/rules/0/backendRefs/1/weight",
-		"value":100
-    }
-]'
-```
-Response:
-```text
-httproute.gateway.networking.k8s.io/echo patched
-```
+    ```bash
+    kubectl patch --type json httproute echo -p='[
+        {
+    	    "op":"add",
+    		"path":"/spec/rules/0/backendRefs/0/weight",
+    		"value":200
+        },
+        {   "op":"add",
+    	    "path":"/spec/rules/0/backendRefs/1/weight",
+    		"value":100
+        }
+    ]'
+    ```
+    The results should look like this:
+    ```text
+    httproute.gateway.networking.k8s.io/echo patched
+    ```
 
-Sending the same requests will now show roughly 1/3 of the requests going to
-`echo2` and 2/3 going to `echo`:
+1. Send the same requests and roughly 1/3 of the requests go to `echo2` and 2/3 going to `echo`:
 
-```bash
-curl -s 192.168.96.0/echo/hostname?iteration=[1-200] -w "\n" | sort | uniq -c
-```
-Response:
-```text
- 67 echo2-7cb798f47-gv6hs
-133 echo-658c5ff5ff-tv275
-```
+    ```bash
+    curl -s "$PROXY_IP/echo/hostname?iteration="{1..200} -w "\n" | sort | uniq -c
+    ```
+    The results should look like this:
+    ```text
+     67 echo2-7cb798f47-gv6hs
+    133 echo-658c5ff5ff-tv275
+   ```


### PR DESCRIPTION
### Description

Tested and validated the guide.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->
```rajakavitha@198 ~ %  kubectl apply -f http://localhost:4000/assets/kubernetes-ingress-controller/examples/echo-services.yaml

service/echo created
deployment.apps/echo created
service/echo2 created
deployment.apps/echo2 created
rajakavitha@198 ~ % echo 'apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: echo
  annotations:
    konghq.com/strip-path: "true"
spec:
  parentRefs:
  - name: kong
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /echo
    backendRefs:
    - name: echo
      kind: Service
      port: 80
    - name: echo2
      kind: Service
      port: 80
' | kubectl apply -f -

httproute.gateway.networking.k8s.io/echo created
rajakavitha@198 ~ %  curl -s "$PROXY_IP/echo/hostname?iteration="{1..200} -w "\n" | sort | uniq -c

 100 echo-77c45dd4dc-8m529
 100 echo2-6bb7f6b587-2v4wk
rajakavitha@198 ~ %  kubectl patch --type json httproute echo -p='[
     {
            "op":"add",
                "path":"/spec/rules/0/backendRefs/0/weight",
                "value":200
     },
     {   "op":"add",
            "path":"/spec/rules/0/backendRefs/1/weight",
                "value":100
     }
 ]'

httproute.gateway.networking.k8s.io/echo patched
rajakavitha@198 ~ %  curl -s "$PROXY_IP/echo/hostname?iteration="{1..200} -w "\n" | sort | uniq -c

 133 echo-77c45dd4dc-8m529
  67 echo2-6bb7f6b587-2v4wk
rajakavitha@198 ~ % 
```

