### PR TITLE
Add enterprise image signing verification docs

### DIFF
--- a/app/_data/docs_nav_gateway_3.5.x.yml
+++ b/app/_data/docs_nav_gateway_3.5.x.yml
@@ -308,6 +308,8 @@ items:
             url: /kong-enterprise/fips-support/plugins
       - text: Authenticate your Kong Gateway Amazon RDS database with AWS IAM
         url: /kong-enterprise/aws-iam-auth-to-rds-database
+      - text: Verify signatures for Signed Kong Images
+        url: /kong-enterprise/signing-verify
 
   - title: Kong Manager
     icon: /assets/images/icons/documentation/icn-manager-color.svg

--- a/app/_data/tables/features/gateway.yml
+++ b/app/_data/tables/features/gateway.yml
@@ -93,6 +93,10 @@ features:
         tooltip: Kong Gateway now provides a FIPS mode, which at its core uses the FIPS 140-2 compliant BoringCrypto for cryptographic operations.
         oss: false
         enterprise: true
+      - name: Signed Kong Images
+        tooltip: Kong Gateway container images are signed and verifiable in accordance SLSA guidelines.
+        oss: false
+        enterprise: true
   - name: Observability
     items:
       - name: Simple logging

--- a/app/_src/gateway/kong-enterprise/index.md
+++ b/app/_src/gateway/kong-enterprise/index.md
@@ -146,6 +146,11 @@ For example, you could define three consumer groups:
 Starting in version 3.2, {{site.base_gateway}} can be configured to support configuring new data planes in the event of a control plane outage. For more information, read the [How to Manage New Data Planes during Control Plane Outages](/gateway/latest/kong-enterprise/cp-outage-handling/) documentation, or the [Control Plane Outage Management FAQ](/gateway/latest/kong-enterprise/cp-outage-handling-faq/).
 
 {% endif_version %}
+
+## Docker container image signing
+
+Starting with version 3.5 of {{site.ee_product_name}}, Docker container images are signed, and can be verified using `cosign` with signatures published to a Docker Hub repository. Read the [Verify signatures for Signed Kong Images](/gateway/latest/kong-enterprise/signing-verify/) documentation to learn more.
+
 ## More information
 
 See [Plugin Compatibility](/hub/plugins/compatibility/) for more information about Enterprise-only plugins.

--- a/app/_src/gateway/kong-enterprise/signing-verify/index.md
+++ b/app/_src/gateway/kong-enterprise/signing-verify/index.md
@@ -3,16 +3,15 @@ title: Verify signatures for Signed Kong Images
 badge: enterprise
 ---
 
-As of {{site.ee_product_name}} version 3.5, Docker container images are now signed using `cosign` with signatures published to a Docker Hub repository.
+Starting in the first patch version of {{site.ee_product_name}} 3.5, Docker container images are now signed using `cosign` with signatures published to a Docker Hub repository.
 
 This guide provides steps to verify signatures for signed {{site.ee_product_name}} Docker container images in 2 different ways. The first is the minimal example, used to verify an image without leveraging any annotations. The second is the complete example, leveraging optional annotations for increased trust.
 
 For the minimal example, you only need: Docker details, Github repo name, and Github workflow filename.
 For the complete example, you will need the same details from above, as well as any of the optional annotations you wish to verify:
 
-| "token" | Description | Example Value |
+| Shorthand | Description | Example Value |
 |---|---|---|
-| `<sha>` | Github commit sha | `3687f9f32a80a60869cc3c0b7584be9696973e7e` |
 | `<repo>` | Github repository | `kong-ee` |
 | `<workflow filename>` | Github workflow filename | `release.yml` |
 | `<workflow name>` | Github workflow name | `Package & Release` |
@@ -27,10 +26,10 @@ For both examples, you will need to:
 
 2. Collect the necessary image details
 
-3. Set the `COSIGN_REPOSITORY` environment variable (`kong/notary` or `kong/notary-internal`)
+3. Set the `COSIGN_REPOSITORY` environment variable
 
    ```sh
-   export COSIGN_REPOSITORY=kong/notary-internal
+   export COSIGN_REPOSITORY=kong/notary
    ```
 
 {:.important .no-icon}
@@ -49,7 +48,7 @@ cosign verify \
 
 ```sh
 cosign verify \
-   'kong/kong-gateway-dev:3687f9f32a80a60869cc3c0b7584be9696973e7e@sha256:65310a3947775cb3ac30f3c21504c2c8d28a688825b2256a40678bc2cbee1189' \
+   'kong/kong-gateway:3.5.0.1-ubuntu@sha256:65310a3947775cb3ac30f3c21504c2c8d28a688825b2256a40678bc2cbee1189' \
    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
    --certificate-identity-regexp='https://github.com/Kong/kong-ee/.github/workflows/release.yml*'
 ```
@@ -62,16 +61,14 @@ cosign verify \
    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
    --certificate-identity-regexp='https://github.com/Kong/<repo>/.github/workflows/<workflow filename>*' \
    -a repo="Kong/<repo>" \
-   -a workflow="<workflow name>" \
-   -a sha="<sha>"
+   -a workflow="<workflow name>"
 ```
 
 ```sh
 cosign verify \
-   'kong/kong-gateway-dev:3687f9f32a80a60869cc3c0b7584be9696973e7e@sha256:65310a3947775cb3ac30f3c21504c2c8d28a688825b2256a40678bc2cbee1189' \
+   'kong/kong-gateway:3.5.0.1-ubuntu@sha256:65310a3947775cb3ac30f3c21504c2c8d28a688825b2256a40678bc2cbee1189' \
    --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
    --certificate-identity-regexp='https://github.com/Kong/kong-ee/.github/workflows/release.yml*' \
    -a repo="Kong/kong-ee" \
