### PR TITLE
Fix: Upgrade guide include links

### DIFF
--- a/app/_includes/md/gateway/db-less-upgrade.md
+++ b/app/_includes/md/gateway/db-less-upgrade.md
@@ -2,7 +2,7 @@
 In DB-less mode, each independent {{site.base_gateway}} node loads a copy of declarative {{site.base_gateway}} 
 configuration data into memory without persistent database storage, so failure of some nodes doesn't spread to other nodes.
 
-Deployments in this mode should use the [rolling upgrade](/gateway/{{page.kong_version}}/upgrade/rolling-upgrade/) strategy. 
+Deployments in this mode should use the [rolling upgrade](/gateway/{{include.kong_version}}/upgrade/rolling-upgrade/) strategy. 
 You could parse the validity of the declarative YAML contents with version Y, using the `deck validate` or the `kong config parse` command.
 
 You must back up your current `kong.yaml` file before starting the upgrade.

--- a/app/_includes/md/gateway/hybrid-upgrade.md
+++ b/app/_includes/md/gateway/hybrid-upgrade.md
@@ -26,7 +26,7 @@ CP nodes must be upgraded before DP nodes. CP nodes serve an admin-only role and
 So, you can select from the same upgrade strategies nominated for traditional mode (dual-cluster or in-place), 
 as described in figure 2 and figure 3 respectively.
 
-Upgrading the CP nodes using the [dual-cluster strategy](/gateway/{{page.kong_version}}/upgrade/dual-cluster/):
+Upgrading the CP nodes using the [dual-cluster strategy](/gateway/{{include.kong_version}}/upgrade/dual-cluster/):
 
 {% mermaid %}
 flowchart TD
@@ -56,7 +56,7 @@ flowchart TD
 > _Figure 2: The diagram shows a CP upgrade using the dual-cluster strategy._
 _The new CP Y is deployed alongside the current CP X, while current DP nodes X are still serving API requests._
 
-Upgrading the CP nodes using the [in-place strategy](/gateway/{{page.kong_version}}/upgrade/in-place/):
+Upgrading the CP nodes using the [in-place strategy](/gateway/{{include.kong_version}}/upgrade/in-place/):
 
 {% mermaid %}
 flowchart 
@@ -98,8 +98,8 @@ Once the CP nodes are upgraded, you can move on to upgrade the DP nodes.
 The only supported upgrade strategy for DP upgrades is the rolling upgrade.
 The following diagrams, figure 4 and 5, are the counterparts of figure 2 and 3 respectively. 
 
-Using the [dual-cluster strategy](/gateway/{{page.kong_version}}/upgrade/dual-cluster/) with a 
-[rolling upgrade](/gateway/{{page.kong_version}}/upgrade/rolling-upgrade/) workflow:
+Using the [dual-cluster strategy](/gateway/{{include.kong_version}}/upgrade/dual-cluster/) with a 
+[rolling upgrade](/gateway/{{include.kong_version}}/upgrade/rolling-upgrade/) workflow:
 
 {% mermaid %}
 flowchart TD
@@ -145,8 +145,8 @@ flowchart TD
 _The new CP Y is deployed alongside with the current CP X, while current DP nodes X are still serving API requests._
 _In the image, the background color of the current database and CP X is grey instead of white, signaling that the old CP is already upgraded and might have been decommissioned._
 
-Using the [in-place strategy](/gateway/{{page.kong_version}}/upgrade/in-place/) 
-strategy with a [rolling upgrade](/gateway/{{page.kong_version}}/upgrade/rolling-upgrade/) workflow:
+Using the [in-place strategy](/gateway/{{include.kong_version}}/upgrade/in-place/) 
+strategy with a [rolling upgrade](/gateway/{{include.kong_version}}/upgrade/rolling-upgrade/) workflow:
 
 {% mermaid %}
 flowchart 

--- a/app/_includes/md/gateway/upgrade-backup.md
+++ b/app/_includes/md/gateway/upgrade-backup.md
@@ -4,7 +4,7 @@ Always back up your database or declarative configuration files before an upgrad
 
 There are two main types of backup for {{site.base_gateway}} entities:
 * **Database backup**: PostgreSQL has native exporting and importing tools that are reliable and performant, and that ensure consistency when backing up or restoring data. If you're running {{site.base_gateway}} in traditional or hybrid mode, you should always take a database-native backup.
