### PR TITLE
fix: small update to Oauth2 warning message

### DIFF
--- a/app/_hub/kong-inc/oauth2/overview/_index.md
+++ b/app/_hub/kong-inc/oauth2/overview/_index.md
@@ -10,7 +10,7 @@ Add an OAuth 2.0 authentication layer with one of the following grant flows:
 
 {:.important}
 > **Important**: 
-* This implementation of OAuth2 in Kong is for experimental or testing purposes only and is not recommended for production environments.
+* Using Kong as an identity provider, as is supported by this plugin, is not recommended in production
 * Once applied, any user with a valid credential can access the service.
   To restrict usage to only some of the authenticated users, also add the
   [ACL](/hub/kong-inc/acl/) plugin (not covered here) and create allowed or


### PR DESCRIPTION
### Description

Change the wording on the Oauth2 plugin warning message. 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

