### PR TITLE
Add gateway-37 repo keys

### DIFF
--- a/app/_data/installation/gateway.yml
+++ b/app/_data/installation/gateway.yml
@@ -1,3 +1,7 @@
+# e.g.: https://cloudsmith.io/~kong/repos/internal-gateway-37/pub-keys/
+"37":
+  rsa_key: 4C3E847EC336BAB7
+  gpg_key: 6973875013D1931E
 "36":
   rsa_key: 6D312E174BE30B5A
   gpg_key: 1D935A6039ECFC53


### PR DESCRIPTION
### Description

With 3.5 having shipped, and 3.6 just around the corner, thought I'd get the jump on pre-creating the 3.7 Cloudsmith repos.

Sister PR to: https://github.com/Kong/gateway-docker-compose-generator/pull/133

I don't **believe** adding this now (to main) should cause any issues... @mheap ?

### Testing instructions

Preview link: https://deploy-preview-6776--kongdocs.netlify.app/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

