### PR TITLE
chore: add notice for trusting vault backend's ssl certificate

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -51,6 +51,9 @@ export KONG_VAULT_AWS_ROLE_SESSION_NAME=<aws_assume_role_session_name>
 The vault backend configuration field can also be configured in the `kong.conf` file. See [Gateway Enterprise configuration reference](/gateway/latest/reference/configuration).
 {% endif_version %}
 
+{:.note}
+> **Notice:** When using AWS Vault as a backend, make sure you have configured `system` as part of the [`lua_ssl_trusted_certificate` configuration directive](/gateway/latest/reference/configuration#lua_ssl_trusted_certificate) so that the SSL certificates used by official AWS API can be trusted by Kong.
+
 ### Examples
 
 For example, an AWS Secrets Manager secret with the name `secret-name` may have multiple key=value pairs:

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -52,7 +52,7 @@ The vault backend configuration field can also be configured in the `kong.conf` 
 {% endif_version %}
 
 {:.note}
-> **Notice:** When using AWS Vault as a backend, make sure you have configured `system` as part of the [`lua_ssl_trusted_certificate` configuration directive](/gateway/latest/reference/configuration#lua_ssl_trusted_certificate) so that the SSL certificates used by official AWS API can be trusted by Kong.
+> **Note:** When using AWS Vault as a backend, make sure you have configured `system` as part of the [`lua_ssl_trusted_certificate` configuration directive](/gateway/{{page.release}}/reference/configuration/#lua_ssl_trusted_certificate) so that the SSL certificates used by the official AWS API can be trusted by Kong.
 
 ### Examples
 

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
@@ -36,7 +36,7 @@ documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-i
 > With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` isn't necessary.
 
 {:.note}
-> **Notice:** When using GCP Vault as a backend, make sure you have configured `system` as part of the [`lua_ssl_trusted_certificate` configuration directive](/gateway/latest/reference/configuration#lua_ssl_trusted_certificate) so that the SSL certificates used by official GCP API can be trusted by Kong.
+> **Note:** When using GCP Vault as a backend, make sure you have configured `system` as part of the [`lua_ssl_trusted_certificate` configuration directive](/gateway/{{page.release}}/reference/configuration/#lua_ssl_trusted_certificate) so that the SSL certificates used by the official GCP API can be trusted by Kong.
 
 ### Examples
 

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
@@ -35,6 +35,9 @@ documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-i
 {:.note}
 > With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` isn't necessary.
 
+{:.note}
+> **Notice:** When using GCP Vault as a backend, make sure you have configured `system` as part of the [`lua_ssl_trusted_certificate` configuration directive](/gateway/latest/reference/configuration#lua_ssl_trusted_certificate) so that the SSL certificates used by official GCP API can be trusted by Kong.
+
 ### Examples
 
 To use a GCP Secret Manager

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/gcp-sm.md
@@ -33,10 +33,11 @@ Identity configuration
 documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to).
 
 {:.note}
-> With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` isn't necessary.
-
-{:.note}
-> **Note:** When using GCP Vault as a backend, make sure you have configured `system` as part of the [`lua_ssl_trusted_certificate` configuration directive](/gateway/{{page.release}}/reference/configuration/#lua_ssl_trusted_certificate) so that the SSL certificates used by the official GCP API can be trusted by Kong.
+> **Notes:**
+> * With Workload Identity, setting the `GCP_SERVICE_ACCOUNT` isn't necessary.
+> * When using GCP Vault as a backend, make sure you have configured `system` as part of the
+> [`lua_ssl_trusted_certificate` configuration directive](/gateway/{{page.release}}/reference/configuration/#lua_ssl_trusted_certificate)
+so that the SSL certificates used by the official GCP API can be trusted by Kong.
 
 ### Examples
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

This PR adds a notice in the AWS/GCP vault backend doc page, to remind user to trust system ca-certificates store so that SSL certificate returned by those cloud providers are being trusted by kong.

https://konghq.atlassian.net/browse/FTI-5700

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

