### PR TITLE
chore: add tips for encoding errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ git submodule update --init --recursive
 make run
 ```
 
-If you encounter some errors like:
+### Troubleshooting the local build
+
+If you encounter an error that looks like this:
 
 ```
 app/_plugins/generators/utils/frontmatter_parser.rb:8:in `match': invalid byte sequence in US-ASCII (ArgumentError)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ git submodule update --init --recursive
 make run
 ```
 
+If you encounter some errors like:
+
+```
+app/_plugins/generators/utils/frontmatter_parser.rb:8:in `match': invalid byte sequence in US-ASCII (ArgumentError)
+
+      @result = @string.match(Jekyll::Document::YAML_FRONT_MATTER_REGEXP)
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    from app/_plugins/generators/utils/frontmatter_parser.rb:8:in `match'
+```
+
+You can try setting the `LANG` or `LC_ALL` environment variable to `en_US.UTF-8`. For example:
+
+```bash
+export LANG=en_US.UTF-8
+```
+
 ### OAS Pages
 
 Create local .env file


### PR DESCRIPTION
### Description

Adding some tips for resolving the encoding errors while executing the `make run` command.

I usually encounter this issue because I don't have `LANG` or `LC_ALL` set in my environment for each shell session.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

