### PR TITLE
fix: Update label on generate OAS action

### DIFF
--- a/.github/workflows/sync-konnect-oas-data.yml
+++ b/.github/workflows/sync-konnect-oas-data.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           title: Sync Konnect OAS Data
           commit-message: Sync Konnect OAS Data
-          labels: 'review:tech'
+          labels: skip-changelog,review:general
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
I noticed I have to manually add the label every time and I think this might fix that. I also added the `skip-changelog` label. 