### PR TITLE
Update: Set max version for app registration plugin

### DIFF
--- a/app/_hub/kong-inc/application-registration/versions.yml
+++ b/app/_hub/kong-inc/application-registration/versions.yml
@@ -1,6 +1,7 @@
 strategy: gateway
 releases:
   minimum_version: '2.1.x'
+  maximum_version: '3.4.x'
 
 overrides:
   2.8.x: 2.0.0


### PR DESCRIPTION
### Description

On-prem Dev Portal docs have been removed from Gateway 3.5. Along with that, we should set 3.4 as the latest version for the App Registration plugin, as it can only be used with on-prem Dev Portal.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

