### PR TITLE
chore: Replace mockbin with httpbin/httpbun

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -61,7 +61,6 @@ Loggly
 Lua's
 Luarocks
 Memcached
-Mockbin
 Moesif
 MongoDB
 NAT

--- a/app/_hub/kong-inc/acme/how-to/_local-testing-development.md
+++ b/app/_hub/kong-inc/acme/how-to/_local-testing-development.md
@@ -33,7 +33,7 @@ Leave the process running.
     ```bash
     curl http://localhost:8001/services \
     -d name=acme-test \
-    -d url=http://mockbin.org
+    -d url=http://httpbin.org
     ```
 
 1. Configure a route:

--- a/app/_hub/kong-inc/exit-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/overview/_index.md
@@ -177,7 +177,7 @@ end
     ```bash
     curl -i -X POST http://localhost:8001/services \
       --data name=example.com \
-      --data url='http://mockbin.org'
+      --data url='http://httpbin.org'
     ```
 
 2. Create a route in Kong:

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/how-to/_costs.md
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/how-to/_costs.md
@@ -14,7 +14,7 @@ See the [Costs API reference](/hub/kong-inc/graphql-rate-limiting-advanced/api/)
 ```sh
 curl -X POST http://localhost:8001/services \
   --data "name=example" \
-  --data "host=mockbin.org" \
+  --data "host=httpbin.org" \
   --data "port=443" \
   --data "protocol=https"
 curl -X POST http://localhost:8001/services/example/routes \

--- a/app/_hub/kong-inc/request-transformer-advanced/how-to/_index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/how-to/_index.md
@@ -10,7 +10,7 @@ title: Examples of different transforms
 Add multiple headers by passing each header:value pair separately:
 
 ```bash
-curl -X POST http://localhost:8001/services/mockbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers[1]=h1:v1" \
   --data "config.add.headers[2]=h2:v1"
@@ -25,7 +25,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 Add multiple headers by passing comma separated header:value pair:
 
 ```bash
-curl -X POST http://localhost:8001/services/mockbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v2"
 ```
@@ -39,7 +39,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 Add multiple headers passing config as a JSON body:
 
 ```bash
-curl -X POST http://localhost:8001/services/mockbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
   --header 'content-type: application/json' \
   --data '{"name": "request-transformer-advanced", "config": {"add": {"headers": ["h1:v2", "h2:v1"]}}}'
 ```
@@ -53,7 +53,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 Add multiple headers and query string parameters if not already set:
 
 ```bash
-curl -X POST http://localhost:8001/services/mockbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v1,h2:v1" \
   --data "config.add.querystring=q1:v2,q2:v1" \
@@ -73,7 +73,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 ## Example: Adding a querystring and a header
 
 ```bash
-curl -X POST http://localhost:8001/services/mockbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.querystring=q1:v2,q2=v1" \
   --data "config.add.headers=h1:v1"
@@ -95,7 +95,7 @@ curl -X POST http://localhost:8001/services/mockbin/plugins \
 Append multiple headers and remove a body parameter:
 
 ```bash
-curl -X POST http://localhost:8001/services/mockbin/plugins \
+curl -X POST http://localhost:8001/services/httpbin/plugins \
   --data "name=request-transformer-advanced" \
   --data "config.add.headers=h1:v2,h2:v1" \
   --data "config.remove.body=p1" \

--- a/app/_hub/kong-inc/request-transformer-advanced/how-to/_templates.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/how-to/_templates.md
@@ -87,12 +87,12 @@ above).
 
 ### Examples using template as value
 
-1. Add a service named `test` which routes requests to the mockbin.com upstream service:
+1. Add a service named `test` which routes requests to the httpbin.org upstream service:
 
     ```bash
     curl -X POST http://localhost:8001/services \
         --data 'name=test' \
-        --data 'url=http://mockbin.com/requests'
+        --data 'url=http://httpbin.org/anything'
     ```
 
 2. Create a route for the `test` service, capturing a `user_id` field from the 

--- a/app/_hub/kong-inc/request-transformer/how-to/_add-body-value.md
+++ b/app/_hub/kong-inc/request-transformer/how-to/_add-body-value.md
@@ -47,12 +47,12 @@ curl -i -X POST $KONG_ADMIN_API/services/mock/plugins \
 If successful the API will return a `201 Created` HTTP response code with a 
 JSON body including information about the new plugin instance.
 
-Next, use the `mock` service's `/requests` endpoint to test the behavior of the plugin.
-The `/requests` API will echo back helpful information from the request we send it, including
+Next, use the `mock` service's `/anything` endpoint to test the behavior of the plugin.
+The `/anything` API will echo back helpful information from the request we send it, including
 headers and the request body.
 
 ```sh
-curl -s -XPOST $KONG_PROXY/mock/requests \
+curl -s -XPOST $KONG_PROXY/mock/anything \
 	-H 'Content-Type: application/json' \
 	-d '{"existing-field": "abc123"}'
 ```
@@ -62,7 +62,7 @@ JSON body sent to the service. You can use `jq` to fully extract the request bod
 returned from the `mock` service, as follows:
 
 ```sh
-curl -s -XPOST $KONG_PROXY/mock/requests \
+curl -s -XPOST $KONG_PROXY/mock/anything \
 	-H 'Content-Type: application/json' \
 	-d '{"existing-field": "Kong FTW!"}' | \
 	jq -r '.postData.text'

--- a/app/_hub/kong-inc/request-transformer/how-to/_templates.md
+++ b/app/_hub/kong-inc/request-transformer/how-to/_templates.md
@@ -72,12 +72,12 @@ above).
 
 ## Examples using template as a value
 
-Add a Service named `test` which routes requests to the mockbin.com upstream service:
+Add a Service named `test` which routes requests to the httpbin.org upstream service:
 
 ```bash
 curl -X POST http://localhost:8001/services \
     --data 'name=test' \
-    --data 'url=http://mockbin.com/requests'
+    --data 'url=http://httpbin.org/anything'
 ```
 
 Create a route for the `test` service, capturing a `user_id` field from the third segment of the request path:
@@ -90,15 +90,18 @@ Create a route for the `test` service, capturing a `user_id` field from the thir
   these based on their order in the URL path. For example `$(uri_captures[1])`
   obtains the value of the first capture group.
 ```bash
-curl -X POST http://localhost:8001/services/test/routes --data "name=test_user" \
-    --data-urlencode 'paths=~/requests/user/(?<user_id>\w+)'
+curl -X POST http://localhost:8001/services/test/routes \
+  --data "name=test_user" \
+  --data-urlencode 'paths=~/requests/user/(?<user_id>\w+)'
 ```
 
 Enable the `request-transformer` plugin to add a new header, `x-user-id`,
 whose value is being set from the captured group in the route path specified above:
 
 ```bash
-curl -XPOST http://localhost:8001/routes/test_user/plugins --data "name=request-transformer" --data "config.add.headers=x-user-id:\$(uri_captures['user_id'])"
+curl -XPOST http://localhost:8001/routes/test_user/plugins \
+  --data "name=request-transformer" \
+  --data "config.add.headers=x-user-id:\$(uri_captures['user_id'])"
 ```
 
 Now send a request with a user id in the route path:

--- a/app/_hub/kong-inc/session/overview/_index.md
+++ b/app/_hub/kong-inc/session/overview/_index.md
@@ -40,13 +40,13 @@ For usage with [Key Auth] plugin
 1. Create an example Service and a Route
 
    Issue the following cURL request to create `example-service` pointing to
-   mockbin.org, which echoes the request:
+   httpbin.org, which echoes the request:
 
    ```bash
    curl -i -X POST \
      --url http://localhost:8001/services/ \
      --data 'name=example-service' \
-     --data 'url=http://mockbin.org/request'
+     --data 'url=http://httpbin.org/anything'
    ```
 
    Add a route to the Service:
@@ -160,7 +160,7 @@ Add all these to the declarative config file:
 ```yaml
 services:
   - name: example-service
-    url: http://mockbin.org/request
+    url: http://httpbin.org/anything
 
 routes:
   - service: example-service

--- a/app/_src/deck/guides/apiops.md
+++ b/app/_src/deck/guides/apiops.md
@@ -30,15 +30,15 @@ Let's assume you have the following minimal OAS in a file named `oas.yaml`:
 ```yaml
 openapi: 3.0.0
 info:
-  title: Mockbin API
+  title: httpbin API
   description: Simple API for testing purposes
   version: 1.0.0
 servers:
-  - url: http://mockbin.org
+  - url: http://httpbin.org
 paths:
   /request:
     get:
-      summary: Get a simple response from the /request resource of the mockbin API
+      summary: Get a simple response from the /request resource of the httpbin API
       responses:
         '200':
           description: Successful response
@@ -49,7 +49,7 @@ You can generate a {{site.base_gateway}} configuration with the following:
 ```sh
 deck file openapi2kong \
   --spec oas.yaml \
-  --output-file mockbin.yaml
+  --output-file httpbin.yaml
 ```
 
 Which produces a complete decK configuration file:
@@ -57,9 +57,9 @@ Which produces a complete decK configuration file:
 ```yaml
 _format_version: "3.0"
 services:
-- host: mockbin.org
+- host: httpbin.org
   id: de7107e7-a39c-5574-9e8c-e66787ae50e7
-  name: mockbin-api
+  name: httpbin-api
   path: /
   plugins: []
   port: 80
@@ -68,7 +68,7 @@ services:
   - id: 803b324e-98ed-5ec5-aecf-b4ce973036f4
     methods:
     - GET
-    name: mockbin-api_request_get
+    name: httpbin-api_request_get
     paths:
     - ~/request$
     plugins: []
@@ -86,14 +86,14 @@ can help you quickly run a gateway in Docker to follow along with these instruct
 You can synchronize this directly to the gateway using `deck sync`:
 
 ```sh
-deck sync -s mockbin.yaml
+deck sync -s httpbin.yaml
 ```
 
 Which creates the service and route:
 
 ```sh
-creating service mockbin-api
-creating route mockbin-api_request_get
+creating service httpbin-api
+creating route httpbin-api_request_get
 Summary:
   Created: 2
   Updated: 0
@@ -122,14 +122,14 @@ Continuing the example above, let's take a look at how commands can be pipelined
 
 Let's assume you have a second team that builds a different API, and
 provides a {{site.base_gateway}} decK configuration segment for their service and route. Copy the 
-following configuration into a file named `another-mockbin.yaml`:
+following configuration into a file named `another-httpbin.yaml`:
 
 ```yaml
 _format_version: "3.0"
 services:
-- host: mockbin.org
+- host: httpbin.org
   id: 7cc31086-3837-4e7e-bbe9-271e51c1f614 
-  name: another-mockbin-api
+  name: another-httpbin-api
   path: /
   plugins: []
   port: 80
@@ -138,7 +138,7 @@ services:
   - id: 08ac3482-843a-40f8-a277-a4e73baf19d9 
     methods:
     - GET
-    name: another-mockbin-api_request_get
+    name: another-httpbin-api_request_get
     paths:
     - ~/another-request$
     plugins: []
@@ -152,7 +152,7 @@ upstreams: []
 You can use the decK `file merge` command to bring these two configurations into one:
 
 ```sh
