### PR TITLE
chore: improve docs about support of gRPC in KIC

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
@@ -8,8 +8,10 @@ purpose: |
 ## Overview
 
 This guide walks through deploying a [Service][svc] that listens for [gRPC connections][gRPC] and exposes this service outside of the cluster using {{site.base_gateway}}.
+Currently, only gRPC over HTTP/2 with TLS is supported. Thus Gateway's listener must be configured with `protocol: HTTPS` as in the presented example.
 
 For this example, you need to:
+
 * Deploy a gRPC test application.
 * Route gRPC traffic to it using Ingress or GRPCRoute.
 
@@ -19,8 +21,6 @@ To make `gRPC` requests, you need a client that can invoke gRPC requests. You ca
 
 ## Deploy a gRPC test application
 
-Kong assumes that services are HTTP-based by default. You need to configure Kong to use gRPCs protocol when it talks to the upstream service using the `konghq.com/protocol` annotation
-
 ```bash
 echo "---
 apiVersion: v1
@@ -29,8 +29,6 @@ metadata:
   name: grpcbin
   labels:
     app: grpcbin
-  annotations:
-    konghq.com/protocol: grpcs
 spec:
   ports:
   - name: tls

--- a/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
@@ -8,7 +8,7 @@ purpose: |
 ## Overview
 
 This guide walks through deploying a [Service][svc] that listens for [gRPC connections][gRPC] and exposes this service outside of the cluster using {{site.base_gateway}}.
-Currently, only gRPC over HTTP/2 with TLS is supported. Thus Gateway's listener must be configured with `protocol: HTTPS` as in the presented example.
+Currently, only gRPC over HTTP/2 with TLS is supported. Hence, configure the Gateway's listener using `protocol: HTTPS` when routing GRPC traffic.
 
 For this example, you need to:
 


### PR DESCRIPTION
### Description

Improve documentation for gRPC support in KIC
- as long as https://github.com/Kong/kubernetes-ingress-controller/issues/4273 is not resolved only gRPC over HTTPS is supported, so mention it
- remove the redundant annotation `konghq.com/protocol: grpcs` from the service, because in [examples/gateway-grpcroute.yaml](https://github.com/Kong/kubernetes-ingress-controller/blob/314951c3279dcd38cb7de7e53f71969379a0340a/examples/gateway-grpcroute.yaml#L5-L17) it's not specified and that configuration is tested in KIC CI so it works



<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-6497--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/services/grpc/#overview

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

