### PR TITLE
Document in FAQ running KIC as DaemonSet

### DIFF
--- a/app/_src/kic-v2/faq.md
+++ b/app/_src/kic-v2/faq.md
@@ -32,3 +32,13 @@ This means that if consumers and credentials are created dynamically, they are n
 [kube-proxy]: https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy
 [k8s-endpointslices]: https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/
 [k8s-endpoints]: https://kubernetes.io/docs/concepts/services-networking/service/#endpoints
+
+### Is it possible to deploy Kong Ingress Controller with Kong Gateway as DaemonSet?
+
+It is possible. Such configuration may be useful in environments where LoadBalancer or NodePort Service
+is not a desired choice. Deploy Kong as DaemonSet and configure Pods to use the network of the host they run on instead
+of a dedicated network namespace. The benefit of this approach is that the Kong can bind ports 80 and 443 directly to
+Kubernetes nodes' network interfaces, without the extra network translation imposed by NodePort Services. Read more about
+such configuration in the [dedicated Helm chart docs section][chart-using-a-daemonset].
+
+[chart-using-a-daemonset]: (https://github.com/Kong/charts/blob/main/charts/kong/README.md#using-a-daemonset)


### PR DESCRIPTION
### Description

Based on information gathered from 

- https://github.com/Kong/charts/pull/269
- https://github.com/Kong/kubernetes-ingress-controller/issues/682
- https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#via-the-host-network

document when and how deploy KIC as DaemonSet, update of Helm chart docs is needed to, see and review https://github.com/Kong/charts/pull/918


Closes https://github.com/Kong/kubernetes-ingress-controller/issues/4728

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

