### PR TITLE
[Sitemap] Only include `latest` version for gateway-operator

### DIFF
--- a/app/_plugins/generators/seo/index_entry_builder.rb
+++ b/app/_plugins/generators/seo/index_entry_builder.rb
@@ -3,7 +3,7 @@
 module SEO
   class IndexEntryBuilder
     VERSIONED_PRODUCTS = %w[
-      gateway mesh kubernetes-ingress-controller deck
+      gateway mesh kubernetes-ingress-controller deck gateway-operator
     ].freeze
 
     GLOBAL_PAGES = %w[changelog].freeze


### PR DESCRIPTION
### Description

The sitemap included both `latest` and `1.0.x` URLs.
Fixes the issue by just including `latest`

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

