### PR TITLE
(chore) correct port number in readiness check

### DIFF
--- a/app/_src/gateway/production/monitoring/readiness-check.md
+++ b/app/_src/gateway/production/monitoring/readiness-check.md
@@ -56,7 +56,7 @@ status_listen = 0.0.0.0:8100
 Once you've enabled the Node Readiness endpoint, you can send a GET request to check the readiness of your {{site.base_gateway}} instance:
 
 ```sh
-# Replace `localhost:8001` with the appropriate host and port for
+# Replace `localhost:8100` with the appropriate host and port for
 # your Status API server
 
 curl -i http://localhost:8100/status/ready


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-6690--kongdocs.netlify.app/gateway/latest/production/monitoring/readiness-check/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

