### PR TITLE
chore: Remove anchor link redirects

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -48,21 +48,6 @@
 
 # API markdown doc deprecation
 
-/gateway/latest/admin-api/#health-routes    /gateway/api/admin-ee/latest/#/Information/get-status/
-/gateway/latest/admin-api/#tags        /gateway/api/admin-ee/latest/#/tags/get-tags/
-/gateway/latest/admin-api/#debug-routes /gateway/api/admin-ee/latest/#/debug/put-debug-cluster-control-planes-nodes-log-level-log_level/
-/gateway/latest/admin-api/#service-object   /gateway/api/admin-ee/latest/#/Services/list-service/
-/gateway/latest/admin-api/#route-object /gateway/api/admin-ee/latest/#/Routes/list-route/
-/gateway/latest/admin-api/#consumer-object  /gateway/api/admin-ee/latest/#/Consumers/list-consumer/
-/gateway/latest/admin-api/#plugin-object    /gateway/api/admin-ee/latest/#/Plugins/list-plugin
-/gateway/latest/admin-api/#certificate-object   /gateway/api/admin-ee/latest/#/Certificates/list-certificate/
-/gateway/latest/admin-api/#ca-certificate-object    /gateway/api/admin-ee/latest/#/CA%20Certificates/list-ca_certificate/
-/gateway/latest/admin-api/#sni-object   /gateway/api/admin-ee/latest/#/SNIs/list-sni-with-certificate/
-/gateway/latest/admin-api/#upstream-object  /gateway/api/admin-ee/latest/#/Upstreams/list-upstream/
-/gateway/latest/admin-api/#target-object    /gateway/api/admin-ee/latest/#/Targets/list-target-with-upstream/
-/gateway/latest/admin-api/#vaults-object    /gateway/api/admin-ee/latest/#/Vaults/list-vault/
-/gateway/latest/admin-api/#keys-object      /gateway/api/admin-ee/latest/#/Keys/list-key/
-/gateway/latest/admin-api/#filter-chains    /gateway/api/admin-ee/latest/#/filter-chains/get-filter-chains/
 /gateway/latest/admin-api/licenses/reference   /gateway/api/admin-ee/latest/#/licenses/get-licenses/
 /gateway/latest/admin-api/workspaces/reference/   /gateway/api/admin-ee/latest/#/Workspaces/list-workspace/
 /gateway/latest/admin-api/rbac/reference/        /gateway/api/admin-ee/latest/#/rbac/get-rbac-users/


### PR DESCRIPTION
### Description

Removing redirects from anchor links like `/gateway/latest/admin-api/#vaults-object`. 
These redirects aren't supported and don't do anything.

Instead, we have a general redirect that covers anything under `/gateway/latest/admin-api/*`, and that should cover most situations. Old anchor links will just land at the top of `/gateway/latest/admin-api/`.

### Testing instructions

Preview link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

