### PR TITLE
Fix: Incorrect value listed for OIDC consumer claim field

### DIFF
--- a/app/_src/gateway/kong-enterprise/dev-portal/authentication/okta-config.md
+++ b/app/_src/gateway/kong-enterprise/dev-portal/authentication/okta-config.md
@@ -40,7 +40,8 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
       ![OIDC with Okta Issuer URL](/assets/images/products/gateway/dev-portal/oidc-issuer-url.png)
 
-   2. In the `Config.Consumer Claim` field, enter your `<application_id>`.
+   2. In the `Config.Consumer Claim` field, enter the name of the field from the Okta payload that contains the application ID. 
+   This is usually `sub`.
 
    **Tip:** Because Okta's discovery document does not include all supported
    auth types by default, ensure the
@@ -54,7 +55,7 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
    {
      "issuer": "<auth_server_issuer_url>",
      "verify_credentials": false,
-     "consumer_claim": "<application_id>",
+     "consumer_claim": "sub",
    }
 
    ```

--- a/app/gateway/2.6.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/gateway/2.6.x/developer-portal/administration/application-registration/okta-config.md
@@ -48,7 +48,8 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
       ![OIDC with Okta Issuer URL](/assets/images/products/gateway/dev-portal/oidc-issuer-url.png)
 
-   2. In the `Config.Consumer Claim` field, enter your `<application_id>`.
+   2. In the `Config.Consumer Claim` field, enter the name of the field from the Okta payload that contains the application ID. 
+   This is usually `sub`.
 
    **Tip:** Because Okta's discovery document does not include all supported
    auth types by default, ensure the
@@ -58,11 +59,11 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
    The core configuration should be:
 
-   ```
+   ```json
    {
      "issuer": "<auth_server_issuer_url>",
      "verify_credentials": false,
-     "consumer_claim": "<application_id>",
+     "consumer_claim": "sub",
    }
 
    ```

--- a/app/gateway/2.7.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/gateway/2.7.x/developer-portal/administration/application-registration/okta-config.md
@@ -40,7 +40,8 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
       ![OIDC with Okta Issuer URL](/assets/images/products/gateway/dev-portal/oidc-issuer-url.png)
 
-   2. In the `Config.Consumer Claim` field, enter your `<application_id>`.
+   2. In the `Config.Consumer Claim` field, enter the name of the field from the Okta payload that contains the application ID. 
+   This is usually `sub`.
 
    **Tip:** Because Okta's discovery document does not include all supported
    auth types by default, ensure the
@@ -54,7 +55,7 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
    {
      "issuer": "<auth_server_issuer_url>",
      "verify_credentials": false,
-     "consumer_claim": "<application_id>",
+     "consumer_claim": "sub",
    }
 
    ```

--- a/app/gateway/2.8.x/developer-portal/administration/application-registration/okta-config.md
+++ b/app/gateway/2.8.x/developer-portal/administration/application-registration/okta-config.md
@@ -40,7 +40,8 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
 
       ![OIDC with Okta Issuer URL](/assets/images/products/gateway/dev-portal/oidc-issuer-url.png)
 
-   2. In the `Config.Consumer Claim` field, enter your `<application_id>`.
+   2. In the `Config.Consumer Claim` field, enter the name of the field from the Okta payload that contains the application ID. 
+   This is usually `sub`.
 
    **Tip:** Because Okta's discovery document does not include all supported
    auth types by default, ensure the
@@ -54,7 +55,7 @@ of the `Issuer` URL, which you will use to associate Kong with your authorizatio
    {
      "issuer": "<auth_server_issuer_url>",
      "verify_credentials": false,
-     "consumer_claim": "<application_id>",
+     "consumer_claim": "sub",
    }
 
    ```


### PR DESCRIPTION
### Description

Fix okta config doc bug, where the consumer claim field was listed as needing an application ID, but actually needs the name of the field that _contains_ the application ID.

https://konghq.atlassian.net/browse/DOCU-1456

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

