### PR TITLE
chore: Add nested sidenav items to plugin

### DIFF
--- a/app/_plugins/generators/plugin_single_source/pages/base.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/base.rb
@@ -3,7 +3,7 @@
 module PluginSingleSource
   module Pages
     class Base
-      attr_reader :site, :release
+      attr_reader :site, :release, :file
       attr_accessor :sidenav
 
       def initialize(release:, file:, source_path:)

--- a/app/_plugins/generators/plugin_single_source/plugin/pages_builder.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/pages_builder.rb
@@ -36,67 +36,9 @@ module PluginSingleSource
 
       def sidenav
         @sidenav ||= ::Jekyll::Drops::Sidenav.new(
-          sidenav_items,
+          Sidenav.new(@release).items,
           { 'plugin-key' => "#{@release.vendor}-#{@release.name}-#{@release.version}" }
         )
-      end
-
-      def icon
-        '/assets/images/icons/hub-layout/icn-how-to.svg'
-      end
-
-      def items_for(pages)
-        pages.flatten.compact.map { |p| { 'text' => p.nav_title, 'url' => p.permalink } }
-      end
-
-      def sidenav_items # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-        items = [
-          { 'title' => 'Introduction',
-            'items' => items_for(@release.overviews),
-            'icon' => '/assets/images/icons/hub-layout/icn-overview.svg' }
-        ]
-
-        if @release.configuration
-          items.push({
-                       'title' => @release.configuration.nav_title,
-                       'url' => @release.configuration.permalink,
-                       'icon' => '/assets/images/icons/hub-layout/icn-configuration.svg'
-                     })
-        end
-
-        if @release.configuration_examples
-          if @release.vendor == 'kong-inc'
-            items.push({
-                         'title' => 'Using the plugin',
-                         'items' => items_for([@release.configuration_examples, @release.how_tos]),
-                         'icon' => icon
-                       })
-          else
-            items.push({
-                         'title' => @release.configuration_examples.nav_title,
-                         'url' => @release.configuration_examples.permalink,
-                         'icon' => icon
-                       })
-          end
-        end
-
-        if @release.references
-          items.push({
-                       'title' => @release.references.nav_title,
-                       'url' => @release.references.permalink,
-                       'icon' => @release.references.icon
-                     })
-        end
-
-        if @release.changelog
-          items.push({
-                       'title' => @release.changelog.nav_title,
-                       'url' => @release.changelog.permalink,
-                       'icon' => @release.changelog.icon
-                     })
-        end
-
-        items
       end
     end
   end

--- a/spec/app/_plugins/generators/plugin_single_source/pages/how_to_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/how_to_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe PluginSingleSource::Pages::HowTo do
           { text: 'Authentication', url: '/hub/?category=authentication' },
           { text: 'Kong JWT Signer', url: '/hub/kong-inc/jwt-signer/' },
           { text: 'How to', url: '/hub/kong-inc/jwt-signer/how-to/' },
-          { text: 'Nested tutorial', url: '/hub/kong-inc/jwt-signer/how-to/nested/tutorial/' }
+          { text: 'Nested Tutorial Nav title', url: '/hub/kong-inc/jwt-signer/how-to/nested/tutorial/' }
         ])
       end
 

--- a/spec/fixtures/app/_hub/kong-inc/jwt-signer/how-to/_index.md
+++ b/spec/fixtures/app/_hub/kong-inc/jwt-signer/how-to/_index.md
@@ -1,4 +1,5 @@
 ---
+nav_title: Manage key signing
 ---
 ## Manage key signing
 

--- a/spec/fixtures/app/_hub/kong-inc/jwt-signer/how-to/nested/_tutorial.md
+++ b/spec/fixtures/app/_hub/kong-inc/jwt-signer/how-to/nested/_tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: Nested tutorial
-nav_title: Nested tutorial
+nav_title: Nested Tutorial Nav title
 ---
 
 # Nested Tutorial

--- a/spec/templates/plugin_with_versions_spec.rb
+++ b/spec/templates/plugin_with_versions_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe 'Plugin page with multiple versions' do
       expect(html).not_to have_css('.old-version-banner')
     end
 
+    it 'renders the sidenav' do
+      expect(html).to have_css('.docs-sidebar .sidebar-item:nth-of-type(2)', text: 'Introduction')
+      expect(html).to have_css('.docs-sidebar .sidebar-item:nth-of-type(3)', text: 'Configuration reference')
+      expect(html).to have_css('.docs-sidebar .sidebar-item:nth-of-type(4)', text: 'Using the plugin')
+      expect(html).to have_css('.docs-sidebar .sidebar-item:nth-of-type(5)', text: 'Changelog')
+
+      how_tos = html.find('.docs-sidebar .sidebar-item:nth-of-type(4)', text: 'Using the plugin')
+      expect(how_tos).to have_css('.sidebar-item:nth-of-type(1)', text: 'Basic config examples')
+      expect(how_tos).to have_css('.sidebar-item:nth-of-type(2)', text: 'Manage key signing')
+      expect(how_tos).to have_css('.sidebar-item:nth-of-type(3)', text: 'Nested')
+
+      nested_how_to = how_tos.find('.sidebar-item:nth-of-type(3)')
+      expect(nested_how_to).to have_css('.sidebar-item', text: 'Nested Tutorial Nav title')
+    end
+
     context 'plugins that are `paid` or `premium`' do
       it 'renders a banner for using the plugins in Konnect' do
         expect(html).to have_css('blockquote', text: 'Did you know that you can try this plugin without talking to anyone')


### PR DESCRIPTION
### Description

Pull in Fabian's how-to nesting edits.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

