### PR TITLE
(chore) Add Mesh and KIC variables

### DIFF
--- a/app/contributing/variables.md
+++ b/app/contributing/variables.md
@@ -23,6 +23,8 @@ Variable | Output | Definition
 {% raw %}`{{site.ce_product_name}}`{% endraw %} | {{site.ce_product_name}} | Kong's open-source API gateway. Use when referring to something that's _only_ available in open-source.
 {% raw %}`{{site.konnect_product_name}}`{% endraw %}| {{site.konnect_product_name}} | The full name of Kong Konnect.
 {% raw %}`{{site.konnect_short_name}}`{% endraw %} | {{site.konnect_short_name}} | The short name of the SaaS Konnect control plane.
+{% raw %}`{{site.mesh_product_name}}`{% endraw %} | {{site.mesh_product_name}}| The enterprise product offering built on top of CNCF's Kuma.
+{% raw %}`{{site.kic_product_name}}`{% endraw %} | {{site.kic_product_name}}| The Kong Ingress Controller (KIC) for Kubernetes.
 {% raw %}`{{site.company_name}}`{% endraw %} | {{site.company_name}} | The name of the company. <br><br> Sometimes "Kong" is used to refer to Kong Gateway. For branding reasons, we should avoid using this term to refer to Kong Gateway going forward, however, user communities will continue to use this term as shorthand.
 
 ## Links


### PR DESCRIPTION
### Description

I noticed while reviewing https://github.com/Kong/docs.konghq.com/pull/6224 that we have Mesh and KIC product variables, so adding those to the contribution guide. 

### Testing instructions

Preview link: https://deploy-preview-6676--kongdocs.netlify.app/contributing/variables/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

