### PR TITLE
Feat(plugins): Collapsible sections styling

### DIFF
--- a/app/_assets/stylesheets/collapsible-sections.less
+++ b/app/_assets/stylesheets/collapsible-sections.less
@@ -1,25 +1,35 @@
 .hub {
     details {
-    border-top: 1px solid #e0e4ea;
+        border-top: 1px solid #e0e4ea;
 
-    summary {
-        margin-top: 8px;
-        margin-bottom: 8px;
-        font-size: 1.1em;
-        font-weight: 500;
+        summary {
+            margin-top: 8px;
+            margin-bottom: 8px;
+            font-size: 1.1em;
+            font-weight: 500;
 
-        &:after {
-        content: "\f107";
-        font-family: FontAwesome, "Font Awesome", FontAwesome;
-        margin-right: 8px;
-        float: right;
+            &:after {
+            content: "\f107";
+            font-family: FontAwesome, "Font Awesome", FontAwesome;
+            margin-right: 8px;
+            float: right;
+            }
+            
+            &:hover {
+            cursor: pointer;
+            opacity: 0.7;
+            }
         }
-        
-        &:hover {
-        cursor: pointer;
-        opacity: 0.7;
+
+    &.collapsible-note {
+        border-top: none;
+
+        summary {
+            font-size: unset;
+            font-weight: unset;
+            margin: unset;
+            }
         }
-    }
     }
 
     details[open] summary {

--- a/app/_assets/stylesheets/collapsible-sections.less
+++ b/app/_assets/stylesheets/collapsible-sections.less
@@ -1,31 +1,33 @@
-details {
-  border-top: 1px solid #e0e4ea;
+.hub {
+    details {
+    border-top: 1px solid #e0e4ea;
 
-  summary {
-    margin-top: 8px;
-    margin-bottom: 8px;
-    font-size: 1.1em;
-    font-weight: 500;
+    summary {
+        margin-top: 8px;
+        margin-bottom: 8px;
+        font-size: 1.1em;
+        font-weight: 500;
 
-    &:after {
-      content: "\f35a";
-      font-family: FontAwesome, "Font Awesome", FontAwesome;
-      margin-right: 8px;
-      float: right;
+        &:after {
+        content: "\f107";
+        font-family: FontAwesome, "Font Awesome", FontAwesome;
+        margin-right: 8px;
+        float: right;
+        }
+        
+        &:hover {
+        cursor: pointer;
+        opacity: 0.7;
+        }
     }
-    
-    &:hover {
-      cursor: pointer;
-      opacity: 0.7;
     }
-  }
-}
 
-details[open] summary {
-  &:after {
-      content: "\f35a";
-      font-family: FontAwesome, "Font Awesome", FontAwesome;
-      transform: rotate(90deg);
-      float: right;
-  }
+    details[open] summary {
+        &:after {
+            content: "\f107";
+            font-family: FontAwesome, "Font Awesome", FontAwesome;
+            transform: rotate(180deg);
+            float: right;
+        }
+    }
 }

--- a/app/_assets/stylesheets/collapsible-sections.less
+++ b/app/_assets/stylesheets/collapsible-sections.less
@@ -1,0 +1,31 @@
+details {
+  border-top: 1px solid #e0e4ea;
+
+  summary {
+    margin-top: 8px;
+    margin-bottom: 8px;
+    font-size: 1.1em;
+    font-weight: 500;
+
+    &:after {
+      content: "\f35a";
+      font-family: FontAwesome, "Font Awesome", FontAwesome;
+      margin-right: 8px;
+      float: right;
+    }
+    
+    &:hover {
+      cursor: pointer;
+      opacity: 0.7;
+    }
+  }
+}
+
+details[open] summary {
+  &:after {
+      content: "\f35a";
+      font-family: FontAwesome, "Font Awesome", FontAwesome;
+      transform: rotate(90deg);
+      float: right;
+  }
+}

--- a/app/_assets/stylesheets/index.less
+++ b/app/_assets/stylesheets/index.less
@@ -30,3 +30,4 @@
 @import "modal";
 @import "docsearch";
 @import "roboto-fonts";
+@import "collapsible-sections";

--- a/app/_includes/md/plugins-hub/oidc-prereqs.md
+++ b/app/_includes/md/plugins-hub/oidc-prereqs.md
@@ -150,22 +150,12 @@ The examples in this guide use Keycloak as a sample IdP.
 
 Expand the following sections to configure Keycloak and {{site.base_gateway}}.
 
-<blockquote class="note no-icon"><details><summary>
-    <strong>Configure Keycloak &nbsp;<i class="fas fa-arrow-right"></i> </strong>
-  </summary>
-
-<br>
+<details><summary>Configure Keycloak</summary>
 {{ prereqs_keycloak | markdownify }}
 
 </details>
-</blockquote>
 
-<blockquote class="note no-icon"><details><summary>
-   <strong> Configure {{site.base_gateway}} &nbsp;<i class="fas fa-arrow-right"></i> </strong>
-  </summary>
-
-<br>
+<details><summary>Configure {{site.base_gateway}} </summary>
 {{ prereqs_kong | markdownify }}
 
 </details>
-</blockquote>

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -43,8 +43,8 @@ breadcrumbs:
 
 {% if page.bundled == false or page.bundled == false %}
   <blockquote class="important">
-    <details>
-    <summary style="cursor:pointer;"><strong>This plugin is not enabled by default</strong>. Click here for instructions to enable it &nbsp;&nbsp;⬇️</summary>
+    <details class="collapsible-note">
+    <summary style="cursor:pointer;"><strong>This plugin is not enabled by default</strong>. Click here for instructions to enable it</summary>
 
     <ul>
       <li>Package install: Set <strong>plugins=bundled,{{ page.extn_slug }}</strong> in <strong>kong.conf</strong> before starting Kong</li>


### PR DESCRIPTION
### Description

Restyling the collapsible sections in prereqs on the plugin hub to stop using the blue note blocks, as they aren't meant for that purpose.

Edge case when there actually needs to be a note (e.g. when something is a warning or a caution) that contains further info, tested on AppDynamics plugin.

Only applying to plugins for now, as the OIDC docs need it. Considered doing this for everything, but would need to rework the KIC prereq sections a fair bit, so that would need some more thought.

Current approach:
<img width="825" alt="Screenshot 2024-02-05 at 9 29 24 AM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/c175da99-c814-4468-8265-f41b1deea42d">

Other explored options:
<img width="821" alt="Screenshot 2024-02-02 at 1 42 01 PM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/bbbf6ac8-ec95-4f10-9afd-fc069c7653c2">

<img width="826" alt="Screenshot 2024-02-05 at 9 30 33 AM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/4ad8fa96-4df3-4dd1-b50d-1f455fe7c8d7">

### Testing instructions

Preview link: 
[OpenID Connect prereqs](https://deploy-preview-6902--kongdocs.netlify.app/hub/kong-inc/openid-connect/how-to/authentication/client-credentials/#prerequisites)
[AppDynamics note to "enable the plugin"](https://deploy-preview-6902--kongdocs.netlify.app/hub/kong-inc/app-dynamics/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

