### PR TITLE
[Plugin Hub] Position nested sidenav subitems before links

### DIFF
--- a/app/_plugins/generators/plugin_single_source/plugin/sidenav.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/sidenav.rb
@@ -29,9 +29,10 @@ module PluginSingleSource
         pages.flatten.compact.map { |p| { 'text' => p.nav_title, 'url' => p.permalink } }
       end
 
-      def nested_items(prefix, pages) # rubocop:disable Metrics/MethodLength
+      def nested_items(prefix, pages) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         pages
           .group_by { |h| Pathname.new(h.file.gsub("#{prefix}/", '')).dirname.to_s }
+          .sort_by(&:first).rotate.to_h # Process nested folders first
           .each_with_object([]) do |(folder, nested_pages), array|
             if folder == '.'
               nested_pages.map do |page|

--- a/spec/templates/plugin_with_versions_spec.rb
+++ b/spec/templates/plugin_with_versions_spec.rb
@@ -48,10 +48,10 @@ RSpec.describe 'Plugin page with multiple versions' do
 
       how_tos = html.find('.docs-sidebar .sidebar-item:nth-of-type(4)', text: 'Using the plugin')
       expect(how_tos).to have_css('.sidebar-item:nth-of-type(1)', text: 'Basic config examples')
-      expect(how_tos).to have_css('.sidebar-item:nth-of-type(2)', text: 'Manage key signing')
-      expect(how_tos).to have_css('.sidebar-item:nth-of-type(3)', text: 'Nested')
+      expect(how_tos).to have_css('.sidebar-item:nth-of-type(2)', text: 'Nested')
+      expect(how_tos).to have_css('.sidebar-item:nth-of-type(3)', text: 'Manage key signing')
 
-      nested_how_to = how_tos.find('.sidebar-item:nth-of-type(3)')
+      nested_how_to = how_tos.find('.sidebar-item:nth-of-type(2)')
       expect(nested_how_to).to have_css('.sidebar-item', text: 'Nested Tutorial Nav title')
     end
 


### PR DESCRIPTION
### Description

[Plugin Hub] Position nested sidenav subitems before links

<img width="1341" alt="Screenshot 2024-01-17 at 10 53 02" src="https://github.com/Kong/docs.konghq.com/assets/715229/d173ed8f-3613-4cea-8e90-c4efba8f8f27">


### Testing instructions

[Preview link](https://deploy-preview-6767--kongdocs.netlify.app/hub/kong-inc/openid-connect/how-to/basic-example/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

