### PR TITLE
Fix: Spacing on gateway overview page

### DIFF
--- a/app/_src/gateway/index.md
+++ b/app/_src/gateway/index.md
@@ -174,21 +174,23 @@ Here are some of the things you can do with Kong Manager:
 * Activate or deactivate plugins with a couple of clicks
 * Group your teams, services, plugins, consumer management, and everything else
 exactly how you want them
-{% if_version lte:3.4.x %}
+{%- if_version lte:3.4.x -%}
 * Monitor performance: visualize cluster-wide, workspace-level, or
 object-level health using intuitive, customizable dashboards
+{% endif_version %}
 
+{% if_version lte:3.4.x %}
 ### Kong Dev Portal
 {:.badge .enterprise}
 
 [Kong Dev Portal](/gateway/{{page.kong_version}}/kong-enterprise/dev-portal/) is used to onboard new developers and to generate API documentation, create custom pages, manage API versions, and secure developer access.
-
 
 ### Kong Vitals
 {:.badge .enterprise}
 
 [Kong Vitals](/gateway/{{page.kong_version}}/kong-enterprise/analytics/) provides useful metrics about the health and performance of your {{site.base_gateway}} nodes, as well as metrics about the usage of your proxied APIs. You can visually monitor vital signs and pinpoint anomalies in real-time, and use visual API analytics to see exactly how your APIs and Gateway are performing and access key statistics. Kong Vitals is part of the Kong Manager UI.
 {% endif_version %}
+
 ### Kubernetes
 
 {{site.base_gateway}} can run natively on Kubernetes with its custom [ingress controller](/kubernetes-ingress-controller/), Helm chart, and Operator. A Kubernetes ingress controller is a proxy that exposes Kubernetes services from applications (for example, Deployments, ReplicaSets) running on a Kubernetes cluster to client applications running outside of the cluster. The intent of an ingress controller is to provide a single point of control for all incoming traffic into the Kubernetes cluster.


### PR DESCRIPTION
### Description

`if_version` tags aren't spaced out correctly, so they're causing the following issues:

3.5:
![Screenshot 2024-01-02 at 9 46 10 AM](https://github.com/Kong/docs.konghq.com/assets/54370747/538c4d26-510e-4b07-ba39-f4321d7c33e7)

3.4 and earlier:
![Screenshot 2024-01-02 at 9 45 55 AM](https://github.com/Kong/docs.konghq.com/assets/54370747/eaa019ac-e6bf-4242-8686-8701161a7be5)

Fixing by splitting out `if_version` tags, so that they don't encompass part of a still-existing section. The previous approach is harder to maintain + causes these spacing issues.

### Testing instructions

Preview link: check the Gateway overview page on 3.5 and 3.4.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

