### PR TITLE
Fix broken links

### DIFF
--- a/.github/workflows/scheduled-broken-link-checker.yml
+++ b/.github/workflows/scheduled-broken-link-checker.yml
@@ -68,6 +68,6 @@ jobs:
         run: |
           cd tools/broken-link-checker
           npm ci
-          node full.js --host http://localhost:8888
+          node full.js --host http://localhost:8888 --ignore linux.die.net
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}

--- a/app/moved_urls.yml
+++ b/app/moved_urls.yml
@@ -131,6 +131,7 @@
 /gateway/VERSION/reference/proxy/: "/gateway/VERSION/how-kong-works/routing-traffic/"
 /gateway/VERSION/reference/health-checks-circuit-breakers/: "/gateway/VERSION/how-kong-works/health-checks/"
 /gateway/VERSION/reference/clustering/: "/gateway/VERSION/production/clustering/"
+/gateway/VERSION/reference/router-expressions-language/: "/gateway/VERSION/reference/expressions-language/"
 /gateway/VERSION/pdk/: "/gateway/VERSION/plugin-development/pdk/"
 /gateway/VERSION/pdk/kong.client/: "/gateway/VERSION/plugin-development/pdk/kong.client/"
 /gateway/VERSION/pdk/kong.client.tls/: "/gateway/VERSION/plugin-development/pdk/kong.client.tls/"

--- a/app/moved_urls.yml
+++ b/app/moved_urls.yml
@@ -157,10 +157,13 @@
 # KIC 3.0
 # No new page available
 /kubernetes-ingress-controller/VERSION/concepts/expression-based-router/: /kubernetes-ingress-controller/VERSION/
+/kubernetes-ingress-controller/VERSION/concepts/ingress-versions/: /kubernetes-ingress-controller/VERSION/
 /kubernetes-ingress-controller/VERSION/availability-stages/: /kubernetes-ingress-controller/VERSION/
+/kubernetes-ingress-controller/VERSION/deployment/overview/: /kubernetes-ingress-controller/VERSION/
 /kubernetes-ingress-controller/VERSION/guides/configuring-fallback-service/: /kubernetes-ingress-controller/VERSION/ 
 /kubernetes-ingress-controller/VERSION/guides/using-kong-with-knative/: /kubernetes-ingress-controller/VERSION/
-/kubernetes-ingress-controller/VERSION/concepts/ingress-versions/: /kubernetes-ingress-controller/VERSION/
+/kubernetes-ingress-controller/VERSION/guides/choose-gateway-image/: /kubernetes-ingress-controller/VERSION/
+
 # Redirected to new page
 /kubernetes-ingress-controller/VERSION/references/annotations/: /kubernetes-ingress-controller/VERSION/reference/annotations/
 /kubernetes-ingress-controller/VERSION/references/custom-resources/: /kubernetes-ingress-controller/VERSION/reference/custom-resources/
@@ -168,6 +171,7 @@
 /kubernetes-ingress-controller/VERSION/concepts/k4k8s-with-kong-enterprise/: /kubernetes-ingress-controller/VERSION/license/
 /kubernetes-ingress-controller/VERSION/concepts/ha-and-scaling/: /kubernetes-ingress-controller/VERSION/guides/high-availability/kic/
 /kubernetes-ingress-controller/VERSION/concepts/ingress-classes/: /kubernetes-ingress-controller/VERSION/concepts/ingress/
+/kubernetes-ingress-controller/VERSION/concepts/deployment/: /kubernetes-ingress-controller/VERSION/production/deployment-topologies/
 /kubernetes-ingress-controller/VERSION/deployment/minikube/: /kubernetes-ingress-controller/VERSION/install/helm/
 /kubernetes-ingress-controller/VERSION/deployment/k4k8s/: /kubernetes-ingress-controller/VERSION/install/helm/
 /kubernetes-ingress-controller/VERSION/deployment/k4k8s-enterprise/: /kubernetes-ingress-controller/VERSION/install/helm/


### PR DESCRIPTION
### Description

