### PR TITLE
Bump deps after revert

### DIFF
--- a/app/_assets/javascripts/components/Sidebar.vue
+++ b/app/_assets/javascripts/components/Sidebar.vue
@@ -79,7 +79,7 @@ async function fetchOperations () {
   try {
     const res = await versionsAPI.getProductVersionSpecOperations({
       productId,
-      versionId: props.activeProductVersionId
+      productVersionId: props.activeProductVersionId
     });
 
     operations.value = res.data.operations?.map(operation => ({

--- a/app/_assets/javascripts/components/Spec.vue
+++ b/app/_assets/javascripts/components/Spec.vue
@@ -66,7 +66,7 @@ async function fetchSpec() {
 
   return await versionsAPI.getProductVersionSpec({
     productId: props.product?.id,
-    versionId: props.productVersionId
+    productVersionId: props.productVersionId
   }).then(async res => {
     const parsedSpec = jsyaml.load(res.data.content);
 

--- a/app/_assets/javascripts/services/api.js
+++ b/app/_assets/javascripts/services/api.js
@@ -1,5 +1,5 @@
 import { Configuration, PortalApi, SearchApi, VersionsApi, ProductsApi } from '@kong/sdk-portal-js'
-import axios, { AxiosInstance } from 'axios'
+import axios from 'axios'
 
 export default class ApiService {
   constructor () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -412,9 +412,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.4.tgz",
+      "integrity": "sha512-vf3Xna6UEprW+7t6EtOmFpHNAuxw3xqPZghy+brsnusscJRW5BMUzzHZc5ICjULee81WeUV2jjakG09MDglJXQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1256,9 +1256,9 @@
       }
     },
     "node_modules/@kong/kongponents": {
-      "version": "8.126.2",
-      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-8.126.2.tgz",
-      "integrity": "sha512-isTzDHB/21O+hMq+tMRH5A3WyOVC5FZqLs1YrfW8zb6VX9Xm1tmtVHO0Qtfo2DpMs2c9rNdl/yBa1vijkOSkHA==",
+      "version": "8.127.0",
+      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-8.127.0.tgz",
+      "integrity": "sha512-C/MFT+OZtyul62ElgHEggqMYPbLjXiRJg5GE3il8MZpaep2D5QV+F5UQ7frbA98TkZCCVBD4LpR0OmiwXKs+tg==",
       "dependencies": {
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.0",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@kong/sdk-portal-js": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@kong/sdk-portal-js/-/sdk-portal-js-2.3.7.tgz",
-      "integrity": "sha512-RNs5KRke7Vu7OlXYP9c4u1CvZS8A1HgLc/kkWee5/u+HfTNoUclnAWjM2pUz/rlrZtAcslJjfaqbokxFP+FcjA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@kong/sdk-portal-js/-/sdk-portal-js-2.5.0.tgz",
+      "integrity": "sha512-nt74ub5WpLF2Vh/dVeHIycccaNr9wVOfcvDaGnoccfH41Pi5jtBa/5lJSEG2hMSRloRVAX8J6TRWT5vHNYCiKg==",
       "dependencies": {
         "axios": "1.6.0"
       }
@@ -5088,36 +5088,36 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.8.tgz",
-      "integrity": "sha512-hN/NNBUECw8SusQvDSqqcVv6gWq8L6iAktUR0UF3vGu2OhzRqcOiAno0FmBJWwxhYEXRlQJT5XnoKsVq1WZx4g==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
+      "integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
       "dependencies": {
-        "@babel/parser": "^7.23.0",
-        "@vue/shared": "3.3.8",
+        "@babel/parser": "^7.23.3",
+        "@vue/shared": "3.3.9",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.8.tgz",
-      "integrity": "sha512-+PPtv+p/nWDd0AvJu3w8HS0RIm/C6VGBIRe24b9hSyNWOAPEUosFZ5diwawwP8ip5sJ8n0Pe87TNNNHnvjs0FQ==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
+      "integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
       "dependencies": {
-        "@vue/compiler-core": "3.3.8",
-        "@vue/shared": "3.3.8"
+        "@vue/compiler-core": "3.3.9",
+        "@vue/shared": "3.3.9"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.8.tgz",
-      "integrity": "sha512-WMzbUrlTjfYF8joyT84HfwwXo+8WPALuPxhy+BZ6R4Aafls+jDBnSz8PDz60uFhuqFbl3HxRfxvDzrUf3THwpA==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
+      "integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
       "dependencies": {
-        "@babel/parser": "^7.23.0",
-        "@vue/compiler-core": "3.3.8",
-        "@vue/compiler-dom": "3.3.8",
-        "@vue/compiler-ssr": "3.3.8",
-        "@vue/reactivity-transform": "3.3.8",
-        "@vue/shared": "3.3.8",
+        "@babel/parser": "^7.23.3",
+        "@vue/compiler-core": "3.3.9",
+        "@vue/compiler-dom": "3.3.9",
+        "@vue/compiler-ssr": "3.3.9",
+        "@vue/reactivity-transform": "3.3.9",
+        "@vue/shared": "3.3.9",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5",
         "postcss": "^8.4.31",
@@ -5125,12 +5125,12 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.8.tgz",
-      "integrity": "sha512-hXCqQL/15kMVDBuoBYpUnSYT8doDNwsjvm3jTefnXr+ytn294ySnT8NlsFHmTgKNjwpuFy7XVV8yTeLtNl/P6w==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
+      "integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
       "dependencies": {
-        "@vue/compiler-dom": "3.3.8",
-        "@vue/shared": "3.3.8"
+        "@vue/compiler-dom": "3.3.9",
+        "@vue/shared": "3.3.9"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -5139,60 +5139,60 @@
       "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.8.tgz",
-      "integrity": "sha512-ctLWitmFBu6mtddPyOKpHg8+5ahouoTCRtmAHZAXmolDtuZXfjL2T3OJ6DL6ezBPQB1SmMnpzjiWjCiMYmpIuw==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
+      "integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
       "dependencies": {
-        "@vue/shared": "3.3.8"
+        "@vue/shared": "3.3.9"
       }
     },
     "node_modules/@vue/reactivity-transform": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.8.tgz",
-      "integrity": "sha512-49CvBzmZNtcHua0XJ7GdGifM8GOXoUMOX4dD40Y5DxI3R8OUhMlvf2nvgUAcPxaXiV5MQQ1Nwy09ADpnLQUqRw==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
+      "integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
       "dependencies": {
-        "@babel/parser": "^7.23.0",
-        "@vue/compiler-core": "3.3.8",
-        "@vue/shared": "3.3.8",
+        "@babel/parser": "^7.23.3",
+        "@vue/compiler-core": "3.3.9",
+        "@vue/shared": "3.3.9",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.8.tgz",
-      "integrity": "sha512-qurzOlb6q26KWQ/8IShHkMDOuJkQnQcTIp1sdP4I9MbCf9FJeGVRXJFr2mF+6bXh/3Zjr9TDgURXrsCr9bfjUw==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
+      "integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
       "dependencies": {
-        "@vue/reactivity": "3.3.8",
-        "@vue/shared": "3.3.8"
+        "@vue/reactivity": "3.3.9",
+        "@vue/shared": "3.3.9"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.8.tgz",
-      "integrity": "sha512-Noy5yM5UIf9UeFoowBVgghyGGPIDPy1Qlqt0yVsUdAVbqI8eeMSsTqBtauaEoT2UFXUk5S64aWVNJN4MJ2vRdA==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
+      "integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
       "dependencies": {
-        "@vue/runtime-core": "3.3.8",
-        "@vue/shared": "3.3.8",
+        "@vue/runtime-core": "3.3.9",
+        "@vue/shared": "3.3.9",
         "csstype": "^3.1.2"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.8.tgz",
-      "integrity": "sha512-zVCUw7RFskvPuNlPn/8xISbrf0zTWsTSdYTsUTN1ERGGZGVnRxM2QZ3x1OR32+vwkkCm0IW6HmJ49IsPm7ilLg==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
+      "integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.3.8",
-        "@vue/shared": "3.3.8"
+        "@vue/compiler-ssr": "3.3.9",
+        "@vue/shared": "3.3.9"
       },
       "peerDependencies": {
-        "vue": "3.3.8"
+        "vue": "3.3.9"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.8.tgz",
-      "integrity": "sha512-8PGwybFwM4x8pcfgqEQFy70NaQxASvOC5DJwLQfpArw1UDfUXrJkdxD3BhVTMS+0Lef/TU7YO0Jvr0jJY8T+mw=="
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+      "integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -13716,15 +13716,15 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.8.tgz",
-      "integrity": "sha512-5VSX/3DabBikOXMsxzlW8JyfeLKlG9mzqnWgLQLty88vdZL7ZJgrdgBOmrArwxiLtmS+lNNpPcBYqrhE6TQW5w==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
+      "integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
       "dependencies": {
-        "@vue/compiler-dom": "3.3.8",
-        "@vue/compiler-sfc": "3.3.8",
-        "@vue/runtime-dom": "3.3.8",
-        "@vue/server-renderer": "3.3.8",
-        "@vue/shared": "3.3.8"
+        "@vue/compiler-dom": "3.3.9",
+        "@vue/compiler-sfc": "3.3.9",
+        "@vue/runtime-dom": "3.3.9",
+        "@vue/server-renderer": "3.3.9",
+        "@vue/shared": "3.3.9"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/tools/konnect-oas-data-generator/package-lock.json
+++ b/tools/konnect-oas-data-generator/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "node_modules/@kong/sdk-portal-js": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@kong/sdk-portal-js/-/sdk-portal-js-2.3.7.tgz",
-      "integrity": "sha512-RNs5KRke7Vu7OlXYP9c4u1CvZS8A1HgLc/kkWee5/u+HfTNoUclnAWjM2pUz/rlrZtAcslJjfaqbokxFP+FcjA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@kong/sdk-portal-js/-/sdk-portal-js-2.5.0.tgz",
+      "integrity": "sha512-nt74ub5WpLF2Vh/dVeHIycccaNr9wVOfcvDaGnoccfH41Pi5jtBa/5lJSEG2hMSRloRVAX8J6TRWT5vHNYCiKg==",
       "dependencies": {
         "axios": "1.6.0"
       }


### PR DESCRIPTION
### Description

Bring back deps update.
Update code to match latest sdk-portal-api deps, it fixes the issue with the API pages.

### Testing instructions

Actually, any API spec link should work.
Oh and btw, they now work in preview apps 🎉 
[Preview link](https://deploy-preview-6562--kongdocs.netlify.app/gateway/api/admin-ee/latest/)

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

