### PR TITLE
Fix: Incorrect request format in DB-less and declarative config doc

### DIFF
--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -237,8 +237,8 @@ Kong node with the Admin API, using the `/config` endpoint. The
 following example loads `kong.yml`:
 
 ```sh
-curl -i -X GET http://localhost:8001/config \
-  --data config=@kong.yml
+curl -i -X POST http://localhost:8001/config \
+  --form config=@kong.yml
 ```
 
 {:.important}


### PR DESCRIPTION
### Description

Corrected the command to send the config to the Gateway. It was using a GET instead of POST and when using form-urlencoded data (--data) it throws a 400 error.  

{"message":"declarative config is invalid: {error=\"failed parsing declarative configuration: 1:1: found character that cannot start any token\"}","name":"invalid declarative configuration","code":14,"fields":{"error":"failed parsing declarative configuration: 1:1: found character that cannot start any token"}}

This was changed to use multipart/form-data (--form)


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

