### PR TITLE
fix: HTTPS redirects

### DIFF
--- a/app/_includes/md/kic/add-tls-conf.md
+++ b/app/_includes/md/kic/add-tls-conf.md
@@ -34,3 +34,38 @@ kubectl patch --type=json gateway kong -p='[{
 		}
     }
 }]'
+
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+    The results should look like this:
+
+    {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Ingress %}
+```text
+ingress.networking.k8s.io/echo patched
+```
+{% endnavtab %}
+{% navtab Gateway APIs %}
+```text
+gateway.gateway.networking.k8s.io/kong patched
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+1. Send requests to verify if the configured certificate is served.
+
+    ```bash
+    curl -ksv https://kong.example/echo --resolve kong.example:443:$PROXY_IP 2>&1 | grep -A1 "certificate:"
+    ```
+    The results should look like this:
+    ```text
+    * Server certificate:
+    *  subject: CN=kong.example
+    ```

--- a/app/_includes/md/kic/add-tls-conf.md
+++ b/app/_includes/md/kic/add-tls-conf.md
@@ -1,0 +1,36 @@
+
+{% include_cached /md/kic/add-certificate.md hostname=include.hostname kong_version=page.kong_version %}
+
+1. Update your routing configuration to use this certificate.
+ {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Ingress %}
+```bash
+kubectl patch --type json ingress echo -p='[{
+    "op":"add",
+	"path":"/spec/tls",
+	"value":[{
+        "hosts":["kong.example"],
+		"secretName":"{{include.hostname}}"
+    }]
+}]'
+```
+{% endnavtab %}
+{% navtab Gateway APIs %}
+```bash
+kubectl patch --type=json gateway kong -p='[{
+    "op":"add",
+	"path":"/spec/listeners/-",
+	"value":{
+		"name":"proxy-ssl",
+		"port":443,
+		"protocol":"HTTPS",
+		"tls":{
+				"certificateRefs":[{
+				    "group":"",
+					"kind":"Secret",
+					"name":"{{include.hostname}}"
+				}]
+		}
+    }
+}]'

--- a/app/_src/kubernetes-ingress-controller/guides/services/https-redirect.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/https-redirect.md
@@ -13,18 +13,16 @@ microservices is encrypted.
 
 {% include_cached /md/kic/http-test-service.md kong_version=page.kong_version %}
 
-{% include_cached /md/kic/class.md kong_version=page.kong_version %}
-
 {% include_cached /md/kic/http-test-routing.md kong_version=page.kong_version %}
 
 ## Add TLS configuration
 
 {% include_cached /md/kic/add-tls-conf.md hostname='kong.example' kong_version=page.kong_version %}
 
-## Configure an HTTPS redirect
+## Configure a HTTPS redirect
 
 Kong handles HTTPS redirects by automatically issuing redirects to requests
