### PR TITLE
Fix: Add cross-links between kong.conf guides and reference

### DIFF
--- a/app/_src/gateway/production/environment-variables.md
+++ b/app/_src/gateway/production/environment-variables.md
@@ -5,13 +5,17 @@ content-type: how-to
 
 ## Environment variables
 
-{{site.base_gateway}} can be fully configured with environment variables. When loading properties from `kong.conf`, {{site.base_gateway}} will check existing
-environment variables. 
+{{site.base_gateway}} can be fully configured with environment variables. 
+
+[All parameters defined in `kong.conf`](/gateway/{{page.kong_version}}/reference/configuration/) 
+can be managed via environment variables.
+When loading properties from `kong.conf`, {{site.base_gateway}} checks existing
+environment variables first.
 
 To override a setting using an environment variable, declare an environment
 variable with the name of the setting, prefixed with `KONG_`.
 
-To override the `log_level` parameter:
+For example, to override the `log_level` parameter:
 
 ```
 log_level = debug # in kong.conf
@@ -23,8 +27,8 @@ set `KONG_LOG_LEVEL` as an environment variable:
 export KONG_LOG_LEVEL=error
 ```
 
+## More information
 
-## More Information
-
-* [How to use `kong.conf`](/gateway/latest/production/kong-conf/)
-* [How to serve an API and a website with Kong](/gateway/latest/production/website-api-serving/)
+* [How to use `kong.conf`](/gateway/{{page.kong_version}}/production/kong-conf/)
+* [How to serve an API and a website with Kong](/gateway/{{page.kong_version}}/production/website-api-serving/)
+* [Configuration parameter reference](/gateway/{{page.kong_version}}/reference/configuration/)

--- a/app/_src/gateway/production/kong-conf.md
+++ b/app/_src/gateway/production/kong-conf.md
@@ -3,10 +3,11 @@ title: Kong Configuration File
 content-type: how-to
 ---
 
+{{site.base_gateway}} comes with a default configuration file `kong.conf`. If you installed {{site.base_gateway}} using an official package, this file can be found at `/etc/kong/kong.conf.default`. 
 
-{{site.base_gateway}} comes with a default configuration file `kong.conf`. If you installed {{site.base_gateway}} using an official package, this file can be found at:
-`/etc/kong/kong.conf.default`. The {{site.base_gateway}} configuration file is a YAML file that can be used to configure individual properties of your Kong instance. This guide will explain how to configure {{site.base_gateway}} using the `kong.conf` file.
+The {{site.base_gateway}} configuration file is a YAML file that can be used to configure individual properties of your Kong instance. This guide explains how to configure {{site.base_gateway}} using the `kong.conf` file.
 
+For all available parameters in `kong.conf`, see the [Configuration Parameter reference](/gateway/{{page.kong_version}}/reference/configuration/). 
 
 ## Configure {{site.base_gateway}}
 
@@ -50,7 +51,7 @@ Boolean values can be specified as `on`/`off` or `true`/`false`:
 > {{site.base_gateway}} will use the default settings for any value in `kong.conf` that is commented out.
 
 ## Verify configuration
-To verify that your configuration is usable, use the `check` command. The `check` command will evaluate the [environment variables](/gateway/latest/production/environment-variables/) you have
+To verify that your configuration is usable, use the `check` command. The `check` command will evaluate the [environment variables](/gateway/{{page.kong_version}}/production/environment-variables/) you have
 currently set, and will output an error if your settings are invalid. 
 
 ```bash
@@ -81,7 +82,7 @@ kong start --conf /path/to/kong.conf
 
 ### Debug mode
 
-You can use the [{{site.base_gateway}} CLI](/gateway/latest/reference/cli/) in debug-mode to output configuration properties in the shell:
+You can use the [{{site.base_gateway}} CLI](/gateway/{{page.kong_version}}/reference/cli/) in debug-mode to output configuration properties in the shell:
 
 ```bash
 kong start -c /etc/kong.conf --vv
@@ -97,6 +98,7 @@ kong start -c /etc/kong.conf --vv
 
 ## More Information
 
-* [Embedding Kong in OpenResty](/gateway/latest/production/kong-openresty/)
-* [Setting environment variables](/gateway/latest/production/environment-variables/)
-* [How to serve an API and a website with Kong](/gateway/latest/production/website-api-serving/)
+* [Embedding Kong in OpenResty](/gateway/{{page.kong_version}}/production/kong-openresty/)
+* [Setting environment variables](/gateway/{{page.kong_version}}/production/environment-variables/)
+* [How to serve an API and a website with Kong](/gateway/{{page.kong_version}}/production/website-api-serving/)
+* [Configuration parameter reference](/gateway/{{page.kong_version}}/reference/configuration/)

--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -17,7 +17,9 @@ source_url: https://github.com/Kong/kong/edit/master/kong.conf.default
 
 Reference for {{site.base_gateway}} configuration parameters. Set these parameters in `kong.conf`.
 
-To learn more about the `kong.conf` file, see the guide on the [Kong Configuration File](/gateway/{{page.kong_version}}/production/kong-conf/).
+To learn more about the `kong.conf` file, see the guide on using the [Kong Configuration File](/gateway/{{page.kong_version}}/production/kong-conf/).
+
+You can also manage all {{site.base_gateway}} configuration parameters using [environment variables](/gateway/{{page.kong_version}}/production/environment-variables/).
 
 ---
 


### PR DESCRIPTION
### Description

There are no links to the kong.conf reference from the kong.conf guides, so users are having trouble finding the reference.
Adding links to fix that.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

