### PR TITLE
tls-metadata-headers is compatible with Konnect

### DIFF
--- a/app/_hub/kong-inc/tls-metadata-headers/_metadata.yml
+++ b/app/_hub/kong-inc/tls-metadata-headers/_metadata.yml
@@ -6,7 +6,7 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-konnect: false
+konnect: true
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 notes: --
 categories:


### PR DESCRIPTION
### Description

Reported by Fero. This is a DP only plugin which _is_ compatible with Konnect

### Testing instructions

Preview link: /hub/kong-inc/tls-metadata-headers/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
