### PR TITLE
Fix: Banner for using plugins in konnect

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -14,13 +14,15 @@ breadcrumbs:
 {% endunless %}
 
 {% unless page.free %}
-  {% if page.paid and page.extn_publisher == "kong-inc" %}
-    <blockquote class="note" role="alert">
-      <p>
-        Did you know that you can try this plugin without talking to anyone with a free
-        trial of Kong Konnect? <a href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=gateway-konnect&utm_content={{ extn_slug }}">Get started in under 5 minutes</a>.
-      </p>
-    </blockquote>
+  {% if page.extn_publisher == "kong-inc" %}
+    {% if page.paid or page.premium %}
+      <blockquote class="note" role="alert">
+        <p>
+          Did you know that you can try this plugin without talking to anyone with a free
+          trial of Kong Konnect? <a href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=gateway-konnect&utm_content={{ extn_slug }}">Get started in under 5 minutes</a>.
+        </p>
+      </blockquote>
+    {% endif %}
   {% endif %}
 {% endunless %}
 


### PR DESCRIPTION
### Description

Plugins labelled as `premium` don't have the "Try in Konnect" banner. This PR fixes that.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

