### PR TITLE
Update gw manager docs

### DIFF
--- a/app/konnect/gateway-manager/index.md
+++ b/app/konnect/gateway-manager/index.md
@@ -59,8 +59,9 @@ entity-specific permissions. For more information, see [Administer teams](/konne
 Every region in every organization starts with one default control plane.
 This control plane can't be deleted, and its status as the default can't be changed.
 
-With an [Enterprise subscription](https://konghq.com/pricing/), you can configure additional
-custom control panes. Use multiple control planes in one {{site.konnect_short_name}} organization to
+With {{site.konnect_short_name}} you can configure additional {{site.base_gateway}}
+control panes, each of which will have isolated configuration.
+Use multiple control planes in one {{site.konnect_short_name}} organization to
 manage data plane nodes and their configuration in any groupings you want.
 
 Some common use cases for using multiple control planes include:


### PR DESCRIPTION
Updating gateway manager doc page since Plus and Enterprise users can create multiple control planes. This was new as part of KOD1 for API Summit.


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

