### PR TITLE
Fix: Azure vault env variables

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/azure-key-vaults.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/azure-key-vaults.md
@@ -1,7 +1,7 @@
 ---
 title: Azure Key Vaults
 badge: enterprise
-content-type: how-to
+content_type: how-to
 ---
 
 The current version of {{site.base_gateway}}'s implementation supports
@@ -19,27 +19,27 @@ with the [Azure Key Vaults API](https://learn.microsoft.com/en-us/rest/api/keyva
 
 You need to specify the following values: 
 
-- Azure ActiveDirectory Tenant Id
-- Azure Client Id
+- Azure ActiveDirectory Tenant ID
+- Azure Client ID
 - `vault_URI`
-- Azure Client Secret - This value can only be configured as an environment variable.
+- Azure Client Secret: This value can only be configured as an environment variable.
 
 You can configure these values with environment variables before starting {{site.base_gateway}}:
 
 ```bash
 export KONG_VAULT_AZURE_VAULT_URI=https://my-vault.vault.azure.com
-export AZURE_TENANT_ID=tenant_id
-export AZURE_CLIENT_ID=client_id
-export AZURE_CLIENT_SECRET=client_secret
+export KONG_VAULT_AZURE_TENANT_ID=tenant_id
+export KONG_VAULT_AZURE_CLIENT_ID=client_id
+export KONG_VAULT_AZURE_CLIENT_SECRET=client_secret
 ```
-{:.note}
 
+{:.note}
 > With `Instance Managed Identity Token`, setting the environment variables isn't necessary.
 
 
 ### Examples
 
-Note that Azure's Key Vault support three different secret types.
+Note that Azure's Key Vault support three different secret types:
 
 - Keys
 - Secrets
@@ -57,13 +57,14 @@ with the name `secret-name`, create a JSON object in Azure Key Vault that contai
 }
 ```
 
-Note that Azure AD tenant Id, client Id, `vault_uri` and client secret need to be specified. You can configure these values with environment variables before starting {{site.base_gateway}}:
+Note that Azure AD tenant ID, client ID, `vault_uri` and client secret need to be specified. 
+You can configure these values with environment variables before starting {{site.base_gateway}}:
 
 ```bash
 export KONG_VAULT_AZURE_VAULT_URI=https://my-vault.vault.azure.com
-export AZURE_TENANT_ID=tenant_id
-export AZURE_CLIENT_ID=client_id
-export AZURE_CLIENT_SECRET=client_secret
+export KONG_VAULT_AZURE_TENANT_ID=tenant_id
+export KONG_VAULT_AZURE_CLIENT_ID=client_id
+export KONG_VAULT_AZURE_CLIENT_SECRET=client_secret
 ```
 
 ```bash
@@ -71,11 +72,11 @@ export AZURE_CLIENT_SECRET=client_secret
 {vault://azure/secret-name/snip}
 ```
 
-alternatively, you can configure the vault via the `vaults entity`.
+Alternatively, you can configure the vault via the vaults entity.
 
 ## Configuration via vaults entity
 
-Once the database is initialized, a Vault entity can be created
+Once the database is initialized, a vault entity can be created
 to encapsulate the provider and the required Azure Key Vault information:
 
 {% navtabs %}


### PR DESCRIPTION
### Description

To set any environment variables to configure Kong Gateway (kong.conf), each env variable must be prefixed with `KONG_`. These prefixes, along with the `VAULT` portion of each config parameter, are missing from the example codeblocks in the Azure Vaults doc.

See https://docs.konghq.com/gateway/latest/reference/configuration/#vault_azure_vault_uri for the relevant parameter names, which all start with `vault`.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