-deck file merge mockbin.yaml another-mockbin.yaml \
+deck file merge httpbin.yaml another-httpbin.yaml \
   --output-file merged-kong.yaml
 ``` 
 
@@ -178,8 +178,8 @@ deck sync -s kong.yaml
 Here is an example of putting the above together in a Unix-style pipeline:
 
 ```sh
-deck file openapi2kong --spec oas.yaml --output-file mockbin.yaml && 
-  deck file merge mockbin.yaml another-mockbin.yaml | 
+deck file openapi2kong --spec oas.yaml --output-file httpbin.yaml && 
+  deck file merge httpbin.yaml another-httpbin.yaml | 
   deck file patch --selector "$.services[*]" --value 'protocol: "https"' |
   deck sync -s -
 ```

--- a/app/_src/deck/guides/defaults-v2.md
+++ b/app/_src/deck/guides/defaults-v2.md
@@ -62,7 +62,7 @@ want to use, skip to [setting defaults](#set-defaults).
     ```yaml
     _format_version: "3.0"
     services:
-      - host: mockbin.org
+      - host: httpbin.org
         name: example_service
         routes:
           - name: mockpath
@@ -114,7 +114,7 @@ deck diff
 ```sh
 updating service example_service  {
    "connect_timeout": 60000,
-   "host": "mockbin.org",
+   "host": "httpbin.org",
    "id": "1c088e59-b5fb-4c14-8d3a-401c02fc50b7",
    "name": "example_service",
    "port": 80,
@@ -169,7 +169,7 @@ Summary:
     _info:
       defaults:
     services:
-      - host: mockbin.org
+      - host: httpbin.org
         name: example_service
         routes:
           - name: mockpath
@@ -213,7 +213,7 @@ Summary:
           read_timeout: 60000
           retries: 5
     services:
-      - host: mockbin.org
+      - host: httpbin.org
         name: example_service
         routes:
           - name: mockpath

--- a/app/_src/deck/guides/defaults.md
+++ b/app/_src/deck/guides/defaults.md
@@ -45,7 +45,7 @@ again to see how decK interprets default values.
    ```yaml
    _format_version: "3.0"
    services:
-     - host: mockbin.org
+     - host: httpbin.org
        name: example_service
        routes:
          - name: mockpath
@@ -141,7 +141,7 @@ overwriting your current state file, specify a different filename:
      - https
    services:
    - connect_timeout: 60000
-     host: mockbin.org
+     host: httpbin.org
      name: example_service
      port: 80
      protocol: http
@@ -200,7 +200,7 @@ configuration would overwrite the value in your environment.
    _info:
      defaults:
    services:
-     - host: mockbin.org
+     - host: httpbin.org
        name: example_service
        routes:
          - name: mockpath
@@ -231,7 +231,7 @@ configuration would overwrite the value in your environment.
          protocol: https
          retries: 10
    services:
-     - host: mockbin.org
+     - host: httpbin.org
        name: example_service
        routes:
          - name: mockpath
@@ -264,7 +264,7 @@ configuration would overwrite the value in your environment.
          read_timeout: 60000
          retries: 10
    services:
-     - host: mockbin.org
+     - host: httpbin.org
        name: example_service
        routes:
          - name: mockpath

--- a/app/_src/gateway-operator/get-started/konnect/create-route.md
+++ b/app/_src/gateway-operator/get-started/konnect/create-route.md
@@ -31,19 +31,19 @@ Once your `DataPlane` is deployed it receives configuration from Konnect, but th
 
 Create a service and a route in your {{ site.konnect_short_name }} control plane using the variables that you set.
 
-The following commands create a service named _Sample_ and a route that proxies all traffic to mockbin.org:
+The following commands create a service named _Sample_ and a route that proxies all traffic to httpbin.org:
 
 ```bash
-SERVICE_ID=$(curl -sS -H "Authorization: Bearer $KONNECT_TOKEN" https://us.api.konghq.com/v2/control-planes/$CP_UUID/core-entities/services -d name=Sample -d url=https://mockbin.org | jq -r .id)
+SERVICE_ID=$(curl -sS -H "Authorization: Bearer $KONNECT_TOKEN" https://us.api.konghq.com/v2/control-planes/$CP_UUID/core-entities/services -d name=Sample -d url=https://httpbin.org | jq -r .id)
 
 curl -sS -H "Authorization: Bearer $KONNECT_TOKEN" https://us.api.konghq.com/v2/control-planes/$CP_UUID/core-entities/services/$SERVICE_ID/routes -d "paths[]=/"
 ```
 
 ## Send test traffic
 
-After the service and route are created, send traffic to the proxy and it will forward the request to mockbin.org. You can use Mockbin's `/request` endpoint to echo the request made in the response.
+After the service and route are created, send traffic to the proxy and it will forward the request to httpbin.org. You can use httpbin's `/anything` endpoint to echo the request made in the response.
 
-To make a request to the proxy we need to fetch the LoadBalancer IP address using `kubectl get services`:
+To make a request to the proxy, fetch the LoadBalancer IP address using `kubectl get services`:
 
 ```bash
 export PROXY_IP=$(kubectl get services -n kong -o json | jq -r '.items[] | .status.loadBalancer?|.ingress[]?|.ip')
@@ -51,12 +51,12 @@ echo "Proxy IP: $PROXY_IP"
 ```
 
 {:.note}
-> Note: if your cluster can not provision LoadBalancer type Services then you may not receive an IP address
+> Note: If your cluster can't provision LoadBalancer type Services, then you might not receive an IP address.
 
-Test the routing rules by sending a request to the proxy IP address.
+Test the routing rules by sending a request to the proxy IP address:
 
 ```bash
-curl $PROXY_IP/request/hello
+curl $PROXY_IP/anything/hello
 ```
 
 ## Delete the test service

--- a/app/_src/gateway/admin-api/developers/reference.md
+++ b/app/_src/gateway/admin-api/developers/reference.md
@@ -491,7 +491,7 @@ HTTP/1.1 200 OK
             },
             "id": "5ff48aaf-3951-4c99-a636-3b682081705c",
             "name": "example_app",
-            "redirect_uri": "http://mockbin.org",
+            "redirect_uri": "http://httpbin.org",
             "updated_at": 1644963627
         },
         {
@@ -504,7 +504,7 @@ HTTP/1.1 200 OK
             },
             "id": "94e0f633-e8fd-4647-a0cd-4c3015ff2722",
             "name": "example_app2",
-            "redirect_uri": "http://mockbin.org",
+            "redirect_uri": "http://httpbin.org",
             "updated_at": 1644963657
         }
     ],
@@ -544,7 +544,7 @@ HTTP/1.1 200 OK
     },
     "id": "ca0d62bd-4616-4b87-b947-43e33e5418f0",
     "name": "testapp",
-    "redirect_uri": "http://mockbin.org",
+    "redirect_uri": "http://httpbin.org",
     "updated_at": 1644965555
 }
 ```
@@ -589,7 +589,7 @@ HTTP/1.1 201 Created
     },
     "id": "ca0d62bd-4616-4b87-b947-43e33e5418f0",
     "name": "testapp",
-    "redirect_uri": "http://mockbin.org",
+    "redirect_uri": "http://httpbin.org",
     "updated_at": 1644965555
 }
 ```
@@ -634,7 +634,7 @@ HTTP/1.1 200 OK
     },
     "id": "5ff48aaf-3951-4c99-a636-3b682081705c",
     "name": "ExampleApp",
-    "redirect_uri": "http://mockbin.org",
+    "redirect_uri": "http://httpbin.org",
     "updated_at": 1645575611
 }
 ```
@@ -701,7 +701,7 @@ HTTP/1.1 200 OK
                 },
                 "id": "645682ae-0be6-420a-bcf3-0e711a391546",
                 "name": "testapp",
-                "redirect_uri": "http://mockbin.org",
+                "redirect_uri": "http://httpbin.org",
                 "updated_at": 1644965487
             },
             "composite_id": "645682ae-0be6-420a-bcf3-0e711a391546_212a758a-810b-4226-9175-b1b44eecebec",
@@ -1412,7 +1412,7 @@ HTTP/1.1 200 OK
             "id": "e22760bc-c6d4-4572-9814-132825286618",
             "name": "example_app",
             "redirect_uris": [
-                "http://mockbin.org"
+                "http://httpbin.org"
             ]
         }
     ],
@@ -1470,7 +1470,7 @@ HTTP/1.1 201 Created
     "id": "2dc8ee2a-ecfd-4ca5-a9c1-db371480e2cf",
     "name": "example_app",
     "redirect_uris": [
-        "http://mockbin.org"
+        "http://httpbin.org"
     ]
 }
 ```
@@ -1508,7 +1508,7 @@ HTTP/1.1 200 OK
     "id": "e22760bc-c6d4-4572-9814-132825286618",
     "name": "example_app",
     "redirect_uris": [
-        "http://mockbin.org"
+        "http://httpbin.org"
     ]
 }
 ```

--- a/app/_src/gateway/get-started/expose-services.md
+++ b/app/_src/gateway/get-started/expose-services.md
@@ -37,8 +37,8 @@ the Service to the backend API.
 
 ## Add a Service
 
-For the purpose of this example, you’ll create a Service pointing to the Mockbin
-API. Mockbin is an “echo” type public website that returns requests back to the
+For the purpose of this example, you’ll create a Service pointing to the httpbin
+API. httpbin is an “echo” type public website that returns requests back to the
 requester as responses. This visualization will be helpful for learning how Kong
 Gateway proxies API requests.
 
@@ -49,7 +49,7 @@ the Admin API.
 ```sh
 curl -i -X POST http://localhost:8001/services \
   --data name=example_service \
-  --data url='http://mockbin.org'
+  --data url='http://httpbin.org'
 ```
 
 If the service is created successfully, you'll get a 201 success message.
@@ -82,17 +82,17 @@ A `201` message indicates the Route was created successfully.
 By default, {{site.base_gateway}} handles proxy requests on port `8000`. The proxy is often referred to as the data plane.
 
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 ## Summary and next steps
 
 In this section, you:
 
-* Added a Service named `example_service` with a URL of `http://mockbin.org`.
+* Added a Service named `example_service` with a URL of `http://httpbin.org`.
 * Added a Route named `/mock`.
 * This means if an HTTP request is sent to the {{site.base_gateway}} node on
 port `8000`(the proxy port) and it matches route `/mock`, then that request is
-sent to `http://mockbin.org`.
+sent to `http://httpbin.org`.
 * Abstracted a backend/upstream service and put a route of your choice on the
 front end, which you can now give to clients to make requests.
 

