### PR TITLE
Add redirect for Openshift install docs for Gateway

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -99,6 +99,7 @@
 /gateway/:version/kong-plugins/algorithms/rate-limiting/      /gateway/:version/reference/rate-limiting/
 /gateway/:version/install/kubernetes/kubectl/  /gateway/:version/install/kubernetes/
 /gateway/:version/install/kubernetes/helm-quickstart/  /gateway/:version/install/kubernetes/
+/gateway/:version/install/kubernetes/openshift/  /gateway/:version/install/kubernetes/
 
 # CONTRIBUTING & STYLE GUIDE
 /contributing/plugin-docs/               /contributing/contribution-templates/


### PR DESCRIPTION
### Description

Add missing redirect for Openshift install docs

### Testing instructions

Preview link:

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)

