### PR TITLE
feat(dbless): add compatibility warning for Kong Manager

### DIFF
--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -296,7 +296,7 @@ since this is a node-specific in-memory operation.
 
 #### Kong Manager compatibility
 
-Kong Manager cannot guarantee compatibility with Kong operating in DB-less mode. You cannot create, update, or delete entities with Kong Manager when Kong is running in this mode. Entity counters in the "Summary" section on the global and workspace overview pages will not work normally as well.
+Kong Manager cannot guarantee compatibility with {{site.base_gateway}} operating in DB-less mode. You cannot create, update, or delete entities with Kong Manager when {{site.base_gateway}} is running in this mode. Entity counters in the "Summary" section on the global and workspace overview pages will not function correctly as well.
 
 #### Plugin compatibility
 

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -294,6 +294,10 @@ This restriction is limited to what would be otherwise database operations. In
 particular, using `POST` to set the health state of targets is still enabled,
 since this is a node-specific in-memory operation.
 
+#### Kong Manager compatibility
+
+Kong Manager cannot guarantee compatibility with Kong operating in DB-less mode. You cannot create, update, or delete entities with Kong Manager when Kong is running in this mode. Entity counters in the "Summary" section on the global and workspace overview pages will not work normally as well.
+
 #### Plugin compatibility
 
 Not all Kong plugins are compatible with DB-less mode. By design, some plugins


### PR DESCRIPTION
### Description

Adding a section for the compatibility warning while using Kong Manager with Kong under DB-less mode.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->


Fixes KAG-3038