### PR TITLE
chore: Add 3.6 upgrade path table

### DIFF
--- a/app/_src/gateway/migrate-cassandra-to-postgres.md
+++ b/app/_src/gateway/migrate-cassandra-to-postgres.md
@@ -15,7 +15,7 @@ Migration steps:
 1. Build a target {{site.base_gateway}} hybrid environment with PostgreSQL. This acts as your blank canvas.
 1. Use decK to export (`dump`) configuration from the old traditional Cassandra-backed deployment. 
 1. Use decK to import (`sync`) the configuration to the new hybrid PostgreSQL-backed deployment.
-1. Create basic auth credentials and local RBAC users using either the Admin Api or Kong Manager.
+1. Create basic auth credentials and local RBAC users using either the Admin API or Kong Manager.
 1. When the {{site.base_gateway}} configuration has been migrated over to the green environment, slowly redirect traffic via canary into the green environment. This lowers the risk of the release with a fast rollback mechanism in place.
 
 

--- a/app/_src/gateway/upgrade/index.md
+++ b/app/_src/gateway/upgrade/index.md
@@ -67,7 +67,7 @@ between the 2.x and 3.x series (both this version and prior versions) and in the
 open-source (OSS) and Enterprise Gateway [changelogs](/gateway/changelog/). Since {{site.base_gateway}}
 is built on an open-source foundation, any breaking changes in OSS affect all {{site.base_gateway}} packages.
 
-An upgrade path is subject to a wide spectrum of conditions, and there is not a one-size-fits-all way applicable to all customers, depending on the deployment modes, custom plugins, customers’ technical capabilities, hardware capacities, SLA, etc. Our engineers should discuss thoroughly and carefully with customers before taking any action.
+An upgrade path is subject to a wide spectrum of conditions, and there is not a one-size-fits-all way applicable to all customers, depending on the deployment modes, custom plugins, customers’ technical capabilities, hardware capacities, SLA, etc. Our engineers should discuss the upgrade process thoroughly and carefully with you before you take any action.
 
 We encourage you to stay updated with {{site.base_gateway}} releases, as that helps maintain a smooth upgrade path. 
 The smaller the version gap is, the less complex the upgrade process becomes.
@@ -197,6 +197,36 @@ The following table outlines various upgrade path scenarios to {{page.release}} 
 | 3.4.x | Traditional | Yes | Upgrade to 3.5.x. |
 | 3.4.x | Hybrid | Yes | Upgrade to 3.5.x. |
 | 3.4.x | DB-less | Yes | Upgrade to 3.5.x. |
+
+{% endif_version %}
+
+{% if_version eq: 3.6.x %}
+| **Current version** | **Topology** | **Direct upgrade possible?** | **Upgrade path** |
+| ------------------- | ------------ | ---------------------------- | ---------------- |
+| 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 2.8.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 2.8.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.0.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.0.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.0.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.1.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.1.0.x-3.1.1.2 | Hybrid | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, upgrade to 3.3.x, upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.1.1.3 | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.1.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.2.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.2.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.2.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.3.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.3.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.3.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 3.4.x | Traditional | No | Upgrade to 3.5.x and then upgrade to 3.6.x. |
+| 3.4.x | Hybrid | No | Upgrade to 3.5.x and then upgrade to 3.6.x. |
+| 3.4.x | DB-less | No | Upgrade to 3.5.x and then upgrade to 3.6.x. |
+| 3.5.x | Traditional | Yes | Upgrade to 3.6.x. |
+| 3.5.x | Hybrid | Yes | Upgrade to 3.6.x. |
+| 3.5.x | DB-less | Yes | Upgrade to 3.6.x. |
 
 {% endif_version %}
 

--- a/app/_src/gateway/upgrade/index.md
+++ b/app/_src/gateway/upgrade/index.md
@@ -67,7 +67,7 @@ between the 2.x and 3.x series (both this version and prior versions) and in the
 open-source (OSS) and Enterprise Gateway [changelogs](/gateway/changelog/). Since {{site.base_gateway}}
 is built on an open-source foundation, any breaking changes in OSS affect all {{site.base_gateway}} packages.
 
-An upgrade path is subject to a wide spectrum of conditions, and there is not a one-size-fits-all way applicable to all customers, depending on the deployment modes, custom plugins, customers’ technical capabilities, hardware capacities, SLA, etc. Our engineers should discuss the upgrade process thoroughly and carefully with you before you take any action.
+An upgrade path is subject to a wide spectrum of conditions, and there is not a one-size-fits-all way applicable to all users, depending on the deployment modes, custom plugins, technical capabilities, hardware capacities, SLA, and so on. You should discuss the upgrade process thoroughly and carefully with our engineers before you take any action.
 
 We encourage you to stay updated with {{site.base_gateway}} releases, as that helps maintain a smooth upgrade path. 
 The smaller the version gap is, the less complex the upgrade process becomes.


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 I added the 3.6 upgrade path table for the upcoming release. I also fixed a few errors that aren't related to the release I noticed as I was going through the docs.
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3633
### Testing instructions

Preview link: https://deploy-preview-6844--kongdocs.netlify.app/gateway/dev/upgrade/#guaranteed-upgrade-paths

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

