### PR TITLE
 Fix KIC TLS Termination guide

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/services/tls.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tls.md
@@ -20,7 +20,7 @@ For `HTTPRoute` or `GRPCRoute`, the route's `hostname` must match the listener h
 
 ## Ingress
 
-The Ingress API supports TLS temination using the `.spec.tls` field. To terminate TLS with the Ingress API, provide `.spec.tls.secretName` that contains a TLS certificate and a list of `.spec.tls.hosts` to match in your Ingress definition. 
+The Ingress API supports TLS termination using the `.spec.tls` field. To terminate TLS with the Ingress API, provide `.spec.tls.secretName` that contains a TLS certificate and a list of `.spec.tls.hosts` to match in your Ingress definition. 
 
 ## Examples
 

--- a/app/_src/kubernetes-ingress-controller/guides/services/tls.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tls.md
@@ -49,7 +49,10 @@ The Ingress API supports TLS temination using the `.spec.tls` field. To terminat
         protocol: HTTPS
         hostname: "demo.example.com"
         tls:
-          mode: Passthrough
+          mode: Terminate
+          certificateRefs:
+            - kind: Secret
+              name: demo-example-com-cert
     ```
 
 2. Bind a `HTTPRoute` to the `Gateway`.
@@ -130,13 +133,10 @@ The Ingress API supports TLS temination using the `.spec.tls` field. To terminat
       listeners:
       - name: https
         port: 443
-        protocol: HTTPS
+        protocol: TLS
         hostname: "demo.example.com"
         tls:
           mode: Passthrough
-          certificateRefs:
-          - kind: Secret
-            name: example-com
     ```
 
 2. Bind a `TLSRoute` to the `Gateway`.


### PR DESCRIPTION
### Description

Fix the Passthrough/Terminate examples for TLS with Gateway API + KIC

### Testing instructions

Preview link: /kubernetes-ingress-controller/latest/guides/services/tls/#tls-termination

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)