Just ran it locally and got this:
```json
[
  {
    "page": "http://localhost:8888/konnect/gateway-manager/kic/",
    "text": "Kong Ingress Controller Deployment",
    "target": "http://localhost:8888/kubernetes-ingress-controller/latest/concepts/deployment/",
    "reason": "HTTP_404"
  },
  {
    "page": "http://localhost:8888/konnect/gateway-manager/kic/",
    "text": "Using Kong Gateway Enterprise",
    "target": "http://localhost:8888/kubernetes-ingress-controller/latest/guides/choose-gateway-image/",
    "reason": "HTTP_404"
  },
  {
    "page": "http://localhost:8888/gateway/latest/how-kong-works/routing-traffic/",
    "text": "Router Expressions language",
    "target": "http://localhost:8888/gateway/latest/reference/router-expressions-language/",
    "reason": "HTTP_404"
  },
  {
    "page": "http://localhost:8888/gateway/latest/production/monitoring/readiness-check/",
    "text": "Get Started with Kong Ingress Controller",
    "target": "http://localhost:8888/kubernetes-ingress-controller/latest/deployment/overview/",
    "reason": "HTTP_404"
  },
  {
    "page": "http://localhost:8888/gateway/3.5.x/how-kong-works/routing-traffic/",
    "text": "Router Expressions language",
    "target": "http://localhost:8888/gateway/latest/reference/router-expressions-language/",
    "reason": "HTTP_404"
  },
  {
    "page": "http://localhost:8888/gateway/3.5.x/production/monitoring/readiness-check/",
    "text": "Get Started with Kong Ingress Controller",
    "target": "http://localhost:8888/kubernetes-ingress-controller/latest/deployment/overview/",
    "reason": "HTTP_404"
  }
]
```

I'm not 💯 sure about these changes though, so please review them carefully.

*
   ```json
    {
      "page": "http://localhost:8888/konnect/gateway-manager/kic/",
      "text": "Kong Ingress Controller Deployment",
      "target": "http://localhost:8888/kubernetes-ingress-controller/latest/concepts/deployment/",
      "reason": "HTTP_404"
    }
  ```
   [prod URL](https://docs.konghq.com/konnect/gateway-manager/kic/)
    <img width="1185" alt="Screenshot 2023-11-23 at 13 52 17" src="https://github.com/Kong/docs.konghq.com/assets/715229/ccf30331-bf62-43c1-8ffd-0ab5877c3d4d">
  I don't think that `/kubernetes-ingress-controller/VERSION/concepts/deployment/: /kubernetes-ingress-controller/VERSION/production/deployment-topologies/` is the right call here, I couldn't find anything remotely similar to it though. We might want to update the `Note` though.

*
  ``` json
  {
    "page": "http://localhost:8888/konnect/gateway-manager/kic/",
    "text": "Using Kong Gateway Enterprise",
    "target": "http://localhost:8888/kubernetes-ingress-controller/latest/guides/choose-gateway-image/",
    "reason": "HTTP_404"
  }
  ```
  This guide no longer exists in KIC v3.

* 
  ```json
  {
    "page": "http://localhost:8888/gateway/latest/how-kong-works/routing-traffic/",
    "text": "Router Expressions language",
    "target": "http://localhost:8888/gateway/latest/reference/router-expressions-language/",
    "reason": "HTTP_404"
  }
  ```
  `reference/router-expressions-language` was removed in [this PR](https://github.com/Kong/docs.konghq.com/pull/6437/files#diff-6a9b955367a5ba2f6c4ad05d0a6feb8ad5980ef1aa26806e074a53c5437c7cba) and most of the references were updated but not all.

* 
  ```json
    {
      "page": "http://localhost:8888/gateway/latest/production/monitoring/readiness-check/",
      "text": "Get Started with Kong Ingress Controller",
      "target": "http://localhost:8888/kubernetes-ingress-controller/latest/deployment/overview/",
      "reason": "HTTP_404"
    }
  ```
  In KIC v3 there's no `deployment/overview`. I couldn't find a similar page though.

This also ignores `linux.die.net`, for some reason it returns `HTTP_403` in the CI - not locally though - 

cc @lena-larionova @mheap 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

