### PR TITLE
fix: update deck schema URL

### DIFF
--- a/app/_src/deck/faqs.md
+++ b/app/_src/deck/faqs.md
@@ -113,7 +113,7 @@ It is derived from the combination of words 'declarative' and 'Kong'.
 
 ### Is there a JSON Schema for decK? 
 
-Yes. The decK team maintains a JSON schema that you can use to validate YAML files on [Github](https://github.com/Kong/deck/blob/main/file/kong_json_schema.json). You can use the schema with a text editor to provide JIT YAML validation. For example, to use the JSON schema with VS Code: 
+Yes. The decK team maintains a JSON schema that you can use to validate YAML files on [Github](https://github.com/Kong/go-database-reconciler/blob/main/pkg/file/kong_json_schema.json). You can use the schema with a text editor to provide JIT YAML validation. For example, to use the JSON schema with VS Code: 
 
 1. Install the Red Hat YAML extension:
 ```console

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -307,6 +307,6 @@ entities.
 For current plugin compatibility, see [Plugin compatibility](/hub/plugins/compatibility/).
 
 ## See also
-* [Declarative configuration schema](https://github.com/Kong/deck/blob/main/file/kong_json_schema.json)
+* [Declarative configuration schema](https://github.com/Kong/go-database-reconciler/blob/main/pkg/file/kong_json_schema.json)
 * [decK documentation](/deck/latest/)
 * [Using decK with {{site.ee_product_name}}](/deck/latest/guides/kong-enterprise/)

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -159,7 +159,7 @@ consumers:
   - key: my-key
 ```
 
-See the [declarative configuration schema](https://github.com/Kong/deck/blob/main/file/kong_json_schema.json)
+See the [declarative configuration schema](https://github.com/Kong/go-database-reconciler/blob/main/pkg/file/kong_json_schema.json)
 for all configuration options.
 
 The only mandatory piece of metadata is `_format_version: "3.0"`, which


### PR DESCRIPTION
### Description

Update the URL of the deck JSON schema. This now resides in another repository.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)