### PR TITLE
Update: custom_fields_by_lua precedence in logging plugins

### DIFF
--- a/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
+++ b/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
@@ -16,6 +16,27 @@ curl -i -X POST http://localhost:8001/plugins \
   --data config.custom_fields_by_lua.header="return kong.request.get_header('h1')"
 ```
 
+### Plugin precedence and managing fields
+
+All logging plugins use the same table for logging. 
+If you set `custom_fields_by_lua` in one plugin, all logging plugins that execute after that plugin will also use the same configuration. 
+For example, if you configure fields via `custom_fields_by_lua` in [File Log](/hub/kong-inc/file-log/), those same fields will appear in [Kafka Log](/hub/kong-inc/kafka-log/), since File Log executes first.
+
+If you want all logging plugins to use the same configuration, we recommend using the [Pre-function](/hub/kong-inc/pre-function/) plugin to call [kong.log.set_serialize_value](/gateway/latest/plugin-development/pdk/kong.log/#konglogset_serialize_valuekey-value-options) so that the function is applied predictably and is easier to manage.
+
+If you **don't** want all logging plugins to use the same configuration, you need to manually disable the relevant fields in each plugin. 
+
+For example, if you configure a field in File Log that you don't want appearing in Kafka Log, set that field to `return nil` in the Kafka Log plugin:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins/ \
+...
+  --data config.name=kafka-log \
+  --data config.custom_fields_by_lua.my_file_log_field="return nil"
+```
+
+See the [plugin execution order reference](/gateway/latest/plugin-development/custom-logic/#plugins-execution-order) for more details on plugin ordering.
+
 ### Limitations
 
 Lua code runs in a restricted sandbox environment, whose behavior is governed


### PR DESCRIPTION
### Description

The `custom_fields_by_lua` config field in logging plugins affects all logging plugins, not just the one you configure it for. Adding this info and a workaround to the plugin docs. 

### Testing instructions

Appears in all logging plugins. For example: https://deploy-preview-6741--kongdocs.netlify.app/hub/kong-inc/file-log/#plugin-precedence-and-managing-fields

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

