### PR TITLE
feat: support Debian 12

### DIFF
--- a/app/_data/tables/support/gateway/packages.yml
+++ b/app/_data/tables/support/gateway/packages.yml
@@ -72,6 +72,13 @@ _packages:
     arm: false
     fips: false
     graviton: false
+  debian12: &debian12
+    os: Debian
+    version: 12
+    package: true
+    arm: false
+    fips: false
+    graviton: false
   debian-stable: &debian-stable
     os: Debian
     version: stable

--- a/app/_data/tables/support/gateway/versions/35.yml
+++ b/app/_data/tables/support/gateway/versions/35.yml
@@ -18,6 +18,10 @@ distributions:
     docker: true
     arm: true
     graviton: true
+  - <<: *debian12
+    docker: true
+    arm: true
+    graviton: true
   - *rhel7
   - <<: *rhel8
     docker: false


### PR DESCRIPTION
### Description

Support Debian 12 in Gateway 3.5.

Related kong-ee PR: kong/kong-ee#7673

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

KAG-3015

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

