### PR TITLE
Fix custom Docker build instructions

### DIFF
--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -64,7 +64,6 @@ RUN set -ex; \
     && rm -rf /tmp/kong.deb \
     && chown kong:0 /usr/local/bin/kong \
     && chown -R kong:0 /usr/local/kong \
-    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
     && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
@@ -88,7 +87,6 @@ RUN set -ex; \
     && rm -rf /tmp/kong.deb \
     && chown kong:0 /usr/local/bin/kong \
     && chown -R kong:0 /usr/local/kong \
-    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
     && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
@@ -110,7 +108,6 @@ RUN set -ex; \
     && rm /tmp/kong.rpm \
     && chown kong:0 /usr/local/bin/kong \
     && chown -R kong:0 /usr/local/kong \
-    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
     && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
@@ -139,7 +136,6 @@ RUN set -ex; \
     && chown kong:0 /usr/local/bin/kong \
     && chmod -R g=u /usr/local/kong \
     && rm -rf /tmp/kong.tar.gz \
-    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
     && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
     && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -17,7 +17,8 @@ chmod +x docker-entrypoint.sh
 ```
 
 1. Download the {{site.base_gateway}} package:
-    * **Debian and Ubuntu**: [.deb]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/jammy/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
+    * **Debian**: [.deb]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/debian/pool/bullseye/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
+    * **Ubuntu**: [.deb]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/jammy/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
     {% comment %}
     not all of the older alpine "packages" met Cloudsmith's definition for what an alpine package must be
     so some are uploaded there as "raw" artifacts instead and must be linked to differently

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -32,7 +32,6 @@ chmod +x docker-entrypoint.sh
 
 1. Create a `Dockerfile`, ensuring you replace the filename by the first `COPY` with the name of the {{site.base_gateway}} file you downloaded in step 2:
 
-{% if_version lte:3.3.x %}
 {% capture dockerfile_run_steps %}COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 USER kong
@@ -119,6 +118,8 @@ RUN set -ex; \
 {{ dockerfile_run_steps }}
 ```
 {% endnavtab %}
+
+{% if_version lte:3.3.x %}
 {% navtab Alpine %}
 ```dockerfile
 
@@ -147,102 +148,11 @@ RUN set -ex; \
 {{ dockerfile_run_steps }}
 ```
 {% endnavtab %}
+{% endif_version %}
+
 {% endnavtabs %}
 {% endcapture %}
 {{ dockerfile | indent }}
-{% endif_version %}
-
-{% if_version gte:3.4.x %}
-{% capture dockerfile_run_steps %}COPY docker-entrypoint.sh /docker-entrypoint.sh
-
-USER kong
-
-ENTRYPOINT ["/docker-entrypoint.sh"]
-
-EXPOSE 8000 8443 8001 8444 8002 8445 8003 8446 8004 8447
-
-STOPSIGNAL SIGQUIT
-
-HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health
-
-CMD ["kong", "docker-start"]{% endcapture %}
-
-{% capture dockerfile %}
-{% navtabs codeblock indent %}
-
-{% navtab Debian %}
-```dockerfile
-
-FROM debian:bullseye-slim
-
-COPY kong.deb /tmp/kong.deb
-
-RUN set -ex; \
-    apt-get update \
-    && apt-get install --yes /tmp/kong.deb \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/kong.deb \
-    && chown kong:0 /usr/local/bin/kong \
-    && chown -R kong:0 /usr/local/kong \
-    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
-    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
-    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
-    && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
-    && kong version
-
-{{ dockerfile_run_steps }}
-```
-{% endnavtab %}
-
-{% navtab Ubuntu %}
-```dockerfile
-
-FROM ubuntu:20.04
-
-COPY kong.deb /tmp/kong.deb
-
-RUN set -ex; \
-    apt-get update \
-    && apt-get install --yes /tmp/kong.deb \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/kong.deb \
-    && chown kong:0 /usr/local/bin/kong \
-    && chown -R kong:0 /usr/local/kong \
-    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
-    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
-    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
-    && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
-    && kong version
-
-{{ dockerfile_run_steps }}
-```
-{% endnavtab %}
-
-{% navtab RHEL %}
-```dockerfile
-
-FROM registry.access.redhat.com/ubi8/ubi:8.1
-
-COPY kong.rpm /tmp/kong.rpm
-
-RUN set -ex; \
-    yum install -y /tmp/kong.rpm \
-    && rm /tmp/kong.rpm \
-    && chown kong:0 /usr/local/bin/kong \
-    && chown -R kong:0 /usr/local/kong \
-    && ln -s /usr/local/openresty/bin/resty /usr/local/bin/resty \
-    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit \
-    && ln -s /usr/local/openresty/luajit/bin/luajit /usr/local/bin/lua \
-    && ln -s /usr/local/openresty/nginx/sbin/nginx /usr/local/bin/nginx \
-    && kong version
-
-{{ dockerfile_run_steps }}
-```
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-{{ dockerfile | indent }}
-{% endif_version %}
 
 1. Build your image:
 ```bash

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -3,7 +3,7 @@ title: Build your own Docker images
 content_type: how-to
 ---
 
-Kong is distributed as prebuilt `apk`, `deb`, and `rpm` packages, in addition to official Docker images hosted on [DockerHub](https://hub.docker.com/r/kong)
+Kong is distributed as prebuilt {% if_version lte:3.3.x %}`apk`, {% endif_version %}`deb` and `rpm` packages, in addition to official Docker images hosted on [DockerHub](https://hub.docker.com/r/kong)
 
 Kong builds and verifies [Debian](#dockerhub-debian-link-here) and [RHEL](#dockerhub-rhel-link-here) images for use in production. {% if_version lte:3.3.x %}[Alpine](#dockerhub-alpine-link-here) images are provided for **development purposes only** as they contain development tooling such as `git` for plugin development purposes.{% endif_version %}
 

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -152,13 +152,15 @@ RUN set -ex; \
 {{ dockerfile | indent }}
 
 1. Build your image:
-```bash
-docker build --no-cache -t kong-image .
-```
+
+    ```bash
+    docker build --platform linux/amd64 --no-cache -t kong-image .
+    ```
 
 1. Test that the image built correctly:
-```
-docker run -it --rm kong-image kong version
-```
+
+    ```
+    docker run -it --rm kong-image kong version
+    ```
 
 1. To run {{ site.base_gateway }} and process traffic, follow the [Docker install instructions](/gateway/latest/install/docker/), replacing the image name with your custom name.


### PR DESCRIPTION
### Description

Fix custom Docker build instructions. `openresty` is now symlinked in the package, which caused the `Dockerfile` provided to fail.

### Testing instructions

Preview link: /gateway/latest/install/docker/build-custom-images/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
