### PR TITLE
kic: add explanation for Gateway's publish service

### DIFF
--- a/app/_src/kubernetes-ingress-controller/concepts/gateway-api.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/gateway-api.md
@@ -160,3 +160,21 @@ kubectl get gateway kong -o=jsonpath='{.status.addresses}' | jq
   }
 ]
 ```
+
+### Gateway's "publish" Service
+
+When an unmanaged Gateway is reconciled by KIC, it gets annotated with `konghq.com/publish-service` equal to a Service’s
+namespaced name configured in `--publish-service` (and optionally in `--publish-service-udp`) CLI flag. The annotation value is used by the Gateway controller to
+determine its Listeners’ statuses.
+ 
+{:.note}
+> Once the Gateway's `konghq.com/publish-service` annotation is assigned, it will no longer be auto-updated by {{site.kic_product_name}} 
+> to match the `--publish-service` CLI flag. If, for any reason, any of those change after the annotation is assigned, the Gateway controller will not be able to
+> determine the Gateway's Listeners' statuses. Manual intervention will be required to update the annotation to match the CLI flag.
+
+If you’d like to migrate an already annotated Gateway to a KIC installation that uses another `--publish-service` (or `--publish-service-udp`), you should modify 
+the Gateway’s annotation to match the CLI flag. Otherwise, you may experience the Gateway controller getting stuck looking up the Service:
+
+```console
+One of publish services defined in Gateway's "konghq.com/publish-service" annotation didn't match controller manager's configuration    {"GatewayV1Gateway": {"name":"kong","namespace":"default"}, "namespace": "default", "name": "kong", "service": "kong/kong-proxy", "error": "publish service reference \"kong/kong-proxy\" from Gateway's annotations did not match configured controller manager's publish services (\"kong/new-kong-proxy\")"}
+```


### PR DESCRIPTION
### Description

Adds an explanation of `--publish-service` vs. `konghq.com/publish-service` Gateway's annotation relation.

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5328.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] For unreleased versions: [conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

    For example, if this change is for an upcoming 3.6 release, surround your change in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

