### PR TITLE
chore: Add postgres 16 as a supported version for Kong Gateway 3.4 and 3.5

### DIFF
--- a/app/_data/tables/support/gateway/versions/34.yml
+++ b/app/_data/tables/support/gateway/versions/34.yml
@@ -43,6 +43,7 @@ third-party:
   datastore:
     - <<: *postgres
       versions:
+        - 16
         - 15
         - 14
         - 13

--- a/app/_data/tables/support/gateway/versions/35.yml
+++ b/app/_data/tables/support/gateway/versions/35.yml
@@ -40,6 +40,7 @@ third-party:
   datastore:
     - <<: *postgres
       versions:
+        - 16
         - 15
         - 14
         - 13


### PR DESCRIPTION
### Description

We have tests running on different postgres versions including the latest, which is 16.1. We run these tests for 3.5.0.0 version and for 3.4.0.0. The docs site doesn't list postgres 16 as a supported version, so this PR updates the support tables.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

