### PR TITLE
KIC: Use standard repository in Helm example instructions

### DIFF
--- a/app/_src/kubernetes-ingress-controller/install/helm.md
+++ b/app/_src/kubernetes-ingress-controller/install/helm.md
@@ -17,9 +17,8 @@ You can use any of the [configuration options](https://github.com/Kong/charts/bl
 controller:
   ingressController:
     image:
-      repository: kong/nightly-ingress-controller
-      tag: nightly
-      effectiveSemver: "{{ site.data.kong_latest_KIC.version }}"
+      repository: kong/kubernetes-ingress-controller
+      tag: "{{ site.data.kong_latest_KIC.version }}"
 ```
 
 


### PR DESCRIPTION
### Description

The KIC Helm install docs showed how to customise the image by using the nightly KIC image. This confused some users who actually tried to use the nightly image in a non-test environment.

### Testing instructions

Preview link: [/kubernetes-ingress-controller/3.0.x/install/helm/](https://deploy-preview-6842--kongdocs.netlify.app/kubernetes-ingress-controller/3.0.x/install/helm/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)