-whose characteristics match an HTTPS-only route except for the protocol. For
+whose characteristics match a HTTPS-only route except for the protocol. For
 example, with a Kong route such as this:
 
 ```json
@@ -112,9 +110,9 @@ ingress.networking.k8s.io/echo annotated
 {% endcapture %}
 {{ the_code | indent }}
 
-> **Note**: The GatewayAPI _does not_ use an [HTTPRequestRedirectFilter](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.HTTPRequestRedirectFilter)
+> **Note**: The GatewayAPI _does not_ use a [HTTPRequestRedirectFilter](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.HTTPRequestRedirectFilter)
 to configure the redirect. Using the filter to redirect HTTP to HTTPS requires
-a separate HTTPRoute to handle redirected HTTPS traffic, which does not mesh
+a separate HTTPRoute to handle redirected HTTPS traffic, which does not align
 well with Kong's single route redirect model.
 
 Work to support the standard filter-based configuration is ongoing. Until then,

--- a/app/_src/kubernetes-ingress-controller/guides/services/https-redirect.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/https-redirect.md
@@ -4,3 +4,181 @@ type: how-to
 purpose: |
   Force HTTP requests to use a HTTPS endpoint
 ---
+
+Learn to configure the {{site.kic_product_name}} to redirect HTTP requests to
+HTTPS so that all communication from the external world to your APIs and
+microservices is encrypted.
+
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false %}
+
+{% include_cached /md/kic/http-test-service.md kong_version=page.kong_version %}
+
+{% include_cached /md/kic/class.md kong_version=page.kong_version %}
+
+{% include_cached /md/kic/http-test-routing.md kong_version=page.kong_version %}
+
+## Add TLS configuration
+
+{% include_cached /md/kic/add-tls-conf.md hostname='kong.example' kong_version=page.kong_version %}
+
+## Configure an HTTPS redirect
+
+Kong handles HTTPS redirects by automatically issuing redirects to requests
+whose characteristics match an HTTPS-only route except for the protocol. For
+example, with a Kong route such as this:
+
+```json
+{ "protocols": ["https"], "hosts": ["kong.example"],
+  "https_redirect_status_code": 301, "paths": ["/echo/"], "name": "example" }
+```
+
+A request for `http://kong.example/echo/green` receives a 301 response with
+a `Location: https://kong.example/echo/green` header. Kubernetes resource
+annotations instruct the controller to create a route with `protocols=[https]`
+and `https_redirect_status_code` set to the code of your choice (the default if
+unset is `426`).
+1. Configure the protocols that are allowed in the `konghq.com/protocols` annotation.
+   {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Gateway APIs %}
+
+```bash
+kubectl annotate httproute echo konghq.com/protocols=https
+```
+{% endnavtab %}
+{% navtab Ingress %}
+
+```bash
+kubectl annotate ingress echo konghq.com/protocols=https
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+    The results should look like this:
+
+    {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Gateway APIs %}
+```text
+httproute.gateway.networking.k8s.io/echo annotated
+```
+{% endnavtab %}
+{% navtab Ingress %}
+```text
+ingress.networking.k8s.io/echo annotated
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+
+1. Configure the status code used to redirect in the `konghq.com/https-redirect-status-code`` annotation. 
+   {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Gateway APIs %}
+
+```bash
+kubectl annotate httproute echo konghq.com/https-redirect-status-code="301"
+```
+{% endnavtab %}
+{% navtab Ingress %}
+
+```bash
+kubectl annotate ingress echo konghq.com/https-redirect-status-code="301"
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+   The results should look like this:
+
+   {% capture the_code %}
+{% navtabs codeblock %}
+{% navtab Gateway APIs %}
+```text
+httproute.gateway.networking.k8s.io/echo annotated
+```
+{% endnavtab %}
+{% navtab Ingress %}
+```text
+ingress.networking.k8s.io/echo annotated
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+> **Note**: The GatewayAPI _does not_ use an [HTTPRequestRedirectFilter](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.HTTPRequestRedirectFilter)
+to configure the redirect. Using the filter to redirect HTTP to HTTPS requires
+a separate HTTPRoute to handle redirected HTTPS traffic, which does not mesh
+well with Kong's single route redirect model.
+
+Work to support the standard filter-based configuration is ongoing. Until then,
+the annotations allow you to configure HTTPS-only HTTPRoutes.
+
+## Test the configuration
+
+With the redirect configuration in place, HTTP requests now receive a
+redirect rather than being proxied upstream:
+1. Send a HTTP request.
+    ```bash
+    curl -ksvo /dev/null http://kong.example/echo --resolve kong.example:80:$PROXY_IP 2>&1 | grep -i http
+    ```
+
+    The results should look like this:
+
+    ```text
+    > GET /echo HTTP/1.1
+    < HTTP/1.1 301 Moved Permanently
+    < Location: https://kong.example/echo
+    ```
+
+1. Send a curl request to follow redirects using the `-L` flag navigates
+to the HTTPS URL and receive a proxied response from upstream.
+
+    ```bash
+    curl -Lksv http://kong.example/echo --resolve kong.example:80:$PROXY_IP --resolve kong.example:443:$PROXY_IP 2>&1
+    ```
+
+    The results should look like this (some output removed for brevity):
+
+    ```text
+    > GET /echo HTTP/1.1
+    > Host: kong.example
+    >
+    < HTTP/1.1 301 Moved Permanently
+    < Location: https://kong.example/echo
+    < Server: kong/3.4.2
+    
+    * Issue another request to this URL: 'https://kong.example/echo'
+
+    * Server certificate:
+    *  subject: CN=kong.example
+     
+    > GET /echo HTTP/2
+    > Host: kong.example
+    >
+    < HTTP/2 200
+    < via: kong/3.4.2
+    <
+    Welcome, you are connected to node kind-control-plane.
+    Running on Pod echo-74d47cc5d9-pq2mw.
+    In namespace default.
+    With IP address 10.244.0.7.
+    ```
+
+Kong correctly serves the request only on HTTPS protocol and redirects the user
+if the HTTP protocol is used. The `-k` flag in cURL skips certificate
+validation as the certificate served by Kong is a self-signed one. If you are
+serving this traffic through a domain that you control and have configured TLS
+properties for it, then the flag won't be necessary.
+
+If you have a domain that you control but don't have TLS/SSL certificates for
+it, see [Using cert-manager with
+Kong](/kubernetes-ingress-controller/{{page.kong_version}}/guides/cert-manager)
+guide which can get TLS certificates setup for you automatically. And it's
+free, thanks to Let's Encrypt!


### PR DESCRIPTION
### Description

Port content to 3.0
GatewayAPI first tab and Ingress as second tab
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

