### PR TITLE
Add KIC 3.0 install methods

### DIFF
--- a/app/_data/docs_nav_kic_3.0.x.yml
+++ b/app/_data/docs_nav_kic_3.0.x.yml
@@ -61,10 +61,10 @@ items:
             url: /production/deployment-topologies/sidecar
       - text: Installation Methods
         items: 
-          - text: Kong Gateway Operator
-            url: /install/gateway-operator
           - text: Helm
             url: /install/helm
+          - text: Kong Gateway Operator
+            url: /install/gateway-operator
       - text: Cloud Deployment
         items: 
           - text: Azure

--- a/app/_includes/snippets/gateway-operator/install_with_kubectl_all_controllers.md
+++ b/app/_includes/snippets/gateway-operator/install_with_kubectl_all_controllers.md
@@ -1,8 +1,8 @@
 To install {{ site.kgo_product_name }} use `kubectl apply`:
 
 ```bash
-kubectl apply -f {{site.links.web}}/assets/gateway-operator/v{{page.version}}/crds.yaml --server-side
-kubectl apply -f {{site.links.web}}/assets/gateway-operator/v{{page.version}}/all_controllers.yaml
+kubectl apply -f {{site.links.web}}/assets/gateway-operator/v{{include.version}}/crds.yaml --server-side
+kubectl apply -f {{site.links.web}}/assets/gateway-operator/v{{include.version}}/all_controllers.yaml
 ```
 
 You can wait for the operator to be ready using `kubectl wait`:

--- a/app/_src/gateway-operator/get-started/kic/install.md
+++ b/app/_src/gateway-operator/get-started/kic/install.md
@@ -17,4 +17,4 @@ kubectl apply -k https://github.com/Kong/kubernetes-ingress-controller/config/cr
 kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.8.1"
 ```
 
-{% include snippets/gateway-operator/install_with_kubectl_all_controllers.md %}
+{% include snippets/gateway-operator/install_with_kubectl_all_controllers.md version=page.version%}

--- a/app/_src/kubernetes-ingress-controller/get-started/index.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/index.md
@@ -7,4 +7,4 @@ purpose: |
   Install KIC using Helm
 ---
 
-{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_accordian=true %}
+{% include /md/kic/prerequisites.md kong_version=page.kong_version disable_accordian=true %}

--- a/app/_src/kubernetes-ingress-controller/install/gateway-operator.md
+++ b/app/_src/kubernetes-ingress-controller/install/gateway-operator.md
@@ -1,6 +1,10 @@
 ---
-title: Gateway Operator
+title: Install Kong Ingress Controller with the KGO
 type: how-to
 purpose: |
   Using KGO to install KIC
 ---
+
+{{ site.kgo_product_name }} configures and manages {{ site.kic_product_name }} automatically using [Gateway API](https://github.com/kubernetes-sigs/gateway-api) resources. This is in contrast to Helm, which provides an ingress controller that has the [`konghq.com/gatewayclass-unmanaged: 'true'` annotation](/kubernetes-ingress-controller/latest/gateway-api/#gatewayclass--gateway).
+
+For more information, see the [{{ site.kgo_product_name }} with KIC](/gateway-operator/latest/get-started/kic/install/) getting started guide.

--- a/app/_src/kubernetes-ingress-controller/install/helm.md
+++ b/app/_src/kubernetes-ingress-controller/install/helm.md
@@ -1,6 +1,36 @@
 ---
-title: Helm
+title: Install Kong Ingress Controller with Helm
 type: how-to
 purpose: |
   Using Helm to install KIC
 ---
+
+{{ site.kic_product_name }} is installed using the [kong/ingress](https://github.com/Kong/charts/tree/main/charts/ingress) Helm chart.
+
+The `kong/ingress` chart is a wrapper around `kong/kong` that manages separate {{ site.kic_product_name }} and {{ site.base_gateway }} deployments automatically.
+
+You can use any [configuration option](https://github.com/Kong/charts/blob/main/charts/kong/README.md#configuration) available in the `kong/kong` chart when using the `kong/ingress` chart.
+
+To configure the {{ site.kic_product_name }} deployment, place the keys from `kong/kong` under a `controller` key in your `values.yaml` file.
+
+```yaml
+controller:
+  ingressController:
+    image:
+      repository: kong/nightly-ingress-controller
+      tag: nightly
+      effectiveSemver: "{{ site.data.kong_latest_KIC.version }}"
+```
+
+
+To configure the {{ site.base_gateway }} deployment, place the keys from `kong/kong` under a `gateway` key in your `values.yaml` file.
+
+```yaml
+gateway:
+  env:
+    router_flavor: expressions
+```
+
+## Installation
+
+{% include /md/kic/prerequisites.md kong_version=page.kong_version disable_accordian=true %}

--- a/app/_src/kubernetes-ingress-controller/install/helm.md
+++ b/app/_src/kubernetes-ingress-controller/install/helm.md
@@ -9,9 +9,9 @@ purpose: |
 
 The `kong/ingress` chart is a wrapper around `kong/kong` that manages separate {{ site.kic_product_name }} and {{ site.base_gateway }} deployments automatically.
 
-You can use any [configuration option](https://github.com/Kong/charts/blob/main/charts/kong/README.md#configuration) available in the `kong/kong` chart when using the `kong/ingress` chart.
+You can use any of the [configuration options](https://github.com/Kong/charts/blob/main/charts/kong/README.md#configuration) available in the `kong/kong` chart when using the `kong/ingress` chart.
 
-To configure the {{ site.kic_product_name }} deployment, place the keys from `kong/kong` under a `controller` key in your `values.yaml` file.
+*  To configure the {{ site.kic_product_name }} deployment, place the keys from `kong/kong` under a `controller` key in the values.yaml` file.
 
 ```yaml
 controller:
@@ -23,7 +23,7 @@ controller:
 ```
 
 
-To configure the {{ site.base_gateway }} deployment, place the keys from `kong/kong` under a `gateway` key in your `values.yaml` file.
+*  To configure the {{ site.base_gateway }} deployment, place the keys from `kong/kong` under a `gateway` key in the `values.yaml` file.
 
 ```yaml
 gateway:


### PR DESCRIPTION
### Description

Add KIC 3.0 Helm + KGO install instructions

### Testing instructions

Preview link: 

* https://deploy-preview-6421--kongdocs.netlify.app/kubernetes-ingress-controller/latest/install/helm/
* https://deploy-preview-6421--kongdocs.netlify.app/kubernetes-ingress-controller/latest/install/gateway-operator/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)