### PR TITLE
KIC: Fix GRPC Guide

### DIFF
--- a/app/_data/docs_nav_kic_3.0.x.yml
+++ b/app/_data/docs_nav_kic_3.0.x.yml
@@ -101,8 +101,8 @@ items:
             url: /guides/services/tcp
           - text: UDP Service
             url: /guides/services/udp
-          #- text: gRPC Service
-          #  url: /guides/services/grpc
+          - text: gRPC Service
+            url: /guides/services/grpc
           - text: TLS
             url: /guides/services/tls
           - text: External Service

--- a/app/_includes/md/kic/add-certificate.md
+++ b/app/_includes/md/kic/add-certificate.md
@@ -1,7 +1,9 @@
+{% unless include.cert_required %}
 The routing configuration can include a certificate to present when clients connect
 over HTTPS. This is not required, as {{site.base_gateway}} will serve a default
 certificate if it cannot find another, but including TLS configuration along
 with routing configuration is typical.
+{% endunless %}
 
 1. Create a test certificate for the `{{ include.hostname }}` hostname.
 

--- a/app/_src/kic-v2/guides/using-ingress-with-grpc.md
+++ b/app/_src/kic-v2/guides/using-ingress-with-grpc.md
@@ -3,94 +3,6 @@ title: Exposing a gRPC service
 content_type: tutorial
 ---
 
