### PR TITLE
Final performance tweaks

### DIFF
--- a/app/_plugins/drops/plugins/versions_dropdown.rb
+++ b/app/_plugins/drops/plugins/versions_dropdown.rb
@@ -65,10 +65,9 @@ module Jekyll
         end
 
         def gateway_releases
-          @gateway_releases ||= Jekyll::GeneratorSingleSource::Product::Edition
-                                .new(edition: 'gateway', site: @page.site)
-                                .releases
-                                .select { |r| extn_releases.include?(r.value) }
+          @gateway_releases ||= @page.site.data.dig('editions', 'gateway')
+                                     .releases
+                                     .select { |r| extn_releases.include?(r.value) }
         end
       end
     end

--- a/app/_plugins/drops/sidenav.rb
+++ b/app/_plugins/drops/sidenav.rb
@@ -68,8 +68,7 @@ module Jekyll
       end
 
       def edition
-        @edition ||= Jekyll::GeneratorSingleSource::Product::Edition
-                     .new(edition: @options['docs_url'], site: Jekyll.sites.first)
+        @edition ||= Jekyll.sites.first.data.dig('editions', @options['docs_url'])
       end
     end
 

--- a/app/_plugins/generators/plugin_single_source/pages/base.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/base.rb
@@ -37,9 +37,8 @@ module PluginSingleSource
       end
 
       def gateway_release
-        @gateway_release ||= Jekyll::GeneratorSingleSource::Product::Edition
-                             .new(edition: 'gateway', site: @site)
-                             .releases.detect { |r| r.value == @release.version }&.to_s || @release.version
+        @gateway_release ||= @site.data.dig('editions', 'gateway')
+                                  .releases.detect { |r| r.value == @release.version }&.to_s || @release.version
       end
 
       def source_file

--- a/app/_plugins/generators/plugin_single_source/plugin/unversioned.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/unversioned.rb
@@ -23,9 +23,7 @@ module PluginSingleSource
       end
 
       def latest_release
-        Jekyll::GeneratorSingleSource::Product::Edition
-          .new(edition: 'gateway', site: @site)
-          .latest_release
+        @site.data.dig('editions', 'gateway').latest_release
       end
     end
   end

--- a/app/_plugins/generators/plugin_single_source/plugin/versioned.rb
+++ b/app/_plugins/generators/plugin_single_source/plugin/versioned.rb
@@ -37,16 +37,15 @@ module PluginSingleSource
         )
       end
 
-      def supported_releases
+      def supported_releases # rubocop:disable Metrics/AbcSize
         min, max = data['releases'].values_at('minimum_version', 'maximum_version')
         raise ArgumentError, '`releases` must have a `minimum_version` version set' unless min
 
-        Jekyll::GeneratorSingleSource::Product::Edition
-          .new(edition: 'gateway', site: @site)
-          .releases
-          .map(&:value)
-          .select { |v| Gem::Version.new(v) >= Gem::Version.new(min) }
-          .select { |v| max.nil? || Gem::Version.new(v) <= Gem::Version.new(max) }
+        site.data.dig('editions', 'gateway')
+            .releases
+            .map(&:value)
+            .select { |v| Gem::Version.new(v) >= Gem::Version.new(min) }
+            .select { |v| max.nil? || Gem::Version.new(v) <= Gem::Version.new(max) }
       end
 
       def replacements

--- a/app/_plugins/generators/plugin_single_source_generator.rb
+++ b/app/_plugins/generators/plugin_single_source_generator.rb
@@ -2,7 +2,7 @@
 
 module PluginSingleSource
   class Generator < Jekyll::Generator
-    priority :highest
+    priority :high
 
     PLUGINS_FOLDER = '_hub'
     SAMPLE_PLUGIN = '_init/my-extension'

--- a/app/_plugins/generators/seo/index_entry/global_page.rb
+++ b/app/_plugins/generators/seo/index_entry/global_page.rb
@@ -18,8 +18,7 @@ module SEO
         # We set the version to "latest" for this URL to ensure that it's
         # always added to the index
         @version ||= Utils::Version.to_version(
-          Jekyll::GeneratorSingleSource::Product::Edition
-          .new(edition: @page.data['edition'], site: @page.site)
+          @page.site.data.dig('editions', @page.data['edition'])
           .latest_release
           .value
         )

--- a/app/_plugins/generators/seo/index_entry/hub_html_page.rb
+++ b/app/_plugins/generators/seo/index_entry/hub_html_page.rb
@@ -27,8 +27,7 @@ module SEO
 
       def version
         Utils::Version.to_version(
-          Jekyll::GeneratorSingleSource::Product::Edition
-          .new(edition: 'gateway', site: @page.site)
+          @page.site.data.dig('editions', 'gateway')
           .latest_release
           .value
         )

--- a/app/_plugins/generators/seo/index_entry_builder.rb
+++ b/app/_plugins/generators/seo/index_entry_builder.rb
@@ -52,9 +52,7 @@ module SEO
     def product_page?
       return false unless @page.data['edition']
 
