### PR TITLE
Plugin priorities

### DIFF
--- a/app/_includes/plugins/priority_table.html
+++ b/app/_includes/plugins/priority_table.html
@@ -1,22 +1,3 @@
-{% if include.type == 'oss' %}
-  <table>
-    <thead>
-      <tr>
-        <th>correlation-id</th>
-        <th>Priority</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for type in include.correlation_id %}
-        <tr>
-          <td><span class="badge {{ type[0] }}"></span></td>
-          <td>{{ type[1] }}</td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-{% endif %}
-
 <table>
   <thead>
     <tr>
@@ -26,14 +7,10 @@
   </thead>
   <tbody>
     {%- for plugin in include.plugins -%}
-      {% if include.type == 'oss' and plugin[0] == 'correlation-id' %}
-        {% continue %}
-      {% else %}
-        <tr>
-          <td>{{ plugin[0] }}</td>
-          <td>{{ plugin[1] }}</td>
-        </tr>
-      {% endif %}
+      <tr>
+        <td>{{ plugin[0] }}</td>
+        <td>{{ plugin[1] }}</td>
+      </tr>
     {%- endfor -%}
   </tbody>
 </table>

--- a/app/_includes/plugins/priority_table.html
+++ b/app/_includes/plugins/priority_table.html
@@ -1,0 +1,39 @@
+{% if include.type == 'oss' %}
+  <table>
+    <thead>
+      <tr>
+        <th>correlation-id</th>
+        <th>Priority</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for type in include.correlation_id %}
+        <tr>
+          <td><span class="badge {{ type[0] }}"></span></td>
+          <td>{{ type[1] }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
+
+<table>
+  <thead>
+    <tr>
+      <th>Plugin</th>
+      <th>Priority</th>
+    </tr>
+  </thead>
+  <tbody>
+    {%- for plugin in include.plugins -%}
+      {% if include.type == 'oss' and plugin[0] == 'correlation-id' %}
+        {% continue %}
+      {% else %}
+        <tr>
+          <td>{{ plugin[0] }}</td>
+          <td>{{ plugin[1] }}</td>
+        </tr>
+      {% endif %}
+    {%- endfor -%}
+  </tbody>
+</table>

--- a/app/_plugins/tags/plugins_priority_table.rb
+++ b/app/_plugins/tags/plugins_priority_table.rb
@@ -29,7 +29,7 @@ module Jekyll
     private
 
     def plugins
-      @plugins ||= JSON.parse(File.read("#{PRIORITIES_PATH}/#{type}/#{version}.json"))
+      @plugins = JSON.parse(File.read("#{PRIORITIES_PATH}/#{type}/#{version}.json"))
     end
 
     def template
@@ -37,11 +37,11 @@ module Jekyll
     end
 
     def version
-      @version ||= if @page['release']
-                     @page['release'].value
-                   else
-                     latest_release
-                   end
+      @version = if @page['release']
+                   @page['release'].value
+                 else
+                   latest_release
+                 end
     end
 
     def type

--- a/app/_plugins/tags/plugins_priority_table.rb
+++ b/app/_plugins/tags/plugins_priority_table.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Jekyll
+  class PluginsPriorityTable < Liquid::Tag
+    PRIORITIES_PATH = 'app/_src/.repos/kong-plugins/data/priorities'
+
+    def initialize(tag_name, type, tokens)
+      super
+
+      @type = type.strip
+    end
+
+    def render(context)
+      @context = context
+      @site = context.registers[:site]
+      @page = context.environments.first['page']
+
+      Liquid::Template
+        .parse(template)
+        .render(
+          { 'page' => @page,
+            'include' => { 'plugins' => plugins, 'type' => @type, 'correlation_id' => correlation_id } },
+          { registers: context.registers }
+        )
+    end
+
+    private
+
+    def correlation_id
+      if type == 'oss'
+        oss_priority = plugins['correlation-id']
+        free_priority = JSON.parse(File.read("#{PRIORITIES_PATH}/ee/#{version}.json"))['correlation-id']
+      else
+        free_priority = plugins['correlation-id']
+        oss_priority = JSON.parse(File.read("#{PRIORITIES_PATH}/oss/#{version}.json"))['correlation-id']
+      end
+      { 'free' => free_priority, 'oss' => oss_priority }
+    end
+
+    def plugins
+      @plugins ||= JSON.parse(File.read("#{PRIORITIES_PATH}/#{type}/#{version}.json"))
+    end
+
+    def template
+      @template ||= File.read(File.expand_path('app/_includes/plugins/priority_table.html'))
+    end
+
+    def version
+      @version ||= if @page['release']
+                     @page['release'].value
+                   else
+                     latest_release
+                   end
+    end
+
+    def type
+      case @type
+      when 'oss'
+        'oss'
+      when 'enterprise'
+        'ee'
+      end
+    end
+
+    def latest_release
+      @latest_release ||= Jekyll::GeneratorSingleSource::Product::Edition
+                          .new(edition: 'gateway', site: @site)
+                          .latest_release
+                          .value
+    end
+  end
+end
+
+Liquid::Template.register_tag('plugins_priority_table', Jekyll::PluginsPriorityTable)

--- a/app/_plugins/tags/plugins_priority_table.rb
+++ b/app/_plugins/tags/plugins_priority_table.rb
@@ -21,23 +21,12 @@ module Jekyll
         .parse(template)
         .render(
           { 'page' => @page,
-            'include' => { 'plugins' => plugins, 'type' => @type, 'correlation_id' => correlation_id } },
+            'include' => { 'plugins' => plugins, 'type' => @type } },
           { registers: context.registers }
         )
     end
 
     private
