### PR TITLE
Add link to `Catalog` to OAS pages

### DIFF
--- a/app/_assets/javascripts/views/SpecView.vue
+++ b/app/_assets/javascripts/views/SpecView.vue
@@ -136,6 +136,10 @@ function initActiveProductVersionId () {
   top: var(--spacing-xl);
 }
 
+.breadcrumbs :deep(.k-breadcrumbs .k-breadcrumbs-item .k-breadcrumb-divider) {
+  line-height: 0;
+}
+
 .sidebar-wrapper {
   flex: 0 0 auto;
   position: sticky;

--- a/app/_assets/javascripts/views/SpecView.vue
+++ b/app/_assets/javascripts/views/SpecView.vue
@@ -60,11 +60,12 @@ const state = reactive({ activeOperation });
 const productError = ref(null);
 const deprecatedProductVersion = ref(false);
 
-const breadcrumbs = [{
-  key: 'product-catalog',
-  to: '/api/',
-  text: 'Catalog'
-}]
+const breadcrumbs = computed(() => {
+  return [
+    { key: 'product-catalog', to: '/api/', text: 'Catalog' },
+    { key: 'api-product', title: product.value.name, text: product.value.name }
+  ];
+});
 
 function onOperationSelected(event) {
   activeOperation.value = event;

--- a/app/_assets/javascripts/views/SpecView.vue
+++ b/app/_assets/javascripts/views/SpecView.vue
@@ -23,6 +23,11 @@
           class="deprecated-warning"
           alert-message="This product version is now deprecated. The endpoints will remain fully usable until this version is sunsetted."
         />
+
+        <div class="swagger-ui has-sidebar breadcrumbs">
+          <KBreadcrumbs :items="breadcrumbs" />
+        </div>
+
         <Spec
           :product="product"
           :product-version-id="activeProductVersionId"
@@ -54,6 +59,12 @@ const activeOperation = ref(null);
 const state = reactive({ activeOperation });
 const productError = ref(null);
 const deprecatedProductVersion = ref(false);
+
+const breadcrumbs = [{
+  key: 'product-catalog',
+  to: '/api/',
+  text: 'Catalog'
+}]
 
 function onOperationSelected(event) {
   activeOperation.value = event;
@@ -117,6 +128,13 @@ function initActiveProductVersionId () {
 .app-container {
   display: flex;
 }
+
+.app-container .breadcrumbs {
+  position: relative;
+  left: var(--spacing-xl);
+  top: var(--spacing-xl);
+}
+
 .sidebar-wrapper {
   flex: 0 0 auto;
   position: sticky;


### PR DESCRIPTION
### Description

[Jira ticket](https://konghq.atlassian.net/browse/DOCU-3581)

Add link to `Catalog` to OAS pages.

### Testing instructions

OAS pages now render a link back to the catalog

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
* https://deploy-preview-6643--kongdocs.netlify.app/konnect/api/runtime-groups-configuration/latest/
* https://deploy-preview-6643--kongdocs.netlify.app/konnect/api/portal-rbac/latest/
* https://deploy-preview-6643--kongdocs.netlify.app/gateway/api/admin-ee/latest/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

