### PR TITLE
Add explicit RHEL7 and RHEL9 test targets

### DIFF
--- a/tools/install-tester/config/jobs.yaml
+++ b/tools/install-tester/config/jobs.yaml
@@ -12,10 +12,10 @@
     - 3.2.x/debian/enterprise/repository
     - 3.3.x/debian/enterprise/package
     - 3.3.x/debian/enterprise/repository
-    - 3.2.x/rhel/enterprise/package
-    - 3.2.x/rhel/enterprise/repository
-    - 3.3.x/rhel/enterprise/package
-    - 3.3.x/rhel/enterprise/repository
+    - 3.2.x/rhel:9/enterprise/package
+    - 3.2.x/rhel:9/enterprise/repository
+    - 3.3.x/rhel:9/enterprise/package
+    - 3.3.x/rhel:9/enterprise/repository
   arch:
     - linux/arm64
   outputs:

--- a/tools/install-tester/config/jobs.yaml
+++ b/tools/install-tester/config/jobs.yaml
@@ -29,7 +29,7 @@
   distros:
     - amazon-linux
     - ubuntu
-    - rhel:9
+    - rhel:7
     - debian
   arch:
     - linux/amd64

--- a/tools/install-tester/config/jobs.yaml
+++ b/tools/install-tester/config/jobs.yaml
@@ -6,7 +6,7 @@
     - amazon-linux
     - ubuntu
     - debian
-    - rhel
+    - rhel:9
   skip:
     - 3.2.x/debian/enterprise/package
     - 3.2.x/debian/enterprise/repository
@@ -29,7 +29,7 @@
   distros:
     - amazon-linux
     - ubuntu
-    - rhel
+    - rhel:9
     - debian
   arch:
     - linux/amd64
@@ -43,7 +43,7 @@
       - enterprise
   distros:
     - ubuntu
-    - rhel
+    - rhel:7
     - amazon-linux
     - debian
     - centos

--- a/tools/install-tester/config/setup.yaml
+++ b/tools/install-tester/config/setup.yaml
@@ -14,7 +14,13 @@ debian:
     - useradd tester -m -p password
     - usermod -aG sudo tester
     - "echo 'ALL            ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/tester"
-rhel:
+"rhel:7":
+  image: "registry.access.redhat.com/ubi7/ubi-init:latest"
+  setup:
+    - yum install -y curl gpg sudo
+    - useradd tester -m -p password
+    - "echo 'ALL            ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/tester"
+"rhel:9":
   image: "registry.access.redhat.com/ubi9/ubi-init:latest"
   setup:
     - yum install -y gpg sudo


### PR DESCRIPTION
### Description

Test RHEL 2.x installation topics on el7 rather than el9

### Testing instructions

Preview link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)