### PR TITLE
[URGENT] Remove 2 unwanted changelog entries from 3.5.0.0

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -286,12 +286,8 @@ was called multiple times in a request lifecycle.
  [#11360](https://github.com/Kong/kong/issues/11360)
 * Bumped `lua-resty-aws` from 1.3.1 to 1.3.2
  [#11551](https://github.com/Kong/kong/issues/11551)
-* Bumped `luasec` from 1.3.1 to 1.3.2
- [#11553](https://github.com/Kong/kong/issues/11553)
 * Bumped `lua-resty-aws` from 1.3.2 to 1.3.5
  [#11613](https://github.com/Kong/kong/issues/11613)
-* Bumped `ngx_wasm_module` to latest rolling release version
- [#11678](https://github.com/Kong/kong/issues/11678)
 * Bumped `wasmtime` version from 8.0.1 to 12.0.2
  [#11738](https://github.com/Kong/kong/issues/11738)
 * Bumped `openssl` from 3.1.2 to 3.1.4


### PR DESCRIPTION

### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

We found two changelog entries should be removed from `3.5.0.0`.

CC @AndyZhang0707 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

