### PR TITLE
Feat: Kong Mesh OPA example JWT validation doc

### DIFF
--- a/app/_data/docs_nav_mesh_2.4.x.yml
+++ b/app/_data/docs_nav_mesh_2.4.x.yml
@@ -164,6 +164,13 @@ inherit:
           url: /features/access-audit
         - text: MeshGlobalRateLimit (beta)
           url: /features/meshglobalratelimit
+    - title: Guides
+      action: insert
+      index: -3
+      icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
+      items:
+        - text: Use OPA to validate JWT tokens
+          url: /guides/jwt-validation/
     - path: [ Reference ]
       action: modify
       icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_mesh_2.5.x.yml
+++ b/app/_data/docs_nav_mesh_2.5.x.yml
@@ -164,6 +164,13 @@ inherit:
           url: /features/access-audit
         - text: MeshGlobalRateLimit (beta)
           url: /features/meshglobalratelimit
+    - title: Guides
+      action: insert
+      index: -3
+      icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
+      items:
+        - text: Use OPA to validate JWT tokens
+          url: /guides/jwt-validation/
     - path: [ Reference ]
       action: modify
       icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_mesh_dev.yml
+++ b/app/_data/docs_nav_mesh_dev.yml
@@ -164,6 +164,13 @@ inherit:
           url: /features/access-audit
         - text: MeshGlobalRateLimit (beta)
           url: /features/meshglobalratelimit
+    - title: Guides
+      action: insert
+      index: -3
+      icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
+      items:
+        - text: Use OPA to validate JWT tokens
+          url: /guides/jwt-validation/
     - path: [ Reference ]
       action: modify
       icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_src/mesh/guides/jwt-validation.md
+++ b/app/_src/mesh/guides/jwt-validation.md
@@ -19,7 +19,7 @@ In this tutorial, you are a security engineer at your company. The company has c
 ## Prerequisites
 
 * [Deploy {{site.mesh_product_name}}](/mesh/{{page.kong_version}}/production/deployment/) in either standalone or multi-zone mode.
-* A valid JWT token
+* A valid JWT token stored securely?
 * install example app?:
     ```bash
     kubectl apply -f https://bit.ly/demokuma
@@ -89,7 +89,9 @@ spec:
 echo "
 type: OPAPolicy
 mesh: default
-name: opa-1
+metadata:
+  name: require-jwt
+  namespace: kuma-demo
 selectors:
 - match:
     kuma.io/service: '*'
@@ -153,6 +155,17 @@ verify that it won’t accept something without a JWT token
 verify that it will accept something with the token and any modifiers (if they were configured)
 
 troubleshooting if issues?
+
+{% navtabs %}
+{% navtab Kubernetes %}
+```yaml
+```
+{% endnavtab %}
+{% navtab Universal %}
+```yaml
+```
+{% endnavtab %}
+{% endnavtabs %}
 
 
 

--- a/app/_src/mesh/guides/jwt-validation.md
+++ b/app/_src/mesh/guides/jwt-validation.md
@@ -1,0 +1,28 @@
+---
+title: Use OPA to validate JWT tokens
+content-type: how-to
+description: Validate JWT tokens using an OPA policy in Kong Mesh.
+---
+
+In this use case, you are ----
+
+Use case ideas:
+* apply security policies for upstream services 
+* EnvoyFilter can be configured to include Envoy’s External Authorization filter to delegate authorization decisions to OPA. 
+* Envoy’s External authorization filter can be used with OPA as an authorization service to enforce security policies over API requests received by Envoy. The tutorial also covers examples of authoring custom policies over the HTTP request body.
+
+
+diagram that explains how the tech works
+
+## Prerequisites
+
+* install example app:
+    ```bash
+    kubectl apply -f https://bit.ly/demokuma
+    ```
+    why? what does this contain? maybe not since we want this to apply to a bunch of use cases?
+
+## instructions
+
+
+

--- a/app/_src/mesh/guides/jwt-validation.md
+++ b/app/_src/mesh/guides/jwt-validation.md
@@ -4,15 +4,13 @@ content-type: tutorial
 description: Validate JWT tokens using an OPA policy in Kong Mesh.
 ---
 
-A common problem companies face is how to determine that a user is who they say they are when logging in, and how to ensure only authorized users have access to certain applications and enforce security policies over API requests and for upstream services. {{site.mesh_product_name}} uses a [MeshOPA (beta)](/mesh/{{page.kong_version}}/features/meshopa/) policy to authorize JWT tokens by using [Envoy's External authorization filter](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ext_authz_filter.html) with [OPA](https://www.openpolicyagent.org/docs/latest/envoy-introduction/). Keep in mind that OPA doesn't handle authentication, it only handles authorization.
+A companies commonly face the following security problems:
+* How to determine that a user is who they say they are when logging in
+* How to ensure that only authorized users have access to certain applications and enforce security policies over API requests and for upstream services. 
 
-In this tutorial, you are a security engineer at your company. The company has created a new application that employees can log in to, but it's an internal application, so they don't want the public to be able to access it. Your company already uses an IdP for authentication, so you figure you can use the JWT token presented by the IdP to authorize employees to use the internal application. You are already using {{site.mesh_product_name}} to proxy services, so you decide to use the [MeshOPA (beta)](/mesh/{{page.kong_version}}/features/meshopa/) policy to authorize JWT tokens because <!--what are the advantages of this over other options?-->.
+These problems can be solved by using a {{site.mesh_product_name}} [MeshOPA (beta)](/mesh/{{page.kong_version}}/features/meshopa/) policy to authorize JWT tokens by using [Envoy's External authorization filter](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ext_authz_filter.html) with [OPA](https://www.openpolicyagent.org/docs/latest/envoy-introduction/). Keep in mind that OPA doesn't handle authentication, it only handles authorization.
 
-<!--Use case ideas:
-* apply security policies for upstream services 
-* EnvoyFilter can be configured to include Envoy’s External Authorization filter to delegate authorization decisions to OPA. 
-* Envoy’s External authorization filter can be used with OPA as an authorization service to enforce security policies over API requests received by Envoy. The tutorial also covers examples of authoring custom policies over the HTTP request body.-->
-
+This guide explains how to configure and deploy a MeshOPA policy that authorizes users based on if they have a valid JWT token. <!--what are the advantages of this over other options?-->.
 
 {diagram that explains how the tech works}
 
@@ -27,10 +25,6 @@ In this tutorial, you are a security engineer at your company. The company has c
     why? what does this contain? maybe not since we want this to apply to a bunch of use cases?
 
 ## Use an OPA policy to validate JWT tokens
-
-Each of the following sections details a different use case for using an OPA policy to validate JWT tokens, along with an example policy.
-
-### general
 
 {% navtabs %}
 {% navtab Kubernetes %}
@@ -132,19 +126,6 @@ conf:
 " | kumactl apply -f -
 ```
 1. Export the token to a variable and make the request (somehow not manually, like how would this be done in real life):
