### PR TITLE
Set `cloneSubmodules` to true in renovate's config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
   "labels": [
     "review:tech"
   ],
+  "cloneSubmodules": true,
   "packageRules": [
     {
       "groupName": "Non-major dependencies",


### PR DESCRIPTION
### Description

One dependency is shared with Kuma and lives in the submodule. This causes Renovate to fail to update our ruby dependencies because the submodules aren't cloned by default. Setting this config to true should fix the issue
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

