### PR TITLE
Cache products and use them in generators

### DIFF
--- a/app/_plugins/generators/pages/productable.rb
+++ b/app/_plugins/generators/pages/productable.rb
@@ -21,9 +21,7 @@ module Jekyll
       end
 
       def products
-        @products ||= Jekyll::GeneratorSingleSource::Product::Edition
-                      .all(site: @site)
-                      .keys
+        @products ||= @page.site.data['editions'].keys
       end
     end
   end

--- a/app/_plugins/generators/pages/version_data.rb
+++ b/app/_plugins/generators/pages/version_data.rb
@@ -33,8 +33,7 @@ module Jekyll
       end
 
       def edition
-        @edition ||= Jekyll::GeneratorSingleSource::Product::Edition
-                     .new(edition: product, site: @site)
+        @edition ||= @site.data.dig('editions', product)
       end
 
       def set_release_data # rubocop:disable Metrics/AbcSize

--- a/app/_plugins/generators/versions.rb
+++ b/app/_plugins/generators/versions.rb
@@ -14,6 +14,15 @@ module Jekyll
       konnect = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'konnect', site:)
       contributing = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'contributing', site:)
 
+      site.data['editions'] = {}
+      site.data['editions']['deck'] = deck
+      site.data['editions']['mesh'] = mesh
+      site.data['editions']['kubernetes-ingress-controller'] = kic
+      site.data['editions']['gateway'] = gateway
+      site.data['editions']['gateway-operator'] = gateway_operator
+      site.data['editions']['konnect'] = konnect
+      site.data['editions']['contributing'] = contributing
+
       site.data['kong_versions_deck'] = deck.releases.map(&:to_h)
       site.data['kong_versions_mesh'] = mesh.releases.map(&:to_h)
       site.data['kong_versions_konnect'] = konnect.releases.map(&:to_h)


### PR DESCRIPTION
### Description

Fixes a performance regression.
Deploys should be back to ~6-7 mins

### Testing instructions

#### before
<img width="350" alt="before" src="https://github.com/Kong/docs.konghq.com/assets/715229/fd5ca16a-36cd-4518-ade2-4f999c39ff98">

#### after
<img width="451" alt="after" src="https://github.com/Kong/docs.konghq.com/assets/715229/fa938658-de7f-4285-9f0f-094df2ee87b7">



### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

