### PR TITLE
Update: Listing a license requires license added via Admin API to begin with

### DIFF
--- a/app/_src/gateway/licenses/examples.md
+++ b/app/_src/gateway/licenses/examples.md
@@ -25,7 +25,9 @@ in some other way, the new license will not apply.
 
 ## List all licenses
 
-Listing licenses depends on the license having been added using the Admin API previously. If a license was not added using the Admin API then the response seen will be as displayed on the `Response if there is no license` tab below.
+{:.note}
+> **Note**: Listing licenses using the Admin API requires the license to have been originally added the same way. 
+If the license was not added using the Admin API, then the response will be the same as displayed on the `Response if there is no license` tab below.
 
 Submit the following request:
 

--- a/app/_src/gateway/licenses/examples.md
+++ b/app/_src/gateway/licenses/examples.md
@@ -25,6 +25,8 @@ in some other way, the new license will not apply.
 
 ## List all licenses
 
+Listing licenses depends on the license having been added using the Admin API previously. If a license was not added using the Admin API then the response seen will be as displayed on the `Response if there is no license` tab below.
+
 Submit the following request:
 
 ```bash


### PR DESCRIPTION
### Description

We've had a few customer support cases where customers are confused by a null response from the /licenses endpoint when they're not actually using the Admin API to load the license in the first place which is a requirement for this to work properly. When using an environment variable to set the license instead, the /licenses endpoint will not work for listing licenses. This PR is to make this clearer in the documentation.

### Testing instructions

N/A

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
