### PR TITLE
Make port 8100 consistent in all examples

### DIFF
--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -59,7 +59,7 @@ Once you've enabled the Node Readiness endpoint, you can send a GET request to c
 # Replace `localhost:8001` with the appropriate host and port for
 # your Status API server
 
-curl -i http://localhost:8001/status/ready
+curl -i http://localhost:8100/status/ready
 ```
 
 If the response code is `200`, the {{site.base_gateway}} instance is ready to serve requests:


### PR DESCRIPTION
Port 8001 is used in the example curl command, but port 8100 is the one used in the rest of the documentation. Changing curl port to 8100.


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

