### PR TITLE
[KAG-2257] Use Cloudsmith for Kong Mesh

### DIFF
--- a/app/_data/tables/install_options.yml
+++ b/app/_data/tables/install_options.yml
@@ -9,7 +9,7 @@ features:
   - name: "Packages"
     items:
       - name: "Alpine"
-        url: https://download.konghq.com/gateway-3.x-alpine/
+        url: https://cloudsmith.io/~kong/packages/?q=distribution%3Aalpine+AND+distribution%3Aany-version&sort=-version
         oss: true
         enterprise: true
         support: true

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -27,12 +27,15 @@ chmod +x docker-entrypoint.sh
     {% comment %}
     not all of the older alpine "packages" met Cloudsmith's definition for what an alpine package must be
     so some are uploaded there as "raw" artifacts instead and must be linked to differently
+    this page doesn't exist for lte:2.8.x
     {% endcomment %}
-    {% if_version lte:3.3.x eq:3.0.x %}
+    {% if_version lte:3.3.x %}
+    {% if_version eq:3.0.x %}
     * **Alpine**: [.apk.tar.gz]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/raw/names/kong-enterprise-edition-x86_64/versions/{{page.versions.ee}}/kong-enterprise-edition-{{page.versions.ee}}.x86_64.apk.tar.gz)
     {% endif_version %}
-    {% if_version lte:3.3.x gte:3.1.x lte:2.8.x %}
+    {% if_version gte:3.1.x %}
     * **Alpine**: [.apk]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/alpine/any-version/main/x86_64/kong-enterprise-edition-{{page.versions.ee}}.apk)
+    {% endif_version %}
     {% endif_version %}
     * **RHEL**:[ .rpm]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/8/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el8.x86_64.rpm)
 

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -23,11 +23,12 @@ chmod +x docker-entrypoint.sh
     not all of the older alpine "packages" met Cloudsmith's definition for what an alpine package must be
     so some are uploaded there as "raw" artifacts instead and must be linked to differently
     {% endcomment %}
+    {% if_version lte:3.3.x %}
     {% if_version eq:3.0.x %}
     * **Alpine**: [.apk]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/raw/names/kong-enterprise-edition-x86_64/versions/{{page.versions.ee}}/kong-enterprise-edition-{{page.versions.ee}}.x86_64.apk.tar.gz)
-    {% endif_version %}
-    {% if_version lte:3.3.x %}
+    {% else %}
     * **Alpine**: [.apk]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/alpine/any-version/main/x86_64/kong-enterprise-edition-{{page.versions.ee}}.apk)
+    {% endif_version %}
     {% endif_version %}
     * **RHEL**:[ .rpm]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/8/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el8.x86_64.rpm)
 

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -17,19 +17,19 @@ chmod +x docker-entrypoint.sh
 ```
 
 1. Download the {{site.base_gateway}} package:
-    * **Debian**: [.deb]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/debian/pool/bullseye/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
-    * **Ubuntu**: [.deb]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/jammy/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
+    * **Debian**: [.deb]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/debian/pool/bullseye/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
+    * **Ubuntu**: [.deb]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/jammy/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
     {% comment %}
     not all of the older alpine "packages" met Cloudsmith's definition for what an alpine package must be
     so some are uploaded there as "raw" artifacts instead and must be linked to differently
     {% endcomment %}
     {% if_version eq:3.0.x %}
-    * **Alpine**: [.apk]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/raw/names/kong-enterprise-edition-x86_64/versions/{{page.versions.ee}}/kong-enterprise-edition-{{page.versions.ee}}.x86_64.apk.tar.gz)
+    * **Alpine**: [.apk]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/raw/names/kong-enterprise-edition-x86_64/versions/{{page.versions.ee}}/kong-enterprise-edition-{{page.versions.ee}}.x86_64.apk.tar.gz)
     {% endif_version %}
     {% if_version lte:3.3.x %}
-    * **Alpine**: [.apk]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/alpine/any-version/main/x86_64/kong-enterprise-edition-{{page.versions.ee}}.apk)
+    * **Alpine**: [.apk]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/alpine/any-version/main/x86_64/kong-enterprise-edition-{{page.versions.ee}}.apk)
     {% endif_version %}
-    * **RHEL**:[ .rpm]({{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/8/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el8.x86_64.rpm)
+    * **RHEL**:[ .rpm]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/8/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el8.x86_64.rpm)
 
 1. Create a `Dockerfile`, ensuring you replace the filename by the first `COPY` with the name of the {{site.base_gateway}} file you downloaded in step 2:
 

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -18,17 +18,21 @@ chmod +x docker-entrypoint.sh
 
 1. Download the {{site.base_gateway}} package:
     * **Debian**: [.deb]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/debian/pool/bullseye/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
+    {% if_version lte:3.0.x %}
+    * **Ubuntu**: [.deb]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/focal/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
+    {% endif_version %}
+    {% if_version gte:3.1.x %}
     * **Ubuntu**: [.deb]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/jammy/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_amd64.deb).
+    {% endif_version %}
     {% comment %}
     not all of the older alpine "packages" met Cloudsmith's definition for what an alpine package must be
     so some are uploaded there as "raw" artifacts instead and must be linked to differently
     {% endcomment %}
-    {% if_version lte:3.3.x %}
-    {% if_version eq:3.0.x %}
-    * **Alpine**: [.apk]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/raw/names/kong-enterprise-edition-x86_64/versions/{{page.versions.ee}}/kong-enterprise-edition-{{page.versions.ee}}.x86_64.apk.tar.gz)
-    {% else %}
-    * **Alpine**: [.apk]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/alpine/any-version/main/x86_64/kong-enterprise-edition-{{page.versions.ee}}.apk)
+    {% if_version lte:3.3.x eq:3.0.x %}
+    * **Alpine**: [.apk.tar.gz]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/raw/names/kong-enterprise-edition-x86_64/versions/{{page.versions.ee}}/kong-enterprise-edition-{{page.versions.ee}}.x86_64.apk.tar.gz)
     {% endif_version %}
+    {% if_version lte:3.3.x gte:3.1.x lte:2.8.x %}
+    * **Alpine**: [.apk]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/alpine/any-version/main/x86_64/kong-enterprise-edition-{{page.versions.ee}}.apk)
     {% endif_version %}
     * **RHEL**:[ .rpm]({{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/8/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el8.x86_64.rpm)
 

--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -18,12 +18,12 @@ Kong is licensed under an
 {:.note}
 > **Notes:** 
 * {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
-* In July of 2023, Kong announced that package hosting was shifting from {{ site.links.download }} to [{{ site.links.cloudsmith }}]({{ site.links.cloudsmith }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
+* In July of 2023, Kong announced that package hosting was shifting from download.konghq.com to [{{ site.links.download }}]({{ site.links.download }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
 {% endif_version %}
 
 {% if_version lte:3.2.x %}
 {:.note}
-> **Note:** In July of 2023, Kong announced that package hosting was shifting from {{ site.links.download }} to [{{ site.links.cloudsmith }}]({{ site.links.cloudsmith }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
+> **Note:** In July of 2023, Kong announced that package hosting was shifting from download.konghq.com to [{{ site.links.download }}]({{ site.links.download }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
 {% endif_version %}
 
 ## Package install
@@ -43,12 +43,12 @@ Install {{site.base_gateway}} on Amazon Linux from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/amzn/%{amzn}/%{_arch}/kong-enterprise-edition-{{page.versions.ee}}.aws.%{_arch}.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/amzn/%{amzn}/%{_arch}/kong-enterprise-edition-{{page.versions.ee}}.aws.%{_arch}.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/amzn/%{amzn}/%{_arch}/kong-{{page.versions.ce}}.aws.%{_arch}.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/amzn/%{amzn}/%{_arch}/kong-{{page.versions.ce}}.aws.%{_arch}.rpm)
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -83,7 +83,7 @@ Install the YUM repository from the command line.
 1. Download the Kong YUM repository:
 
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo > /dev/null
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-{{ page.major_minor_version }}'
     ```
 

