### PR TITLE
Add a step to publish API Product and version docs

### DIFF
--- a/app/konnect/getting-started/publish-service.md
+++ b/app/konnect/getting-started/publish-service.md
@@ -126,6 +126,10 @@ then click **Settings**.
     ```
     https://{ORG_NAME}.portal.cloud.konghq.com/
     ```
+1. To view an API Product's documentation alongside its dynamic API reference (based on the API specification), navigate to {% konnect_icon api-product %} [**API Products**](https://cloud.konghq.com/api-products) and publish your API product along with its API version.
+    * In the API Products section, select your API Product. Then, click **Actions** and select **Publish to portal**.
+    * From the left-side navigation panel, select **Product Version** and click on the version you created previously. On the version's homepage, change the **Status** to **Published**.
+
 1. Open the service you published to check it out.
 
 {% endnavtab %}

--- a/app/konnect/getting-started/publish-service.md
+++ b/app/konnect/getting-started/publish-service.md
@@ -61,6 +61,14 @@ use the [sample Analytics spec](/konnect/vitalsSpec.yaml) for testing.
 This OpenAPI spec will be shown under the version name when this service is
 published to the Dev Portal.
 
+## Publish API Product to the Dev Portal
+
+To view an API Product's documentation alongside its dynamic API reference (based on the API specification), 
+navigate to {% konnect_icon api-product %} [**API Products**](https://cloud.konghq.com/api-products) and publish your API product along with its API version.
+
+1. In the **API Products** section, select your API Product. Then, click **Actions** and select **Publish to portal**.
+1. From the left-side navigation panel, select **Product Version** and click on the version you created previously.
+On the version's homepage, change the **Status** to **Published**.
 
 ## View the published content on Dev Portal
 
@@ -106,7 +114,7 @@ You can't use your {{site.konnect_short_name}} credentials to log in here.
 1. Check your email for a confirmation link. Click the link, then log
 into the Dev Portal.
 
-1. Open the API product you published to check it out.
+1. Open any API product you have published to check it out.
 
 {% endnavtab %}
 {% navtab Public Dev Portal %}
@@ -126,11 +134,8 @@ then click **Settings**.
     ```
     https://{ORG_NAME}.portal.cloud.konghq.com/
     ```
-1. To view an API Product's documentation alongside its dynamic API reference (based on the API specification), navigate to {% konnect_icon api-product %} [**API Products**](https://cloud.konghq.com/api-products) and publish your API product along with its API version.
-    * In the API Products section, select your API Product. Then, click **Actions** and select **Publish to portal**.
-    * From the left-side navigation panel, select **Product Version** and click on the version you created previously. On the version's homepage, change the **Status** to **Published**.
 
-1. Open the service you published to check it out.
+1. Open any API Product you have published to check it out.
 
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
The step-by-step process is clear; however, one critical step was missing - guiding users on how to publish the API documentation and a dynamic API reference to the public portal. To address this issue, I am adding an extra step that instructs users on how to publish their API Product and version documentation.
 


### Testing instructions

Preview link: https://docs.konghq.com/konnect/getting-started/publish-service/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

