### PR TITLE
fix: cert bound access token conditional rendering

### DIFF
--- a/app/_hub/kong-inc/openid-connect/overview/_index.md
+++ b/app/_hub/kong-inc/openid-connect/overview/_index.md
@@ -396,8 +396,10 @@ difficulties during this phase, please refer to the [Keycloak documentation](htt
    <br>
    <img src="/assets/images/products/plugins/openid-connect/keycloak-client-service-auth.png">
    <br>
+{% if_version gte:3.5.x %}
 3. Optional: Create another confidential client `cert-bound` with settings similar to the `service` client created previously.
    From the **Advanced** tab, enable the **OAuth 2.0 Mutual TLS Certificate Bound Access Tokens Enabled** toggle.
+{% endif_version %}
 
 4. Create a verified user with the name: `john` and the non-temporary password: `doe` that can be used with the password grant:
    <br><br>
@@ -422,7 +424,10 @@ to
 The Keycloak default `https` port conflicts with the default Kong TLS proxy port,
 and that can be a problem if both are started on the same host.
 
-**Note:** the mTLS proof of possession feature that validates OAuth 2.0 Mutual TLS Certificate Bound Access Tokens requires configuring Keycloak to validate client certificates using mTLS with the `--https-client-auth=request` option. For more information please refer to the [Keycloak documentation](https://www.keycloak.org/server/enabletls).
+{% if_version gte:3.5.x %}
+{:.note}
+> **Note:** The mTLS proof of possession feature that validates OAuth 2.0 Mutual TLS Certificate Bound Access Tokens requires configuring Keycloak to validate client certificates using mTLS with the `--https-client-auth=request` option. For more information, see the [Keycloak documentation](https://www.keycloak.org/server/enabletls).
+{% endif_version %}
 
 [keycloak]: http://www.keycloak.org/
 
@@ -1740,6 +1745,7 @@ Nice, as you can see the plugin even added the `X-Consumer-Id` and `X-Consumer-U
 
 > It is possible to make consumer mapping optional and non-authorizing by setting the `config.consumer_optional=true`.
 
+{% if_version gte:3.5.x %}
 ## Certificate-Bound Access Tokens
 
 One of the main vulnerabilities of OAuth are bearer tokens because presenting a valid bearer token is enough proof to access a resource. This can create problems since the client presenting the token isn't validated as the legitimate user that the token was issued to. 
@@ -1849,7 +1855,7 @@ The following example shows how to enable this feature for the JWT Access Token 
     ```http
     HTTP/1.1 200 OK
     ```
-
+{% endif_version %}
 ## Headers
 
 Before you proceed, check that you have completed [the preparations](#preparations).


### PR DESCRIPTION
### Description

When I merged the certificate-bound access token PR(#6284 ), I forgot to add conditional rendering. This fixes that.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

