### PR TITLE
Update: Add admin token auth to Gateway EE spec [skip ci]

### DIFF
--- a/api-specs/Gateway-EE/3.5/kong-ee-3.5.yaml
+++ b/api-specs/Gateway-EE/3.5/kong-ee-3.5.yaml
@@ -5709,6 +5709,21 @@ components:
                 config.functions:
                   - '"functions": [             "return function (data, event, source, pid)\n  local user = data.entity.username\n  error(\"Event hook on consumer \" .. user .. \"\")\nend\n"         ]'
       description: Request body for adding a lambda event hook
+  securitySchemes:
+    kongAdminToken:
+      type: apiKey
+      in: header
+      name: Kong-Admin-Token
+      description: |
+        When RBAC is enabled, an admin token is required to use the Kong Admin API. 
+        This token is passed in a `Kong-Admin-Token` header by default. 
+        To configure the header name, adjust `rbac_auth_header` in `kong.conf`.
+        <br><br>
+        Each admin has their own token.
+        The admin associated with the token must have relevant permissions for the object they're interacting with.
+        Generate tokens using the `/admins` API.
+        <br><br>
+        If RBAC isn't enabled, this token isn't required.
 
 externalDocs:
   description: Kong Gateway Enterprise Admin API
@@ -13636,6 +13651,8 @@ servers:
         enum:
           - http
           - https
+security:
+  - kongAdminToken: []
 tags:
   - description: |
       Service entities are abstractions of your microservice interfaces or formal APIs. For example, a service could be a data transformation microservice or a billing API.


### PR DESCRIPTION
### Description

Add RBAC auth to the Kong Admin EE spec.

https://konghq.atlassian.net/browse/DOCU-180

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

