### PR TITLE
fix: remove unnecessary brackets from proxy config

### DIFF
--- a/app/_src/kubernetes-ingress-controller/concepts/gateway-api.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/gateway-api.md
@@ -102,7 +102,7 @@ proxy:
     servicePort: 443
     containerPort: 8443
 
-  stream: []
+  stream:
     - containerPort: 9901
       servicePort: 9901
       protocol: TCP


### PR DESCRIPTION
### Description

Removes unnecessary brackets from example helm values proxy configuration that break it.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

