### PR TITLE
Update Konnect curl request in renew-certificates.md

### DIFF
--- a/app/konnect/gateway-manager/data-plane-nodes/renew-certificates.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/renew-certificates.md
@@ -75,7 +75,8 @@ You can generate a certificate locally and use the [pin data plane client certif
 1. `POST` the certificate to your control plane using the Konnect API:
 
     ```bash
-    curl https://{region}.api.konghq.com/v2/control-planes/{controlPlaneId}/dp-client-certificates --json '{"cert":"'$CERT'"}'
+    curl https://{region}.api.konghq.com/v2/control-planes/{controlPlaneId}/dp-client-certificates --json '{"cert":"'"$CERT"'"}' \
+       --header "Authorization: Bearer ${KONNECT_TOKEN}"
     ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Description

Modified curl example for Konnect:

- needed to add double-quotes to properly expand $CERT envvar (curl was giving an error)
https://superuser.com/questions/835587/how-to-include-environment-variable-in-bash-line-curl#:~:text=Inside%20single%2Dquotes%2C%20the%20shell,completed%22'.%22%7D'

- Included the Authorization header in the Konnect request


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