-
-    def correlation_id
-      if type == 'oss'
-        oss_priority = plugins['correlation-id']
-        free_priority = JSON.parse(File.read("#{PRIORITIES_PATH}/ee/#{version}.json"))['correlation-id']
-      else
-        free_priority = plugins['correlation-id']
-        oss_priority = JSON.parse(File.read("#{PRIORITIES_PATH}/oss/#{version}.json"))['correlation-id']
-      end
-      { 'free' => free_priority, 'oss' => oss_priority }
-    end
 
     def plugins
       @plugins ||= JSON.parse(File.read("#{PRIORITIES_PATH}/#{type}/#{version}.json"))

--- a/app/_src/gateway/plugin-development/custom-logic.md
+++ b/app/_src/gateway/plugin-development/custom-logic.md
@@ -77,7 +77,7 @@ To reduce unexpected behaviour changes, {{site.base_gateway}} does not start if 
 | Function name       | Phase               | Request Protocol              | Description
 |---------------------|---------------------|-------------------------------|------------
 | `init_worker`       | [init_worker]       | *                             | Executed upon every Nginx worker process's startup.
-| `configure`         | [init_worker]/timer | *                             | Executed everytime Kong plugin iterator is rebuild (aka after changes to configure plugins)
+| `configure`         | [init_worker]/timer | *                             | Executed every time the Kong plugin iterator is rebuilt (after changes to configure plugins).
 | `certificate`       | [ssl_certificate]   | `https`, `grpcs`, `wss`       | Executed during the SSL certificate serving phase of the SSL handshake.
 | `rewrite`           | [rewrite]           | *                             | Executed for every request upon its reception from a client as a rewrite phase handler. <br> In this phase, neither the `Service` nor the `Consumer` have been identified, hence this handler will only be executed if the plugin was configured as a global plugin.
 | `access`            | [access]            | `http(s)`, `grpc(s)`, `ws(s)` | Executed for every request from a client and before it is being proxied to the upstream service.
@@ -100,7 +100,7 @@ To reduce unexpected behaviour changes, {{site.base_gateway}} does not start if 
 | Function name   | Phase                                                                        | Description
 |-----------------|------------------------------------------------------------------------------|------------
 | `init_worker`   | [init_worker]                                                                | Executed upon every Nginx worker process's startup.
-| `configure`     | [init_worker]/timer                                                         | Executed everytime Kong plugin iterator is rebuild (aka after changes to configure plugins)
+| `configure`     | [init_worker]/timer                                                         | Executed every time the Kong plugin iterator is rebuilt (after changes to configure plugins).
 | `preread`       | [preread]                                                                    | Executed once for every connection.
 | `log`           | [log](https://github.com/openresty/stream-lua-nginx-module#log_by_lua_block) | Executed once for each connection after it has been closed.
 | `certificate`   | [ssl_certificate]                                                            | Executed during the SSL certificate serving phase of the SSL handshake.
@@ -445,12 +445,13 @@ for more information.
 {% navtab OSS %}
 
 The following list includes all plugins bundled with open-source
-{{site.base_gateway}} or {{site.base_gateway}} running in Free mode.
+{{site.base_gateway}}.
 
 {:.note}
-> **Note:** The correlation-id plugin's execution order is different depending
-on whether you're running {{site.base_gateway}} in Free mode or using the
-open-source package.
+> **Note:** The Correlation ID plugin's priority changes depending on
+> whether you're running it in open-source or Free mode.
+> Free mode uses the {{site.ee_product_name}} package.
+> Switch to the **Enterprise** tab to see the correct priority for this plugin.
 
 The current order of execution for the bundled plugins is:
 
@@ -458,8 +459,9 @@ The current order of execution for the bundled plugins is:
 
 {% endnavtab %}
 {% navtab Enterprise %}
-The following list includes all plugins bundled with a {{site.base_gateway}}
-Enterprise subscription.
+The following list includes all plugins bundled with a {{site.ee_product_name}}
+subscription. This priority order also applies to plugins running in Free mode, 
+which uses the {{site.ee_product_name}} package.
 
 The current order of execution for the bundled plugins is:
 

--- a/app/_src/gateway/plugin-development/custom-logic.md
+++ b/app/_src/gateway/plugin-development/custom-logic.md
@@ -442,7 +442,7 @@ This can be adjusted dynamically using the `ordering` option. See
 for more information.
 
 {% navtabs %}
-{% navtab Open-source or Free mode %}
+{% navtab OSS %}
 
 The following list includes all plugins bundled with open-source
 {{site.base_gateway}} or {{site.base_gateway}} running in Free mode.

--- a/app/_src/gateway/plugin-development/custom-logic.md
+++ b/app/_src/gateway/plugin-development/custom-logic.md
@@ -454,7 +454,7 @@ open-source package.
 
 The current order of execution for the bundled plugins is:
 
-{% include /md/plugin-priority.md edition='oss' %}
+{% plugins_priority_table oss %}
 
 {% endnavtab %}
 {% navtab Enterprise %}
@@ -463,7 +463,7 @@ Enterprise subscription.
 
 The current order of execution for the bundled plugins is:
 
-{% include /md/plugin-priority.md edition='enterprise' %}
+{% plugins_priority_table enterprise %}
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/konnect/reference/plugins.md
+++ b/app/konnect/reference/plugins.md
@@ -23,4 +23,4 @@ Enterprise subscription.
 
 The current order of execution for the bundled plugins is:
 
-{% include /md/plugin-priority.md edition='enterprise' %}
+{% plugins_priority_table enterprise %}


### PR DESCRIPTION
### Description

To generate the table, use the priorities defined in `app/_src/.repos/kong-plugins/app/data/priorities/`.
Add a new liquid tag `plugins_priority_table`, that takes `enterprise` or `oss` as an argument and uses the page's release (or latest for Konnect) to fetch the data. 


@lena-larionova I wasn't sure how we wanted to handle the case for `correlation-id`, so I added a separate table for it 🤷. From what I understand `free mode` uses the enterprise value and `oss` well, the oss one.

WDYT?
We could try to replicate the current behaviour too, it's a bit more complex though, but definitely doable.

### Testing instructions

[Preview link](https://deploy-preview-6866--kongdocs.netlify.app/gateway/latest/plugin-development/custom-logic/)

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] For unreleased versions: [conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

    For example, if this change is for an upcoming 3.6 release, surround your change in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