--- a/app/_src/gateway/install/linux/debian.md
+++ b/app/_src/gateway/install/linux/debian.md
@@ -22,12 +22,12 @@ The {{site.base_gateway}} software is governed by the
 {:.note}
 > **Notes:**
 * {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
-* In July of 2023, Kong announced that package hosting was shifting from {{ site.links.download }} to [{{ site.links.cloudsmith }}]({{ site.links.cloudsmith }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
+* In July of 2023, Kong announced that package hosting was shifting from download.konghq.com to [{{ site.links.download }}]({{ site.links.download }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
 {% endif_version %}
 
 {% if_version lte:3.2.x %}
 {:.note}
-> **Note:** In July of 2023, Kong announced that package hosting was shifting from {{ site.links.download }} to [{{ site.links.cloudsmith }}]({{ site.links.cloudsmith }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
+> **Note:** In July of 2023, Kong announced that package hosting was shifting from download.konghq.com to [{{ site.links.download }}]({{ site.links.download }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
 {% endif_version %}
 
 ## Package install
@@ -48,12 +48,12 @@ Install {{site.base_gateway}} on Debian from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/debian/pool/bullseye/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_$(dpkg --print-architecture).deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.deb "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/debian/pool/bullseye/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_$(dpkg --print-architecture).deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/debian/pool/bullseye/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_$(dpkg --print-architecture).deb"
+curl -Lo kong-{{page.versions.ce}}.deb "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/debian/pool/bullseye/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_$(dpkg --print-architecture).deb"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -92,8 +92,8 @@ Install the APT repository from the command line.
 
 1. Download the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg > /dev/null
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list > /dev/null
     ```
 2. Update the repository:
     ```bash

--- a/app/_src/gateway/install/linux/rhel.md
+++ b/app/_src/gateway/install/linux/rhel.md
@@ -15,7 +15,7 @@ Kong is licensed under an
 * (Enterprise only) A `license.json` file from Kong
 
 {:.note}
-> **Note:** In July of 2023 Kong announced that package hosting was shifting from {{ site.links.download }} to [{{ site.links.cloudsmith }}]({{ site.links.cloudsmith }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
+> **Note:** In July of 2023 Kong announced that package hosting was shifting from download.konghq.com to [{{ site.links.download }}]({{ site.links.download }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
 
 ## Package install
 
@@ -35,12 +35,12 @@ Install {{site.base_gateway}} on RHEL from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/%{_arch}/kong-enterprise-edition-{{page.versions.ee}}.el%{rhel}.%{_arch}.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/%{_arch}/kong-enterprise-edition-{{page.versions.ee}}.el%{rhel}.%{_arch}.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/%{_arch}/kong-{{page.versions.ce}}.el%{rhel}.%{_arch}.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/%{_arch}/kong-{{page.versions.ce}}.el%{rhel}.%{_arch}.rpm)
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -91,7 +91,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-{{ page.major_minor_version }}'
     ```
 

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -22,12 +22,12 @@ Once you have everything you need, choose an installation path:
 {:.note}
 > **Notes:**
 * {{site.base_gateway}} supports running on [AWS Graviton processors](https://aws.amazon.com/ec2/graviton/). It can run in all AWS Regions where AWS Graviton is supported.
-* In July of 2023, Kong announced that package hosting was shifting from {{ site.links.download }} to [{{ site.links.cloudsmith }}]({{ site.links.cloudsmith }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
+* In July of 2023, Kong announced that package hosting was shifting from download.konghq.com to [{{ site.links.download }}]({{ site.links.download }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
 {% endif_version %}
 
 {% if_version lte:3.2.x %}
 {:.note}
-> **Note:** In July of 2023, Kong announced that package hosting was shifting from {{ site.links.download }} to [{{ site.links.cloudsmith }}]({{ site.links.cloudsmith }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
+> **Note:** In July of 2023, Kong announced that package hosting was shifting from download.konghq.com to [{{ site.links.download }}]({{ site.links.download }}). Read more about it in this [blog post](https://konghq.com/blog/product-releases/changes-to-kong-package-hosting)!
 {% endif_version %}
 
 ## Installation
@@ -110,12 +110,12 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/{{ ubuntu_flavor }}/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_$(dpkg --print-architecture).deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.deb "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/{{ ubuntu_flavor }}/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_$(dpkg --print-architecture).deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/{{ ubuntu_flavor }}/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_$(dpkg --print-architecture).deb"
+curl -Lo kong-{{page.versions.ce}}.deb "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/ubuntu/pool/{{ ubuntu_flavor }}/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_$(dpkg --print-architecture).deb"
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -154,8 +154,8 @@ Install the APT repository from the command line.
 
 1. Setup the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg > /dev/null
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename={{ ubuntu_flavor }}" | sudo tee /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename={{ ubuntu_flavor }}" | sudo tee /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list > /dev/null
     ```
 
 2. Update the repository:

--- a/app/_src/gateway/kong-enterprise/fips-support.md
+++ b/app/_src/gateway/kong-enterprise/fips-support.md
@@ -18,8 +18,8 @@ The FIPS compliant Ubuntu 20.04 and Ubuntu 22.04 packages can be installed using
 
 1. Set up the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor >> /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename=$(lsb_release -sc)" > /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor >> /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename=$(lsb_release -sc)" > /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list
     ```
 
 2. Update the repository:
@@ -46,8 +46,8 @@ The FIPS compliant Ubuntu 20.04 package can be installed using the package disti
 
 1. Set up the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor >> /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename=$(lsb_release -sc)" > /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor >> /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename=$(lsb_release -sc)" > /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list
     ```
 
 2. Update the repository:
@@ -72,7 +72,7 @@ The FIPS compliant Red Hat 8 package can be installed using the package distinct
 1. Download the FIPS package:
 
     ```sh
-    curl -Lo kong-enterprise-edition-fips-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/x86_64/kong-enterprise-edition-fips-{{page.versions.ee}}.el%{rhel}.x86_64.rpm)
+    curl -Lo kong-enterprise-edition-fips-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/x86_64/kong-enterprise-edition-fips-{{page.versions.ee}}.el%{rhel}.x86_64.rpm)
     ```
 
 2. Install the {{site.base_gateway}} FIPS package:
@@ -86,7 +86,7 @@ The FIPS compliant Red Hat 8 package can be installed using the package distinct
 1. Set up the Kong Yum repository:
 
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-{{ page.major_minor_version }}'
     ```
 

--- a/app/_src/gateway/kong-enterprise/fips-support/install.md
+++ b/app/_src/gateway/kong-enterprise/fips-support/install.md
@@ -15,8 +15,8 @@ The FIPS-compliant Ubuntu 20.04 package can be installed using the package disti
 
 1. Set up the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor >> /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename=$(lsb_release -sc)" > /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor >> /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename=$(lsb_release -sc)" > /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list
     ```
 
 2. Update the repository:
@@ -41,7 +41,7 @@ The FIPS-compliant Red Hat 8 package can be installed using the package distinct
 1. Download the FIPS package:
 
     ```sh
-    curl -Lo kong-enterprise-edition-fips-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/x86_64/kong-enterprise-edition-fips-{{page.versions.ee}}.el%{rhel}.x86_64.rpm)
+    curl -Lo kong-enterprise-edition-fips-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/x86_64/kong-enterprise-edition-fips-{{page.versions.ee}}.el%{rhel}.x86_64.rpm)
     ```
 
 2. Install the {{site.base_gateway}} FIPS package:
@@ -55,7 +55,7 @@ The FIPS-compliant Red Hat 8 package can be installed using the package distinct
 1. Set up the Kong Yum repository:
 
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-{{ page.major_minor_version }}'
     ```
 

--- a/app/_src/mesh/installation/amazonlinux.md
+++ b/app/_src/mesh/installation/amazonlinux.md
@@ -35,7 +35,7 @@ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} sh 
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/_src/mesh/installation/centos.md
+++ b/app/_src/mesh/installation/centos.md
@@ -34,7 +34,7 @@ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} sh 
 
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/_src/mesh/installation/debian.md
+++ b/app/_src/mesh/installation/debian.md
@@ -27,7 +27,7 @@ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} sh 
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/_src/mesh/installation/kubernetes.md
+++ b/app/_src/mesh/installation/kubernetes.md
@@ -35,11 +35,11 @@ You can also download the distribution manually. Download a distribution for
 the client host from the machine where you plan to run the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/_src/mesh/installation/macos.md
+++ b/app/_src/mesh/installation/macos.md
@@ -36,8 +36,8 @@ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} sh 
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also download the [amd64]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz) {% if_version gte:1.8.x %}
-or [arm64]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-arm64.tar.gz){% endif_version %} distribution manually.
+You can also download the [amd64]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz) {% if_version gte:1.8.x %}
+or [arm64]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-arm64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-arm64.tar.gz){% endif_version %} distribution manually.
 
 Then, extract the archive with:
 

--- a/app/_src/mesh/installation/openshift.md
+++ b/app/_src/mesh/installation/openshift.md
@@ -38,11 +38,11 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/_src/mesh/installation/redhat.md
+++ b/app/_src/mesh/installation/redhat.md
@@ -32,7 +32,7 @@ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} sh 
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
 
 Then, extract the archive with:
 

--- a/app/_src/mesh/installation/ubuntu.md
+++ b/app/_src/mesh/installation/ubuntu.md
@@ -28,7 +28,7 @@ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} sh 
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
  the distribution manually.
 
 Then, extract the archive with:

--- a/app/gateway/2.6.x/install-and-run/amazon-linux.md
+++ b/app/gateway/2.6.x/install-and-run/amazon-linux.md
@@ -30,12 +30,12 @@ Install {{site.base_gateway}} on Amazon Linux from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/amzn/%{amzn}/noarch/kong-enterprise-edition-{{page.versions.ee}}.aws.noarch.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/amzn/%{amzn}/noarch/kong-enterprise-edition-{{page.versions.ee}}.aws.noarch.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/amzn/%{amzn}/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/amzn/%{amzn}/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -69,7 +69,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo > /dev/null
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-legacy'
     ```
 

--- a/app/gateway/2.6.x/install-and-run/centos.md
+++ b/app/gateway/2.6.x/install-and-run/centos.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on CentOS from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/el/%{centos_ver}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{centos_ver}.noarch.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/el/%{centos_ver}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{centos_ver}.noarch.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/el/%{centos_ver}/x86_64/kong-{{page.versions.ce}}.el%{centos_ver}.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/el/%{centos_ver}/x86_64/kong-{{page.versions.ce}}.el%{centos_ver}.x86_64.rpm)
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -66,7 +66,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-legacy'
     ```
 

--- a/app/gateway/2.6.x/install-and-run/debian.md
+++ b/app/gateway/2.6.x/install-and-run/debian.md
@@ -31,12 +31,12 @@ Install {{site.base_gateway}} on Debian from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.cloudsmith }}/public/gateway-legacy/deb/debian/pool/stretch/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.direct }}/gateway-legacy/deb/debian/pool/stretch/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.cloudsmith }}/public/gateway-legacy/deb/debian/pool/stretch/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.direct }}/gateway-legacy/deb/debian/pool/stretch/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -83,8 +83,8 @@ Install the APT repository from the command line.
 
 1. Download the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee -a /usr/share/keyrings/kong-gateway-legacy-archive-keyring.gpg > /dev/null
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.deb.txt?distro=debian&codename=stretch" | sudo tee /etc/apt/sources.list.d/kong-gateway-legacy.list > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee -a /usr/share/keyrings/kong-gateway-legacy-archive-keyring.gpg > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.deb.txt?distro=debian&codename=stretch" | sudo tee /etc/apt/sources.list.d/kong-gateway-legacy.list > /dev/null
     ```
 2. Update the repository:
     ```bash

--- a/app/gateway/2.6.x/install-and-run/rhel.md
+++ b/app/gateway/2.6.x/install-and-run/rhel.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on RHEL from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/el/%{rhel}/noarch/kong-enterprise-edition-{{page.versions.ee}}.el%{rhel}.noarch.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/el/%{rhel}/noarch/kong-enterprise-edition-{{page.versions.ee}}.el%{rhel}.noarch.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/el/%{rhel}/x86_64/kong-{{page.versions.ce}}.el%{rhel}.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/el/%{rhel}/x86_64/kong-{{page.versions.ce}}.el%{rhel}.x86_64.rpm)
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -83,7 +83,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-legacy'
     ```
 

--- a/app/gateway/2.6.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.6.x/install-and-run/ubuntu.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.cloudsmith }}/public/gateway-legacy/deb/ubuntu/pool/xenial/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.direct }}/gateway-legacy/deb/ubuntu/pool/xenial/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.all.deb "{{ site.links.cloudsmith }}/public/gateway-legacy/deb/ubuntu/pool/xenial/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.all.deb "{{ site.links.direct }}/gateway-legacy/deb/ubuntu/pool/xenial/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -68,8 +68,8 @@ Install the APT repository from the command line.
 
 1. Setup the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee -a /usr/share/keyrings/kong-gateway-legacy-archive-keyring.gpg > /dev/null
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.deb.txt?distro=ubuntu&codename=xenial" | sudo tee /etc/apt/sources.list.d/kong-gateway-legacy.list > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee -a /usr/share/keyrings/kong-gateway-legacy-archive-keyring.gpg > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.deb.txt?distro=ubuntu&codename=xenial" | sudo tee /etc/apt/sources.list.d/kong-gateway-legacy.list > /dev/null
     ```
 
 2. Update the repository:

--- a/app/gateway/2.7.x/install-and-run/amazon-linux.md
+++ b/app/gateway/2.7.x/install-and-run/amazon-linux.md
@@ -30,12 +30,12 @@ Install {{site.base_gateway}} on Amazon Linux from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/amzn/%{amzn}/noarch/kong-enterprise-edition-{{page.versions.ee}}.aws.noarch.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/amzn/%{amzn}/noarch/kong-enterprise-edition-{{page.versions.ee}}.aws.noarch.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/amzn/%{amzn}/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/amzn/%{amzn}/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -69,7 +69,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo > /dev/null
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-legacy'
     ```
 

--- a/app/gateway/2.7.x/install-and-run/centos.md
+++ b/app/gateway/2.7.x/install-and-run/centos.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on CentOS from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/el/%{centos_ver}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{centos_ver}.noarch.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/el/%{centos_ver}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{centos_ver}.noarch.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/el/%{centos_ver}/x86_64/kong-{{page.versions.ce}}.el%{centos_ver}.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/el/%{centos_ver}/x86_64/kong-{{page.versions.ce}}.el%{centos_ver}.x86_64.rpm)
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -66,7 +66,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-legacy'
     ```
 

--- a/app/gateway/2.7.x/install-and-run/debian.md
+++ b/app/gateway/2.7.x/install-and-run/debian.md
@@ -31,12 +31,12 @@ Install {{site.base_gateway}} on Debian from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.cloudsmith }}/public/gateway-legacy/deb/debian/pool/buster/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.direct }}/gateway-legacy/deb/debian/pool/buster/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.cloudsmith }}/public/gateway-legacy/deb/debian/pool/buster/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.direct }}/gateway-legacy/deb/debian/pool/buster/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -83,8 +83,8 @@ Install the APT repository from the command line.
 
 1. Download the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee -a /usr/share/keyrings/kong-gateway-legacy-archive-keyring.gpg > /dev/null
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-legacy.list > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee -a /usr/share/keyrings/kong-gateway-legacy-archive-keyring.gpg > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-legacy.list > /dev/null
     ```
 2. Update the repository:
     ```bash

--- a/app/gateway/2.7.x/install-and-run/rhel.md
+++ b/app/gateway/2.7.x/install-and-run/rhel.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on RHEL from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/el/%{rhel}/noarch/kong-enterprise-edition-{{page.versions.ee}}.el%{rhel}.noarch.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/el/%{rhel}/noarch/kong-enterprise-edition-{{page.versions.ee}}.el%{rhel}.noarch.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-legacy/rpm/el/%{rhel}/x86_64/kong-{{page.versions.ce}}.el%{rhel}.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-legacy/rpm/el/%{rhel}/x86_64/kong-{{page.versions.ce}}.el%{rhel}.x86_64.rpm)
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -83,7 +83,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-legacy.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-legacy'
     ```
 

--- a/app/gateway/2.7.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.7.x/install-and-run/ubuntu.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.cloudsmith }}/public/gateway-legacy/deb/ubuntu/pool/xenial/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.direct }}/gateway-legacy/deb/ubuntu/pool/xenial/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.all.deb "{{ site.links.cloudsmith }}/public/gateway-legacy/deb/ubuntu/pool/xenial/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.all.deb "{{ site.links.direct }}/gateway-legacy/deb/ubuntu/pool/xenial/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -68,8 +68,8 @@ Install the APT repository from the command line.
 
 1. Setup the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee -a /usr/share/keyrings/kong-gateway-legacy-archive-keyring.gpg > /dev/null
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-legacy/config.deb.txt?distro=ubuntu&codename=xenial" | sudo tee /etc/apt/sources.list.d/kong-gateway-legacy.list > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee -a /usr/share/keyrings/kong-gateway-legacy-archive-keyring.gpg > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-legacy/config.deb.txt?distro=ubuntu&codename=xenial" | sudo tee /etc/apt/sources.list.d/kong-gateway-legacy.list > /dev/null
     ```
 
 2. Update the repository:

--- a/app/gateway/2.8.x/install-and-run/amazon-linux.md
+++ b/app/gateway/2.8.x/install-and-run/amazon-linux.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on Amazon Linux from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-28/rpm/amzn/%{amzn}/noarch/kong-enterprise-edition-{{page.versions.ee}}.aws.noarch.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-28/rpm/amzn/%{amzn}/noarch/kong-enterprise-edition-{{page.versions.ee}}.aws.noarch.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-28/rpm/amzn/%{amzn}/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-28/rpm/amzn/%{amzn}/x86_64/kong-{{page.versions.ce}}.aws.x86_64.rpm)
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -68,7 +68,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo > /dev/null
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-{{ page.major_minor_version }}'
     ```
 

--- a/app/gateway/2.8.x/install-and-run/centos.md
+++ b/app/gateway/2.8.x/install-and-run/centos.md
@@ -35,7 +35,7 @@ Install {{site.base_gateway}} on CentOS from the command line.
 1. Download the Kong package:
 
     ```bash
-    curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/%{centos_ver}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{centos_ver}.noarch.rpm)
+    curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{centos_ver}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{centos_ver}.noarch.rpm)
     ```
 
 2. Install the package:
@@ -51,7 +51,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong yum repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-{{ page.major_minor_version }}'
     ```
 

--- a/app/gateway/2.8.x/install-and-run/debian.md
+++ b/app/gateway/2.8.x/install-and-run/debian.md
@@ -30,12 +30,12 @@ Install {{site.base_gateway}} on Debian from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/debian/pool/buster/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/debian/pool/buster/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/deb/debian/pool/buster/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/deb/debian/pool/buster/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -71,8 +71,8 @@ Install the APT repository from the command line.
 
 1. Download the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-28/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-28-archive-keyring.gpg > /dev/null
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-28/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-28.list > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-28/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-28-archive-keyring.gpg > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-28/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-28.list > /dev/null
     ```
 2. Update the repository:
     ```bash

--- a/app/gateway/2.8.x/install-and-run/rhel.md
+++ b/app/gateway/2.8.x/install-and-run/rhel.md
@@ -27,12 +27,12 @@ Install {{site.base_gateway}} on RHEL from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{rhel}.noarch.rpm)
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{rhel}.noarch.rpm)
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/x86_64/kong-{{page.versions.ce}}.el%{rhel}.x86_64.rpm)
+curl -Lo kong-{{page.versions.ce}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{rhel}/x86_64/kong-{{page.versions.ce}}.el%{rhel}.x86_64.rpm)
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -83,7 +83,7 @@ Install the YUM repository from the command line.
 
 1. Download the Kong YUM repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-{{ page.major_minor_version }}.repo
     sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-{{ page.major_minor_version }}'
     ```
 

--- a/app/gateway/2.8.x/install-and-run/ubuntu.md
+++ b/app/gateway/2.8.x/install-and-run/ubuntu.md
@@ -34,12 +34,12 @@ Install {{site.base_gateway}} on Ubuntu from the command line.
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.cloudsmith }}/public/gateway-28/deb/ubuntu/pool/jammy/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
+curl -Lo kong-enterprise-edition-{{page.versions.ee}}.all.deb "{{ site.links.direct }}/gateway-28/deb/ubuntu/pool/jammy/main/k/ko/kong-enterprise-edition_{{page.versions.ee}}/kong-enterprise-edition_{{page.versions.ee}}_all.deb"
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.cloudsmith }}/public/gateway-28/deb/ubuntu/pool/bionic/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
+curl -Lo kong-{{page.versions.ce}}.amd64.deb "{{ site.links.direct }}/gateway-28/deb/ubuntu/pool/bionic/main/k/ko/kong_{{page.versions.ce}}/kong_{{page.versions.ce}}_amd64.deb"
  ```
 {% endnavtab %}
 {% endnavtabs_ee %}
@@ -75,8 +75,8 @@ Install the APT repository from the command line.
 
 1. Setup the Kong APT repository:
     ```bash
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg > /dev/null
-    curl -1sLf "{{ site.links.cloudsmith }}/public/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename=focal" | sudo tee /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg > /dev/null
+    curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename=focal" | sudo tee /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list > /dev/null
     ```
 
 2. Update the repository:

--- a/app/mesh/1.2.x/installation/amazonlinux.md
+++ b/app/mesh/1.2.x/installation/amazonlinux.md
@@ -35,7 +35,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.2.x/installation/centos.md
+++ b/app/mesh/1.2.x/installation/centos.md
@@ -29,7 +29,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.2.x/installation/debian.md
+++ b/app/mesh/1.2.x/installation/debian.md
@@ -27,7 +27,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.2.x/installation/helm.md
+++ b/app/mesh/1.2.x/installation/helm.md
@@ -163,4 +163,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.2.x/quickstart/kubernetes/).

--- a/app/mesh/1.2.x/installation/kubernetes.md
+++ b/app/mesh/1.2.x/installation/kubernetes.md
@@ -35,11 +35,11 @@ You can also download the distribution manually. Download a distribution for
 the client host from the machine where you plan to run the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.2.x/installation/kubernetes.md
+++ b/app/mesh/1.2.x/installation/kubernetes.md
@@ -188,4 +188,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.2.x/quickstart/kubernetes/).

--- a/app/mesh/1.2.x/installation/macos.md
+++ b/app/mesh/1.2.x/installation/macos.md
@@ -36,7 +36,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.2.x/installation/openshift.md
+++ b/app/mesh/1.2.x/installation/openshift.md
@@ -262,4 +262,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.2.x/quickstart/kubernetes/).

--- a/app/mesh/1.2.x/installation/openshift.md
+++ b/app/mesh/1.2.x/installation/openshift.md
@@ -38,11 +38,11 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.2.x/installation/redhat.md
+++ b/app/mesh/1.2.x/installation/redhat.md
@@ -27,7 +27,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
 
 Then, extract the archive with:
 

--- a/app/mesh/1.2.x/installation/ubuntu.md
+++ b/app/mesh/1.2.x/installation/ubuntu.md
@@ -28,7 +28,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
  the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.3.x/installation/amazonlinux.md
+++ b/app/mesh/1.3.x/installation/amazonlinux.md
@@ -35,7 +35,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.3.x/installation/centos.md
+++ b/app/mesh/1.3.x/installation/centos.md
@@ -34,7 +34,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.3.x/installation/debian.md
+++ b/app/mesh/1.3.x/installation/debian.md
@@ -27,7 +27,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.3.x/installation/helm.md
+++ b/app/mesh/1.3.x/installation/helm.md
@@ -171,4 +171,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.3.x/quickstart/kubernetes/).

--- a/app/mesh/1.3.x/installation/kubernetes.md
+++ b/app/mesh/1.3.x/installation/kubernetes.md
@@ -35,11 +35,11 @@ You can also download the distribution manually. Download a distribution for
 the client host from the machine where you plan to run the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.3.x/installation/kubernetes.md
+++ b/app/mesh/1.3.x/installation/kubernetes.md
@@ -188,4 +188,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.3.x/quickstart/kubernetes/).

--- a/app/mesh/1.3.x/installation/macos.md
+++ b/app/mesh/1.3.x/installation/macos.md
@@ -36,7 +36,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.3.x/installation/openshift.md
+++ b/app/mesh/1.3.x/installation/openshift.md
@@ -262,4 +262,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.3.x/quickstart/kubernetes/).

--- a/app/mesh/1.3.x/installation/openshift.md
+++ b/app/mesh/1.3.x/installation/openshift.md
@@ -38,11 +38,11 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.3.x/installation/redhat.md
+++ b/app/mesh/1.3.x/installation/redhat.md
@@ -32,7 +32,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
 
 Then, extract the archive with:
 

--- a/app/mesh/1.3.x/installation/ubuntu.md
+++ b/app/mesh/1.3.x/installation/ubuntu.md
@@ -28,7 +28,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
  the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.4.x/installation/amazonlinux.md
+++ b/app/mesh/1.4.x/installation/amazonlinux.md
@@ -35,7 +35,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.4.x/installation/centos.md
+++ b/app/mesh/1.4.x/installation/centos.md
@@ -34,7 +34,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.4.x/installation/debian.md
+++ b/app/mesh/1.4.x/installation/debian.md
@@ -27,7 +27,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.4.x/installation/helm.md
+++ b/app/mesh/1.4.x/installation/helm.md
@@ -172,4 +172,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.4.x/quickstart/kubernetes/).

--- a/app/mesh/1.4.x/installation/kubernetes.md
+++ b/app/mesh/1.4.x/installation/kubernetes.md
@@ -35,11 +35,11 @@ You can also download the distribution manually. Download a distribution for
 the client host from the machine where you plan to run the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.4.x/installation/kubernetes.md
+++ b/app/mesh/1.4.x/installation/kubernetes.md
@@ -188,4 +188,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.4.x/quickstart/kubernetes/).

--- a/app/mesh/1.4.x/installation/macos.md
+++ b/app/mesh/1.4.x/installation/macos.md
@@ -36,7 +36,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.4.x/installation/openshift.md
+++ b/app/mesh/1.4.x/installation/openshift.md
@@ -262,4 +262,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.4.x/quickstart/kubernetes/).

--- a/app/mesh/1.4.x/installation/openshift.md
+++ b/app/mesh/1.4.x/installation/openshift.md
@@ -38,11 +38,11 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.4.x/installation/redhat.md
+++ b/app/mesh/1.4.x/installation/redhat.md
@@ -32,7 +32,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
 
 Then, extract the archive with:
 

--- a/app/mesh/1.4.x/installation/ubuntu.md
+++ b/app/mesh/1.4.x/installation/ubuntu.md
@@ -28,7 +28,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
  the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.5.x/installation/amazonlinux.md
+++ b/app/mesh/1.5.x/installation/amazonlinux.md
@@ -35,7 +35,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.5.x/installation/centos.md
+++ b/app/mesh/1.5.x/installation/centos.md
@@ -34,7 +34,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.5.x/installation/debian.md
+++ b/app/mesh/1.5.x/installation/debian.md
@@ -27,7 +27,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.5.x/installation/helm.md
+++ b/app/mesh/1.5.x/installation/helm.md
@@ -172,4 +172,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.5.x/quickstart/kubernetes/).

--- a/app/mesh/1.5.x/installation/kubernetes.md
+++ b/app/mesh/1.5.x/installation/kubernetes.md
@@ -188,4 +188,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.5.x/quickstart/kubernetes/).

--- a/app/mesh/1.5.x/installation/kubernetes.md
+++ b/app/mesh/1.5.x/installation/kubernetes.md
@@ -35,11 +35,11 @@ You can also download the distribution manually. Download a distribution for
 the client host from the machine where you plan to run the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.5.x/installation/macos.md
+++ b/app/mesh/1.5.x/installation/macos.md
@@ -36,7 +36,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.5.x/installation/openshift.md
+++ b/app/mesh/1.5.x/installation/openshift.md
@@ -262,4 +262,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.5.x/quickstart/kubernetes/).

--- a/app/mesh/1.5.x/installation/openshift.md
+++ b/app/mesh/1.5.x/installation/openshift.md
@@ -38,11 +38,11 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.5.x/installation/redhat.md
+++ b/app/mesh/1.5.x/installation/redhat.md
@@ -32,7 +32,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
 
 Then, extract the archive with:
 

--- a/app/mesh/1.5.x/installation/ubuntu.md
+++ b/app/mesh/1.5.x/installation/ubuntu.md
@@ -28,7 +28,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
  the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.5.x/installation/windows.md
+++ b/app/mesh/1.5.x/installation/windows.md
@@ -32,7 +32,7 @@ Invoke-Expression ([System.Text.Encoding]::UTF8.GetString((Invoke-WebRequest -Ur
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-windows-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-windows-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-windows-amd64.tar.gz)
 the distribution manually.
 
 Then extract the archive with:

--- a/app/mesh/1.6.x/installation/amazonlinux.md
+++ b/app/mesh/1.6.x/installation/amazonlinux.md
@@ -35,7 +35,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.6.x/installation/centos.md
+++ b/app/mesh/1.6.x/installation/centos.md
@@ -34,7 +34,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.6.x/installation/debian.md
+++ b/app/mesh/1.6.x/installation/debian.md
@@ -27,7 +27,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.6.x/installation/helm.md
+++ b/app/mesh/1.6.x/installation/helm.md
@@ -184,4 +184,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.6.x/quickstart/kubernetes/).

--- a/app/mesh/1.6.x/installation/kubernetes.md
+++ b/app/mesh/1.6.x/installation/kubernetes.md
@@ -188,4 +188,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.6.x/quickstart/kubernetes/).

--- a/app/mesh/1.6.x/installation/kubernetes.md
+++ b/app/mesh/1.6.x/installation/kubernetes.md
@@ -35,11 +35,11 @@ You can also download the distribution manually. Download a distribution for
 the client host from the machine where you plan to run the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.6.x/installation/macos.md
+++ b/app/mesh/1.6.x/installation/macos.md
@@ -36,7 +36,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.6.x/installation/openshift.md
+++ b/app/mesh/1.6.x/installation/openshift.md
@@ -38,11 +38,11 @@ You can also download the distribution manually. Download a distribution for
 the **client host** from where you will be executing the commands to access
 Kubernetes:
 
-* [CentOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
-* [Red Hat]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
-* [Debian]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
-* [Ubuntu]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
-* [macOS]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
+* [CentOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-centos-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-centos-amd64.tar.gz)
+* [Red Hat]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz)
+* [Debian]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-debian-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-debian-amd64.tar.gz)
+* [Ubuntu]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+* [macOS]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-darwin-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-darwin-amd64.tar.gz)
 
 Then, extract the archive with:
 

--- a/app/mesh/1.6.x/installation/openshift.md
+++ b/app/mesh/1.6.x/installation/openshift.md
@@ -262,4 +262,4 @@ is fully compatible with {{site.mesh_product_name}}, except that you are
 running {{site.mesh_product_name}} containers instead of Kuma containers.
 
 To start using {{site.mesh_product_name}}, see the
-[quickstart guide for Kubernetes deployments](https://kuma.io/docs/latest/quickstart/kubernetes/).
+[quickstart guide for Kubernetes deployments](https://kuma.io/docs/1.6.x/quickstart/kubernetes/).

--- a/app/mesh/1.6.x/installation/redhat.md
+++ b/app/mesh/1.6.x/installation/redhat.md
@@ -32,7 +32,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 ```
 {% endnavtab %}
 {% navtab Manually %}
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-rhel-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-rhel-amd64.tar.gz) the distribution manually.
 
 Then, extract the archive with:
 

