### PR TITLE
Keep a Set of the pages' urls, it has an Array's operations

### DIFF
--- a/app/_plugins/drops/releases_dropdown.rb
+++ b/app/_plugins/drops/releases_dropdown.rb
@@ -41,7 +41,7 @@ module Jekyll
       end
 
       def page_exists?(url)
-        !@page.site.pages.detect { |p| p.url == url }.nil?
+        @page.site.data['pages_urls'].include?(url)
       end
 
       def root_url

--- a/app/_plugins/hooks/pages_urls_hash.rb
+++ b/app/_plugins/hooks/pages_urls_hash.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Jekyll::Hooks.register :site, :pre_render do |site|
+  site.data['pages_urls'] = Set.new
+
+  site.pages.each do |page|
+    site.data['pages_urls'] << page.url
+  end
+end

--- a/app/_plugins/tags/page_exists.rb
+++ b/app/_plugins/tags/page_exists.rb
@@ -13,9 +13,7 @@ module Jekyll
 
       # Loop through all registered pages, and return if there
       # is a page with the URL that we're expecting
-      !context.registers[:site].pages.detect do |page|
-        page.url == url
-      end.nil?
+      context.registers[:site].data['pages_urls'].include?(url)
     end
   end
 end

--- a/spec/app/_plugins/drops/option_spec.rb
+++ b/spec/app/_plugins/drops/option_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Jekyll::Drops::Option do
   end
 
   describe '#url' do
+    before do
+      allow(site.data).to receive(:[]).and_call_original
+      allow(site.data).to receive(:[]).with('pages_urls').and_return(Set.new(urls))
+    end
+
     context 'previous version' do
       let(:page) { find_page_by_url('/gateway/latest/reference/configuration/') }
       let(:release) do
@@ -40,9 +45,7 @@ RSpec.describe Jekyll::Drops::Option do
       end
 
       context 'when the url exists' do
-        before do
-          site.pages = [double('url' => '/gateway/2.5.x/reference/configuration/'), page]
-        end
+        let(:urls) { ['/gateway/2.5.x/reference/configuration/'] }
 
         it 'it links to it' do
           expect(subject.url).to eq('/gateway/2.5.x/reference/configuration/')
@@ -50,6 +53,8 @@ RSpec.describe Jekyll::Drops::Option do
       end
 
       context 'when the url does not exist' do
+        let(:urls) { [] }
+
         it 'links to the root page' do
           expect(subject.url).to eq('/gateway/2.5.x/')
         end
@@ -66,13 +71,15 @@ RSpec.describe Jekyll::Drops::Option do
       end
 
       context 'when the url exists' do
+        let(:urls) { ['/kubernetes-ingress-controller/2.7.x/introduction/'] }
+
         it 'it links to it' do
           expect(subject.url).to eq('/kubernetes-ingress-controller/2.7.x/introduction/')
         end
       end
 
       context 'when the url does not exist' do
-        before { site.pages = [] }
+        let(:urls) { [] }
 
         it 'links to the root page' do
           expect(subject.url).to eq('/kubernetes-ingress-controller/2.7.x/')


### PR DESCRIPTION
### Description

Quick and dirty solution that speeds up the rendering process locally by ~ 25%.
Keep a Set of the pages' urls, it has an Array's operations with a Hash's fast lookup.

When we released the `version_if` refactor we added 3mins+ to the  deploy time, this was mainly because we added 3 unreleased versions (kic, gateway and kgo).
Build times however are better with the change:

#### before
<img width="655" alt="before-process-summary" src="https://github.com/Kong/docs.konghq.com/assets/715229/c26150a3-fe80-4ab9-97f3-3104bb1865ff">
<img width="712" alt="before-done-in" src="https://github.com/Kong/docs.konghq.com/assets/715229/6554c21c-94c8-4f28-a0f0-ee4cc4890a10">


#### now
<img width="472" alt="after-process-summary" src="https://github.com/Kong/docs.konghq.com/assets/715229/8c4153d5-a815-4e61-a149-8b2b8249a9b1">
<img width="702" alt="after-done-in" src="https://github.com/Kong/docs.konghq.com/assets/715229/89c98821-f52b-480a-87e3-6261c771b3c8">



### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

