### PR TITLE
Use extn_slug when setting name for non-bundled plugins

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -47,9 +47,9 @@ breadcrumbs:
     <summary style="cursor:pointer;"><strong>This plugin is not enabled by default</strong>. Click here for instructions to enable it &nbsp;&nbsp;⬇️</summary>
 
     <ul>
-      <li>Package install: Set <strong>plugins=bundled,{{ page.name }}</strong> in <strong>kong.conf</strong> before starting Kong</li>
-      <li>Docker: Set <strong>KONG_PLUGINS=bundled,{{ page.name }}</strong> in the environment</li>
-      <li>Kubernetes: Set <strong>KONG_PLUGINS=bundled,{{ page.name }}</strong> using <a href="/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/#modify-configuration">these instructions</a></li>
+      <li>Package install: Set <strong>plugins=bundled,{{ page.extn_slug }}</strong> in <strong>kong.conf</strong> before starting Kong</li>
+      <li>Docker: Set <strong>KONG_PLUGINS=bundled,{{ page.extn_slug }}</strong> in the environment</li>
+      <li>Kubernetes: Set <strong>KONG_PLUGINS=bundled,{{ page.extn_slug }}</strong> using <a href="/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/#modify-configuration">these instructions</a></li>
     </ul>
     </details>
   </blockquote>


### PR DESCRIPTION
### Description

The `page.name` does not contain the plugin name to add to `KONG_PLUGINS` when enabling non-bundled plugins. `extn_slug` contains the correct name

![CleanShot 2023-12-15 at 20 59 39](https://github.com/Kong/docs.konghq.com/assets/59130/59acf9e1-b360-40ca-ace8-bd685a8865c5)

### Testing instructions

Preview link: /hub/kong-inc/app-dynamics/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)
