### PR TITLE
fix(jwt): state what happens when multiple JWTs are provided

### DIFF
--- a/app/_hub/kong-inc/jwt/overview/_index.md
+++ b/app/_hub/kong-inc/jwt/overview/_index.md
@@ -16,6 +16,8 @@ You can then pass a token through any of the following:
 Kong will either proxy the request to your upstream services if the token's
 signature is verified, or discard the request if not. Kong can also perform
 verifications on some of the registered claims of RFC 7519 (`exp` and `nbf`).
+If Kong finds multiple tokens that differ - even if they are valid - the request
+will be rejected to prevent JWT smuggling.
 
 ## Using the plugin
 


### PR DESCRIPTION
### Description

A user asked to clarify the docs in scenario when multiple JWTs tokens are provided: https://github.com/Kong/kong/issues/11796. With the change from some time ago: https://github.com/Kong/kong/pull/9946 - kong rejects request when multiple JWTs were provided that differ from each other. 
 
This PR explicitly states that the request will be rejected.

### Testing instructions

Preview link: https://deploy-preview-6353--kongdocs.netlify.app/

A shortcut to the change: https://deploy-preview-6353--kongdocs.netlify.app/hub/kong-inc/jwt/

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

