### PR TITLE
Fix: Add missing docker image options to Gateway install overview

### DIFF
--- a/app/_data/tables/install_options.yml
+++ b/app/_data/tables/install_options.yml
@@ -65,7 +65,7 @@ features:
         oss: true
         enterprise: true
         support: true
-        url: /gateway/VERSION/install/docker/
+        url: /gateway/VERSION/install/docker/build-custom-images/
         icon: /assets/images/icons/third-party/debian-logo.jpg
       - name: "RHEL (8-ubi)"
         oss: true
@@ -79,6 +79,18 @@ features:
         support: false
         url: /gateway/VERSION/install/docker/build-custom-images/
         icon: /assets/images/icons/third-party/alpinelinux-icon.svg
+      - name: "Ubuntu"
+        oss: true
+        enterprise: true
+        support: true
+        url: /gateway/VERSION/install/docker/
+        icon: /assets/images/icons/third-party/ubuntu.png
+      - name: "Amazon Linux (2 and 2022)"
+        oss: true
+        enterprise: true
+        support: true
+        url: https://hub.docker.com/r/kong/kong-gateway/tags?page=1&name=amazonlinux
+        icon: /assets/images/icons/third-party/amazon-linux.png
 
   - name: "Other"
     items:

--- a/app/_data/tables/install_options_34x.yml
+++ b/app/_data/tables/install_options_34x.yml
@@ -59,7 +59,7 @@ features:
         oss: true
         enterprise: true
         support: true
-        url: /gateway/VERSION/install/docker/
+        url: /gateway/VERSION/install/docker/build-custom-images/
         icon: /assets/images/icons/third-party/debian-logo.jpg
       - name: "RHEL (8-ubi)"
         oss: true
@@ -67,6 +67,18 @@ features:
         support: true
         url: /gateway/VERSION/install/docker/build-custom-images/
         icon: /assets/images/icons/third-party/rhel.jpg
+      - name: "Ubuntu"
+        oss: true
+        enterprise: true
+        support: true
+        url: /gateway/VERSION/install/docker/
+        icon: /assets/images/icons/third-party/ubuntu.png
+      - name: "Amazon Linux (2 and 2023)"
+        oss: true
+        enterprise: true
+        support: true
+        url: https://hub.docker.com/r/kong/kong-gateway/tags?page=1&name=amazonlinux
+        icon: /assets/images/icons/third-party/amazon-linux.png
 
   - name: "Other"
     items:


### PR DESCRIPTION
### Description

On our [installation overview page for Gateway](https://docs.konghq.com/gateway/latest/install/), we only list RHEL and Debian as Docker options. Since this page was created, we've added support for Ubuntu and AL 2 & 2023 docker images. Ubuntu, especially, is the base OS for our convenience tags (eg latest, 3.4, 3.4.1.1) so not having it listed here is very confusing. 

### Testing instructions

Preview link: https://deploy-preview-6380--kongdocs.netlify.app/gateway/latest/install/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

