### PR TITLE
Add x-errors support to OAS docs

### DIFF
--- a/app/_plugins/generators/oas_definition/error_page.rb
+++ b/app/_plugins/generators/oas_definition/error_page.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module OasDefinition
+  class ErrorPage < ::Jekyll::Page
+    def initialize(site:, data:) # rubocop:disable Lint/MissingSuper
+      # Prevent modification of source data that's used in OasDefinition::Page
+      data = data.clone
+
+      @site = site
+      @base = site.source
+
+      @basename = 'index'
+      @ext = '.html'
+
+      @data = data
+      @relative_path = data['source_file']
+
+      # Error specific overrides
+      override_data_for_error!
+      spec = load_api_file
+      @content = generate_error_table(spec)
+    end
+
+    private
+
+    def override_data_for_error!
+      @dir = "#{data['dir']}errors/"
+      @data['layout'] = 'docs-v2'
+      @data['permalink'] = "#{@data['permalink']}errors/"
+    end
+
+    def generate_error_table(spec)
+      raise "No x-errors key found for #{api_spec_path}" unless spec['x-errors']
+
+      # heredoc string return
+      <<~HEREDOC
+        <div><a class="no-link-icon" href="../">&laquo; Back to API</a></div>
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Code</th>
+              <th>Description</th>
+              <th>Resolution</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            #{spec['x-errors'].map { |k, v| generate_error_row(k, v) }.join("\n")}
+          </tbody>
+        </table>
+      HEREDOC
+    end
+
+    def generate_error_row(key, error)
+      # heredoc string return
+      <<~HEREDOC
+        <tr id="#{key}">
+          <td>#{key}</td>
+          <td>#{error['description']}</td>
+          <td>#{error['resolution']}</td>
+          <td>#{generate_error_link(error['link'])}</td>
+        </tr>
+      HEREDOC
+    end
+
+    def generate_error_link(link)
+      return '' unless link
+
+      "<a href=\"#{link['url']}\">#{link['text']}</a>"
+    end
+
+    def api_spec_path
+      spec_file = CGI.unescape(@data['insomnia_link']).split('&uri=')[1].gsub(
+        'https://raw.githubusercontent.com/Kong/docs.konghq.com/main/', ''
+      )
+      File.join(@base, '..', spec_file)
+    end
+
+    def load_api_file
+      YAML.load_file(api_spec_path)
+    end
+  end
+end

--- a/app/_plugins/generators/oas_definition/product.rb
+++ b/app/_plugins/generators/oas_definition/product.rb
@@ -14,13 +14,19 @@ module OasDefinition
       product['versions'].map do |version|
         data = OasDefinition::PageData.generate(product:, version:, file:, site:)
 
-        site.pages << ::OasDefinition::Page.new(site:, data:)
+        generate_product_pages!(product, data)
       end
 
       generate_latest_page!
+      generate_latest_error_page!
     end
 
     private
+
+    def generate_product_pages!(product, data)
+      site.pages << ::OasDefinition::Page.new(site:, data:)
+      site.pages << ::OasDefinition::ErrorPage.new(site:, data:) if product['generateErrorsPage']
+    end
 
     def generate_latest_page!
       version = product['latestVersion']
@@ -31,6 +37,17 @@ module OasDefinition
       site.data['ssg_oas_pages'] << latest_page
 
       site.pages << latest_page
+    end
+
+    def generate_latest_error_page!
+      return unless product['generateErrorsPage']
+
+      version = product['latestVersion']
+      data = OasDefinition::PageData.generate(product:, version:, file:, site:, latest: true)
+
+      latest_error_page = ::OasDefinition::ErrorPage.new(site:, data:)
+
+      site.pages << latest_error_page
     end
   end
 end

--- a/app/_plugins/generators/seo/index_entry/oas_page.rb
+++ b/app/_plugins/generators/seo/index_entry/oas_page.rb
@@ -19,8 +19,13 @@ module SEO
 
       def version
         # (\d+ match or /latest/)
+        segments = @page.url.split('/')
+
+        # Remove the errors page segment
+        segments.pop if segments.last == 'errors'
+
         @version ||= Utils::Version.to_version(
-          @page.url.split('/').last
+          segments.last
         )
       end
 


### PR DESCRIPTION
### Description

Adds support for per-API errors in the OpenAPI specs. If a spec contains an `x-errors` key and `"generateErrorsPage": true` is set in `konnect_oas_data.json` then a page will be generated from the errors in the docs. This allows us to return a URL in the API which links to docs e.g. https://kongapi.info/api-products/solar-error would link to /konnect/api/api-products/latest/errors/#solar-error


#### Example config

```yaml
x-errors:
  example-error:
    description: The provided API product does not contain a "foobar"
    resolution: Send the "beebaz" parameter with a key starting with "ABC123"
    link:
      text: View API reference
      url: /api/redact#transaction

  solar-error:
    description: The sun has come too close to the earth and your request could not be served
    resolution: Wait until the sun moves away

  create-rate-limit:
    description: The request was rate limited
    resolution: API Products supports 170 POST requests per second. Slow down your request rate
```

#### Example rendering

![CleanShot 2023-12-06 at 16 50 05](https://github.com/Kong/docs.konghq.com/assets/59130/f45fe439-988c-425f-b0fe-f1b6bb6963a8)

### Testing instructions

Preview link: N/A - no specs contain the `x-errors` key yet. This will be a followup PR to `platform-api` which gets synced to this repo

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)