-{% if_version lte:2.8.x %}
-## Installation
-
-Please follow the [deployment](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/overview/) documentation to install
-the {{site.kic_product_name}} onto your Kubernetes cluster.
-
-## Prerequisite
-
-To make `gRPC` requests, you need a client that can invoke gRPC requests.
-In this guide, we use
-[`grpcurl`](https://github.com/fullstorydev/grpcurl#installation).
-Ensure that you have it installed on your local system.
-
-## Test connectivity to Kong
-
-This guide assumes that the `PROXY_IP` environment variable is
-set to contain the IP address or URL pointing to Kong.
-If you haven't done so, follow one of the
-[deployment guides](/kubernetes-ingress-controller/{{page.kong_version}}/deployment/overview) to configure the `PROXY_IP` environment variable.
-
-If everything is set up correctly, Kong returns
-`HTTP 404 Not Found` since the system does not know yet how to proxy the request. 
-
-```bash
-curl -i $PROXY_IP
-HTTP/1.1 404 Not Found
-Content-Type: application/json; charset=utf-8
-Connection: keep-alive
-Content-Length: 48
-Server: kong/1.2.1
-
-{"message":"no Route matched with those values"}
-```
-
-#### Run gRPC
-
-1. Add a gRPC deployment and service:
-
-    ```bash
-    kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/v{{site.data.kong_latest_KIC.version}}/deploy/manifests/sample-apps/grpc.yaml
-    service/grpcbin created
-    deployment.apps/grpcbin created
-    ```
-2. Create a demo gRPC ingress rule:
-
-    ```bash
-    echo "apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: demo
-      annotations:
-        kubernetes.io/ingress.class: kong
-    spec:
-      rules:
-      - http:
-          paths:
-          - path: /
-            backend:
-              serviceName: grpcbin
-              servicePort: 9001" | kubectl apply -f -
-    ingress.extensions/demo created
-    ```
-
-3. Next, we need to update the Ingress rule to specify gRPC as the protocol.
-By default, all routes are assumed to be either HTTP or HTTPS. This annotation
-informs Kong that this route is a gRPC(s) route and not a plain HTTP route:
-
-    ```bash
-    kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/protocols":"grpc,grpcs"}}}'
-    ```
-
-4. We also update the upstream protocol to be `grpcs`.
-Similar to routes, Kong assumes that services are HTTP-based by default.
-With this annotation, we configure Kong to use gRPCs protocol when it
-talks to the upstream service:
-
-    ```bash
-    kubectl patch svc grpcbin -p '{"metadata":{"annotations":{"konghq.com/protocol":"grpcs"}}}'
-    ```
-
-5. You should be able to run a request over `gRPC`:
-
-    ```bash
-    grpcurl -v -d '{"greeting": "Kong Hello world!"}' -insecure $PROXY_IP:443 hello.HelloService.SayHello
-    ```
-{% endif_version %}
-
-{% if_version gte:2.9.x %}
 ## Overview
 
 This guide walks through deploying a simple [Service][svc] that listens for
@@ -101,29 +13,16 @@ For this example, you will:
 * Deploy a gRPC test application.
 * Route gRPC traffic to it using Ingress or GRPCRoute.
 
-{% include_cached /md/kic/installation.md kong_version=page.kong_version %}
-
-{% include_cached /md/kic/class.md kong_version=page.kong_version %}
-
-[svc]:https://kubernetes.io/docs/concepts/services-networking/service/
-[gRPC]:https://grpc.io/
-
-## Prerequisite
-
 To make `gRPC` requests, you need a client that can invoke gRPC requests.
 In this guide, we use
 [`grpcurl`](https://github.com/fullstorydev/grpcurl#installation).
 Ensure that you have it installed on your local system.
 
-## Enable the `GatewayAlpha` feature gate
-
-If you are using the Gateway API, you need to enable the 
-[`GatewayAlpha`](/kubernetes-ingress-controller/{{page.kong_version}}/references/feature-gates) 
-feature gate in the {{site.kic_product_name}}.
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=true %}
 
 ## Deploy a gRPC test application
 
-Add a gRPC deployment and service:
+Kong assumes that services are HTTP-based by default. We configure Kong to use gRPCs protocol when it talks to the upstream service with the `konghq.com/protocol` annotation
 
 ```bash
 echo "---
@@ -133,10 +32,12 @@ metadata:
   name: grpcbin
   labels:
     app: grpcbin
+  annotations:
+    konghq.com/protocol: grpcs
 spec:
   ports:
-  - name: grpc
-    port: 443
+  - name: tls
+    port: 9001
     targetPort: 9001
   selector:
     app: grpcbin
@@ -173,103 +74,50 @@ service/grpcbin created
 Now that the test application is running, you can create GRPC routing configuration that
 proxies traffic to the application:
 
-{% navtabs api %}
-{% navtab Ingress %}
+All routes are assumed to be either HTTP or HTTPS by default. We need to update the Ingress rule to specify gRPC as the protocol by adding a `konghq.com/protocols` annotation.
+
+This annotation informs Kong that this route is a gRPC route and not a plain HTTP route
+
 ```bash
 echo "apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: demo
   annotations:
-    kubernetes.io/ingress.class: kong
+    konghq.com/protocols: grpcs
 spec:
+  ingressClassName: kong
   rules:
   - http:
-    paths:
-    - path: /
-      backend:
-        serviceName: grpcbin
-        servicePort: 443" | kubectl apply -f -
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service: 
+            name: grpcbin
+            port: 
+              number: 9001" | kubectl apply -f -
 ```
 Response:
 ```text
 ingress.networking.k8s.io/demo created
 ```
-{% endnavtab %}
-{% navtab Gateway API %}
-```bash
-echo "apiVersion: gateway.networking.k8s.io/v1alpha2
-kind: GRPCRoute
-metadata:
-  name: grpcbin
-spec:
-  parentRefs:
-  - name: kong
-  hostnames:
-  - example.com
-  rules:
-  - backendRefs:
-    - name: grpcbin
-      port: 443
-" | kubectl apply -f -
-```
-Response:
-```text
-grpcroute.gateway.networking.k8s.io/demo created
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-## Update the Ingress rule
-
-Next, if using the ingress, we need to update the Ingress rule to specify gRPC as the protocol.
-By default, all routes are assumed to be either HTTP or HTTPS. This annotation
-informs Kong that this route is a gRPC(s) route and not a plain HTTP route:
-
-{% navtabs api %}
-{% navtab Ingress %}
-```bash
-kubectl patch ingress demo -p '{"metadata":{"annotations":{"konghq.com/protocols":"grpc,grpcs"}}}'
-```
-{% endnavtab %}
-{% endnavtabs %}
-
-We also need to update the upstream protocol to be `grpcs`.
-Similar to routes, Kong assumes that services are HTTP-based by default.
-With this annotation, we configure Kong to use gRPCs protocol when it
-talks to the upstream service:
-
-{% navtabs api %}
-{% navtab Ingress %}
-```bash
-kubectl patch svc grpcbin -p '{"metadata":{"annotations":{"konghq.com/protocol":"grpcs"}}}'
-```
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Test the configuration
 
-First, retrieve the external IP address of the Kong proxy service:
+Use `grpcurl` to send a gRPC request through the proxy:
 
 ```bash
-export PROXY_IP="$(kubectl -n kong get service kong-proxy \
-    -o=go-template='{% raw %}{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}{% endraw %}')"
+grpcurl -d '{"greeting": "Kong"}' -insecure $PROXY_IP:443 hello.HelloService.SayHello
 ```
 
-After, use `grpcurl` to send a gRPC request through the proxy:
+Response:
 
-{% navtabs codeblock %}
-{% navtab Command %}
-```bash
-grpcurl -d '{"greeting": "Kong"}' -servername example.com -insecure $PROXY_IP:443 hello.HelloService.SayHello
-```
-{% endnavtab %}
-{% navtab Response %}
 ```text
 {
   "reply": "hello Kong"
 }
 ```
-{% endnavtab %}
-{% endnavtabs %}
-{% endif_version %}
+
+[svc]:https://kubernetes.io/docs/concepts/services-networking/service/
+[gRPC]:https://grpc.io/

--- a/app/_src/kic-v2/guides/using-ingress-with-grpc.md
+++ b/app/_src/kic-v2/guides/using-ingress-with-grpc.md
@@ -22,7 +22,7 @@ Ensure that you have it installed on your local system.
 
 ## Deploy a gRPC test application
 
-Kong assumes that services are HTTP-based by default. We configure Kong to use gRPCs protocol when it talks to the upstream service with the `konghq.com/protocol` annotation
+By default, Kong considers all services to be HTTP-based. You need to configure Kong to use gRPCs protocol when it talks to the upstream service using the `konghq.com/protocol` annotation.
 
 ```bash
 echo "---
@@ -72,9 +72,9 @@ service/grpcbin created
 ## Route GRPC traffic
 
 Now that the test application is running, you can create GRPC routing configuration that
-proxies traffic to the application:
+proxies traffic to the application.
 
-All routes are assumed to be either HTTP or HTTPS by default. We need to update the Ingress rule to specify gRPC as the protocol by adding a `konghq.com/protocols` annotation.
+All routes are assumed to be either HTTP or HTTPS by default. You need to update the Ingress rule to specify gRPC as the protocol by adding a `konghq.com/protocols` annotation.
 
 This annotation informs Kong that this route is a gRPC route and not a plain HTTP route
 
@@ -98,7 +98,7 @@ spec:
             port: 
               number: 9001" | kubectl apply -f -
 ```
-Response:
+The results should look like this:
 ```text
 ingress.networking.k8s.io/demo created
 ```
@@ -111,7 +111,7 @@ Use `grpcurl` to send a gRPC request through the proxy:
 grpcurl -d '{"greeting": "Kong"}' -insecure $PROXY_IP:443 hello.HelloService.SayHello
 ```
 
-Response:
+The results should look like this:
 
 ```text
 {

--- a/app/_src/kubernetes-ingress-controller/gateway-api.md
+++ b/app/_src/kubernetes-ingress-controller/gateway-api.md
@@ -54,4 +54,4 @@ spec:
 * [`HTTPRoute`](/kubernetes-ingress-controller/{{ page.release }}/guides/services/http/)
 * [`TCPRoute`](/kubernetes-ingress-controller/{{ page.release }}/guides/services/tcp/)
 * [`UDPRoute`](/kubernetes-ingress-controller/{{ page.release }}/guides/services/udp/)
-* `GRPCRoute`
+* [`GRPCRoute`](/kubernetes-ingress-controller/{{ page.release }}/guides/services/grpc/)

--- a/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
@@ -4,3 +4,179 @@ type: how-to
 purpose: |
   How to proxy gRPC requests
 ---
+
+## Overview
+
+This guide walks through deploying a [Service][svc] that listens for [gRPC connections][gRPC] and exposes this service outside of the cluster using {{site.base_gateway}}.
+
+For this example, you will:
+* Deploy a gRPC test application.
+* Route gRPC traffic to it using Ingress or GRPCRoute.
+
+To make `gRPC` requests, you need a client that can invoke gRPC requests.  In this guide, we use [`grpcurl`](https://github.com/fullstorydev/grpcurl#installation). Ensure that you have it installed on your local system.
+
+{% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false gateway_api_experimental=true %}
+
+## Deploy a gRPC test application
+
+Kong assumes that services are HTTP-based by default. We configure Kong to use gRPCs protocol when it talks to the upstream service with the `konghq.com/protocol` annotation
+
+```bash
+echo "---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpcbin
+  labels:
+    app: grpcbin
+  annotations:
+    konghq.com/protocol: grpcs
+spec:
+  ports:
+  - name: tls
+    port: 9001
+    targetPort: 9001
+  selector:
+    app: grpcbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpcbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grpcbin
+  template:
+    metadata:
+      labels:
+        app: grpcbin
+    spec:
+      containers:
+      - image: moul/grpcbin
+        name: grpcbin
+        ports:
+        - containerPort: 9001
+" | kubectl apply -f -
+```
+Response:
+```text
+deployment.apps/grpcbin created
+service/grpcbin created
+```
+
+## Create a certificate
+
+{% include /md/kic/add-certificate.md hostname='example.com' kong_version=page.kong_version cert_required=true %}
+
+## Route GRPC traffic
+
+Now that the test application is running, you can create GRPC routing configuration that
+proxies traffic to the application:
+
+{% navtabs api %}
+{% navtab Gateway API %}
+If you are using the Gateway APIs (GRPCRoute), your Gateway needs additional configuration under `listeners`.
+
+```bash
+kubectl patch --type=json gateway kong -p='[
+
+    {
+        "op":"add",
+        "path":"/spec/listeners/-",
+        "value":{
+            "name":"grpc",
+            "port":443,
+            "protocol":"HTTPS",
+            "hostname":"example.com",
+            "tls": {
+                "certificateRefs":[{
+                    "group":"",
+                    "kind":"Secret",
+                    "name":"example.com"
+                 }]
+            }
+        }
+    }
+]'
+```
+The results should look like this:
+```text
+gateway.gateway.networking.k8s.io/kong patched
+```
+
+Next, create a `GRPCRoute`:
+
+```bash
+echo 'apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: GRPCRoute
+metadata:
+  name: grpcbin
+spec:
+  parentRefs:
+  - name: kong
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: grpcbin
+      port: 9001
+' | kubectl apply -f -
+```
+Response:
+```text
+grpcroute.gateway.networking.k8s.io/grpcbin created
+```
+{% endnavtab %}
+{% navtab Ingress %}
+
+All routes are assumed to be either HTTP or HTTPS by default. We need to update the route to specify gRPC as the protocol by adding a `konghq.com/protocols` annotation.
+
+This annotation informs Kong that this route is a gRPC route and not a plain HTTP route
+
+```bash
+echo "apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grpcbin
+  annotations:
+    konghq.com/protocols: grpcs
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: grpcbin
+            port:
+              number: 9001" | kubectl apply -f -
+```
+Response:
+```text
+ingress.networking.k8s.io/grpcbin created
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+## Test the configuration
+
+Use `grpcurl` to send a gRPC request through the proxy:
+
+```bash
+grpcurl -d '{"greeting": "Kong"}' -servername example.com -insecure $PROXY_IP:443 hello.HelloService.SayHello
+```
+
+Response:
+
+```text
+{
+  "reply": "hello Kong"
+}
+```
+
+[svc]:https://kubernetes.io/docs/concepts/services-networking/service/
+[gRPC]:https://grpc.io/

--- a/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
@@ -9,17 +9,17 @@ purpose: |
 
 This guide walks through deploying a [Service][svc] that listens for [gRPC connections][gRPC] and exposes this service outside of the cluster using {{site.base_gateway}}.
 
-For this example, you will:
+For this example, you need to:
 * Deploy a gRPC test application.
 * Route gRPC traffic to it using Ingress or GRPCRoute.
 
-To make `gRPC` requests, you need a client that can invoke gRPC requests.  In this guide, we use [`grpcurl`](https://github.com/fullstorydev/grpcurl#installation). Ensure that you have it installed on your local system.
+To make `gRPC` requests, you need a client that can invoke gRPC requests. You can use [`grpcurl`](https://github.com/fullstorydev/grpcurl#installation) as the client. Ensure that you have it installed on your local system.
 
 {% include_cached /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false gateway_api_experimental=true %}
 
 ## Deploy a gRPC test application
 
-Kong assumes that services are HTTP-based by default. We configure Kong to use gRPCs protocol when it talks to the upstream service with the `konghq.com/protocol` annotation
+Kong assumes that services are HTTP-based by default. You need to configure Kong to use gRPCs protocol when it talks to the upstream service using the `konghq.com/protocol` annotation
 
 ```bash
 echo "---
@@ -60,7 +60,7 @@ spec:
         - containerPort: 9001
 " | kubectl apply -f -
 ```
-Response:
+The results should look like this:
 ```text
 deployment.apps/grpcbin created
 service/grpcbin created
@@ -124,7 +124,7 @@ spec:
       port: 9001
 ' | kubectl apply -f -
 ```
-Response:
+The results should look like this:
 ```text
 grpcroute.gateway.networking.k8s.io/grpcbin created
 ```
@@ -133,7 +133,7 @@ grpcroute.gateway.networking.k8s.io/grpcbin created
 
 All routes are assumed to be either HTTP or HTTPS by default. We need to update the route to specify gRPC as the protocol by adding a `konghq.com/protocols` annotation.
 
-This annotation informs Kong that this route is a gRPC route and not a plain HTTP route
+This annotation informs Kong that this route is a gRPC route and not a plain HTTP route.
 
 ```bash
 echo "apiVersion: networking.k8s.io/v1
@@ -155,7 +155,7 @@ spec:
             port:
               number: 9001" | kubectl apply -f -
 ```
-Response:
+The results should look like this:
 ```text
 ingress.networking.k8s.io/grpcbin created
 ```
@@ -170,7 +170,7 @@ Use `grpcurl` to send a gRPC request through the proxy:
 grpcurl -d '{"greeting": "Kong"}' -servername example.com -insecure $PROXY_IP:443 hello.HelloService.SayHello
 ```
 
-Response:
+The results should look like this:
 
 ```text
 {


### PR DESCRIPTION
### Description

Add GRPC guide to KIC 3.0 docs 

### Testing instructions

Preview link: See guides->services->grpc

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)