### PR TITLE
Add aria-labels to buttons

### DIFF
--- a/app/_includes/sidebar/item.html
+++ b/app/_includes/sidebar/item.html
@@ -20,7 +20,7 @@
       {% include_cached sidebar/item_label.html icon=include.item.icon label=include.item.label items_size=include.item.items.size %}
 
         {% if include.item.items.size > 0 %}
-          <button class="sidebar-tree-toggle">
+          <button class="sidebar-tree-toggle" aria-label="toggle {{ include.item.label }} subtree">
             <i class="fa fa-chevron-down"></i>
           </button>
         {% endif %}


### PR DESCRIPTION
### Description

Quick follow-up to https://github.com/Kong/docs.konghq.com/pull/6657
Adds `aria-labels` to the buttons

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

