### PR TITLE
Add labels to the PR created in sync-kuma-submodule.yml

### DIFF
--- a/.github/workflows/sync-kuma-submodule.yml
+++ b/.github/workflows/sync-kuma-submodule.yml
@@ -78,4 +78,5 @@ jobs:
             ${{ env.SUBMODULE_PR_LOG }}
 
             Triggered by [action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            labels: skip-changelog,review:general
           draft: false


### PR DESCRIPTION
Adds the `skip-changelog` and `review:general` labels to this changelog so that the PR's from this action won't be picked up in the auto changelog.

