### PR TITLE
Fix TLS parentRef when using Gateway API

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/services/tls.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tls.md
@@ -64,7 +64,7 @@ The Ingress API supports TLS termination using the `.spec.tls` field. To termina
       name: demo-example 
     spec:
       parentRefs:
-      - name: kong
+      - name: example-gateway
         sectionName: https
       hostnames:
       - demo.example.com
@@ -148,7 +148,7 @@ The Ingress API supports TLS termination using the `.spec.tls` field. To termina
       name: demo-example-passthrough
     spec:
       parentRefs:
-      - name: kong
+      - name: example-gateway
         sectionName: https
       hostnames:
       - demo.example.com


### PR DESCRIPTION
### Description

The `parentRef` for TLS HTTPRoutes was incorrectly set to `kong` rather than `example-gateway` as the guide expected. Reported by @liyangau.
 

### Testing instructions

Preview link: /kubernetes-ingress-controller/latest/guides/services/tls/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)