### PR TITLE
fix: Broken links to APIOps guide

### DIFF
--- a/app/_src/deck/index.md
+++ b/app/_src/deck/index.md
@@ -14,9 +14,12 @@ Features include:
 * Sync configuration to a running Kong cluster
 * diff configuration to detect any drift or manual changes
 * Back up your instance's configuration
-* Build pipelines of automation with [APIOps](/deck/{{page.kong_version}}/guides/apiops/)
 * Manage Kong’s configuration in a distributed way using tags, helping you split
 the configuration across various teams
+{% if_version gte:1.24.x %}
+* Build pipelines of automation with [APIOps](/deck/{{page.kong_version}}/guides/apiops/)
+{% endif_version %}
+
 
 [View our introductory screencast explaining decK](https://asciinema.org/a/238318).
 
@@ -36,12 +39,16 @@ manual interventions.
 that if an entity is created in Kong and isn't added to the config file,
 decK will detect the change.
 
-* **Configuration Generation**: decK can generate gateway configurations from OpenAPI 
+{% if_version gte:1.24.x %}
+* **Configuration generation**: decK can generate gateway configurations from OpenAPI 
 Specifications.
+{% endif_version %}
 
-* **Configuration Transformations**: decK provides multiple transformation commands 
+{% if_version gte:1.24.x %}
+* **Configuration transformations**: decK provides multiple transformation commands 
 to manipulate full and partial configuration files. This feature allows you to build 
 API delivery automations, or [APIOps](/deck/{{page.kong_version}}/guides/apiops/).
+{% endif_version %}
 
 * **Validation**: decK can validate YAML files that you backup or modify to
 catch errors early on.


### PR DESCRIPTION
### Description

Set `if_version` on links to the APIOps decK guide, as it was added with 1.24.x. 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

