### PR TITLE
Fix: Remove dev portal entries from 3.5 changelog

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -164,7 +164,7 @@ action items when certain conditions are met.
 #### Enterprise
 
 * Fixed a keyring issue where Kong nodes failed to send keyring material when using the cluster strategy.
-* Enforced Content Security Policy (CSP) headers for serving static resources via Dev Portal and Kong Manager.
+* Enforced Content Security Policy (CSP) headers for serving static resources via Kong Manager.
 * Fixed an RBAC issue related to retrieving group roles with a numeric group name type.
 * When using `openid-connect` as the `admin_gui_auth` method for Kong Manager, some `admin_gui_auth_conf` required settings are now hardcoded.
 * Fixed an issue where the data plane hostname was `nil` in Vitals when running Kong Gateway in hybrid mode.
@@ -179,11 +179,6 @@ action items when certain conditions are met.
 * Removed FIPS from free mode.
 * Implemented lazy enabling of FIPS mode upon receiving a valid license, emitting warnings instead of blocking Kong Gateway startup. This approach allows normal use of non-FIPS content without a license, and FIPS mode activates only with a valid license. When no license is present, the service can start with a warning log, and FIPS mode remains disabled until a valid license is added. Additionally, deleting a valid license via the Admin API results in a warning without disabling FIPS mode.
 * Unified the error responses for failed admin authentication via Admin and Portal APIs.
-
-##### Dev Portal
-
-* Sanitized developer names in emails to prevent hyperlink recognition and mitigate the risk of unexpected visits to email receivers (admins).
-* Fixed an issue causing 500 errors during Dev Portal visits by verifying replacement types and converting unsupported types to strings before passing to `string.gsub`.
 
 ##### Kong Manager
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -25,7 +25,7 @@ For product versions that have reached the end of sunset support, see the [chang
 This change alters the behavior of `logout_post_arg` in such a way that it is no longer considered, 
 unless `read_body_for_logout` is explicitly set to `true`. This adjustment prevents the Session plugin from automatically reading request bodies for logout detection, particularly on POST requests.
 
-* As of this release, the product component known as Kong Enterprise Portal is no longer included in the Kong Gateway Enterprise (previously known as Kong Enterprise) software package. Existing customers who have purchased Kong Enterprise Portal can continue to use it and be supported via a dedicated mechanism. 
+* As of this release, the product component known as Kong Enterprise Portal (Developer Portal) is no longer included in the Kong Gateway Enterprise (previously known as Kong Enterprise) software package. Existing customers who have purchased Kong Enterprise Portal can continue to use it and be supported via a dedicated mechanism. 
   
   If you have purchased Kong Enterprise Portal in the past and would like to continue to use it with this release or a future release of Kong Gateway Enterprise, contact [Kong Support](https://support.konghq.com/support/s/) for more information.
 


### PR DESCRIPTION
### Description

As Dev Portal is deprecated on Gateway going forward, we should list any fixes for it in the changelog.

Fixes requested by PM.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

