### PR TITLE
Add a `Deprecated` section to the OAS Catalog page

### DIFF
--- a/app/_assets/stylesheets/pages/landing-oas.less
+++ b/app/_assets/stylesheets/pages/landing-oas.less
@@ -4,6 +4,11 @@
     font-size: 30px;
   }
 
+  .feature-title-oas-deprecated {
+    text-align: left;
+    padding: 20px 0;
+  }
+
   .card.default {
     .title {
       align-self: start;

--- a/app/_includes/oas/card.html
+++ b/app/_includes/oas/card.html
@@ -1,0 +1,27 @@
+<div class="card default">
+  <div class="title">
+    <a href="{{ include.oas_page.canonical_url }}">
+      {{ include.oas_page.product.title }}
+    </a>
+  </div>
+  <hr>
+  <div class="description">
+    <span>{{ include.oas_page.description }}</span>
+  </div>
+  <hr>
+
+  <div class="links-container">
+    <div class="spec-links">
+    <span>Latest Version: {{ include.oas_page.product.latest_version }}</span>
+    <a href="{{ include.oas_page.canonical_url }}" class="link-text">
+      Specification
+      <img src="/assets/images/icons/icn-arrow-right.svg" alt="link to {{ include.oas_page.product.title }} specification">
+    </a>
+    </div>
+    {% if include.oas_page.insomnia_link %}
+    <div class="insomnia-link">
+      <a href="{{ include.oas_page.insomnia_link }}" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>
+    </div>
+    {% endif %}
+  </div>
+</div>

--- a/app/_layouts/oas/index.html
+++ b/app/_layouts/oas/index.html
@@ -15,34 +15,20 @@ layout: default
 
     <section class="features">
       <div class="cards-container">
-        {% for oas_page in site.data.ssg_oas_pages %}
-        <div class="card default">
-          <div class="title">
-            <a href="{{ oas_page.canonical_url }}">
-              {{ oas_page.product.title }}
-            </a>
-          </div>
-          <hr>
-          <div class="description">
-            <span>{{ oas_page.description }}</span>
-          </div>
-          <hr>
+        {% assign oas_pages = site.data.ssg_oas_pages | where_exp: "oas_page", "oas_page.product.deprecated? == false" %}
+        {% for oas_page in oas_pages %}
+          {% include oas/card.html oas_page=oas_page %}
+        {% endfor %}
+      </div>
+    </section>
 
-          <div class="links-container">
-            <div class="spec-links">
-            <span>Latest Version: {{ oas_page.product.latest_version }}</span>
-            <a href="{{ oas_page.canonical_url }}" class="link-text">
-              Specification
-              <img src="/assets/images/icons/icn-arrow-right.svg" alt="link to {{ oas_page.product.title }} specification">
-            </a>
-            </div>
-            {% if oas_page.insomnia_link %}
-            <div class="insomnia-link">
-              <a href="{{ oas_page.insomnia_link }}" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>
-            </div>
-            {% endif %}
-          </div>
-        </div>
+
+    <h4 class="feature-title feature-title-oas feature-title-oas-deprecated">Deprecated</h4>
+    <section class="features">
+      <div class="cards-container">
+        {% assign deprecated_oas_pages = site.data.ssg_oas_pages | where_exp: "oas_page", "oas_page.product.deprecated?" %}
+        {% for oas_page in deprecated_oas_pages %}
+          {% include oas/card.html oas_page=oas_page %}
         {% endfor %}
       </div>
     </section>

--- a/app/_plugins/drops/oas/product.rb
+++ b/app/_plugins/drops/oas/product.rb
@@ -27,6 +27,14 @@ module Jekyll
         def as_json
           { id: }
         end
+
+        def deprecated?
+          version = @product.fetch('versions', []).detect do |v|
+            v.fetch('name') == latest_version
+          end
+
+          version&.fetch('deprecated')
+        end
       end
     end
   end


### PR DESCRIPTION
### Description

Related [Jira ticket](https://konghq.atlassian.net/browse/DOCU-3608)
 
Add a `Deprecated` section to the OAS Catalog page

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

