### PR TITLE
fix: add missing `X-Kong-Request-Debug-Token` header of request-debug docs

### DIFF
--- a/app/_src/gateway/production/debug-request.md
+++ b/app/_src/gateway/production/debug-request.md
@@ -57,7 +57,7 @@ If the `X-Kong-Request-Debug-Log` header is set to true, timing information will
 
 ### X-Kong-Request-Debug-Token header
 
-Token for authenticating the client and making the debug request to prevent abuse. Debug requests originating from loopback addresses do not require this header.
+The `X-Kong-Request-Debug-Token` is a token for authenticating the client and making the debug request to prevent abuse. Debug requests originating from loopback addresses don't require this header.
 
 
 ## Debug request example 

--- a/app/_src/gateway/production/debug-request.md
+++ b/app/_src/gateway/production/debug-request.md
@@ -55,6 +55,11 @@ If this header isn't present or contains an unknown value, timing information wi
 
 If the `X-Kong-Request-Debug-Log` header is set to true, timing information will also be logged in the {{site.base_gateway}} error log with a log level of `notice`. By default, the `X-Kong-Request-Debug-Log` header is set to `false`. The log line will have the `[request-debug]` prefix to aid in searching.
 
+### X-Kong-Request-Debug-Token header
+
+Token for authenticating the client and making the debug request to prevent abuse. Debug requests originating from loopback addresses do not require this header.
+
+
 ## Debug request example 
 
 The following is an example debug request:

--- a/app/_src/gateway/production/debug-request.md
+++ b/app/_src/gateway/production/debug-request.md
@@ -22,7 +22,7 @@ request_debug = on | off # enable or disable request debugging
 request_debug_token <token> # Set debug token explicitly. Otherwise, it will be generated randomly when Kong starts, restarts, and reloads. 
 ```
 
-The usage of debug token (`request-debug-token`) prevents abuse of the feature as only authorozied personnel are able to issue debug requests. 
+The usage of debug token (`request-debug-token`) prevents abuse of the feature as only authorized personnel are able to issue debug requests. 
 
 You can find the debug token in the following locations:
 * **{{site.base_gateway}} error log:** The debug token is logged in the error log (notice level) when {{site.base_gateway}} starts, restarts, or reloads. The log line will have the `[request-debug]` prefix to aid in searching.


### PR DESCRIPTION
### Description

The header `X-Kong-Request-Debug-Token` of the request-debug feature of Gateway is missing.

_[KAG-3365]_

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->



[KAG-3365]: https://konghq.atlassian.net/browse/KAG-3365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