### PR TITLE
fix: add missing references to Azure Key Vault

### DIFF
--- a/app/_data/tables/support/gateway/third-party.yml
+++ b/app/_data/tables/support/gateway/third-party.yml
@@ -64,6 +64,9 @@ _third_party:
   aws-sm: &aws-sm
     name: AWS Secrets Manager
     icon: aws.svg
+  azure-key-vaults: &azure-key-vaults
+    name: Microsoft Azure Key Vault
+    icon: azure.svg
   gcp-sm: &gcp-sm
     name: Google Secrets Manager
     icon: gcp.svg

--- a/app/_data/tables/support/gateway/versions/35.yml
+++ b/app/_data/tables/support/gateway/versions/35.yml
@@ -59,6 +59,7 @@ third-party:
   vault:
     - *vaultproject
     - *aws-sm
+    - *azure-key-vaults
     - *gcp-sm
 
   identity_provider:

--- a/app/_src/gateway/kong-enterprise/index.md
+++ b/app/_src/gateway/kong-enterprise/index.md
@@ -56,6 +56,7 @@ The Vitals platform provides deep insights into services, routes, and applicatio
 {{site.ee_product_name}} offers out of the box secrets management with the following backends: 
 
 * [Amazon Web Services (AWS)](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/aws-sm/)
+* [Microsoft Azure](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/azure-key-vaults/)
 * [Google Cloud Platform (GCP)](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/gcp-sm/)
 * [Hashicorp Vault](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/hashicorp-vault/)
 

--- a/app/_src/gateway/kong-enterprise/index.md
+++ b/app/_src/gateway/kong-enterprise/index.md
@@ -56,7 +56,9 @@ The Vitals platform provides deep insights into services, routes, and applicatio
 {{site.ee_product_name}} offers out of the box secrets management with the following backends: 
 
 * [Amazon Web Services (AWS)](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/aws-sm/)
+{% if_version gte:3.5.x %}
 * [Microsoft Azure](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/azure-key-vaults/)
+{% endif_version %}
 * [Google Cloud Platform (GCP)](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/gcp-sm/)
 * [Hashicorp Vault](/gateway/{{page.kong_version}}/kong-enterprise/secrets-management/backends/hashicorp-vault/)
 


### PR DESCRIPTION
### Description

Support for Azure Key Vault as a secrets backend was added in Gateway 3.5. This PR adds references to this support in the 3rd party tools page and Gateway Enterprise index.
 
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

