### PR TITLE
fix: Add missing Azure vault table entry

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/index.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/index.md
@@ -7,6 +7,11 @@ The following Vault implementations are supported:
 |                                                                                                               | Tier       |
 |---------------------------------------------------------------------------------------------------------------|------------|
 | [AWS Secrets Manager](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/aws-sm/)      | Enterprise |
+
+{% if_version gte:3.5.x %}
+| [Azure Key Vault](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/azure-key-vaults/) | Enterprise |
+{% endif_version %}
+
 | [GCP Secrets Manager](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/gcp-sm/)      | Enterprise |
 | [HashiCorp Vault](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/hashicorp-vault/) | Enterprise |
 | [Environment Variable](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/env/)        | Free       |


### PR DESCRIPTION
### Description

The vault backends list is missing Azure key vault, which was added in 3.5.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

