### PR TITLE
Fix: Admin API markdown doc edits

### DIFF
--- a/app/_src/gateway/admin-api/index_latest.md
+++ b/app/_src/gateway/admin-api/index_latest.md
@@ -18,7 +18,6 @@ title: Kong Gateway Admin API
 
 ## Documentation
 
-
 The Kong Admin API is documented in OpenAPI format:
 
 | Spec | Insomnia link |
@@ -30,8 +29,6 @@ See the following links for individual entity documentation:
 
 {% navtabs %}
 {% navtab Enterprise endpoints %}
-
-
 
 | [Information Routes](/gateway/api/admin-ee/latest/#/Information/get-endpoints) | [Health Routes](/gateway/api/admin-ee/latest/#/Information/get-status) | [Tags](/gateway/api/admin-ee/latest/#/tags/get-tags) |
 | [Debug Routes](/gateway/api/admin-ee/latest/#/debug/put-debug-cluster-control-planes-nodes-log-level-log_level) | [Services](/gateway/api/admin-ee/latest/#/Services/list-service) | [Routes](/gateway/api/admin-ee/latest/#/Routes/list-route) |
@@ -51,26 +48,18 @@ See the following links for individual entity documentation:
 {% endnavtab %}
 {% endnavtabs %}
 
-
-
 ## DB-less mode
 
-
 In [DB-less mode](/gateway/{{page.release}}/production/deployment-topologies/db-less-and-declarative-config/),
-the Admin API can be used to load a new declarative
-configuration, and for inspecting the current configuration. In DB-less mode,
-the Admin API for each Kong node functions independently, reflecting the memory state
-of that particular Kong node. This is the case because there is no database
-coordination between Kong nodes.
+you [configure {{site.base_gateway}} declaratively](/gateway/{{page.release}}/admin-api/declarative-configuration/).
+The Admin API for each Kong node functions independently, reflecting the memory state of that particular Kong node. 
+This is the case because there is no database coordination between Kong nodes. 
+Therefore, the Admin API is mostly read-only. 
 
-In DB-less mode, you configure {{site.base_gateway}} declaratively.
-Therefore, the Admin API is mostly read-only. The only tasks it can perform are all
-related to handling the declarative config, including:
-
-* [Validating configurations against schemas](#validate-a-configuration-against-a-schema)
-* [Validating plugin configurations against schemas](#validate-a-plugin-configuration-against-the-schema)
-* [Reloading the declarative configuration](#reload-declarative-configuration)
-* [Setting a target's health status in the load balancer](#set-target-as-healthy)
+When running {{site.base_gateway}} in DB-less mode, the Admin API can only perform tasks related to handling the declarative config:
+* [Validating configurations against schemas](/gateway/api/admin-oss/latest/#/Information/post-schemas-entity-validate)
+* [Validating plugin configurations against schemas](/gateway/api/admin-oss/latest/#/Information/post-schemas-plugins-validate)
+* [Reloading the declarative configuration](/gateway/{{page.release}}/admin-api/declarative-configuration/)
 
 ## Supported content types
 
@@ -135,7 +124,6 @@ curl -i -X POST http://localhost:8001/services/test-service/routes \
     -d "paths=/path/two"
 ```
 
-
 ### multipart/form-data
 
 The `multipart/form-data` content type is similar to URL-encoded. This content type uses dotted keys to reference nested
@@ -157,9 +145,7 @@ curl -i -X POST http://localhost:8001/services/test-service/routes \
      -F "paths[2]=/path/two"
 ```
 
-
-
-### Using the API in workspaces 
+## Using the API in workspaces 
 {:.badge .enterprise}
 
 {% include_cached /md/gateway/admin-api-workspaces.md %}


### PR DESCRIPTION
### Description

Follow-up to markdown doc deprecation, we missed some anchor links + a bit of formatting. Also rephrased the DB-less section to stop repeating itself so much and to flow better.

### Testing instructions

Preview link: https://deploy-preview-6880--kongdocs.netlify.app/gateway/latest/admin-api/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

