### PR TITLE
chore: Add missing search aliases and supported versions for 3rd party plugins

### DIFF
--- a/app/_hub/TheLEGOGroup/aws-request-signing/_metadata.yml
+++ b/app/_hub/TheLEGOGroup/aws-request-signing/_metadata.yml
@@ -28,3 +28,7 @@ kong_version_compatibility:
       - 3.2.x
 
 dbless_compatible: yes
+
+search_aliases:
+  - the lego group
+  - aws-request-signing

--- a/app/_hub/amberflo/kong-plugin-amberflo/_metadata.yml
+++ b/app/_hub/amberflo/kong-plugin-amberflo/_metadata.yml
@@ -27,3 +27,7 @@ kong_version_compatibility:
   enterprise_edition:
     compatible:
       - 3.0.x
+
+search_aliases:
+  - amberflo.io inc.
+  - kong-plugin-amberflow

--- a/app/_hub/datadome/kong-plugin-datadome/_metadata.yml
+++ b/app/_hub/datadome/kong-plugin-datadome/_metadata.yml
@@ -30,3 +30,6 @@ kong_version_compatibility:
       - 3.2.x
       - 3.0.x
       - 2.8.x
+
+search_aliases:
+  - kong-plugin-datadome

--- a/app/_hub/imperva/imp-appsec-connector/_metadata.yml
+++ b/app/_hub/imperva/imp-appsec-connector/_metadata.yml
@@ -20,3 +20,6 @@ kong_version_compatibility:
     compatible:
       - 3.0.x
       - 3.2.x
+
+search_aliases:
+  - imp-appsec-connector

--- a/app/_hub/moesif/kong-plugin-moesif/_metadata.yml
+++ b/app/_hub/moesif/kong-plugin-moesif/_metadata.yml
@@ -78,3 +78,6 @@ kong_version_compatibility: # required
       - 0.31-x
       - 0.30-x
     #incompatible:
+
+search_aliases:
+  - kong-plugin-moesif

--- a/app/_hub/nonamesecurity/nonamesecurity-kongprevention/_metadata.yml
+++ b/app/_hub/nonamesecurity/nonamesecurity-kongprevention/_metadata.yml
@@ -40,3 +40,6 @@ konnect: false
 
 dbless_compatible: yes
 
+search_alises: 
+  - noname-prevention
+  - nonamesecurity-kongprevention

--- a/app/_hub/nonamesecurity/nonamesecurity-kongtrafficsource/_metadata.yml
+++ b/app/_hub/nonamesecurity/nonamesecurity-kongtrafficsource/_metadata.yml
@@ -41,3 +41,5 @@ konnect: true
 
 dbless_compatible: yes
 
+search_aliases:
+  - nonamesecurity-kongtrafficsource

--- a/app/_hub/optum/kong-response-size-limiting/_metadata.yml
+++ b/app/_hub/optum/kong-response-size-limiting/_metadata.yml
@@ -18,8 +18,11 @@ free: true
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 0.14.x
+      - ">= 1.x"
 
   enterprise_edition:
     compatible:
-      - 0.34-x
+      - ">= 1.x"
+
+search_aliases:
+  - optum

--- a/app/_hub/optum/kong-service-virtualization/_metadata.yml
+++ b/app/_hub/optum/kong-service-virtualization/_metadata.yml
@@ -19,11 +19,11 @@ free: true
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 0.14.x
-      - 0.13.x
+      - ">= 1.x"
 
   enterprise_edition:
     compatible:
-      - 0.34-x
-      - 0.33-x
-      - 0.32-x
+      - ">= 1.x"
+
+search_aliases:
+  - optum

--- a/app/_hub/optum/kong-spec-expose/_metadata.yml
+++ b/app/_hub/optum/kong-spec-expose/_metadata.yml
@@ -21,14 +21,11 @@ free: true
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 0.14.x
-      - 0.13.x
-      - 0.12.x
+      - ">= 1.x"
 
   enterprise_edition:
     compatible:
-      - 0.34-x
-      - 0.33-x
-      - 0.32-x
-      - 0.31-x
-      - 0.30-x
+      - ">= 1.x"
+
+search_aliases:
+  - optum

--- a/app/_hub/optum/kong-splunk-log/_metadata.yml
+++ b/app/_hub/optum/kong-splunk-log/_metadata.yml
@@ -19,11 +19,11 @@ free: true
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 0.14.x
-      - 0.13.x
+      - ">= 3.x"
 
   enterprise_edition:
     compatible:
-      - 0.34-x
-      - 0.33-x
-      - 0.32-x
+      - ">= 3.x"
+
+search_aliases:
+  - optum

--- a/app/_hub/optum/kong-upstream-jwt/_metadata.yml
+++ b/app/_hub/optum/kong-upstream-jwt/_metadata.yml
@@ -20,14 +20,11 @@ free: true
 kong_version_compatibility:
   community_edition:
     compatible:
-      - 0.14.x
-      - 0.13.x
-      - 0.12.x
+      - ">= 3.x"
 
   enterprise_edition:
     compatible:
-      - 0.34-x
-      - 0.33-x
-      - 0.32-x
-      - 0.31-x
-      - 0.30-x
+      - ">= 3.x"
+
+search_aliases:
+  - optum

--- a/app/_hub/salt/salt/_metadata.yml
+++ b/app/_hub/salt/salt/_metadata.yml
@@ -44,3 +44,6 @@ kong_version_compatibility:
       - 0.34-x
 
 reference_param_name: salt-agent
+
+search_aliases: 
+  - salt-agent


### PR DESCRIPTION
### Description

Keep expecting to find third-party plugins by filtering on publisher name, but that doesn't work. 

Adding 3rd party plugin publisher names as search aliases, as well as literal plugin names (eg `aws-request-signing`). 

Also updating the supported versions for Optum plugins. Versions are based on the plugins' source code repos.

### Testing instructions

Test the new search terms in the plugin hub filter box.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

