### PR TITLE
fix: do not mention default router change

### DIFF
--- a/app/_src/kubernetes-ingress-controller/reference/faq/router.md
+++ b/app/_src/kubernetes-ingress-controller/reference/faq/router.md
@@ -8,5 +8,3 @@ purpose: |
 {{ site.kic_product_name }} supports the `traditional`, `traditional_compatible` and `expressions` {{ site.base_gateway }} routers. Set `gateway.env.router_flavor` in your `values.yaml` when installing with Helm to configure the router used.
 
 When using Gateway API resources we recommend using the `expressions` router because it supports advanced features such as query string matching, which the `traditional` and `traditional_compatible` routers do not support
-
-{{ site.kic_product_name }} 3.0 changed the default `router_flavor` from `traditional_compatible` to `expressions`. For DB-less deployments you should not notice any difference in behaviour. For DB-backed deployments, set `gateway.env.router_flavor: traditional_compatible` in your Helm values file.


### PR DESCRIPTION
### Description

We haven't changed the default router flavor in the chart so we should not mention it in the docs. For now, the change of the default is on hold.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

