### PR TITLE
fix: fixed link to kong prometheus plugin reference

### DIFF
--- a/app/_src/gateway/production/monitoring/prometheus.md
+++ b/app/_src/gateway/production/monitoring/prometheus.md
@@ -112,7 +112,7 @@ will begin to scrape metrics data from {{site.base_gateway}}.
    ...
    ```
 
-   See the [Kong Prometheus Plugin documentation](https://docs.konghq.com/hub/kong-inc/prometheus/)
+   See the [Kong Prometheus Plugin documentation](/hub/kong-inc/prometheus/)
    for details on the available metrics and configurations.
 
 1. Prometheus provides multiple ways to query collected metric data. 

--- a/app/_src/gateway/production/monitoring/prometheus.md
+++ b/app/_src/gateway/production/monitoring/prometheus.md
@@ -112,7 +112,7 @@ will begin to scrape metrics data from {{site.base_gateway}}.
    ...
    ```
 
-   See the [Kong Prometheus Plugin documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration://docs.konghq.com/hub/kong-inc/prometheus/)
+   See the [Kong Prometheus Plugin documentation](https://docs.konghq.com/hub/kong-inc/prometheus/)
    for details on the available metrics and configurations.
 
 1. Prometheus provides multiple ways to query collected metric data. 


### PR DESCRIPTION
### Description

The link to prometheus plugin link was incorrect, hence fixed it
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

