### PR TITLE
fix: fix URL of services page

### DIFF
--- a/app/_src/gateway/get-started/services-and-routes.md
+++ b/app/_src/gateway/get-started/services-and-routes.md
@@ -184,7 +184,9 @@ complete that before proceeding.
 The [Admin API documentation](/gateway/latest/admin-api/#update-service) provides
 the full service update specification. 
 
-You can also view the configuration for your services in the Kong Manager UI by navigating to the following URL in your browser: [http://localhost:8002/services](http://localhost:8002/services)
+You can also view the configuration for your services in the Kong Manager UI by navigating to the following URL in your browser: 
+* Kong Manager OSS: [http://localhost:8002/services](http://localhost:8002/services) 
+* Kong Manager Enterprise: [http://localhost:8002/default/services](http://localhost:8002/default/services), where `default` is the workspace name.
    
 ### Managing routes
 

--- a/app/_src/gateway/get-started/services-and-routes.md
+++ b/app/_src/gateway/get-started/services-and-routes.md
@@ -184,7 +184,7 @@ complete that before proceeding.
 The [Admin API documentation](/gateway/latest/admin-api/#update-service) provides
 the full service update specification. 
 
-You can also view the configuration for your services in the Kong Manager UI by navigating to the following URL in your browser: [http://localhost:8002/default/services](http://localhost:8002/default/services)
+You can also view the configuration for your services in the Kong Manager UI by navigating to the following URL in your browser: [http://localhost:8002/services](http://localhost:8002/services)
    
 ### Managing routes
 


### PR DESCRIPTION



### Description

Got 404 when visiting the URL shown in the document. Found the correct page after clicking "Gateway Services" and it turned out the correct URL didn't include the "/default" part. 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

