### PR TITLE
Chore: Support matrix updates for Gateway 3.5

### DIFF
--- a/app/_data/tables/support/gateway/versions/35.yml
+++ b/app/_data/tables/support/gateway/versions/35.yml
@@ -12,7 +12,8 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - *debian10
+  - <<: *debian10
+    eol: June 2024
   - <<: *debian11
     docker: true
     arm: true
@@ -43,9 +44,6 @@ third-party:
         - 14
         - 13
         - 12
-        - 11
-        - 10
-        - 9
         - Amazon RDS
         - Amazon Aurora
     - *redis

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -48,7 +48,7 @@ Kong supports the following versions of {{site.ee_product_name}}:
 
 {% navtabs %}
   {% navtab 3.5 %}
-    {% include_cached gateway-support.html version="3.5" data=site.data.tables.support.gateway.versions.35 eol="TBD" %}
+    {% include_cached gateway-support.html version="3.5" data=site.data.tables.support.gateway.versions.35 eol="Nov 2024" %}
   {% endnavtab %}
   {% navtab 3.4 LTS %}
     {% include_cached gateway-support.html version="3.4" data=site.data.tables.support.gateway.versions.34 eol="August 2026" %}


### PR DESCRIPTION
### Description

Setting the EOL date for 3.5.

Also removing Postgres 9-11 (was already removed from 3.4) and setting the EOL date for Debian 10 at June 2024, as that EOL is earlier than the general release EOL.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

