### PR TITLE
Fix API URL in Konnect Custom Plugin docs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -86,6 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v39

--- a/app/konnect/gateway-manager/plugins/add-custom-plugin.md
+++ b/app/konnect/gateway-manager/plugins/add-custom-plugin.md
@@ -43,6 +43,9 @@ Upload a custom plugin schema to create a configurable entity in {{site.konnect_
 {% navtabs %}
 {% navtab Konnect UI %}
 
+{:.note}
+> **Note**: The UI is not available when using KIC in Konnect. Please use the Konnect API instead.
+
 1. From the **Gateway Manager**, open a control plane.
 1. Open **Plugins** from the side navigation, then click **Add Plugin**.
 1. Open the **Custom Plugins** tab, then click **Create** on the Custom Plugin tile.
@@ -56,7 +59,7 @@ Upload the `schema.lua` file for your plugin using the [`/plugin-schemas`](/konn
 
 ```sh
 curl -i -X POST \
-  https://{region}.api.konghq.com/v2/{controlPlaneId}/core-entities/plugin-schemas \
+  https://{region}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/plugin-schemas \
   --header 'Content-Type: application/json' \
   --data "{\"lua_schema\": <your escaped Lua schema>}"
 ```
@@ -73,7 +76,7 @@ You can check that your schema was uploaded using the following request:
 
 ```sh
 curl -i -X GET \
-  https://{region}.api.konghq.com/v2/{controlPlaneId}/core-entities/plugin-schemas
+  https://{region}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/plugin-schemas
 ```
 
 This request returns an `HTTP 200` response with the schema for your plugin as a JSON object.


### PR DESCRIPTION
### Description

Fix the API URL for uploading custom plugin schemas

### Testing instructions

Preview link: /konnect/gateway-manager/plugins/add-custom-plugin/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

