### PR TITLE
docs: clarify on rate-limit redis cluster support

### DIFF
--- a/app/_hub/kong-inc/rate-limiting/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/overview/_index.md
@@ -80,7 +80,7 @@ Two common use cases are:
 
 {:.warning}
 > **Note**: **Enterprise-Only**: The Kong Community Edition of this Rate Limiting plugin does not
-include [Redis Cluster](https://redis.io/docs/management/scaling/) nor [Redis Sentinel](https://redis.io/topics/sentinel) support. Only [{{site.ee_product_name}}](https://www.konghq.com/kong) customers can use Redis Cluster or Redis Sentinel with Kong Rate Limiting, enabling them to deliver highly performant and available primary-replica deployments.
+include [Redis Cluster](https://redis.io/docs/management/scaling/) or [Redis Sentinel](https://redis.io/topics/sentinel) support. Only [{{site.ee_product_name}}](https://www.konghq.com/kong) customers can use Redis Cluster or Redis Sentinel with Kong Rate Limiting, enabling them to deliver highly performant and available primary-replica deployments.
 
 #### Every transaction counts
 

--- a/app/_hub/kong-inc/rate-limiting/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/overview/_index.md
@@ -80,7 +80,7 @@ Two common use cases are:
 
 {:.warning}
 > **Note**: **Enterprise-Only**: The Kong Community Edition of this Rate Limiting plugin does not
-include [Redis Sentinel](https://redis.io/topics/sentinel) support. Only [{{site.ee_product_name}}](https://www.konghq.com/kong) customers can use Redis Sentinel with Kong Rate Limiting, enabling them to deliver highly available primary-replica deployments.
+include [Redis Cluster](https://redis.io/docs/management/scaling/) nor [Redis Sentinel](https://redis.io/topics/sentinel) support. Only [{{site.ee_product_name}}](https://www.konghq.com/kong) customers can use Redis Cluster or Redis Sentinel with Kong Rate Limiting, enabling them to deliver highly performant and available primary-replica deployments.
 
 #### Every transaction counts
 


### PR DESCRIPTION
### Description

Adds clarification that the basic rate-limiting plugin does not support Redis Cluster mode.
 
[Context](https://github.com/Kong/kong/issues/11846#issuecomment-1810350623)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