--- a/app/_src/gateway/get-started/key-authentication.md
+++ b/app/_src/gateway/get-started/key-authentication.md
@@ -115,7 +115,7 @@ Installing the plugin globally means *every* proxy request to {{site.base_gatewa
    Try to access the service without providing the key:
    
    ```sh
-   curl -i http://localhost:8000/mock/request
+   curl -i http://localhost:8000/mock/anything
    ```
    
    Since you enabled key authentication globally, you will receive an unauthorized response:
@@ -133,7 +133,7 @@ Installing the plugin globally means *every* proxy request to {{site.base_gatewa
    Try to access the service with the wrong key:
    
    ```sh
-   curl -i http://localhost:8000/mock/request \
+   curl -i http://localhost:8000/mock/anything \
      -H 'apikey:bad-key'
    ```
   
@@ -152,7 +152,7 @@ Installing the plugin globally means *every* proxy request to {{site.base_gatewa
    Send a request with the valid key in the `apikey` header:
 
    ```sh
-   curl -i http://localhost:8000/mock/request \
+   curl -i http://localhost:8000/mock/anything \
      -H 'apikey:top-secret-key'
    ```
 
@@ -212,7 +212,7 @@ in any requests going forward. If you don’t want to keep specifying the key, d
    Now you can make a request without providing an API key:
 
    ```sh
-   curl -i http://localhost:8000/mock/request
+   curl -i http://localhost:8000/mock/anything
    ```
 
    You should receive:

--- a/app/_src/gateway/get-started/load-balancing.md
+++ b/app/_src/gateway/get-started/load-balancing.md
@@ -20,7 +20,7 @@ used to health check, circuit break, and load balance incoming requests over mul
 
 In this section, you’ll re-configure the service created earlier, (`example_service`) to point to an upstream 
 instead of a specific host. For the purposes of our example, the upstream will point to two different targets, 
-`httpbin.org` and `mockbin.org`. More commonly, targets will be instances of the same backend service running on different host systems.
+`httpbin.org` and `httpbun.com`. More commonly, targets will be instances of the same backend service running on different host systems.
 
 Here is a diagram illustrating the setup:
 
@@ -61,7 +61,7 @@ If you haven't completed these steps already, complete them before proceeding.
    
    ```sh
    curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
-     --data target='mockbin.org:80'
+     --data target='httpbun.com:80'
    curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
      --data target='httpbin.org:80'
    ```
@@ -69,14 +69,14 @@ If you haven't completed these steps already, complete them before proceeding.
 1. **Update the service**
 
    In the [services and routes](/gateway/latest/get-started/services-and-routes/) section of this guide, you created `example_service` which pointed
-   to an explicit host, `http://mockbin.org`. Now you'll modify that service to point to the upstream instead:
+   to an explicit host, `http://httpbun.com`. Now you'll modify that service to point to the upstream instead:
    
    ```sh
    curl -X PATCH http://localhost:8001/services/example_service \
      --data host='example_upstream'
    ```
 
-   You now have an upstream with two targets, `httpbin.org` and `mockbin.org`, and a service pointing to that upstream.
+   You now have an upstream with two targets, `httpbin.org` and `httpbun.com`, and a service pointing to that upstream.
 
 1. **Validate**
 
@@ -84,8 +84,8 @@ If you haven't completed these steps already, complete them before proceeding.
    Validate that the upstream you configured is working by visiting the route 
    `http://localhost:8000/mock` using a web browser or CLI.
   
-   * **Web browser**: Visit `http://localhost:8000/mock` and refresh the page several times to see the site change from `httpbin` to `mockbin`.
-   * **CLI**: Execute the command `curl -s http://localhost:8000/mock/headers |grep -i -A1 '"host"'` several times. You will see the hostname change between `httpbin` and `mockbin`.
+   * **Web browser**: Visit `http://localhost:8000/mock` and refresh the page several times to see the site change from `httpbin` to `httpbun`.
+   * **CLI**: Execute the command `curl -s http://localhost:8000/mock/headers |grep -i -A1 '"host"'` several times. You will see the hostname change between `httpbin` and `httpbun`.
 
 ## What's next
 

--- a/app/_src/gateway/get-started/proxy-caching.md
+++ b/app/_src/gateway/get-started/proxy-caching.md
@@ -85,7 +85,7 @@ will potentially be cached.
    information headers prefixed with `X-Cache`, so use `grep` to filter for that information:
 
    ```
-   curl -i -s -XGET http://localhost:8000/mock/requests | grep X-Cache
+   curl -i -s -XGET http://localhost:8000/mock/anythings | grep X-Cache
    ```
 
    On the initial request, there should be no cached responses, and the headers will indicate this with

--- a/app/_src/gateway/get-started/proxy-caching.md
+++ b/app/_src/gateway/get-started/proxy-caching.md
@@ -85,7 +85,7 @@ will potentially be cached.
    information headers prefixed with `X-Cache`, so use `grep` to filter for that information:
 
    ```
-   curl -i -s -XGET http://localhost:8000/mock/anythings | grep X-Cache
+   curl -i -s -XGET http://localhost:8000/mock/anything | grep X-Cache
    ```
 
    On the initial request, there should be no cached responses, and the headers will indicate this with

--- a/app/_src/gateway/get-started/rate-limiting.md
+++ b/app/_src/gateway/get-started/rate-limiting.md
@@ -85,13 +85,13 @@ will be subject to rate limit enforcement.
 Run the following command to quickly send 6 mock requests:
 
 ```sh
-for _ in {1..6}; do curl -s -i localhost:8000/mock/request; echo; sleep 1; done
+for _ in {1..6}; do curl -s -i localhost:8000/mock/anything; echo; sleep 1; done
 ```
 
 {% endnavtab %}
 {% navtab Web browser %}
 
-Open [http://localhost:8000/mock/request](http://localhost:8000/mock/request) in your browser 
+Open [http://localhost:8000/mock/anything](http://localhost:8000/mock/anything) in your browser 
 and refresh the page 6 times within 1 minute. 
 
 {% endnavtab %}

--- a/app/_src/gateway/get-started/ratelimiting.md
+++ b/app/_src/gateway/get-started/ratelimiting.md
@@ -48,7 +48,7 @@ If you configured {{site.base_gateway}} with the [configure services and routes]
 {% navtab Admin API %}
 
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 
 {% endnavtab %}

--- a/app/_src/gateway/get-started/services-and-routes.md
+++ b/app/_src/gateway/get-started/services-and-routes.md
@@ -57,10 +57,10 @@ also offers other options for configuration management including
 [{{site.konnect_saas}}](/konnect/) and [decK](/deck/latest/).
 
 In this section of the tutorial, you will complete the following steps:
-* Create a service pointing to the [Mockbin](https://mockbin.org/) API, which provides testing facilities 
+* Create a service pointing to the [httpbin](https://httpbin.org/) API, which provides testing facilities 
   for HTTP requests and responses.
 * Define a route by providing a URL path that will be available to clients on the running {{site.base_gateway}}.
-* Use the new Mockbin service to echo a test request, helping you understand how 
+* Use the new httpbin service to echo a test request, helping you understand how 
   {{site.base_gateway}} proxies API requests. 
 
 ### Prerequisites
@@ -84,11 +84,11 @@ complete that before proceeding.
    ```sh
    curl -i -s -X POST http://localhost:8001/services \
      --data name=example_service \
-     --data url='http://mockbin.org'
+     --data url='http://httpbin.org'
    ```
 
    This request instructs {{site.base_gateway}} to create a new 
-   service mapped to the upstream URL `http://mockbin.org`.
+   service mapped to the upstream URL `http://httpbin.org`.
    
    In our example, the request body contained two strings: 
    
@@ -100,7 +100,7 @@ complete that before proceeding.
 
    ```text
    {
-     "host": "mockbin.org",
+     "host": "httpbin.org",
      "name": "example_service",
      "enabled": true,
      "connect_timeout": 60000,
@@ -142,7 +142,7 @@ complete that before proceeding.
    
    ```text
    {
-     "host": "mockbin.org",
+     "host": "httpbin.org",
      "name": "example_service",
      "enabled": true,
      ...
@@ -165,7 +165,7 @@ complete that before proceeding.
    
    ```sh
    {
-     "host": "mockbin.org",
+     "host": "httpbin.org",
      "name": "example_service",
      "enabled": true,
      "retries": 6,
@@ -377,16 +377,16 @@ You can also view the configuration for your routes in the Kong Manager UI by na
 
 Kong is an API Gateway, it takes requests from clients and routes them to the appropriate upstream application 
 based on a the current configuration. Using the service and route that was previously configured, you can now 
-access `https://mockbin.org/` using `http://localhost:8000/mock`.
+access `https://httpbin.org/` using `http://localhost:8000/mock`.
 
 By default, {{site.base_gateway}}'s Admin API listens for administrative requests on port `8001`, this is sometimes referred to as the
 *control plane*. Clients use port `8000` to make data requests, and this is often referred to as the *data plane*.
 
-Mockbin provides a `/requests` resource which will echo back to clients information about requests made to it.
-Proxy a request through {{site.base_gateway}} to the `/requests` resource:
+Httpbin provides an `/anything` resource which will echo back to clients information about requests made to it.
+Proxy a request through {{site.base_gateway}} to the `/anything` resource:
 
 ```sh
-curl -X GET http://localhost:8000/mock/requests
+curl -X GET http://localhost:8000/mock/anything
 ```
 
 You should see a response similar to the following:
@@ -395,11 +395,11 @@ You should see a response similar to the following:
   "startedDateTime": "2022-08-24T13:44:28.449Z",
   "clientIPAddress": "172.19.0.1",
   "method": "GET",
-  "url": "http://localhost/requests",
+  "url": "http://localhost/anything",
   "httpVersion": "HTTP/1.1",
   "cookies": {},
   "headers": {
-    "host": "mockbin.org",
+    "host": "httpbin.org",
     "connection": "close",
     "accept-encoding": "gzip",
     "x-forwarded-for": "172.19.0.1,98.63.188.11, 162.158.63.41",
@@ -408,7 +408,7 @@ You should see a response similar to the following:
     "cf-visitor": "{\"scheme\":\"http\"}",
     "x-forwarded-host": "localhost",
     "x-forwarded-port": "80",
-    "x-forwarded-path": "/mock/requests",
+    "x-forwarded-path": "/mock/anything",
     "x-forwarded-prefix": "/mock",
     "user-agent": "curl/7.79.1",
     "accept": "*/*",

--- a/app/_src/gateway/install/docker/index.md
+++ b/app/_src/gateway/install/docker/index.md
@@ -328,7 +328,7 @@ backed up by a Redis cluster).
     _transform: true
 
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http

--- a/app/_src/gateway/key-concepts/upstreams.md
+++ b/app/_src/gateway/key-concepts/upstreams.md
@@ -10,12 +10,12 @@ In {{site.base_gateway}}, an upstream object represents a virtual hostname and c
 
 You can configure a [service](/gateway/{{ page.kong_version }}/key-concepts/services/) to point to an upstream instead of a host. 
 For example, if you have a service called `example_service` and an upstream called `example_upstream`, you can point `example_service` to `example_upstream` instead of specifying a host. 
-The `example_upstream` upstream can then point both `httpbin.org` and `mockbin.org`. 
+The `example_upstream` upstream can then point to two different targets: `httpbin.org` and `httpbun.com`. 
 In a real environment, the upstream points to the same service running on multiple systems.
 
 This setup allows you to [load balance](/gateway/{{ page.kong_version }}/how-kong-works/load-balancing) between upstream targets. 
 For example, if an application is deployed across two different servers or upstream targets, {{site.base_gateway}} needs to load balance across both servers. 
-This is so that if one of the servers (like `httpbin.org` in the previous example) is unavailable, it automatically detects the problem and routes all traffic to the working server (`mockbin.org`). 
+This is so that if one of the servers (like `httpbin.org` in the previous example) is unavailable, it automatically detects the problem and routes all traffic to the working server (`httpbun.com`). 
 
 
 ## Upstream configuration

--- a/app/_src/gateway/kong-enterprise/plugin-ordering/get-started.md
+++ b/app/_src/gateway/kong-enterprise/plugin-ordering/get-started.md
@@ -76,7 +76,7 @@ ordering:
     ``` yaml
     _format_version: "3.0"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -203,7 +203,7 @@ ordering:
     ``` yaml
     _format_version: "3.0"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http

--- a/app/_src/gateway/kong-manager/get-started/load-balancing.md
+++ b/app/_src/gateway/kong-manager/get-started/load-balancing.md
@@ -23,12 +23,12 @@ From the **Workspaces** tab in Kong Manager:
 4. Click on your new upstream to open its detail page.
 5. From the sub-menu, open **Targets**, then click **New Target**.
 6. In the target field, set the value `httpbin.org:80`, and click **Create**.
-7. Create another target, this time for `mockbin.org:80`.
+7. Create another target, this time for `httpbun.com:80`.
 8. Open the **Services** page.
 9. Open your `example_service`, then click **Edit**.
 10. Change the **Host** field to `example_upstream`, then click **Update**.
 
-You now have an upstream with two targets, `httpbin.org` and `mockbin.org`, and a service pointing to that upstream.
+You now have an upstream with two targets, `httpbin.org` and `httpbun.com`, and a service pointing to that upstream.
 
 ## Validate the upstream services
 
@@ -36,7 +36,7 @@ To test that {{site.base_gateway}} is load balancing traffic across the two targ
 
 1. With the upstream configured, validate that it’s working by visiting the route `http://localhost:8000/mock` using a web browser or the shell.
 
-2. Refresh the page a few times. The site should change back and forth from `httpbin` to `mockbin`.
+2. Refresh the page a few times. The site should change back and forth from `httpbin` to `httpbun`.
 
 ## Next steps
 

--- a/app/_src/gateway/kong-manager/get-started/services-and-routes.md
+++ b/app/_src/gateway/kong-manager/get-started/services-and-routes.md
@@ -13,8 +13,8 @@ You need a {{site.base_gateway}} instance with Kong Manager [enabled](/gateway/{
 
 ## Add a service
 
-In this tutorial, you’ll create a service pointing to the Mockbin
-API. Mockbin is an “echo” type public website that returns requests back to the
+In this tutorial, you’ll create a service pointing to the httpbin
+API. Httpbin is an “echo” type public website that returns requests back to the
 requester as responses.
 
 On the Workspaces tab in Kong Manager:
@@ -27,7 +27,7 @@ On the Workspaces tab in Kong Manager:
 2. From the **Services** section, click **New Service**.
 
 3. In the **Create service** dialog, enter the name `example_service` and the
-URL `http://mockbin.org`.
+URL `http://httpbin.org`.
 
 4. Click **Create**.
 
@@ -61,7 +61,7 @@ The new route appears under the Routes section.
 
 By default, {{site.base_gateway}} handles proxy requests on port `8000`.
 
-From a web browser, navigate to `http://localhost:8000/mock/request`.
+From a web browser, navigate to `http://localhost:8000/mock/anything`.
 
 ## Next steps
 

--- a/app/_src/gateway/kong-plugins/authentication/reference.md
+++ b/app/_src/gateway/kong-plugins/authentication/reference.md
@@ -47,14 +47,14 @@ the corresponding Route:
 
 1. **Create an example Service and a Route**
 
-    Issue the following cURL request to create `example-service` pointing to `mockbin.org`, which will echo
+    Issue the following cURL request to create `example-service` pointing to `httpbin.org`, which will echo
     the request:
 
     ```bash
     curl -i -X POST \
       --url http://localhost:8001/services/ \
       --data 'name=example-service' \
-      --data 'url=http://mockbin.org/request'
+      --data 'url=http://httpbin.org/anything'
     ```
 
     Add a Route to the Service:
@@ -158,7 +158,7 @@ the corresponding Route:
     This is the same request you made in step #3; however, this time the request should succeed because you
     enabled anonymous access in step #5.
 
-    The response (which is the request as Mockbin received it) should have these elements:
+    The response (which is the request as httpbin received it) should have these elements:
 
     ```json
     {

--- a/app/_src/gateway/plugin-development/access-the-datastore.md
+++ b/app/_src/gateway/plugin-development/access-the-datastore.md
@@ -60,8 +60,8 @@ For example, inserting a Service and a Plugin is as easy as:
 
 ```lua
 local inserted_service, err = kong.db.services:insert({
-  name = "mockbin",
-  url  = "http://mockbin.org",
+  name = "httpbin",
+  url  = "http://httpbin.org",
 })
 
 local inserted_plugin, err = kong.db.plugins:insert({

--- a/app/_src/gateway/plugin-development/wasm.md
+++ b/app/_src/gateway/plugin-development/wasm.md
@@ -66,7 +66,7 @@ e.g. `kong.yml`:
 _format_version: '3.0'
 services:
   - name: my-wasm-service
-    url: http://mockbin.org
+    url: http://httpbin.org
     routes:
       - name: my-wasm-route
         paths:

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -248,7 +248,7 @@ environment variable:
 
 ```
 export KONG_DATABASE=off
-export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"mockbin.com","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}'
+export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"httpbin.org","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}'
 kong start
 ```
 

--- a/app/_src/gateway/production/monitoring/prometheus.md
+++ b/app/_src/gateway/production/monitoring/prometheus.md
@@ -78,7 +78,7 @@ will begin to scrape metrics data from {{site.base_gateway}}.
    requests over one minute. Run the following in a new terminal:
 
    ```bash
-   for _ in {1..60}; do {curl -s localhost:8000/mock/request; sleep 1; } done
+   for _ in {1..60}; do {curl -s localhost:8000/mock/anything; sleep 1; } done
    ```
 
 1. You can view the metric data directly from {{site.base_gateway}} by querying the

--- a/app/_src/gateway/production/monitoring/statsd.md
+++ b/app/_src/gateway/production/monitoring/statsd.md
@@ -62,7 +62,7 @@ observe the collected monitoring data.
    requests over one minute. Run the following in a new terminal:
 
    ```sh
-   for _ in {1..60}; do {curl localhost:8000/mock/request; sleep 1; } done
+   for _ in {1..60}; do {curl localhost:8000/mock/anything; sleep 1; } done
    ```
 
 1. Query the StatsD management interface to see the collected metrics from {{site.base_gateway}}:

--- a/app/gateway/2.6.x/configure/auth/index.md
+++ b/app/gateway/2.6.x/configure/auth/index.md
@@ -47,14 +47,14 @@ the corresponding Route:
 
 1. **Create an example Service and a Route**
 
-    Issue the following cURL request to create `example-service` pointing to `mockbin.org`, which will echo
+    Issue the following cURL request to create `example-service` pointing to `httpbin.org`, which will echo
     the request:
 
     ```bash
     $ curl -i -X POST \
       --url http://localhost:8001/services/ \
       --data 'name=example-service' \
-      --data 'url=http://mockbin.org/request'
+      --data 'url=http://httpbin.org/anything'
     ```
 
     Add a Route to the Service:
@@ -158,7 +158,7 @@ the corresponding Route:
     This is the same request you made in step #3; however, this time the request should succeed because you
     enabled anonymous access in step #5.
 
-    The response (which is the request as Mockbin received it) should have these elements:
+    The response (which is the request as httpbin received it) should have these elements:
 
     ```json
     {

--- a/app/gateway/2.6.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/expose-services.md
@@ -37,8 +37,8 @@ the Service to the backend API.
 
 ## Add a Service
 
-For the purpose of this example, you’ll create a Service pointing to the Mockbin
-API. Mockbin is an “echo” type public website that returns requests back to the
+For the purpose of this example, you’ll create a Service pointing to the httpbin
+API. Httpbin is an “echo” type public website that returns requests back to the
 requester as responses. This visualization will be helpful for learning how Kong
 Gateway proxies API requests.
 
@@ -58,7 +58,7 @@ click the **default** workspace.
 2. Scroll down to **Services** and click **Add a Service**.
 
 3. In the **Create Service** dialog, enter the name `example_service` and the
-URL `http://mockbin.org`.
+URL `http://httpbin.org`.
 
 4. Click **Create**.
 
@@ -73,14 +73,14 @@ The service is created, and the page automatically redirects back to the
 ```sh
 curl -i -X POST http://localhost:8001/services \
   --data name=example_service \
-  --data url='http://mockbin.org'
+  --data url='http://httpbin.org'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
 http POST :8001/services \
   name=example_service \
-  url='http://mockbin.org'
+  url='http://httpbin.org'
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -111,12 +111,12 @@ http :8001/services/example_service
 1. In the `kong.yaml` file you exported in
 [Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
 define a Service with the name `example_service` and the URL
-`http://mockbin.org`:
+`http://httpbin.org`:
 
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -216,7 +216,7 @@ A `201` message indicates the Route was created successfully.
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -253,7 +253,7 @@ A `201` message indicates the Route was created successfully.
     ``` yaml
     services:
     - connect_timeout: 60000
-      host: mockbin.org
+      host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -302,12 +302,12 @@ Using the Admin API, issue the following:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request
+http :8000/mock/anything
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -321,11 +321,11 @@ http :8000/mock/request
 
 In this section, you:
 
-* Added a Service named `example_service` with a URL of `http://mockbin.org`.
+* Added a Service named `example_service` with a URL of `http://httpbin.org`.
 * Added a Route named `/mock`.
 * This means if an HTTP request is sent to the {{site.base_gateway}} node on
 port `8000`(the proxy port) and it matches route `/mock`, then that request is
-sent to `http://mockbin.org`.
+sent to `http://httpbin.org`.
 * Abstracted a backend/upstream service and put a route of your choice on the
 front end, which you can now give to clients to make requests.
 

--- a/app/gateway/2.6.x/get-started/comprehensive/improve-performance.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/improve-performance.md
@@ -91,7 +91,7 @@ plugin with a timeout of 30 seconds for Content-Type
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -134,12 +134,12 @@ Access the */mock* route using the Admin API and note the response headers:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request
+http :8000/mock/anything
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/load-balancing.md
@@ -10,7 +10,7 @@ If you are following the getting started workflow, make sure you have completed 
 
 An **Upstream Object** refers to your upstream API/service sitting behind {{site.base_gateway}}, to which client requests are forwarded. In {{site.base_gateway}}, an Upstream Object represents a virtual hostname and can be used to health check, circuit break, and load balance incoming requests over multiple services (targets).
 
-In this topic, you’ll configure the service created earlier (`example_service`) to point to an upstream instead of the host. For the purposes of our example, the upstream will point to two different targets, `httpbin.org` and `mockbin.org`. In a real environment, the upstream will point to the same service running on multiple systems.
+In this topic, you’ll configure the service created earlier (`example_service`) to point to an upstream instead of the host. For the purposes of our example, the upstream will point to two different targets, `httpbin.org` and `httpbun.com`. In a real environment, the upstream will point to the same service running on multiple systems.
 
 Here is a diagram illustrating the setup:
 
@@ -35,7 +35,7 @@ In this section, you will create an Upstream named `example_upstream` and add tw
 6. On the Upstreams page, find the new upstream service and click **View**.
 7. Scroll down and click **New Target**.
 8. In the target field, specify `httpbin.org` with port `80`, and click **Create**.
-9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
+9. Create another target, this time for `httpbun.com` with port `80`. Click **Create**.
 10. Open the **Services** page.
 11. Find your `example_service` and click **Edit**.
 12. Change the **Host** field to `example_upstream`, then click **Update**.
@@ -80,7 +80,7 @@ http PATCH :8001/services/example_service \
 {% endnavtabs %}
 <!-- end codeblock tabs -->
 
-Add two targets to the upstream, each with port 80: `mockbin.org:80` and
+Add two targets to the upstream, each with port 80: `httpbun.com:80` and
 `httpbin.org:80`:
 
 <!-- codeblock tabs -->
@@ -88,7 +88,7 @@ Add two targets to the upstream, each with port 80: `mockbin.org:80` and
 {% navtab cURL %}
 ```sh
 curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
-  --data target='mockbin.org:80'
+  --data target='httpbun.com:80'
 
 curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='httpbin.org:80'
@@ -97,7 +97,7 @@ curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
 {% navtab HTTPie %}    
 ```sh
 http POST :8001/upstreams/example_upstream/targets \
-  target=mockbin.org:80
+  target=httpbun.com:80
 http POST :8001/upstreams/example_upstream/targets \
   target=httpbin.org:80
 ```
@@ -109,7 +109,7 @@ http POST :8001/upstreams/example_upstream/targets \
 
 {% navtab Using decK (YAML) %}
 1. In your `kong.yaml` file, create an Upstream with two targets, each with port
-80: `mockbin.org:80` and `httpbin.org:80`.
+80: `httpbun.com:80` and `httpbin.org:80`.
 
     ``` yaml
     upstreams:
@@ -117,7 +117,7 @@ http POST :8001/upstreams/example_upstream/targets \
       targets:
         - target: httpbin.org:80
           weight: 100
-        - target: mockbin.org:80
+        - target: httpbun.com:80
           weight: 100
     ```
 
@@ -159,7 +159,7 @@ Upstream:
       targets:
         - target: httpbin.org:80
           weight: 100
-        - target: mockbin.org:80
+        - target: httpbun.com:80
           weight: 100
     plugins:
     - name: rate-limiting
@@ -182,18 +182,18 @@ Upstream:
 {% endnavtab %}
 {% endnavtabs %}
 
-You now have an Upstream with two targets, `httpbin.org` and `mockbin.org`, and a service pointing to that Upstream.
+You now have an Upstream with two targets, `httpbin.org` and `httpbun.com`, and a service pointing to that Upstream.
 
 ## Validate the Upstream Services
 
 1. With the Upstream configured, validate that it’s working by visiting the route `http://localhost:8000/mock` using a web browser or CLI.
-2. Continue hitting the endpoint and the site should change from `httpbin` to `mockbin`.
+2. Continue hitting the endpoint and the site should change from `httpbin` to `httpbun`.
 
 ## Summary and next steps
 
 In this topic, you:
 
 * Created an Upstream object named `example_upstream` and pointed the Service `example_service` to it.
-* Added two targets, `httpbin.org` and `mockbin.org`, with equal weight to the Upstream.
+* Added two targets, `httpbin.org` and `httpbun.com`, with equal weight to the Upstream.
 
 If you have a {{site.konnect_product_name}} subscription, go on to [Managing Administrative Teams](/gateway/{{page.kong_version}}/get-started/comprehensive/manage-teams/).

--- a/app/gateway/2.6.x/get-started/comprehensive/protect-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/protect-services.md
@@ -95,7 +95,7 @@ and in-memory, on the node:
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -150,12 +150,12 @@ To validate rate limiting, access the API six (6) times from the CLI to confirm 
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request
+http :8000/mock/anything
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.6.x/get-started/comprehensive/secure-services.md
@@ -120,7 +120,7 @@ add a plugin section and enable the `key-auth` plugin:
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -258,7 +258,7 @@ You now have a consumer with an API key provisioned to access the route.
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -317,13 +317,13 @@ To validate the Key Authentication plugin, access the *mocking* route again, usi
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i http://localhost:8000/mock/request \
+curl -i http://localhost:8000/mock/anything \
   -H 'apikey:apikey'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request apikey:apikey
+http :8000/mock/anything apikey:apikey
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.6.x/get-started/quickstart/configuring-a-service.md
+++ b/app/gateway/2.6.x/get-started/quickstart/configuring-a-service.md
@@ -6,7 +6,7 @@ In this section, you'll be adding an API to Kong. In order to do this, you'll
 first need to add a _Service_; that is the name Kong uses to refer to the upstream APIs and microservices
 it manages.
 
-For the purpose of this guide, we'll create a Service pointing to the [Mockbin API][mockbin]. Mockbin is
+For the purpose of this guide, we'll create a Service pointing to the [httpbin API][httpbin]. Httpbin is
 an "echo" type public website which returns the requests it gets back to the requester, as responses. This
 makes it helpful for learning how Kong proxies your API requests.
 
@@ -24,14 +24,14 @@ You have installed and started {{site.base_gateway}}, either through the [Docker
 
 ## 1. Add your Service using the Admin API
 
-Issue the following cURL request to add your first Service (pointing to the [Mockbin API][mockbin])
+Issue the following cURL request to add your first Service (pointing to the [httpbin API][httpbin])
 to Kong:
 
 ```bash
 curl -i -X POST \
   --url http://localhost:8001/services/ \
   --data 'name=example-service' \
-  --data 'url=http://mockbin.org'
+  --data 'url=http://httpbin.org'
 ```
 
 You should receive a response similar to:
@@ -42,7 +42,7 @@ Content-Type: application/json
 Connection: keep-alive
 
 {
-   "host":"mockbin.org",
+   "host":"httpbin.org",
    "created_at":1519130509,
    "connect_timeout":60000,
    "id":"92956672-f5ea-4e9a-b096-667bf55bc40c",
@@ -129,4 +129,4 @@ Go to [Enabling Plugins &rsaquo;][enabling-plugins]
 [API]: /gateway/{{page.kong_version}}/admin-api
 [enabling-plugins]: /gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins
 [proxy-port]: /gateway/{{page.kong_version}}/reference/configuration/#nginx-section
-[mockbin]: https://mockbin.com/
+[httpbin]: https://httpbin.org/

--- a/app/gateway/2.6.x/install-and-run/docker.md
+++ b/app/gateway/2.6.x/install-and-run/docker.md
@@ -278,7 +278,7 @@ backed up by a Redis cluster).
     _transform: true
 
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http

--- a/app/gateway/2.6.x/plugin-development/access-the-datastore.md
+++ b/app/gateway/2.6.x/plugin-development/access-the-datastore.md
@@ -51,8 +51,8 @@ For example, inserting a Service and a Plugin is as easy as:
 
 ```lua
 local inserted_service, err = kong.db.services:insert({
-  name = "mockbin",
-  url  = "http://mockbin.org",
+  name = "httpbin",
+  url  = "http://httpbin.org",
 })
 
 local inserted_plugin, err = kong.db.plugins:insert({

--- a/app/gateway/2.6.x/reference/db-less-and-declarative-config.md
+++ b/app/gateway/2.6.x/reference/db-less-and-declarative-config.md
@@ -240,7 +240,7 @@ environment variable.
 
 ```
 export KONG_DATABASE=off 
-export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"mockbin.com","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}' 
+export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"httpbin.org","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}' 
 kong start
 ```
 

--- a/app/gateway/2.7.x/configure/auth/index.md
+++ b/app/gateway/2.7.x/configure/auth/index.md
@@ -47,14 +47,14 @@ the corresponding Route:
 
 1. **Create an example Service and a Route**
 
-    Issue the following cURL request to create `example-service` pointing to `mockbin.org`, which will echo
+    Issue the following cURL request to create `example-service` pointing to `httpbin.org`, which will echo
     the request:
 
     ```bash
     $ curl -i -X POST \
       --url http://localhost:8001/services/ \
       --data 'name=example-service' \
-      --data 'url=http://mockbin.org/request'
+      --data 'url=http://httpbin.org/anything'
     ```
 
     Add a Route to the Service:
@@ -158,7 +158,7 @@ the corresponding Route:
     This is the same request you made in step #3; however, this time the request should succeed because you
     enabled anonymous access in step #5.
 
-    The response (which is the request as Mockbin received it) should have these elements:
+    The response (which is the request as httpbin received it) should have these elements:
 
     ```json
     {

--- a/app/gateway/2.7.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/expose-services.md
@@ -37,8 +37,8 @@ the Service to the backend API.
 
 ## Add a Service
 
-For the purpose of this example, you’ll create a Service pointing to the Mockbin
-API. Mockbin is an “echo” type public website that returns requests back to the
+For the purpose of this example, you’ll create a Service pointing to the httpbin
+API. Httpbin is an “echo” type public website that returns requests back to the
 requester as responses. This visualization will be helpful for learning how Kong
 Gateway proxies API requests.
 
@@ -58,7 +58,7 @@ click the **default** workspace.
 2. Scroll down to **Services** and click **Add a Service**.
 
 3. In the **Create Service** dialog, enter the name `example_service` and the
-URL `http://mockbin.org`.
+URL `http://httpbin.org`.
 
 4. Click **Create**.
 
@@ -73,14 +73,14 @@ The service is created, and the page automatically redirects back to the
 ```sh
 curl -i -X POST http://localhost:8001/services \
   --data name=example_service \
-  --data url='http://mockbin.org'
+  --data url='http://httpbin.org'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
 http POST :8001/services \
   name=example_service \
-  url='http://mockbin.org'
+  url='http://httpbin.org'
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -111,12 +111,12 @@ http :8001/services/example_service
 1. In the `kong.yaml` file you exported in
 [Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
 define a Service with the name `example_service` and the URL
-`http://mockbin.org`:
+`http://httpbin.org`:
 
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -216,7 +216,7 @@ A `201` message indicates the Route was created successfully.
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -253,7 +253,7 @@ A `201` message indicates the Route was created successfully.
     ``` yaml
     services:
     - connect_timeout: 60000
-      host: mockbin.org
+      host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -302,12 +302,12 @@ Using the Admin API, issue the following:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request
+http :8000/mock/anything
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -321,11 +321,11 @@ http :8000/mock/request
 
 In this section, you:
 
-* Added a Service named `example_service` with a URL of `http://mockbin.org`.
+* Added a Service named `example_service` with a URL of `http://httpbin.org`.
 * Added a Route named `/mock`.
 * This means if an HTTP request is sent to the {{site.base_gateway}} node on
 port `8000`(the proxy port) and it matches route `/mock`, then that request is
-sent to `http://mockbin.org`.
+sent to `http://httpbin.org`.
 * Abstracted a backend/upstream service and put a route of your choice on the
 front end, which you can now give to clients to make requests.
 

--- a/app/gateway/2.7.x/get-started/comprehensive/improve-performance.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/improve-performance.md
@@ -91,7 +91,7 @@ plugin with a timeout of 30 seconds for Content-Type
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -134,12 +134,12 @@ Access the */mock* route using the Admin API and note the response headers:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request
+http :8000/mock/anything
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.7.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/load-balancing.md
@@ -10,7 +10,7 @@ If you are following the getting started workflow, make sure you have completed 
 
 An **Upstream Object** refers to your upstream API/service sitting behind {{site.base_gateway}}, to which client requests are forwarded. In {{site.base_gateway}}, an Upstream Object represents a virtual hostname and can be used to health check, circuit break, and load balance incoming requests over multiple services (targets).
 
-In this topic, you’ll configure the service created earlier (`example_service`) to point to an upstream instead of the host. For the purposes of our example, the upstream will point to two different targets, `httpbin.org` and `mockbin.org`. In a real environment, the upstream will point to the same service running on multiple systems.
+In this topic, you’ll configure the service created earlier (`example_service`) to point to an upstream instead of the host. For the purposes of our example, the upstream will point to two different targets, `httpbin.org` and `httpbun.com`. In a real environment, the upstream will point to the same service running on multiple systems.
 
 Here is a diagram illustrating the setup:
 
@@ -35,7 +35,7 @@ In this section, you will create an Upstream named `example_upstream` and add tw
 6. On the Upstreams page, find the new upstream service and click **View**.
 7. Scroll down and click **New Target**.
 8. In the target field, specify `httpbin.org` with port `80`, and click **Create**.
-9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
+9. Create another target, this time for `httpbun.com` with port `80`. Click **Create**.
 10. Open the **Services** page.
 11. Find your `example_service` and click **Edit**.
 12. Change the **Host** field to `example_upstream`, then click **Update**.
@@ -80,7 +80,7 @@ http PATCH :8001/services/example_service \
 {% endnavtabs %}
 <!-- end codeblock tabs -->
 
-Add two targets to the upstream, each with port 80: `mockbin.org:80` and
+Add two targets to the upstream, each with port 80: `httpbun.com:80` and
 `httpbin.org:80`:
 
 <!-- codeblock tabs -->
@@ -88,7 +88,7 @@ Add two targets to the upstream, each with port 80: `mockbin.org:80` and
 {% navtab cURL %}
 ```sh
 curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
-  --data target='mockbin.org:80'
+  --data target='httpbun.com:80'
 
 curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='httpbin.org:80'
@@ -97,7 +97,7 @@ curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
 {% navtab HTTPie %}    
 ```sh
 http POST :8001/upstreams/example_upstream/targets \
-  target=mockbin.org:80
+  target=httpbun.com:80
 http POST :8001/upstreams/example_upstream/targets \
   target=httpbin.org:80
 ```
@@ -109,7 +109,7 @@ http POST :8001/upstreams/example_upstream/targets \
 
 {% navtab Using decK (YAML) %}
 1. In your `kong.yaml` file, create an Upstream with two targets, each with port
-80: `mockbin.org:80` and `httpbin.org:80`.
+80: `httpbun.com:80` and `httpbin.org:80`.
 
     ``` yaml
     upstreams:
@@ -117,7 +117,7 @@ http POST :8001/upstreams/example_upstream/targets \
       targets:
         - target: httpbin.org:80
           weight: 100
-        - target: mockbin.org:80
+        - target: httpbun.com:80
           weight: 100
     ```
 
@@ -159,7 +159,7 @@ Upstream:
       targets:
         - target: httpbin.org:80
           weight: 100
-        - target: mockbin.org:80
+        - target: httpbun.com:80
           weight: 100
     plugins:
     - name: rate-limiting
@@ -182,18 +182,18 @@ Upstream:
 {% endnavtab %}
 {% endnavtabs %}
 
-You now have an Upstream with two targets, `httpbin.org` and `mockbin.org`, and a service pointing to that Upstream.
+You now have an Upstream with two targets, `httpbin.org` and `httpbun.com`, and a service pointing to that Upstream.
 
 ## Validate the Upstream Services
 
 1. With the Upstream configured, validate that it’s working by visiting the route `http://localhost:8000/mock` using a web browser or CLI.
-2. Continue hitting the endpoint and the site should change from `httpbin` to `mockbin`.
+2. Continue hitting the endpoint and the site should change from `httpbin` to `httpbun`.
 
 ## Summary and next steps
 
 In this topic, you:
 
 * Created an Upstream object named `example_upstream` and pointed the Service `example_service` to it.
-* Added two targets, `httpbin.org` and `mockbin.org`, with equal weight to the Upstream.
+* Added two targets, `httpbin.org` and `httpbun.com`, with equal weight to the Upstream.
 
 If you have a {{site.konnect_product_name}} subscription, go on to [Managing Administrative Teams](/gateway/{{page.kong_version}}/get-started/comprehensive/manage-teams/).

--- a/app/gateway/2.7.x/get-started/comprehensive/protect-services.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/protect-services.md
@@ -95,7 +95,7 @@ and in-memory, on the node:
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -150,12 +150,12 @@ To validate rate limiting, access the API six (6) times from the CLI to confirm 
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request
+http :8000/mock/anything
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.7.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.7.x/get-started/comprehensive/secure-services.md
@@ -120,7 +120,7 @@ add a plugin section and enable the `key-auth` plugin:
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -258,7 +258,7 @@ You now have a consumer with an API key provisioned to access the route.
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -317,13 +317,13 @@ To validate the Key Authentication plugin, access the *mocking* route again, usi
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i http://localhost:8000/mock/request \
+curl -i http://localhost:8000/mock/anything \
   -H 'apikey:apikey'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request apikey:apikey
+http :8000/mock/anything apikey:apikey
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.7.x/get-started/quickstart/configuring-a-service.md
+++ b/app/gateway/2.7.x/get-started/quickstart/configuring-a-service.md
@@ -6,7 +6,7 @@ In this section, you'll be adding an API to Kong. In order to do this, you'll
 first need to add a _Service_; that is the name Kong uses to refer to the upstream APIs and microservices
 it manages.
 
-For the purpose of this guide, we'll create a Service pointing to the [Mockbin API][mockbin]. Mockbin is
+For the purpose of this guide, we'll create a Service pointing to the [httpbin API][httpbin]. Httpbin is
 an "echo" type public website which returns the requests it gets back to the requester, as responses. This
 makes it helpful for learning how Kong proxies your API requests.
 
@@ -24,14 +24,14 @@ You have installed and started {{site.base_gateway}}, either through the [Docker
 
 ## 1. Add your Service using the Admin API
 
-Issue the following cURL request to add your first Service (pointing to the [Mockbin API][mockbin])
+Issue the following cURL request to add your first Service (pointing to the [httpbin API][httpbin])
 to Kong:
 
 ```bash
 curl -i -X POST \
   --url http://localhost:8001/services/ \
   --data 'name=example-service' \
-  --data 'url=http://mockbin.org'
+  --data 'url=http://httpbin.org'
 ```
 
 You should receive a response similar to:
@@ -42,7 +42,7 @@ Content-Type: application/json
 Connection: keep-alive
 
 {
-   "host":"mockbin.org",
+   "host":"httpbin.org",
    "created_at":1519130509,
    "connect_timeout":60000,
    "id":"92956672-f5ea-4e9a-b096-667bf55bc40c",
@@ -129,4 +129,4 @@ Go to [Enabling Plugins &rsaquo;][enabling-plugins]
 [API]: /gateway/{{page.kong_version}}/admin-api
 [enabling-plugins]: /gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins
 [proxy-port]: /gateway/{{page.kong_version}}/reference/configuration/#nginx-section
-[mockbin]: https://mockbin.com/
+[httpbin]: https://httpbin.org/

--- a/app/gateway/2.7.x/install-and-run/docker.md
+++ b/app/gateway/2.7.x/install-and-run/docker.md
@@ -280,7 +280,7 @@ backed up by a Redis cluster).
     _transform: true
 
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http

--- a/app/gateway/2.7.x/plugin-development/access-the-datastore.md
+++ b/app/gateway/2.7.x/plugin-development/access-the-datastore.md
@@ -53,8 +53,8 @@ For example, inserting a Service and a Plugin is as easy as:
 
 ```lua
 local inserted_service, err = kong.db.services:insert({
-  name = "mockbin",
-  url  = "http://mockbin.org",
+  name = "httpbin",
+  url  = "http://httpbin.org",
 })
 
 local inserted_plugin, err = kong.db.plugins:insert({

--- a/app/gateway/2.7.x/reference/db-less-and-declarative-config.md
+++ b/app/gateway/2.7.x/reference/db-less-and-declarative-config.md
@@ -244,7 +244,7 @@ environment variable.
 
 ```
 export KONG_DATABASE=off 
-export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"mockbin.com","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}' 
+export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"httpbin.org","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}' 
 kong start
 ```
 

--- a/app/gateway/2.8.x/admin-api/developers/reference.md
+++ b/app/gateway/2.8.x/admin-api/developers/reference.md
@@ -526,7 +526,7 @@ HTTP/1.1 200 OK
             },
             "id": "5ff48aaf-3951-4c99-a636-3b682081705c",
             "name": "example_app",
-            "redirect_uri": "http://mockbin.org",
+            "redirect_uri": "http://httpbin.org",
             "updated_at": 1644963627
         },
         {
@@ -539,7 +539,7 @@ HTTP/1.1 200 OK
             },
             "id": "94e0f633-e8fd-4647-a0cd-4c3015ff2722",
             "name": "example_app2",
-            "redirect_uri": "http://mockbin.org",
+            "redirect_uri": "http://httpbin.org",
             "updated_at": 1644963657
         }
     ],
@@ -579,7 +579,7 @@ HTTP/1.1 200 OK
     },
     "id": "ca0d62bd-4616-4b87-b947-43e33e5418f0",
     "name": "testapp",
-    "redirect_uri": "http://mockbin.org",
+    "redirect_uri": "http://httpbin.org",
     "updated_at": 1644965555
 }
 ```
@@ -624,7 +624,7 @@ HTTP/1.1 201 Created
     },
     "id": "ca0d62bd-4616-4b87-b947-43e33e5418f0",
     "name": "testapp",
-    "redirect_uri": "http://mockbin.org",
+    "redirect_uri": "http://httpbin.org",
     "updated_at": 1644965555
 }
 ```
@@ -669,7 +669,7 @@ HTTP/1.1 200 OK
     },
     "id": "5ff48aaf-3951-4c99-a636-3b682081705c",
     "name": "ExampleApp",
-    "redirect_uri": "http://mockbin.org",
+    "redirect_uri": "http://httpbin.org",
     "updated_at": 1645575611
 }
 ```
@@ -736,7 +736,7 @@ HTTP/1.1 200 OK
                 },
                 "id": "645682ae-0be6-420a-bcf3-0e711a391546",
                 "name": "testapp",
-                "redirect_uri": "http://mockbin.org",
+                "redirect_uri": "http://httpbin.org",
                 "updated_at": 1644965487
             },
             "composite_id": "645682ae-0be6-420a-bcf3-0e711a391546_212a758a-810b-4226-9175-b1b44eecebec",
@@ -1447,7 +1447,7 @@ HTTP/1.1 200 OK
             "id": "e22760bc-c6d4-4572-9814-132825286618",
             "name": "example_app",
             "redirect_uris": [
-                "http://mockbin.org"
+                "http://httpbin.org"
             ]
         }
     ],
@@ -1503,7 +1503,7 @@ HTTP/1.1 201 Created
     "id": "2dc8ee2a-ecfd-4ca5-a9c1-db371480e2cf",
     "name": "example_app",
     "redirect_uris": [
-        "http://mockbin.org"
+        "http://httpbin.org"
     ]
 }
 ```
@@ -1541,7 +1541,7 @@ HTTP/1.1 200 OK
     "id": "e22760bc-c6d4-4572-9814-132825286618",
     "name": "example_app",
     "redirect_uris": [
-        "http://mockbin.org"
+        "http://httpbin.org"
     ]
 }
 ```

--- a/app/gateway/2.8.x/configure/auth/index.md
+++ b/app/gateway/2.8.x/configure/auth/index.md
@@ -47,14 +47,14 @@ the corresponding Route:
 
 1. **Create an example Service and a Route**
 
-    Issue the following cURL request to create `example-service` pointing to `mockbin.org`, which will echo
+    Issue the following cURL request to create `example-service` pointing to `httpbin.org`, which will echo
     the request:
 
     ```bash
     $ curl -i -X POST \
       --url http://localhost:8001/services/ \
       --data 'name=example-service' \
-      --data 'url=http://mockbin.org/request'
+      --data 'url=http://httpbin.org/anything'
     ```
 
     Add a Route to the Service:
@@ -158,7 +158,7 @@ the corresponding Route:
     This is the same request you made in step #3; however, this time the request should succeed because you
     enabled anonymous access in step #5.
 
-    The response (which is the request as Mockbin received it) should have these elements:
+    The response (which is the request as httpbin received it) should have these elements:
 
     ```json
     {

--- a/app/gateway/2.8.x/get-started/comprehensive/expose-services.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/expose-services.md
@@ -37,8 +37,8 @@ the Service to the backend API.
 
 ## Add a Service
 
-For the purpose of this example, you’ll create a Service pointing to the Mockbin
-API. Mockbin is an “echo” type public website that returns requests back to the
+For the purpose of this example, you’ll create a Service pointing to the httpbin
+API. Httpbin is an “echo” type public website that returns requests back to the
 requester as responses. This visualization will be helpful for learning how Kong
 Gateway proxies API requests.
 
@@ -58,7 +58,7 @@ click the **default** workspace.
 2. Scroll down to **Services** and click **Add a Service**.
 
 3. In the **Create Service** dialog, enter the name `example_service` and the
-URL `http://mockbin.org`.
+URL `http://httpbin.org`.
 
 4. Click **Create**.
 
@@ -73,14 +73,14 @@ The service is created, and the page automatically redirects back to the
 ```sh
 curl -i -X POST http://localhost:8001/services \
   --data name=example_service \
-  --data url='http://mockbin.org'
+  --data url='http://httpbin.org'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
 http POST http://localhost:8001/services \
   name=example_service \
-  url='http://mockbin.org'
+  url='http://httpbin.org'
 ```
 {% endnavtab %}
 {% endnavtabs %}
@@ -111,12 +111,12 @@ http http://localhost:8001/services/example_service
 1. In the `kong.yaml` file you exported in
 [Prepare to Administer {{site.base_gateway}}](/gateway/{{page.kong_version}}/get-started/comprehensive/prepare/#verify-the-kong-gateway-configuration),
 define a Service with the name `example_service` and the URL
-`http://mockbin.org`:
+`http://httpbin.org`:
 
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -216,7 +216,7 @@ A `201` message indicates the Route was created successfully.
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -253,7 +253,7 @@ A `201` message indicates the Route was created successfully.
     ``` yaml
     services:
     - connect_timeout: 60000
-      host: mockbin.org
+      host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -291,7 +291,7 @@ By default, {{site.base_gateway}} handles proxy requests on port `8000`. The pro
 {% navtabs %}
 {% navtab Using a Web Browser %}
 
-From a web browser, navigate to `http://localhost:8000/mock/request`.
+From a web browser, navigate to `http://localhost:8000/mock/anything`.
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -301,11 +301,11 @@ From a web browser, navigate to `http://localhost:8000/mock/request`.
 
 In this section, you:
 
-* Added a Service named `example_service` with a URL of `http://mockbin.org`.
+* Added a Service named `example_service` with a URL of `http://httpbin.org`.
 * Added a Route named `/mock`.
 * This means if an HTTP request is sent to the {{site.base_gateway}} node on
 port `8000`(the proxy port) and it matches route `/mock`, then that request is
-sent to `http://mockbin.org`.
+sent to `http://httpbin.org`.
 * Abstracted a backend/upstream service and put a route of your choice on the
 front end, which you can now give to clients to make requests.
 

--- a/app/gateway/2.8.x/get-started/comprehensive/improve-performance.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/improve-performance.md
@@ -91,7 +91,7 @@ plugin with a timeout of 30 seconds for Content-Type
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -134,12 +134,12 @@ Access the */mock* route using the Admin API and note the response headers:
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request
+http :8000/mock/anything
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.8.x/get-started/comprehensive/load-balancing.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/load-balancing.md
@@ -10,7 +10,7 @@ If you are following the getting started workflow, make sure you have completed 
 
 An **Upstream Object** refers to your upstream API/service sitting behind {{site.base_gateway}}, to which client requests are forwarded. In {{site.base_gateway}}, an Upstream Object represents a virtual hostname and can be used to health check, circuit break, and load balance incoming requests over multiple services (targets).
 
-In this topic, you’ll configure the service created earlier (`example_service`) to point to an upstream instead of the host. For the purposes of our example, the upstream will point to two different targets, `httpbin.org` and `mockbin.org`. In a real environment, the upstream will point to the same service running on multiple systems.
+In this topic, you’ll configure the service created earlier (`example_service`) to point to an upstream instead of the host. For the purposes of our example, the upstream will point to two different targets, `httpbin.org` and `httpbun.com`. In a real environment, the upstream will point to the same service running on multiple systems.
 
 Here is a diagram illustrating the setup:
 
@@ -35,7 +35,7 @@ In this section, you will create an Upstream named `example_upstream` and add tw
 6. On the Upstreams page, find the new upstream service and click **View**.
 7. Scroll down and click **New Target**.
 8. In the target field, specify `httpbin.org` with port `80`, and click **Create**.
-9. Create another target, this time for `mockbin.org` with port `80`. Click **Create**.
+9. Create another target, this time for `httpbun.com` with port `80`. Click **Create**.
 10. Open the **Services** page.
 11. Find your `example_service` and click **Edit**.
 12. Change the **Host** field to `example_upstream`, then click **Update**.
@@ -80,7 +80,7 @@ http PATCH :8001/services/example_service \
 {% endnavtabs %}
 <!-- end codeblock tabs -->
 
-Add two targets to the upstream, each with port 80: `mockbin.org:80` and
+Add two targets to the upstream, each with port 80: `httpbun.com:80` and
 `httpbin.org:80`:
 
 <!-- codeblock tabs -->
@@ -88,7 +88,7 @@ Add two targets to the upstream, each with port 80: `mockbin.org:80` and
 {% navtab cURL %}
 ```sh
 curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
-  --data target='mockbin.org:80'
+  --data target='httpbun.com:80'
 
 curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
   --data target='httpbin.org:80'
@@ -97,7 +97,7 @@ curl -X POST http://localhost:8001/upstreams/example_upstream/targets \
 {% navtab HTTPie %}    
 ```sh
 http POST :8001/upstreams/example_upstream/targets \
-  target=mockbin.org:80
+  target=httpbun.com:80
 http POST :8001/upstreams/example_upstream/targets \
   target=httpbin.org:80
 ```
@@ -109,7 +109,7 @@ http POST :8001/upstreams/example_upstream/targets \
 
 {% navtab Using decK (YAML) %}
 1. In your `kong.yaml` file, create an Upstream with two targets, each with port
-80: `mockbin.org:80` and `httpbin.org:80`.
+80: `httpbun.com:80` and `httpbin.org:80`.
 
     ``` yaml
     upstreams:
@@ -117,7 +117,7 @@ http POST :8001/upstreams/example_upstream/targets \
       targets:
         - target: httpbin.org:80
           weight: 100
-        - target: mockbin.org:80
+        - target: httpbun.com:80
           weight: 100
     ```
 
@@ -159,7 +159,7 @@ Upstream:
       targets:
         - target: httpbin.org:80
           weight: 100
-        - target: mockbin.org:80
+        - target: httpbun.com:80
           weight: 100
     plugins:
     - name: rate-limiting
@@ -182,18 +182,18 @@ Upstream:
 {% endnavtab %}
 {% endnavtabs %}
 
-You now have an Upstream with two targets, `httpbin.org` and `mockbin.org`, and a service pointing to that Upstream.
+You now have an Upstream with two targets, `httpbin.org` and `httpbun.com`, and a service pointing to that Upstream.
 
 ## Validate the Upstream Services
 
 1. With the Upstream configured, validate that it’s working by visiting the route `http://localhost:8000/mock` using a web browser or CLI.
-2. Continue hitting the endpoint and the site should change from `httpbin` to `mockbin`.
+2. Continue hitting the endpoint and the site should change from `httpbin` to `httpbin`.
 
 ## Summary and next steps
 
 In this topic, you:
 
 * Created an Upstream object named `example_upstream` and pointed the Service `example_service` to it.
-* Added two targets, `httpbin.org` and `mockbin.org`, with equal weight to the Upstream.
+* Added two targets, `httpbin.org` and `httpbun.com`, with equal weight to the Upstream.
 
 If you have a {{site.konnect_product_name}} subscription, go on to [Managing Administrative Teams](/gateway/{{page.kong_version}}/get-started/comprehensive/manage-teams/).

--- a/app/gateway/2.8.x/get-started/comprehensive/protect-services.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/protect-services.md
@@ -95,7 +95,7 @@ and in-memory, on the node:
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -150,12 +150,12 @@ To validate rate limiting, access the API six (6) times from the CLI to confirm 
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i -X GET http://localhost:8000/mock/request
+curl -i -X GET http://localhost:8000/mock/anything
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request
+http :8000/mock/anything
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.8.x/get-started/comprehensive/secure-services.md
+++ b/app/gateway/2.8.x/get-started/comprehensive/secure-services.md
@@ -120,7 +120,7 @@ add a plugin section and enable the `key-auth` plugin:
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -258,7 +258,7 @@ You now have a consumer with an API key provisioned to access the route.
     ``` yaml
     _format_version: "1.1"
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http
@@ -317,13 +317,13 @@ To validate the Key Authentication plugin, access the *mocking* route again, usi
 {% navtabs codeblock %}
 {% navtab cURL %}
 ```sh
-curl -i http://localhost:8000/mock/request \
+curl -i http://localhost:8000/mock/anything \
   -H 'apikey:apikey'
 ```
 {% endnavtab %}
 {% navtab HTTPie %}
 ```sh
-http :8000/mock/request apikey:apikey
+http :8000/mock/anything apikey:apikey
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.8.x/get-started/quickstart/configuring-a-service.md
+++ b/app/gateway/2.8.x/get-started/quickstart/configuring-a-service.md
@@ -6,14 +6,14 @@ In this section, you'll be adding an API to Kong. In order to do this, you'll
 first need to add a [Service](/gateway/{{page.kong_version}}/admin-api/#service-object); that is the name Kong uses to refer to the upstream APIs and microservices
 it manages.
 
-For the purpose of this guide, we'll create a Service pointing to the [Mockbin API][mockbin]. Mockbin is
+For the purpose of this guide, we'll create a Service pointing to the [httpbin API][httpbin]. Httpbin is
 an "echo" type public website which returns the requests it gets back to the requester, as responses. This
 makes it helpful for learning how Kong proxies your API requests.
 
 Before you can start making requests against the Service, you will need to add a [Route](/gateway/{{page.kong_version}}/admin-api/#route-object) to it.
 Routes specify how (and if) requests are sent to their Services after they reach Kong. There can be multiple Routes to a Service.
 
-After configuring the Service and a Route, you'll be able to proxy a request through Kong to Mockbin.
+After configuring the Service and a Route, you'll be able to proxy a request through Kong to httpbin.
 
 By default, Kong exposes a [RESTful Admin API][API] on port `8001`. 
 You can use the Admin API to modify Kong's configuration, including adding 
@@ -25,13 +25,13 @@ You have installed and started {{site.base_gateway}}, either through the [Docker
 ## 1. Add a Service using the Admin API
 
 Issue the following `POST` request to add your first Service to Kong.
-This instructs Kong to create a new Service named `example-service` which will accept traffic at `http://mockbin.org`.
+This instructs Kong to create a new Service named `example-service` which will accept traffic at `http://httpbin.org`.
 
 ```bash
 curl -i -X POST \
   --url http://localhost:8001/services/ \
   --data 'name=example-service' \
-  --data 'url=http://mockbin.org'
+  --data 'url=http://httpbin.org'
 ```
 
 You should receive a response similar to:
@@ -42,7 +42,7 @@ Content-Type: application/json
 Connection: keep-alive
 
 {
-   "host":"mockbin.org",
+   "host":"httpbin.org",
    "created_at":1519130509,
    "connect_timeout":60000,
    "id":"92956672-f5ea-4e9a-b096-667bf55bc40c",
@@ -112,7 +112,7 @@ curl -i -X GET \
   --header 'Host: example.com'
 ```
 
-A successful response means Kong is now forwarding requests with a `Host: example.com` header to the Mockbin Service we configured in step #1.
+A successful response means Kong is now forwarding requests with a `Host: example.com` header to the httpbin Service we configured in step #1.
 
 <hr>
 
@@ -125,4 +125,4 @@ Go to [Enabling Plugins &rsaquo;][enabling-plugins]
 [API]: /gateway/{{page.kong_version}}/admin-api
 [enabling-plugins]: /gateway/{{page.kong_version}}/get-started/quickstart/enabling-plugins
 [proxy-port]: /gateway/{{page.kong_version}}/reference/configuration/#nginx-section
-[mockbin]: https://mockbin.com/
+[httpbin]: https://httpbin.org/

--- a/app/gateway/2.8.x/install-and-run/docker.md
+++ b/app/gateway/2.8.x/install-and-run/docker.md
@@ -288,7 +288,7 @@ backed up by a Redis cluster).
     _transform: true
 
     services:
-    - host: mockbin.org
+    - host: httpbin.org
       name: example_service
       port: 80
       protocol: http

--- a/app/gateway/2.8.x/plugin-development/access-the-datastore.md
+++ b/app/gateway/2.8.x/plugin-development/access-the-datastore.md
@@ -53,8 +53,8 @@ For example, inserting a Service and a Plugin is as easy as:
 
 ```lua
 local inserted_service, err = kong.db.services:insert({
-  name = "mockbin",
-  url  = "http://mockbin.org",
+  name = "httpbin",
+  url  = "http://httpbin.org",
 })
 
 local inserted_plugin, err = kong.db.plugins:insert({

--- a/app/gateway/2.8.x/reference/db-less-and-declarative-config.md
+++ b/app/gateway/2.8.x/reference/db-less-and-declarative-config.md
@@ -244,7 +244,7 @@ environment variable.
 
 ```
 export KONG_DATABASE=off
-export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"mockbin.com","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}'
+export KONG_DECLARATIVE_CONFIG_STRING='{"_format_version":"1.1", "services":[{"host":"httpbin.org","port":443,"protocol":"https", "routes":[{"paths":["/"]}]}],"plugins":[{"name":"rate-limiting", "config":{"policy":"local","limit_by":"ip","minute":3}}]}'
 kong start
 ```
 

--- a/app/konnect/dev-portal/access-and-approval/manage-teams.md
+++ b/app/konnect/dev-portal/access-and-approval/manage-teams.md
@@ -46,7 +46,7 @@ In {% konnect_icon runtimes %} [**Gateway Manager**](https://cloud.konghq.com/us
 1. Select **Gateway Services** from the side navigation bar, then **New Gateway Service**.
 1. From the **Add a Gateway Service** dialog, enter the following to create a new service:
     * **Name:** `pizza_ordering`
-    * **Upstream URL:** `http://mockbin.org`
+    * **Upstream URL:** `http://httpbin.org`
     * Use the defaults for the remaining fields.
 1. Click **Save**. 
 1. To create an API product for your service, navigate to **API Products** in the sidebar, click **Add API Product** and enter `Pizza Ordering` in the **Product Name** field.
@@ -74,7 +74,7 @@ The {{site.konnect_short_name}} API uses [Personal Access Token (PAT)](/konnect/
       --header 'accept: application/json' \
       --data '{
           "name": "pizza_ordering",
-          "host": "mockbin.org",
+          "host": "httpbin.org",
           "path": "/pizza_ordering"
       }'
     ```
@@ -87,7 +87,7 @@ The {{site.konnect_short_name}} API uses [Personal Access Token (PAT)](/konnect/
         "connect_timeout": 60000,
         "created_at": 1692885974,
         "enabled": true,
-        "host": "mockbin.org",
+        "host": "httpbin.org",
         "id": "06acc4f4-c6d8-4daf-bef6-79866e88ca86",
         "name": "pizza_ordering",
         "path": "/pizza_ordering",

--- a/app/konnect/gateway-manager/backup-restore.md
+++ b/app/konnect/gateway-manager/backup-restore.md
@@ -45,7 +45,7 @@ consumers:
 - username: example-user2
 services:
 - connect_timeout: 60000
-    host: mockbin.org
+    host: httpbin.org
     name: MyService
     tags:
     - _KonnectService:example_service

--- a/app/konnect/gateway-manager/control-plane-groups/how-to.md
+++ b/app/konnect/gateway-manager/control-plane-groups/how-to.md
@@ -193,7 +193,7 @@ Create a service and route in `CP1`. This will let you test the connection betwe
 1. Click the **New Gateway Service** button and set up the service. 
 For this example, you can use the following values:
    * Name: `example_service`
-   * Host: `mockbin.org`
+   * Host: `httpbin.org`
 
 1. Next, create a route. From the side menu, open **Routes**.
 1. Click the **New Route** button and set up the route. For this example, you can enter `/mock` in the paths field.
@@ -270,7 +270,7 @@ For this example, you can use the following values:
     curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/services \
         -H "Authorization: Bearer <your_KPAT>"  \
         --data "name=example_service" \
-        --data "host=mockbin.org"
+        --data "host=httpbin.org"
     ```
 
     ```sh
@@ -297,7 +297,7 @@ running on the data plane node configured in the `CPG`.
 {% navtabs %}
 {% navtab Konnect UI %}
 
-1. Try to access the route you set up in `CP1`. In a web browser, navigate to `http://localhost:8000/mock/request/hello`. 
+1. Try to access the route you set up in `CP1`. In a web browser, navigate to `http://localhost:8000/mock/anything/hello`. 
 
     You should see a mock request page.
 
@@ -317,10 +317,10 @@ This time, you should receive a prompt to enter a username and password.
 1. Try to access the route you set up in `CP1`:
 
     ```
-    curl localhost:8000/mock/request/hello
+    curl localhost:8000/mock/anything/hello
     ```
 
-    You should see a response from Mockbin.
+    You should see a response from httpbin.
 
 1. Find the ID of `CP2`. In `CP2`, set up the basic authentication plugin:
 
@@ -333,7 +333,7 @@ This time, you should receive a prompt to enter a username and password.
 1. Wait a few seconds, then try to access the route again. This time, you shouldn't be able to access it:
 
     ```sh
-    curl localhost:8000/mock/request/hello
+    curl localhost:8000/mock/anything/hello
     ```
 
     Response:

--- a/app/konnect/gateway-manager/declarative-config.md
+++ b/app/konnect/gateway-manager/declarative-config.md
@@ -115,7 +115,7 @@ For this example, let's add a new service.
       control_plane_name: default
     services:
     - name: MyService
-      host: mockbin.org
+      host: httpbin.org
       port: 80
       protocol: http
       routes:
@@ -132,7 +132,7 @@ For this example, let's add a new service.
             - apikey
     ```
 
-    This snippet defines a service named `MyService` pointing to `mockbin.org`.
+    This snippet defines a service named `MyService` pointing to `httpbin.org`.
     The service has one version, and the version gets implemented with the
     route `/mock`, which means that you can access the service by appending
     this route to your proxy URL.
@@ -251,7 +251,7 @@ header:
   -H 'apikey: {API_KEY}'
  ```
 
-If successful, you should see the homepage for `mockbin.org`. On the Service
+If successful, you should see the homepage for `httpbin.org`. On the Service
 Version overview page, you’ll see a record for status code `200`.
 
 If you try to access the route without a key, you'll get an authorization error:

--- a/app/konnect/getting-started/deploy-service.md
+++ b/app/konnect/getting-started/deploy-service.md
@@ -33,7 +33,7 @@ In the {% konnect_icon runtimes %} [**Gateway Manager**](https://cloud.konghq.co
        For example, you can use `example_service`, `ExampleService`, `Example-Service`.
        However, `Example Service` is invalid.
 
-    1. In the **add using upstream URL** field, enter `http://mockbin.org`.
+    1. In the **add using upstream URL** field, enter `http://httpbin.org`.
 
     1. Use the defaults for the remaining fields.
 
@@ -43,7 +43,7 @@ In the {% konnect_icon runtimes %} [**Gateway Manager**](https://cloud.konghq.co
 
     For this example, enter the following:
 
-    * **Name**: `mockbin`
+    * **Name**: `httpbin`
     * **Protocols**: `HTTP`, `HTTPS`
     * **Path(s)**: `/mock`
 
@@ -62,7 +62,7 @@ you just set. The final URL should look something like this:
 http://localhost:8000/mock
 ```
 
-If successful, you should see the homepage for `mockbin.org`. In the Gateway Manager you will now see a **200** responses recorded in the **Analytics** tab.
+If successful, you should see the homepage for `httpbin.org`. In the Gateway Manager you will now see a **200** responses recorded in the **Analytics** tab.
 
 And that's it! You have your first service set up, running, and routing
 traffic proxied through a {{site.base_gateway}} data plane node.
@@ -73,7 +73,7 @@ To summarize, in this topic you:
 
 * Implemented a Gateway service `example_gateway_service` and the route `/mock`. This means if an HTTP
 request is sent to the {{site.base_gateway}} node and it matches route `/mock`, that
-request is sent to `http://mockbin.org`.
+request is sent to `http://httpbin.org`.
 * Abstracted a backend/upstream service and put a route of your choice on the
 front end, which you can now give to clients to make requests.
 


### PR DESCRIPTION
### Description

Mockbin.org has been retired and is no longer available. Replacing it with [httpbin.org](https://httpbin.org/) wherever possible, or [httpbun.com](https://httpbun.com/) where we're using httpbin already, and mockbin is the second echo service in the example.

https://konghq.atlassian.net/browse/DOCU-3566

### Testing instructions

Preview link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