-   -a workflow="Package & Release" \
-   -a sha="3687f9f32a80a60869cc3c0b7584be9696973e7e"
+   -a workflow="Package & Release"
 ```

--- a/app/_src/gateway/kong-enterprise/signing-verify/index.md
+++ b/app/_src/gateway/kong-enterprise/signing-verify/index.md
@@ -10,9 +10,12 @@ This guide provides steps to verify signatures for signed {{site.ee_product_name
 For the minimal example, you only need: Docker details, Github repo name, and Github workflow filename.
 For the complete example, you will need the same details from above, as well as any of the optional annotations you wish to verify:
 
-- Github commit sha
-- Github repository
-- Github workflow name
+| "token" | Description | Example Value |
+|---|---|---|
+| `<sha>` | Github commit sha | `3687f9f32a80a60869cc3c0b7584be9696973e7e` |
+| `<repo>` | Github repository | `kong-ee` |
+| `<workflow filename>` | Github workflow filename | `release.yml` |
+| `<workflow name>` | Github workflow name | `Package & Release` |
 
 Because Kong uses Github Actions to build and release, Kong also uses Github's OIDC identity to sign images; thus many of these details are Github-related.
 
@@ -52,6 +55,16 @@ cosign verify \
 ```
 
 ### Complete Example
+
+```sh
+cosign verify \
+   <image>:<tag>@sha256:<digest> \
+   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+   --certificate-identity-regexp='https://github.com/Kong/<repo>/.github/workflows/<workflow filename>*' \
+   -a repo="Kong/<repo>" \
+   -a workflow="<workflow name>" \
+   -a sha="<sha>"
+```
 
 ```sh
 cosign verify \

--- a/app/_src/gateway/kong-enterprise/signing-verify/index.md
+++ b/app/_src/gateway/kong-enterprise/signing-verify/index.md
@@ -1,0 +1,64 @@
+---
+title: Verify signatures for Signed Kong Images
+badge: enterprise
+---
+
+As of {{site.ee_product_name}} version 3.5, Docker container images are now signed using `cosign` with signatures published to a Docker Hub repository.
+
+This guide provides steps to verify signatures for signed {{site.ee_product_name}} Docker container images in 2 different ways. The first is the minimal example, used to verify an image without leveraging any annotations. The second is the complete example, leveraging optional annotations for increased trust.
+
+For the minimal example, you only need: Docker details, Github repo name, and Github workflow filename.
+For the complete example, you will need the same details from above, as well as any of the optional annotations you wish to verify:
+
+- Github commit sha
+- Github repository
+- Github workflow name
+
+Because Kong uses Github Actions to build and release, Kong also uses Github's OIDC identity to sign images; thus many of these details are Github-related.
+
+## Examples
+
+For both examples, you will need to:
+
+1. Ensure `cosign` is installed
+
+2. Collect the necessary image details
+
+3. Set the `COSIGN_REPOSITORY` environment variable (`kong/notary` or `kong/notary-internal`)
+
+   ```sh
+   export COSIGN_REPOSITORY=kong/notary-internal
+   ```
+
+{:.important .no-icon}
+> Github owner is case-sensitive (`Kong/kong-ee` vs `kong/kong-ee`).
+
+### Minimal Example
+
+Run the `cosign verify ...` command:
+
+```sh
+cosign verify \
+   <image>:<tag>@sha256:<digest> \
+   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+   --certificate-identity-regexp='https://github.com/Kong/<repo>/.github/workflows/<workflow filename>*'
+```
+
+```sh
+cosign verify \
+   'kong/kong-gateway-dev:3687f9f32a80a60869cc3c0b7584be9696973e7e@sha256:65310a3947775cb3ac30f3c21504c2c8d28a688825b2256a40678bc2cbee1189' \
+   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+   --certificate-identity-regexp='https://github.com/Kong/kong-ee/.github/workflows/release.yml*'
+```
+
+### Complete Example
+
+```sh
+cosign verify \
+   'kong/kong-gateway-dev:3687f9f32a80a60869cc3c0b7584be9696973e7e@sha256:65310a3947775cb3ac30f3c21504c2c8d28a688825b2256a40678bc2cbee1189' \
+   --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+   --certificate-identity-regexp='https://github.com/Kong/kong-ee/.github/workflows/release.yml*' \
+   -a repo="Kong/kong-ee" \
+   -a workflow="Package & Release" \
+   -a sha="3687f9f32a80a60869cc3c0b7584be9696973e7e"
+```


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

These are the customer-facing docs needed to allow customers to take full advantage of the recent changes to the Kong Enterprise build that implement `cosign`-based image signing.

- Confluence: [Solutions Document](https://konghq.atlassian.net/wiki/spaces/KS/pages/3261333515/Solution+-+Image+Container+Signing+-+Cosign#Verifying-the-EE-GW-image-integrity)
- Jira: [SEC-973](https://konghq.atlassian.net/browse/SEC-973)
- https://github.com/Kong/kong-ee/pull/6797

### Testing instructions

Preview link: https://deploy-preview-6435--kongdocs.netlify.app/gateway/latest/kong-enterprise/signing-verify/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

[SEC-973]: https://konghq.atlassian.net/browse/SEC-973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

🚧🚧🚧

Do not merge this PR until https://github.com/Kong/kong-ee/pull/7134 has been merged.
Both this PR and that PR are meant to land in the next patch 3.5 release (not the initial 3.5 release).

🚧🚧🚧