### PR TITLE
Fix KIC prerequisites

### DIFF
--- a/app/_includes/md/kic/prerequisites.md
+++ b/app/_includes/md/kic/prerequisites.md
@@ -52,12 +52,13 @@
        protocol: HTTP
    " | kubectl apply -f -
    ```
-{% endunless %}
+
    The results should look like this:
    ```text
    gatewayclass.gateway.networking.k8s.io/kong created
    gateway.gateway.networking.k8s.io/kong created
    ```
+{% endunless %}
 
 
 ### Install Kong


### PR DESCRIPTION
### Description

KIC prereqs showed the Gateway API results even if Gateway API isn't enabled

### Testing instructions

Preview link: /kubernetes-ingress-controller/latest/guides/configuring-fallback-service/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