-      Jekyll::GeneratorSingleSource::Product::Edition
-        .all(site: @page.site)
-        .keys.include?(@page.data['edition'])
+      @page.site.data['editions'].keys.include?(@page.data['edition'])
     end
 
     def global_page?

--- a/app/_plugins/generators/site_product_data.rb
+++ b/app/_plugins/generators/site_product_data.rb
@@ -1,0 +1,42 @@
+# Language: Ruby, Level: Level 3
+# frozen_string_literal: true
+
+module Jekyll
+  class SiteProductData < Jekyll::Generator
+    priority :highest
+
+    def generate(site) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+      deck = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'deck', site:)
+      mesh = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'mesh', site:)
+      kic = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'kubernetes-ingress-controller', site:)
+      gateway = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'gateway', site:)
+      gateway_operator = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'gateway-operator', site:)
+      konnect = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'konnect', site:)
+      contributing = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'contributing', site:)
+
+      site.data['editions'] = {}
+      site.data['editions']['deck'] = deck
+      site.data['editions']['mesh'] = mesh
+      site.data['editions']['kubernetes-ingress-controller'] = kic
+      site.data['editions']['gateway'] = gateway
+      site.data['editions']['gateway-operator'] = gateway_operator
+      site.data['editions']['konnect'] = konnect
+      site.data['editions']['contributing'] = contributing
+
+      site.data['kong_versions_deck'] = deck.releases.map(&:to_h)
+      site.data['kong_versions_mesh'] = mesh.releases.map(&:to_h)
+      site.data['kong_versions_konnect'] = konnect.releases.map(&:to_h)
+      site.data['kong_versions_kic'] = kic.releases.map(&:to_h)
+      site.data['kong_versions_contributing'] = contributing.releases.map(&:to_h)
+      site.data['kong_versions_gateway'] = gateway.releases.map(&:to_h)
+      site.data['kong_versions_kgo'] = gateway_operator.releases.map(&:to_h)
+
+      # Retrieve the latest version and put it in `site.data.kong_latest.version`
+      site.data['kong_latest_mesh'] = mesh.latest_release.to_h
+      site.data['kong_latest_KIC'] = kic.latest_release.to_h
+      site.data['kong_latest_deck'] = deck.latest_release.to_h
+      site.data['kong_latest_gateway'] = gateway.latest_release.to_h
+      site.data['kong_latest_kgo'] = gateway_operator.latest_release.to_h
+    end
+  end
+end

--- a/app/_plugins/generators/versions.rb
+++ b/app/_plugins/generators/versions.rb
@@ -5,39 +5,7 @@ module Jekyll
   class Versions < Jekyll::Generator
     priority :high
 
-    def generate(site) # rubocop:disable Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/AbcSize
-      deck = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'deck', site:)
-      mesh = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'mesh', site:)
-      kic = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'kubernetes-ingress-controller', site:)
-      gateway = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'gateway', site:)
-      gateway_operator = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'gateway-operator', site:)
-      konnect = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'konnect', site:)
-      contributing = Jekyll::GeneratorSingleSource::Product::Edition.new(edition: 'contributing', site:)
-
-      site.data['editions'] = {}
-      site.data['editions']['deck'] = deck
-      site.data['editions']['mesh'] = mesh
-      site.data['editions']['kubernetes-ingress-controller'] = kic
-      site.data['editions']['gateway'] = gateway
-      site.data['editions']['gateway-operator'] = gateway_operator
-      site.data['editions']['konnect'] = konnect
-      site.data['editions']['contributing'] = contributing
-
-      site.data['kong_versions_deck'] = deck.releases.map(&:to_h)
-      site.data['kong_versions_mesh'] = mesh.releases.map(&:to_h)
-      site.data['kong_versions_konnect'] = konnect.releases.map(&:to_h)
-      site.data['kong_versions_kic'] = kic.releases.map(&:to_h)
-      site.data['kong_versions_contributing'] = contributing.releases.map(&:to_h)
-      site.data['kong_versions_gateway'] = gateway.releases.map(&:to_h)
-      site.data['kong_versions_kgo'] = gateway_operator.releases.map(&:to_h)
-
-      # Retrieve the latest version and put it in `site.data.kong_latest.version`
-      site.data['kong_latest_mesh'] = mesh.latest_release.to_h
-      site.data['kong_latest_KIC'] = kic.latest_release.to_h
-      site.data['kong_latest_deck'] = deck.latest_release.to_h
-      site.data['kong_latest_gateway'] = gateway.latest_release.to_h
-      site.data['kong_latest_kgo'] = gateway_operator.latest_release.to_h
-
+    def generate(site)
       # Add a `version` property to every versioned page
       # Also create aliases under /latest/ for all x.x.x doc pages
       site.pages.each do |page|

--- a/spec/support/shared_contexts/site.rb
+++ b/spec/support/shared_contexts/site.rb
@@ -19,6 +19,9 @@ module SharedContexts
     let(:site) do
       site = Jekyll::Site.new(config)
       site.read
+
+      Jekyll::SiteProductData.new.generate(site)
+
       site
     end
 


### PR DESCRIPTION
### Description

Set Product data to `site` in a generator with the highest priority
Lower the rest of the generators' priorities and update the code to use the cached data

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

