### PR TITLE
fix: fix changelog entry for openssl version bump

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -397,7 +397,6 @@ hang when attempting to expand an API.
 * Bumped `kong-redis-cluster` from 1.5.0 to 1.5.1
 * Bumped `lua-resty-ljsonschema` from 1.1.3 to 1.15
 * Bumped `lua-resty-kafka` from 0.15 to 0.16
-* Bumped `OpenSSL` from 1.1.1t to 3.0.8
 * Bumped `lua-resty-aws` from 1.2.2 to 1.2.3
 * Bumped `lua-resty-openssl` from 0.8.20 to 0.8.23
   [#10837](https://github.com/Kong/kong/pull/10837)

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -489,6 +489,8 @@ doesn't match the provided status.
 
 * Bumped `libxml2` from 2.10.2 to 2.11.5
 * Bumped `lua-resty-kafka` from 0.15 to 0.16
+* Bumped `OpenSSL` from 1.1.1t to 3.1.1
+
 
 ## 3.3.1.0
 **Release Date** 2023/07/03
@@ -989,6 +991,8 @@ images or packages, and Kong will not test package installation on Ubuntu 18.04.
 ### Dependencies
 
 * `lua-resty-kafka` is bumped from 0.15 to 0.16
+* Bumped `OpenSSL` from 1.1.1t to 3.1.1
+
 
 ## 3.2.2.3 
 **Release Date** 2023/06/07
@@ -1405,6 +1409,7 @@ This change is in direct response to the identified vulnerability
 
 ### Dependencies
 
+* Bumped `OpenSSL` from 1.1.1t to 3.1.1
 * Bumped`lua-resty-openssl` from 0.8.15 to 0.8.22
 * Bumped `lua-resty-kafka` from 0.15 to 0.16
 
@@ -2922,6 +2927,7 @@ images or packages, and Kong will not test package installation on Ubuntu 18.04.
 * Fixed an issue where the slow startup of the Go plugin server caused a deadlock.
 
 ### Dependencies
+* Bumped `OpenSSL` from 1.1.1t to 3.1.1
 * Bumped `lodash` for Dev Portal from 4.17.11 to 4.17.21
 * Bumped `lodash` for Kong Manager from 4.17.15 to 4.17.21
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

The PR fixes the issue that the changelog entries of OpenSSL version bumping from 1.1.1t to 3.1.1 are missing from several specific versions.

The missing version list are:
- 2.8.4.2
- 3.1.1.5
- 3.2.2.4
- 3.3.1.1


The PR adds all of them.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

