### PR TITLE
chore: Update readme to include make install-prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,23 @@ For [Gateway Enterprise configuration reference](https://docs.konghq.com/gateway
 For anything other than minor changes, [clone the repository onto your local machine and build locally](docs/platform-install.md). Once you've installed all of the tools required, you can use our `Makefile` to build the docs:
 
 ```bash
+# Install prerequisites
+make install-prerequisites
+
 # Install dependencies
 make install
 
-# Make sure to update submodules
-git submodule update --init --recursive
+# Create local .env file
+# OAS Pages require VITE_PORTAL_API_URL to be set in your current environment, it should match the Kong supplied portal URL
+cp .env.example .env
 
 # Build the site and watch for changes 
 make run
 ```
 
 ### Troubleshooting the local build
+
+#### Invalid byte sequence in US-ASCII 
 
 If you encounter an error that looks like this:
 
@@ -58,16 +64,6 @@ You can try setting the `LANG` or `LC_ALL` environment variable to `en_US.UTF-8`
 ```bash
 export LANG=en_US.UTF-8
 ```
-
-### OAS Pages
-
-Create local .env file
-
-```bash
-cp .env.example .env
-```
-
-OAS Pages require `VITE_PORTAL_API_URL` to be set in your current environment, it should match the Kong supplied portal URL.
 
 ### Generating specific products
 


### PR DESCRIPTION
### Description

Updates to the README:
* Added `make install-prerequisites` to the setup instructions for the docs site.
* Moved `cp .env.example .env` into the same section, since this is needed for the site to run.
* Removed `git submodule update` since it's part of `make install` now.

To do:
* Figure out why `foreman` doesn't get installed - it's included in the gemfile, so it should be. Otherwise, add a troubleshooting section to install foreman.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

