### PR TITLE
Fix: Use config.scopes instead of config.scopes_required in OIDC okta guide

### DIFF
--- a/app/_hub/kong-inc/openid-connect/how-to/third-party/_auth0.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/third-party/_auth0.md
@@ -46,5 +46,5 @@ For basic authentication, use your client ID as the username and your client sec
 [client-credentials-grant]: https://auth0.com/docs/api-auth/tutorials/client-credentials
 [create-auth0-api]: https://auth0.com/docs/apis#how-to-configure-an-api-in-auth0
 [non-interactive-client]: https://auth0.com/docs/clients
-[add-service]: /gateway/latest/admin-api/#service-object
+[add-service]: /gateway/api/admin-ee/latest/#/Services/create-service
 [audience-required]: https://auth0.com/docs/api/authentication#client-credentials

--- a/app/_hub/kong-inc/openid-connect/how-to/third-party/_azure-ad.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/third-party/_azure-ad.md
@@ -129,8 +129,8 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 [azure-create-app]: https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
 [azure-manifest]: https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-app-manifest#configure-the-app-manifest
 [azure-tenant]: https://docs.microsoft.com/en-us/azure/active-directory/develop/single-and-multi-tenant-apps
-[add-certificate]: /gateway/latest/admin-api/#add-certificate
-[add-service]: /gateway/latest/admin-api/#service-object
+[add-certificate]: /gateway/api/admin-ee/latest/#/Certificates/create-certificate
+[add-service]: /gateway/api/admin-ee/latest/#/Services/create-service
 [oidc-id-token]: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
-[credential-claim]: /hub/kong-inc/openid-connect/#configcredential_claim
-[enable-plugin]: /gateway/latest/admin-api/#plugin-object
+[credential-claim]: /hub/kong-inc/openid-connect/configuration/#configcredential_claim
+[enable-plugin]: /gateway/api/admin-ee/latest/#/Plugins/create-plugin-for-consumer

--- a/app/_hub/kong-inc/openid-connect/how-to/third-party/_curity.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/third-party/_curity.md
@@ -206,7 +206,7 @@ With relatively simple configurations in both the Curity Identity Server and the
 
 {% endif_version %}
 
-[kong-add-service]: /gateway/latest/admin-api/#service-object
+[kong-add-service]: /gateway/api/admin-ee/latest/#/Services/create-service
 [curity-phantom-token-introspection]: https://curity.io/resources/learn/introspect-with-phantom-token
 [curity-getting-started]: https://curity.io/resources/getting-started
 [curity-phantom-token-pattern]: https://curity.io/resources/learn/phantom-token-pattern

--- a/app/_hub/kong-inc/openid-connect/how-to/third-party/_google.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/third-party/_google.md
@@ -59,9 +59,9 @@ standardized][oidc-standard-claims], however--if a provider returns an `email` c
 This also requires that clients login using an account mapped to some consumer, which may not be desirable (e.g. you apply OpenID Connect to a service, but only use plugins requiring a consumer on some routes). To deal with this, you can set the `anonymous` parameter in your OIDC plugin configuration to the ID of a generic consumer, which will then be used for all authenticated users that cannot be mapped to some other consumer.
 
 
-[add-certificate]: /gateway/latest/admin-api/#add-certificate
+[add-certificate]: /gateway/api/admin-ee/latest/#/Certificates/create-certificate
 [google-oidc]: https://developers.google.com/identity/protocols/OpenIDConnect
 [google-create-credentials]: https://console.developers.google.com/apis/credentials
-[add-service]: /gateway/latest/admin-api/#service-object
+[add-service]: /gateway/api/admin-ee/latest/#/Services/create-service
 [oidc-id-token]: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [oidc-standard-claims]: http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

--- a/app/_hub/kong-inc/openid-connect/how-to/third-party/_okta.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/third-party/_okta.md
@@ -5,9 +5,11 @@ nav_title: OpenID Connect with Okta
 
 This guide covers an example OpenID Connect plugin configuration to authenticate browser clients using an Okta identity provider.
 
+{% if_plugin_version lte:3.4.x %}
 For information about configuring OIDC using Okta as an Identity provider
 in conjunction with the Application Registration plugin, see
 [Set Up External Portal Application Authentication with Okta and OIDC](/gateway/latest/kong-enterprise/dev-portal/authentication/okta-config).
+{% endif_plugin_version %}
 
 ## Authorization code flow with the OpenID Connect plugin and Okta
 
@@ -220,7 +222,7 @@ following, at minimum:
 
 1. On the **Authorization** tab, configure the following, at a minimum:
 
-    1. For **config.scopes required**, enter `openid, email, profile`. This parameter is the scope of what OpenID Connect checks.
+    1. For **config.scopes**, enter `openid, email, profile`. This parameter is the scope of what OpenID Connect checks.
 
     1. For **config.scopes claim**, enter `scp`.
 
@@ -261,12 +263,12 @@ In this example, the configuration contains the following values:
 * **`auth_method`**: A list of authentication methods to use with the plugin, such as passwords, introspection tokens, etc. The majority of cases use `authorization_code`, and {{site.base_gateway}} will accept all methods if no methods are specified.
 * **`client_id`**: The `client_id` of the OpenID Connect client registered in OpenID Connect Provider. Okta provides one to identify itself.  
 * **`client_secret`**: The `client_secret` of the OpenID Connect client registered in OpenID Connect Provider. These credentials should never be publicly exposed.
-* **`config.scopes_required`**:  The scope of what OpenID Connect checks. This is set to `openid` by default. You must also set `email` and `profile` for this example. 
+* **`config.scopes`**:  The scope of what OpenID Connect checks. This is set to `openid` by default. You must also set `email` and `profile` for this example. 
 * **`config.scopes_claim`**: This should be set to `scp`.
 * **`config.redirect_uri`**: The `redirect_uri` of the client defined with `client_id` (also used as a redirection URI for the authorization code flow).
 
 For a list of all available configuration parameters and what they do, see the
-[OIDC plugin reference](/hub/kong-inc/openid-connect).
+[OIDC plugin reference](/hub/kong-inc/openid-connect/configuration/).
 
 {% endnavtab %}
 {% endnavtabs %}
@@ -334,4 +336,4 @@ Similarly, setting `authenticated_groups_claim` will extract that claim's value 
 
 [okta-authorization-server]: https://developer.okta.com/docs/guides/customize-authz-server/create-authz-server/
 [okta-register-app]: https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/register-app-in-okta/
-[credential-claim]: /hub/kong-inc/openid-connect/#configcredential_claim
+[credential-claim]: /hub/kong-inc/openid-connect/configuration/#configcredential_claim


### PR DESCRIPTION
### Description

The OIDC Okta guide incorrectly references `config.scopes_required` when it's actually configuring `config.scopes`.
Fixing that + some broken/outdated links + Dev Portal info that should be behind a conditional tag.
Also fixing the same links in the rest of the OIDC 3rd party guides.

https://konghq.atlassian.net/browse/DOCU-2277

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

