### PR TITLE
Feat: Improve the Readiness Check page

### DIFF
--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -195,3 +195,4 @@ For more information on Kong and related topics, check out the following resourc
 * [Kong Admin API Documentation](/gateway/latest/admin-api/)
 * [Get Started with {{site.kic_product_name}}](/kubernetes-ingress-controller/latest/deployment/overview/)
 * [Kong Helm Chart](https://github.com/Kong/charts/tree/main/charts/kong)
+* [Kong Hybrid Mode](/gateway/latest/production/deployment-topologies/hybrid-mode/)


### PR DESCRIPTION
### Description

Additional details were added to explain the different kind of health check endpoints, workaround for 3.2 and lower, as well as additional resources and recommendations for users. Corrections were also made (wrong ports were used in the previous examples prior to this PR as one example).

Jira: https://konghq.atlassian.net/browse/DOCU-3591 
Wiki: https://konghq.atlassian.net/wiki/x/FwD_vw (written by @hbagdi - thank you Harry!)

### Testing instructions

Preview link: https://deploy-preview-6588--kongdocs.netlify.app/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)