### PR TITLE
Add HTTP routing guide

### DIFF
--- a/app/_data/docs_nav_kic_3.0.x.yml
+++ b/app/_data/docs_nav_kic_3.0.x.yml
@@ -97,6 +97,8 @@ items:
     items:
       - text: Service Configuration
         items:
+          - text: HTTP Service
+            url: /guides/services/http
           - text: TCP Service
             url: /guides/services/tcp
           - text: UDP Service

--- a/app/_src/kubernetes-ingress-controller/guides/services/http.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/http.md
@@ -1,0 +1,25 @@
+---
+title: Proxy HTTP requests
+type: how-to
+purpose: |
+  How to proxy HTTP requests
+---
+
+Create HTTP routing configuration for {{site.base_gateway}} in Kubernetes using either the `HTTPRoute` Gateway API resource or `Ingress` resource.
+
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version gateway_api_experimental=true %}
+
+## Install echo service
+
+Install an example echo service:
+
+```bash
+kubectl apply -f {{site.links.web}}/assets/kubernetes-ingress-controller/examples/echo-service.yaml
+```
+The results should look like this:
+```text
+service/echo created
+deployment.apps/echo created
+```
+
+{% include_cached /md/kic/http-test-routing.md kong_version=page.kong_version path='/echo' name='echo' service='echo' port='1027' skip_host=true %}


### PR DESCRIPTION
### Description

We have guides for TCP, UDP and GRPC routing. We were missing a HTTP routing guide

### Testing instructions

Preview link: 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

