### PR TITLE
doc(kic) add reference grant guide

### DIFF
--- a/app/_data/docs_nav_kic_3.0.x.yml
+++ b/app/_data/docs_nav_kic_3.0.x.yml
@@ -111,6 +111,8 @@ items:
             url: /guides/services/https-redirect
           - text: Multiple Backend Services
             url: /guides/services/multiple-backends
+          - text: Configuring Gateway API resources across namespaces
+            url: /guides/services/cross-namespace
       - text: Request Manipulation
         items:
           - text: Rewriting Hosts and Paths

--- a/app/_src/kubernetes-ingress-controller/guides/services/cross-namespace.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/cross-namespace.md
@@ -1,0 +1,141 @@
+---
+title: Configuring Gateway API resources across namespaces
+type: how-to
+purpose: |
+  Attach an HTTPRoute to a Gateway and Service that reside in different
+  namespaces.
+---
+
+Unlike Ingress, Gateway API routing resources and use Services in another
+namespace if the Service's namespace permits it. This guide shows how to create
+an HTTPRoute in one namespace that routes to a Service in another, bound to a
+Gateway in a third namespace.
+
+{% include /md/kic/prerequisites.md kong_version=page.kong_version disable_gateway_api=false %}
+
+## Create namespaces and allow references
+
+1. Create separate namespaces to hold the HTTPRoute and target Service:
+   ```bash
+   kubectl create namespace test-source; kubectl create namespace test-destination
+   ```
+   The results should look like this:
+   ```text
+   namespace/test-source created
+   namespace/test-destination created
+   ```
+
+1. Create [a ReferenceGrant resource](https://gateway-api.sigs.k8s.io/api-types/referencegrant/)
+   in the destination namespace:
+
+   ```bash
+   echo 'kind: ReferenceGrant
+   apiVersion: gateway.networking.k8s.io/v1beta1    
+   metadata:                                    
+     name: test-grant
+     namespace: test-destination
+   spec:                        
+     from:
+     - group: gateway.networking.k8s.io
+       kind: HTTPRoute                 
+       namespace: test-source
+     to:                     
+     - group: ""
+       kind: Service
+   ' | kubectl create -f -
+   ```
+
+   The results should look like this:
+   ```text
+   referencegrant.gateway.networking.k8s.io/test-grant created
+   ```
+
+ReferenceGrants allow namespaces to opt in to references from other resources.
+They reside in the namespace of the target resource and list resources and
+namespaces that can talk to specific resources in the ReferenceGrant's
+namespace. The above example allows HTTPRoutes in the `test-source` namespace
+to reference Services in the `test-destination` namespace.
+
+## Update Gateway allowed routes
+
+Gateway resources may also allow references from resources (HTTPRoute,
+TCPRoute, etc.) in other namespaces. However, these references _do not_ use
+ReferenceGrants, as they are defined per listener, not for the entire Gateway.
+A listener's [`allowedRoutes` field](https://gateway-api.sigs.k8s.io/concepts/security-model/#1-route-binding)
+lets you define where routing resources can bind to that listener.
+
+The default Gateway in this guide only allows routes from its same namespace
+(`default`). You'll need to expand its scope to allow routes from the
+`test-source` namespace:
+
+```bash
+kubectl patch --type=json gateways.gateway.networking.k8s.io kong -p='[{"op":"replace","path": "/spec/listeners/0/allowedRoutes/namespaces/from","value":"All"}]'
+```
+
+The results should look like this:
+```text
+gateway.gateway.networking.k8s.io/kong patched
+```
+
+Listeners can allow routes in their own (`from: Same`), any (`from: Any`), or a
+labeled set of namespaces (`from: Selector`).
+
+## Deploy a Service and HTTPRoute
+
+1. Deploy an echo Services to the `test-destination` resource:
+   ```bash
+   kubectl apply -f {{site.links.web}}/assets/kubernetes-ingress-controller/examples/echo-service.yaml -n test-destination
+   ```
+   The results should look like this:
+   ```text
+   service/echo created
+   deployment.apps/echo created
+   ```
+
+1. Deploy a HTTPRoute that sends traffic to both the services. By default, traffic is distributed evenly across all services:
+
+   ```bash
+   echo 'apiVersion: gateway.networking.k8s.io/v1
+   kind: HTTPRoute
+   metadata:
+     name: echo
+     namespace: test-source
+     annotations:
+       konghq.com/strip-path: "true"
+   spec:
+     parentRefs:
+     - name: kong
+       namespace: default
+     rules:
+     - matches:
+       - path:
+           type: PathPrefix
+           value: /echo
+       backendRefs:
+       - name: echo
+         kind: Service
+         port: 1027
+         namespace: test-destination
+   ' | kubectl apply -f -
+   ```
+   The results should look like this:
+   ```text
+   httproute.gateway.networking.k8s.io/echo created
+   ```
+
+   Note the `namespace` fields in both the parent and backend references. By
+   default, entries here attempt to use the same namespace as the HTTPRoute if
+   you do not specify a namespace.
+
+1. Send requests through the route:
+
+   ```bash
+   curl -s "$PROXY_IP/echo"
+   ```
+   The results should look like this:
+   ```text
+   Welcome, you are connected to node kind-control-plane.
+   Running on Pod echo-965f7cf84-z9jv2.
+   In namespace test-destination.
+   With IP address 10.244.0.6.
+   ```


### PR DESCRIPTION
### Description

For https://github.com/Kong/kubernetes-ingress-controller/issues/5154
 
Add a guide that covers using Gateway API resources with KIC across namespaces, including references to a Gateway from another namespace using listener allowedRoutes and references from an HTTPRoute to a Service in another namespace using a ReferenceGrant.

### Testing instructions

Preview link: https://deploy-preview-6677--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/services/cross-namespace/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)