### PR TITLE
Feat: OSS badges

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -550,7 +550,7 @@ jQuery(function () {
       '<div class="tooltip"><span class="tooltiptext">Available in Enterprise Free mode (without a license)</span></div>'
     );
     $(".badge.oss").append(
-      '<div class="tooltip"><span class="tooltiptext" >Available in Kong open-source only</span></div>'
+      '<div class="tooltip"><span class="tooltiptext" >Free open-source plugin</span></div>'
     );
     $(".badge.dbless").append(
       '<div class="tooltip"><span class="tooltiptext">Compatible with DB-less deployments</span></div>'

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -82,9 +82,9 @@
 
   &.oss::after {
     content: "OSS";
-    color: white;
-    border-color: #6e30bf;
-    background-color: #6e30bf;
+    color: #6F28FF;
+    // border-color: #6e30bf;
+    background-color: #F1F0FF;
     text-align: center;
   }
 

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -81,7 +81,7 @@
   }
 
   &.oss::after {
-    content: "OSS ONLY";
+    content: "OSS";
     color: white;
     border-color: #6e30bf;
     background-color: #6e30bf;

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -17,6 +17,9 @@
 {%- if badges.techpartner? -%}
   {%- assign css_classes =  css_classes | append: " techpartner" -%}
 {%- endif -%}
+{%- if badges.oss? -%}
+  {%- assign css_classes =  css_classes | append: " oss" -%}
+{%- endif -%}
 {%- unless extn.enterprise -%}
   {%- assign css_classes = css_classes | append: " open-source" -%}
 {%- endunless -%}
@@ -52,6 +55,9 @@
           {% endif %}
           {% if badges.techpartner? %}
             <span class="badge techpartner"></span>
+          {% endif %}
+          {% if badges.oss? %}
+            <span class="badge oss"></span>
           {% endif %}
         </div>
         <div class="plugin-card--meta__description">{{ extn.desc }}</div>

--- a/app/_includes/plugins/badges.html
+++ b/app/_includes/plugins/badges.html
@@ -10,6 +10,6 @@
 {% if include.badges.techpartner? %}
   <a href="https://konghq.com/partners" target="_blank" class="badge techpartner" aria-label="Verified Kong technical partner"> </a>
 {% endif %}
-{% if include.oss %}
-  <a href="https://konghq.com/pricing" target="_blank" class="badge oss" aria-label="open-source only"> </a>
+{% if include.badges.oss? %}
+  <a href="https://konghq.com/pricing" target="_blank" class="badge oss" aria-label="open-source"> </a>
 {% endif %}

--- a/app/_layouts/plugins/show.html
+++ b/app/_layouts/plugins/show.html
@@ -20,6 +20,8 @@ type: plugin
                       paid=page.paid
                       premium=page.premium
                       enterprise=page.enterprise
+                      free=page.free
+                      oss=page.oss
                       konnect=page.konnect
                       techpartner=page.techpartner
                       extn_publisher=page.extn_publisher

--- a/app/_plugins/drops/plugins/badges.rb
+++ b/app/_plugins/drops/plugins/badges.rb
@@ -15,6 +15,10 @@ module Jekyll
           !!@metadata['konnect']
         end
 
+        def oss?
+          !!@metadata['free'] && @publisher == KONG_INC
+        end
+
         def paid?
           !@metadata['free'] && !!@metadata['paid'] && @publisher == KONG_INC
         end
@@ -37,7 +41,8 @@ module Jekyll
             "paid:#{paid?}-" \
             "premium:#{premium?}-" \
             "enterprise:#{enterprise?}-" \
-            "techpartner:#{techpartner?}"
+            "techpartner:#{techpartner?}-" \
+            "oss:#{oss?}"
         end
       end
     end


### PR DESCRIPTION
### Description

Adding OSS badges to plugins upon request. 
Adjusting the colours of the old OSS badge so it doesn't look like Insomnia + matches the other badges better.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] For unreleased versions: [conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

    For example, if this change is for an upcoming 3.6 release, surround your change in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

