### PR TITLE
fix(opentelemetry): address invalid request to set up plugin

### DIFF
--- a/app/_hub/kong-inc/opentelemetry/overview/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/overview/_index.md
@@ -131,9 +131,16 @@ Enable the plugin:
 
 ```bash
 curl -X POST http://localhost:8001/plugins \
-    --data "name=opentelemetry"  \
-    --data "config.endpoint=http://<opentelemetry-backend>:4318/v1/traces" \
-    --data "config.resource_attributes.service.name=kong-dev"
+    -H 'Content-Type: application/json' \
+    -d '{
+      "name": "opentelemetry",
+      "config": {
+        "endpoint": "http://<opentelemetry-backend>:4318/v1/traces",
+        "resource_attributes": {
+          "service.name": "kong-dev"
+        }
+      }
+    }'
 ```
 
 ## How the OpenTelemetry plugin functions


### PR DESCRIPTION
### Description

The request documented to configure the Opentelemetry plugin is invalid because it uses a dot `.` in the name of the attribute, which is interpreted as a field separator in the curl form data.

This updates the documentation without changing the example, using JSON instead of form data to allow passing a name that includes a dot.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

