### PR TITLE
fix: Typo on aria attribute in modal

### DIFF
--- a/app/_assets/javascripts/modal.js
+++ b/app/_assets/javascripts/modal.js
@@ -12,14 +12,14 @@ $(document).ready(function () {
     toggleModal(false);
 
     modal.removeAttribute("aria-hidden");
-    page.setAttribute("aria-hiddden", true);
+    page.setAttribute("aria-hidden", true);
     modal.querySelector(".button").focus();
   }
 
   function closeModal() {
     toggleModal(true);
 
-    modal.setAttribute("aria-hiddden", true);
+    modal.setAttribute("aria-hidden", true);
     page.removeAttribute("aria-hidden");
   }
 


### PR DESCRIPTION
### Description

Fixing a typo that Lighthouse is complaining about: 

<img width="771" alt="Screenshot 2023-11-20 at 9 09 49 AM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/dd3af599-ada0-47a1-8870-574a3a7e14f7">

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

