### PR TITLE
fix(portal) remove examples with path in portal gui host

### DIFF
--- a/app/_src/gateway/reference/configuration-3.0-3.3.md
+++ b/app/_src/gateway/reference/configuration-3.0-3.3.md
@@ -3104,7 +3104,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 

--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -2915,7 +2915,6 @@ Examples:
 
 - `<IP>:<PORT>` -> `portal_gui_host = 127.0.0.1:8003`
 - `<HOSTNAME>` -> `portal_gui_host = portal_api.domain.tld`
-- `<HOSTNAME>/<PATH>` -> `portal_gui_host = dev-machine/dev-285`
 
 **Default:** `127.0.0.1:8003`
 


### PR DESCRIPTION
### Summary
Removes examples of adding a path when configuring `portal_gui_host`

Related: https://github.com/Kong/docs.konghq.com/pull/4179

### Reason
Adding a path to `portal_gui_host` is not supported

### Testing
<!-- How can your reviewers test your change? How did you test it? -->

<!-- (Optional) Include link to topic in Netlify preview after it's generated 
(around 10mins after PR is created) -->

<!--

When raising a pull request, it's useful to indicate what type of review you're looking for from the team. To help with this, we've added three labels that can be applied:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review from an SME.

At least one of these labels must be applied to a PR or the build will fail.
-->
