### PR TITLE
Redirect to KIC in Konnect on cloud install pages

### DIFF
--- a/app/_includes/md/kic/konnect-setup.md
+++ b/app/_includes/md/kic/konnect-setup.md
@@ -1,0 +1,2 @@
+{:.note}
+> To install {{ site.kic_product_name }} for Konnect, select a {{ site.kic_product_name }} Control Plane in [Gateway Manager](https://cloud.konghq.com/us/gateway-manager/) and follow the instructions in the UI

--- a/app/_src/kubernetes-ingress-controller/install/cloud/aks.md
+++ b/app/_src/kubernetes-ingress-controller/install/cloud/aks.md
@@ -5,6 +5,8 @@ purpose: |
   Additional information needed to install KIC on AKS
 ---
 
+{% include /md/kic/konnect-setup.md %}
+
 ## Prerequisites
 
 * [Set up an AKS cluster](https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough).

--- a/app/_src/kubernetes-ingress-controller/install/cloud/eks.md
+++ b/app/_src/kubernetes-ingress-controller/install/cloud/eks.md
@@ -5,6 +5,8 @@ purpose: |
   Additional information needed to install KIC on Amazon EKS
 ---
 
+{% include /md/kic/konnect-setup.md %}
+
 ## Prerequisites
 
 * [Set up an EKS cluster](https://aws.amazon.com/getting-started/projects/deploy-kubernetes-app-amazon-eks/).

--- a/app/_src/kubernetes-ingress-controller/install/cloud/gke.md
+++ b/app/_src/kubernetes-ingress-controller/install/cloud/gke.md
@@ -5,6 +5,7 @@ purpose: |
   Additional information needed to install KIC on GKE
 ---
 
+{% include /md/kic/konnect-setup.md %}
 
 ## Prerequisites
 


### PR DESCRIPTION
### Description

Make it clear that KIC install instructions are _not_ for Konnect + redirect to Gateway Manager as needed

### Testing instructions

Preview link: /kubernetes-ingress-controller/latest/install/cloud/gke/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

