### PR TITLE
fix: add the missing part of kong gateway vault's secrets versioning description

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -50,6 +50,7 @@ export KONG_VAULT_AWS_ROLE_SESSION_NAME=<aws_assume_role_session_name>
 
 The vault backend configuration field can also be configured in the `kong.conf` file. See [Gateway Enterprise configuration reference](/gateway/latest/reference/configuration).
 {% endif_version %}
+
 ### Examples
 
 For example, an AWS Secrets Manager secret with the name `secret-name` may have multiple key=value pairs:
@@ -66,6 +67,19 @@ Access these secrets from `secret-name` like this:
 ```bash
 {vault://aws/secret-name/foo}
 {vault://aws/secret-name/snip}
+```
+
+Moreover, for an AWS Secrets Manager secret that has multiple versions, accessing the current version(labeled as `AWSCURRENT`) of the secret or the previous version(labeled as`AWSPREVIOUS`) of the secret will be like this:
+
+```bash
+# For AWSCURRENT, not specifying version
+{vault://aws/secret-name/foo}
+
+# For AWSCURRENT, specifying version == 2
+{vault://aws/secret-name/foo#2}
+
+# For AWSPREVIOUS, specifying version == 1
+{vault://aws/secret-name/foo#1}
 ```
 
 ## Configuration via vaults entity

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -69,7 +69,9 @@ Access these secrets from `secret-name` like this:
 {vault://aws/secret-name/snip}
 ```
 
-Moreover, for an AWS Secrets Manager secret that has multiple versions, accessing the current version(labeled as `AWSCURRENT`) of the secret or the previous version(labeled as`AWSPREVIOUS`) of the secret will be like this:
+If you have an AWS Secrets Manager secret with multiple versions, you can access the current version or any previous version of the secret by specifying a version in the reference. 
+
+In the following example, `AWSCURRENT` refers to the latest secret version and `AWSPREVIOUS` refers to an older version:
 
 ```bash
 # For AWSCURRENT, not specifying version

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -77,11 +77,11 @@ In the following example, `AWSCURRENT` refers to the latest secret version and `
 # For AWSCURRENT, not specifying version
 {vault://aws/secret-name/foo}
 
-# For AWSCURRENT, specifying version == 2
-{vault://aws/secret-name/foo#2}
-
-# For AWSPREVIOUS, specifying version == 1
+# For AWSCURRENT, specifying version == 1
 {vault://aws/secret-name/foo#1}
+
+# For AWSPREVIOUS, specifying version == 2
+{vault://aws/secret-name/foo#2}
 ```
 
 ## Configuration via vaults entity

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -132,6 +132,36 @@ Or, if you configured an entity:
 {vault://hashicorp-vault/hello/foo}
 ```
 
+If you've configured a secret value in multiple versions, like this:
+
+```text
+# Requires kv2 engine enabled
+vault kv patch secret/hello foo=world2
+
+======= Metadata =======
+Key                Value
+---                -----
+created_time       2022-01-16T01:40:03.740833Z
+custom_metadata    <nil>
+deletion_time      n/a
+destroyed          false
+version            2
+```
+
+Access an older version of the secret will be like this:
+
+```bash
+# For version 1
+{vault://hcv/hello/foo#1}
+
+# For version 2
+{vault://hcv/hello/foo#2}
+
+# Do not specify version number for the latest version
+{vault://hcv/hello/foo}
+```
+
+
 ## Vault configuration options
 
 Use the following configuration options to configure the vaults entity through

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -132,7 +132,7 @@ Or, if you configured an entity:
 {vault://hashicorp-vault/hello/foo}
 ```
 
-If you've configured a secret value in multiple versions, like this:
+If you have configured a secret value in multiple versions:
 
 ```text
 # Requires kv2 engine enabled
@@ -148,7 +148,7 @@ destroyed          false
 version            2
 ```
 
-Access an older version of the secret will be like this:
+Access an older version of the secret like this:
 
 ```bash
 # For version 1

--- a/app/_src/gateway/kong-enterprise/secrets-management/reference-format.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/reference-format.md
@@ -5,7 +5,7 @@ title: Reference Format
 We use the [URL syntax](https://en.wikipedia.org/wiki/URL) to describe references to a secret store.
 
 ```text
-{vault://<vault-backend|entity>/<secret-id>[/<secret-key][/][?query]}
+{vault://<vault-backend|entity>/<secret-id>[/<secret-key][/][?query][#version]}
 ```
 
 ### Protocol/Scheme
@@ -63,3 +63,13 @@ The `secret-key` is used to identify the secret within the `secret-id` object.
 ### Query
 
 Query arguments are used to denote configuration options in a `key=value` format to the [Vault Prefix](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/reference-format/#vault-prefix)
+
+
+### Version
+
+```text
+{vault://<vault-backend|entity>/<secret-id>[/<secret-key][/][?query][#version]}
+                                                                     ^^^^^^^^
+```
+
+Version, which is the fragment part of the Vault URL, is used to identify the version number of the secret stored in the vault backends which supports versioning.

--- a/app/_src/gateway/kong-enterprise/secrets-management/reference-format.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/reference-format.md
@@ -72,4 +72,4 @@ Query arguments are used to denote configuration options in a `key=value` format
                                                                      ^^^^^^^^
 ```
 
-Version, which is the fragment part of the Vault URL, is used to identify the version number of the secret stored in the vault backends which supports versioning.
+The version, specified as the fragment of the Vault URL, identifies the version number of the secret stored in a vault backend. Applies to any vault backend that supports versioning.


### PR DESCRIPTION



### Description

The PR adds the missing part of Kong Gateway Vault's secrets versioning description.

Gateway's vault supports accessing versioning secrets by specifying version number as a fragment in the vault reference URL.

Note that this is not a new feature added recently, it exists long time ago, only the doc part is missing.

https://konghq.atlassian.net/browse/FTI-5168

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

