### PR TITLE
chore: Remove influxdb from list of supported 3rd party dependencies in 3.5

### DIFF
--- a/app/_data/tables/support/gateway/versions/35.yml
+++ b/app/_data/tables/support/gateway/versions/35.yml
@@ -47,7 +47,6 @@ third-party:
         - Amazon RDS
         - Amazon Aurora
     - *redis
-    - *influxdb
     - *kafka
 
   metrics:


### PR DESCRIPTION
### Description

InfluxDB is not supported in 3.5, since Vitals is deprecated.

### Testing instructions

Preview link: https://deploy-preview-6491--kongdocs.netlify.app/gateway/latest/support/third-party/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

