### PR TITLE
docs(changelog): consolidate the lua-resty-aws version bump changelog

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -284,9 +284,8 @@ was called multiple times in a request lifecycle.
  [#11360](https://github.com/Kong/kong/issues/11360)
 * Bumped `openresty` from 1.21.4.1 to 1.21.4.2
  [#11360](https://github.com/Kong/kong/issues/11360)
-* Bumped `lua-resty-aws` from 1.3.1 to 1.3.2
+* Bumped `lua-resty-aws` from 1.3.1 to 1.3.5
  [#11551](https://github.com/Kong/kong/issues/11551)
-* Bumped `lua-resty-aws` from 1.3.2 to 1.3.5
  [#11613](https://github.com/Kong/kong/issues/11613)
 * Bumped `wasmtime` version from 8.0.1 to 12.0.2
  [#11738](https://github.com/Kong/kong/issues/11738)


### PR DESCRIPTION
### Description

Consolidate the lua-resty-aws version bump entries into one as both entries happened in the same release.

This is for Gateway Enterprise 3.5.0.0 changelog.

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

