### PR TITLE
Chore: Assign metadescriptions to pages by `description`

### DIFF
--- a/app/_includes/head.html
+++ b/app/_includes/head.html
@@ -5,13 +5,12 @@ site.title }}{% endcapture %} {% else %} {% capture page_title %}{{ include.titl
 | {{site.title}}{% endcapture %}
 {% endunless %}
 
-{% assign page_description = site.description %}
-{% if layout.description %}
-  {% assign page_description = layout.description %}
-{% endif %}
-
 {% if include.description %}
   {% assign page_description = include.description %}
+{% elsif layout.description %}
+  {% assign page_description = layout.description %}
+{% else %}
+  {% assign page_description = site.description %}
 {% endif %}
 
 <head>


### PR DESCRIPTION
### Description

As part of SEO work, pages are getting `description` keys added to them for metadata.

Adjusting the way the metadescription gets generated for each page to include this option. 

If a page-specific description exists, it takes priority; otherwise it still falls back to the generic site description.

### Testing instructions

Check the meta description for the https://deploy-preview-6591--kongdocs.netlify.app/contributing/community/ page (open the page in dev tools, expand the `<head>` tag).

You should see:
```
<meta name="description" content="Join the Kong Documentation Contribution Community to collaborate, learn, and contribute to open source projects. Start your journey with Kong today!">
```

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

