### PR TITLE
Fix sitemap generation

### DIFF
--- a/app/_plugins/generators/seo/index_entry_builder.rb
+++ b/app/_plugins/generators/seo/index_entry_builder.rb
@@ -68,7 +68,7 @@ module SEO
     end
 
     def unprocessable_page?
-      ['/404.html', '/moved_urls.yml', '/redirects.json', '/robots.txt'].include?(@page.url)
+      ['/sitemap.xml', '/404.html', '/moved_urls.yml', '/redirects.json', '/robots.txt'].include?(@page.url)
     end
 
     def url_segments

--- a/app/_plugins/generators/utils/canonical_url.rb
+++ b/app/_plugins/generators/utils/canonical_url.rb
@@ -4,8 +4,11 @@ module Utils
   class CanonicalUrl
     def self.generate(url)
       return url if url.end_with?('/')
+      return url if url.end_with?('.html') || url.end_with?('.xml')
 
-      url.concat('/')
+      # call dup here because #concat
+      # modifies the string
+      url.dup.concat('/')
     end
   end
 end

--- a/spec/app/_plugins/generators/seo/index_entry_builder_spec.rb
+++ b/spec/app/_plugins/generators/seo/index_entry_builder_spec.rb
@@ -63,5 +63,13 @@ RSpec.describe SEO::IndexEntryBuilder do
 
       it { expect(subject).to be_a(SEO::IndexEntry::UnprocessablePage) }
     end
+
+    context 'sitemap' do
+      let(:page) do
+        double(url: '/sitemap.xml', path: '/sitemap.xml', relative_path: '/sitemap.xml', data: {})
+      end
+
+      it { expect(subject).to be_a(SEO::IndexEntry::UnprocessablePage) }
+    end
   end
 end

--- a/spec/app/_plugins/generators/utils/canonical_url_spec.rb
+++ b/spec/app/_plugins/generators/utils/canonical_url_spec.rb
@@ -15,5 +15,25 @@ RSpec.describe Utils::CanonicalUrl do
         expect(subject).to eq('/gateway/latest/')
       end
     end
+
+    context 'if the url has an extension' do
+      context '.html' do
+        let(:url) { '/index.html' }
+
+        it 'does not alter the original url' do
+          expect(subject).to eq('/index.html')
+          expect(url).to eq('/index.html')
+        end
+      end
+
+      context '.xml' do
+        let(:url) { '/index.xml' }
+
+        it 'does not alter the original url' do
+          expect(subject).to eq('/index.xml')
+          expect(url).to eq('/index.xml')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION

### Description

There were two issues here:
* the canonical url generator didn't check if the url had an extension
* it was also modifying the provided url



### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