-{% endnavtab %}
-{% endnavtabs %}
-
-### with groups
-
-{% navtabs %}
-{% navtab Kubernetes %}
-```yaml
-```
-{% endnavtab %}
-{% navtab Universal %}
-```yaml
-```
 {% endnavtab %}
 {% endnavtabs %}
 

--- a/app/_src/mesh/guides/jwt-validation.md
+++ b/app/_src/mesh/guides/jwt-validation.md
@@ -1,18 +1,20 @@
 ---
 title: Use OPA to validate JWT tokens
-content-type: how-to
+content-type: tutorial
 description: Validate JWT tokens using an OPA policy in Kong Mesh.
 ---
 
-In this use case, you are ----
+A common problem companies face is how to determine that a user is who they say they are when logging in, and how to ensure only authorized users have access to certain applications and enforce security policies over API requests and for upstream services. {{site.mesh_product_name}} uses a [MeshOPA (beta)](/mesh/{{page.kong_version}}/features/meshopa/) policy to authorize JWT tokens by using [Envoy's External authorization filter](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ext_authz_filter.html) with [OPA](https://www.openpolicyagent.org/docs/latest/envoy-introduction/). Keep in mind that OPA doesn't handle authentication, it only handles authorization.
 
-Use case ideas:
+In this tutorial, you are a security engineer at your company. The company has created a new application that employees can log in to, but it's an internal application, so they don't want the public to be able to access it. Your company already uses an IdP for authentication, so you figure you can use the JWT token presented by the IdP to authorize employees to use the internal application. You are already using {{site.mesh_product_name}} to proxy services, so you decide to use the [MeshOPA (beta)](/mesh/{{page.kong_version}}/features/meshopa/) policy to authorize JWT tokens because <!--what are the advantages of this over other options?-->.
+
+<!--Use case ideas:
 * apply security policies for upstream services 
 * EnvoyFilter can be configured to include Envoy’s External Authorization filter to delegate authorization decisions to OPA. 
-* Envoy’s External authorization filter can be used with OPA as an authorization service to enforce security policies over API requests received by Envoy. The tutorial also covers examples of authoring custom policies over the HTTP request body.
+* Envoy’s External authorization filter can be used with OPA as an authorization service to enforce security policies over API requests received by Envoy. The tutorial also covers examples of authoring custom policies over the HTTP request body.-->
 
 
-diagram that explains how the tech works
+{diagram that explains how the tech works}
 
 ## Prerequisites
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Customers and Kongers have been asking for a page that explains how to do JWT with a Mesh policy along with an example policy template. We went with OPA in this because it's easiest. Also, having a docs page with "JWT validation" in the title will help surface this information in searches, because currently it's hidden in the docs.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3524
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