-* **Declarative backup**: Kong ships two declarative backup tools: [decK](/deck/) and the [Kong CLI](/gateway/{{page.kong_version}}/reference/cli/), which support managing {{site.base_gateway}} entities in the declarative format.
+* **Declarative backup**: Kong ships two declarative backup tools: [decK](/deck/) and the [Kong CLI](/gateway/{{include.kong_version}}/reference/cli/), which support managing {{site.base_gateway}} entities in the declarative format.
 For traditional and hybrid mode deployments, use these tools to create secondary backups. For DB-less mode deployments, use the Kong CLI and manually manage declarative configuration files.
 
 We highly recommend backing up your data using both methods if possible, as this offers you recovery flexibility. 
@@ -13,6 +13,6 @@ The database-native tools are robust and can restore data instantly compared to 
 In case of data corruption, try to do a database-level restore first. 
 Otherwise, bootstrap a new database and use declarative tools to restore configuration from backup files.
 
-Review the [Backup and Restore](/gateway/{{page.kong_version}}/upgrade/backup-and-restore/) guide to 
+Review the [Backup and Restore](/gateway/{{include.kong_version}}/upgrade/backup-and-restore/) guide to 
 prepare backups of your configuration.
 If you run into any issues and need to roll back, you can also reference that guide to restore your old data store.

--- a/app/_src/gateway/upgrade/index.md
+++ b/app/_src/gateway/upgrade/index.md
@@ -48,10 +48,10 @@ Now, let's move on to preparation, starting with determining your upgrade path.
 {{site.base_gateway}} adheres to [semantic versioning](https://semver.org/), which makes a
 distinction between major, minor, and patch versions.
 
-The upgrade to 3.0.x is a **major** upgrade.
+The upgrade from 2.x to 3.x is a **major** upgrade.
 The lowest version that {{site.base_gateway}} 3.0.x supports migrating from is 2.1.x.
 
-{{site.base_gateway}} does not support directly upgrading from 1.x to 3.0.x.
+{{site.base_gateway}} does not support directly upgrading from 1.x to 3.x.
 If you are running 1.x, upgrade to 2.1.0 first at a minimum, then upgrade to 3.0.x from there.
 
 While you can upgrade directly to the latest version, be aware of any
@@ -195,7 +195,7 @@ The following table outlines various upgrade path scenarios to {{page.kong_versi
 
 ## Preparation: Choose a backup strategy
 
-{% include_cached /md/gateway/upgrade-backup.md %}
+{% include_cached /md/gateway/upgrade-backup.md kong_version=page.kong_version %}
 
 ## Preparation: Choose an upgrade strategy based on deployment mode
 
@@ -237,11 +237,11 @@ If you must use this strategy, only use it to upgrade between patch versions.
 
 ### DB-less mode
 
-{% include_cached /md/gateway/db-less-upgrade.md %}
+{% include_cached /md/gateway/db-less-upgrade.md kong_version=page.kong_version %}
 
 ### Hybrid mode
 
-{% include_cached /md/gateway/hybrid-upgrade.md %}
+{% include_cached /md/gateway/hybrid-upgrade.md kong_version=page.kong_version %}
 
 #### Upgrades from 3.1.0.0 or 3.1.1.1
 

--- a/app/_src/gateway/upgrade/lts-upgrade.md
+++ b/app/_src/gateway/upgrade/lts-upgrade.md
@@ -59,7 +59,7 @@ Now, let's move on to preparation, starting with your backup options.
 
 ## Preparation: Choose a backup strategy
 
-{% include_cached /md/gateway/upgrade-backup.md %}
+{% include_cached /md/gateway/upgrade-backup.md kong_version=page.kong_version %}
 
 ## Preparation: Choose an upgrade strategy based on deployment mode
 
@@ -113,11 +113,11 @@ keeping in mind the additional resources and complexities.
 
 ### DB-less mode
 
-{% include_cached /md/gateway/db-less-upgrade.md %}
+{% include_cached /md/gateway/db-less-upgrade.md kong_version=page.kong_version %}
 
 ### Hybrid mode
 
-{% include_cached /md/gateway/hybrid-upgrade.md %}
+{% include_cached /md/gateway/hybrid-upgrade.md kong_version=page.kong_version %}
 
 ## Preparation: Review gateway changes
 


### PR DESCRIPTION
### Description

When using page variables in include, you're supposed to declare them as `include.kong_version` instead of `page.kong_version`. 
Forgot to convert these variables when I turned the reused sections into includes, so the links aren't getting cached correctly.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

