### PR TITLE
feat(openid-connect): cert-bound tokens doc edits

### DIFF
--- a/app/_hub/kong-inc/openid-connect/overview/_index.md
+++ b/app/_hub/kong-inc/openid-connect/overview/_index.md
@@ -1750,17 +1750,17 @@ Nice, as you can see the plugin even added the `X-Consumer-Id` and `X-Consumer-U
 
 One of the main vulnerabilities of OAuth are bearer tokens because presenting a valid bearer token is enough proof to access a resource. This can create problems since the client presenting the token isn't validated as the legitimate user that the token was issued to. 
 
-Certificate-bound access tokens can solve this problem by binding tokens to clients. This ensures the legitimacy of the token because the it requires proof that the sender is authorized to use a particular token to access protected resources. 
+Certificate-bound access tokens can solve this problem by binding tokens to clients. This ensures the legitimacy of the token because it requires proof that the sender is authorized to use a particular token to access protected resources. 
 
-To use enable certificate-bound access for OpenID Connect, you must ensure that the auth server is set up to generate OAuth 2.0 Mutual TLS Certificate Bound Access Tokens.
-If you are configuring this in Keycloak, see the previous [Keycloak configuration](#keycloak-configuration) section.
+To enable certificate-bound access for OpenID Connect, it is necessary to ensure that the Auth server is configured to generate OAuth 2.0 Mutual TLS Certificate Bound Access Tokens. The Certificate Authority should be trusted by both the Auth server and Kong.
+For configuring this in Keycloak, refer to the [Keycloak configuration](#keycloak-configuration) section above.
 For alternative auth servers, consult their documentation to configure this functionality.
 
 Some of the instructions in the previous sections support validation of access tokens using mTLS proof of possession.
-Enabling the `proof_of_possession_mtls` configuration option in the plugin helps to ensure that the supplied access token
+Enabling the `proof_of_possession_mtls` configuration option in the plugin ensures that the supplied access token
 belongs to the client by verifying its binding with the client certificate provided in the request.
 
-The certificate-bound access tokens are supported by the following:
+The certificate-bound access tokens are supported by the following methods:
 
 - [JWT Access Token Authentication](#jwt-access-token-authentication)
 - [Introspection Authentication](#introspection-authentication)
@@ -1769,16 +1769,19 @@ The certificate-bound access tokens are supported by the following:
     {:.note}
     > **Note:** Session Authentication is only compatible with certificate-bound access tokens when used along with one of the other supported authentication methods. When the configuration option `proof_of_possession_auth_methods_validation` is set to `false` and other non-compatible methods are enabled, if a valid session is found, the proof of possession validation will only be performed if the session was originally created using one of the compatible methods. If multiple `openid-connect` plugins are configured with the `session` auth method, we strongly recommend configuring different values of `config.session_secret` across plugins instances for additional security. This avoids sessions being shared across plugins and possibly bypassing the proof of possession validation.
 
+{:.note}
+> **Note:** The mTLS proof of possession feature relies on mutual TLS to be enabled in Kong. For more information refer to the [TLS Handshake Modifier plugin](/hub/kong-inc/tls-handshake-modifier/) or the [Mutual TLS Authentication plugin](/hub/kong-inc/mtls-auth/) documentation.
+
 The following example shows how to enable this feature for the JWT Access Token Authentication method. Similar steps can be followed for the other methods.
 
-1. Configure {{site.base_gateway}} to use mTLS client certificate authentication. You can do this by configuring the [TLS Handshake Modifier plugin](/hub/kong-inc/tls-handshake-modifier/) or the [Mutual TLS Authentication plugin](/hub/kong-inc/mtls-auth/):
+1. Configure {{site.base_gateway}} to use mTLS client certificate authentication. This example uses the [TLS Handshake Modifier plugin](/hub/kong-inc/tls-handshake-modifier/):
 
     ```bash
     http -f post :8001/plugins    \
     name=tls-handshake-modifier \
     service.name=openid-connect
     ```
-    If this is configured correctly, it returns a `200` response and something like the following:
+    If this is configured correctly, a `200` status code is returned, and a response similar to the following:
     ```json
     {
         "id": "a7f676e6-580d-4841-80de-de46e1f79eb2",
@@ -1789,7 +1792,7 @@ The following example shows how to enable this feature for the JWT Access Token 
     }
     ```
 
-1. To enable certificate-bound access tokens, use the `proof_of_possession_mtls` configuration option:
+2. To enable certificate-bound access tokens, use the `proof_of_possession_mtls` configuration option:
 
     ```bash
     http -f put :8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f4f9 \
@@ -1801,7 +1804,7 @@ The following example shows how to enable this feature for the JWT Access Token 
     config.auth_methods=bearer                                   \
     config.proof_of_possession_mtls=strict
     ```
-    If this is configured correctly, it returns a `200` response and something like the following:
+    If this is configured correctly, a `200` status code is returned, and a response similar to the following:
     ```json
     {
         "id": "5f35b796-ced6-4c00-9b2a-90eef745f4f9",
@@ -1819,7 +1822,7 @@ The following example shows how to enable this feature for the JWT Access Token 
     }
     ```
 
-1. Obtain the token from the IdP, making sure to modify the following command for your environment:
+3. Obtain the token from the IdP, making sure to modify the following command appropriately:
     ```bash
     http --cert client-cert.pem --cert-key client-key.pem                                 \
     -f post https://keycloak.test:8440/auth/realms/master/protocol/openid-connect/token \
@@ -1827,14 +1830,14 @@ The following example shows how to enable this feature for the JWT Access Token 
     client_secret=cf4c655a-0622-4ce6-a0de-d3353ef0b714                                  \
     grant_type=client_credentials
     ```
-    If this is configured correctly, it returns a `200` response and something like the following:
+    If this is configured correctly, a `200` status code is returned, and a response similar to the following:
     ```json
     {
         "access_token": "eyJhbG...",
     }
     ```
 
-    The token you obtain should include a claim that consists of the hash of the client certificate:
+    The token obtained should include a claim that consists of the hash of the client certificate:
     ```json
     {
         "exp": 1622556713,
@@ -1845,13 +1848,13 @@ The following example shows how to enable this feature for the JWT Access Token 
     }
     ```
 
-1. Access the service using the same client certificate and key used to obtain the token:
+4. Access the service using the same client certificate and key used to obtain the token:
     ```bash
     http --cert client-cert.pem --cert-key client-key.pem \
     -f post https://kong.test:8443                      \
     Authorization:"Bearer eyJhbGc..."
     ```
-    If this is configured correctly, it returns a `200` response:
+    If this is configured correctly, it returns a `200` status code:
     ```http
     HTTP/1.1 200 OK
     ```


### PR DESCRIPTION
### Description

few typos and rewording of the openid-connect certificate-bound tokens feature (orig: https://github.com/Kong/docs.konghq.com/pull/6284)

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

[KAG-2979](https://konghq.atlassian.net/browse/KAG-2979)

[KAG-2979]: https://konghq.atlassian.net/browse/KAG-2979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