### PR TITLE
chore: Remove performance testing framework from 3.5

### DIFF
--- a/app/_data/docs_nav_gateway_3.5.x.yml
+++ b/app/_data/docs_nav_gateway_3.5.x.yml
@@ -69,8 +69,6 @@ items:
             url: /how-kong-works/load-balancing
           - text: Health Checks and Circuit Breakers
             url: /how-kong-works/health-checks
-          - text: Kong Performance Testing
-            url: /how-kong-works/performance-testing
       - text: Glossary
         url: /glossary
 
@@ -566,8 +564,6 @@ items:
         url: /reference/cli
       - text: Key Management
         url: /reference/key-management
-      - text: Performance Testing Framework
-        url: /reference/performance-testing-framework
       - text: Router Expressions Language
         url: /reference/router-expressions-language
       - text: Rate Limiting Library

--- a/app/_redirects
+++ b/app/_redirects
@@ -39,7 +39,10 @@
 # 3.5
 /gateway/latest/kong-enterprise/analytics/* /gateway/3.4.x/kong-enterprise/analytics/:splat
 /gateway/latest/kong-enterprise/dev-portal/* /gateway/3.4.x/kong-enterprise/dev-portal/:splat
-
+/gateway/latest/how-kong-works/performance-testing/ /gateway/3.4.x/how-kong-works/performance-testing/
+/gateway/3.5.x/how-kong-works/performance-testing/ /gateway/3.4.x/how-kong-works/performance-testing/
+/gateway/latest/reference/performance-testing-framework/ /gateway/3.4.x/reference/performance-testing-framework/
+/gateway/3.5.x/reference/performance-testing-framework/ /gateway/3.4.x/reference/performance-testing-framework/
 
 # 3.4
 

--- a/app/_src/gateway/how-kong-works/performance-testing.md
+++ b/app/_src/gateway/how-kong-works/performance-testing.md
@@ -3,6 +3,9 @@ title: Kong Gateway Performance Testing
 content_type: explanation
 ---
 
+{:.important}
+> **Note**: As of {{site.base_gateway}} 3.5.x, this feature has been deprecated. It is not supported past 3.4.x.
+
 The {{site.base_gateway}} codebase includes a performance testing framework. It allows Kong developers and users to evaluate the performance of Kong itself as well as 
 bundled or custom plugins, and plot frame graphs to debug performance bottlenecks.
 The framework collects RPS (request per second) and latencies of Kong processing the request

--- a/app/_src/gateway/reference/performance-testing-framework.md
+++ b/app/_src/gateway/reference/performance-testing-framework.md
@@ -4,6 +4,9 @@ badge: oss
 content_type: reference
 ---
 
+{:.important}
+> **Note**: As of {{site.base_gateway}} 3.5.x, this feature has been deprecated. It is not supported past 3.4.x.
+
 ### perf.use_defaults()
 
 *syntax: perf.use_defaults()*


### PR DESCRIPTION
### Description

The OSS performance testing framework is no longer in use and is not supported by Kong, as of 3.5.

This PR replaces https://github.com/Kong/docs.konghq.com/pull/6397. We don't want to delete the source file for the doc, as it's still relevant in earlier versions.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

