### PR TITLE
Fix: Remove inaccurate note and links about decK in db-less mode doc

### DIFF
--- a/app/_src/deck/faqs.md
+++ b/app/_src/deck/faqs.md
@@ -35,8 +35,9 @@ Kong can generate such a file with the `kong config db_export` command, which
 dumps almost the entire database of Kong into a file.
 
 You can use a file in this format to configure Kong when it is running in
-a DB-less or in-memory mode. If you're using Kong in the DB-less mode, you
-don't really need decK.
+a DB-less or in-memory mode. If you're using Kong in DB-less mode, you can't
+use decK for any sync, dump, or similar operations, as they require write 
+access to the Admin API.
 
 If you are using Kong alongside a database, you need decK because:
 

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -7,7 +7,9 @@ Traditionally, {{site.base_gateway}} has always required a database, to store it
 services and plugins. Kong uses its configuration file, `kong.conf`, to
 specify the use of the database and its [various settings](/gateway/{{page.kong_version}}/reference/configuration/#datastore-section).
 
-{{site.base_gateway}} can be run without a database using only in-memory storage for entities. We call this DB-less mode. When running {{site.base_gateway}} DB-less, the configuration of entities is done in a second configuration file, in YAML or JSON, using declarative configuration.
+{{site.base_gateway}} can be run without a database using only in-memory storage for entities. 
+We call this DB-less mode. When running {{site.base_gateway}} DB-less, the configuration of 
+entities is done in a second configuration file, in YAML or JSON, using declarative configuration.
 
 The combination of DB-less mode and declarative configuration has a number
 of benefits:
@@ -18,6 +20,11 @@ of benefits:
   entities can be kept in a single source of truth managed via a Git
   repository.
 * Enables more deployment options for {{site.base_gateway}}.
+
+{:.note}
+> **Note**: [decK](/deck/) also manages configuration declaratively, but it requires
+a database to perform any of its sync, dump, or similar operations. Therefore, decK 
+can't be used in DB-less mode.
 
 ## Declarative configuration
 
@@ -114,10 +121,6 @@ Server: kong/{{page.versions.ce}}
 ```
 
 ## Creating a declarative configuration file
-
-{:.note}
-> **Note:** We recommend using decK to manage your declarative configuration.
-See the [decK documentation](/deck/) for more information.
 
 To load entities into DB-less Kong, you need a declarative configuration
 file. The following command creates a skeleton file to get you
@@ -308,5 +311,3 @@ For current plugin compatibility, see [Plugin compatibility](/hub/plugins/compat
 
 ## See also
 * [Declarative configuration schema](https://github.com/Kong/go-database-reconciler/blob/main/pkg/file/kong_json_schema.json)
-* [decK documentation](/deck/latest/)
-* [Using decK with {{site.ee_product_name}}](/deck/latest/guides/kong-enterprise/)


### PR DESCRIPTION
### Description

decK is not meant for DB-less mode, since it uses the Admin API to manage configs. There was some inaccurate info in the docs about this, suggesting that decK _can_ be used for DB-less. Removing that and adding a note on the difference between declarative and decK config.

Issue reported on Slack.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

