### PR TITLE
Add hub.docker.com to ignored_targets

### DIFF
--- a/tools/broken-link-checker/config/ignored_targets.json
+++ b/tools/broken-link-checker/config/ignored_targets.json
@@ -48,5 +48,6 @@
   "https://twitter.com/thekonginc",
   "https://your_okta_domain/",
   "https://github.com/Kong/kong-ee/edit/*",
-  "https://linux.die.net"
+  "https://linux.die.net",
+  "https://hub.docker.com/"
 ]


### PR DESCRIPTION
### Description

Follow up to https://github.com/Kong/docs.konghq.com/pull/6622

Add `https://hub.docker.com/` to broken link checker's ignored_targets
It returns 429 most of the time, causing the check to fail even though the links work.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