--- a/app/mesh/1.6.x/installation/ubuntu.md
+++ b/app/mesh/1.6.x/installation/ubuntu.md
@@ -28,7 +28,7 @@ $ curl -L https://docs.konghq.com/mesh/installer.sh | VERSION={{page.version}} s
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-ubuntu-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-ubuntu-amd64.tar.gz)
  the distribution manually.
 
 Then, extract the archive with:

--- a/app/mesh/1.6.x/installation/windows.md
+++ b/app/mesh/1.6.x/installation/windows.md
@@ -32,7 +32,7 @@ Invoke-Expression ([System.Text.Encoding]::UTF8.GetString((Invoke-WebRequest -Ur
 {% endnavtab %}
 {% navtab Manually %}
 
-You can also [download]({{site.links.download}}/mesh-alpine/kong-mesh-{{page.version}}-windows-amd64.tar.gz)
+You can also [download]({{site.links.direct}}/kong-mesh-legacy/raw/names/kong-mesh-windows-amd64/versions/{{page.version}}/kong-mesh-{{page.version}}-windows-amd64.tar.gz)
 the distribution manually.
 
 Then extract the archive with:

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -23,8 +23,8 @@ description: "Documentation for Kong, the Cloud Connectivity Company for APIs an
 links:
   web: http://localhost:4000
   share: https://docs.konghq.com # legacy link, must maintain for social sharing counters
-  download: https://download.konghq.com
-  cloudsmith: https://packages.konghq.com
+  download: https://cloudsmith.io/~kong/repos
+  direct: https://packages.konghq.com/public
   instaclustr: "https://www.instaclustr.com/products/kong/?utm_source=partnership&utm_medium=link&utm_campaign=mashape"
   learn: https://education.konghq.com # kong academy
   archive: https://legacy-gateway--kongdocs.netlify.app

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -23,8 +23,8 @@ description: "Documentation for Kong, the Cloud Connectivity Company for APIs an
 links:
   web: https://docs.konghq.com
   share: https://docs.konghq.com # legacy link, must maintain for social sharing counters
-  download: https://download.konghq.com
-  cloudsmith: https://packages.konghq.com
+  download: https://cloudsmith.io/~kong/repos
+  direct: https://packages.konghq.com/public
   instaclustr: "https://www.instaclustr.com/products/kong/?utm_source=partnership&utm_medium=link&utm_campaign=mashape"
   learn: https://education.konghq.com # kong academy
   archive: https://legacy-gateway--kongdocs.netlify.app


### PR DESCRIPTION
### Description

The changes in this PR do 2 things:
- swap `{{ site.links.cloudsmith }}` for `{{ site.links.download }}` and `{{ site.links.direct }}` (for GUI and direct download links via Cloudsmith, respectively).
  - this more closely matches forcoming changes to the Kuma docs:
    - https://github.com/kumahq/kuma-website/pull/1628 and
    - https://github.com/kumahq/kuma-website/pull/1625
- swap the `kong-mesh` docs to use Cloudsmith

### Testing instructions

Preview link: https://deploy-preview-6863--kongdocs.netlify.app

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] For unreleased versions: [conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

    For example, if this change is for an upcoming 3.6 release, surround your change in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

Drafting so I can fix broken links as they arise.
