### PR TITLE
Fix: 2.8.1.3 changelog entry for aws-lambda plugin changes to match 3.0.0.0

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -3249,7 +3249,10 @@ The following entities were affected:
 #### Plugins
 
 * [AWS Lambda](/hub/kong-inc/aws-lambda/) (`aws-lambda`)
-   * Added support for cross-account lambda function invocation based on AWS roles.
+  * Added support for cross-account invocation through
+  the `aws_assume_role_arn` and
+  `aws_role_session_name` configuration parameters.
+  [#8900](https://github.com/Kong/kong/pull/8900)
 
 ### Fixes
 


### PR DESCRIPTION
### Description

Copied the text written in 3.0.0.0 changelog entry for the aws-lambda plugin to when it was introduced in 2.8.1.3 for consistency. Makes it easier to find the versions in which those properties were added for `aws_assume_role_arn` for example.

### Testing instructions

N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)