### PR TITLE
kic: extend license guide with KongLicense CRD

### DIFF
--- a/app/_src/kubernetes-ingress-controller/license.md
+++ b/app/_src/kubernetes-ingress-controller/license.md
@@ -5,18 +5,16 @@ purpose: |
   How to get your license and apply it to KIC managed Gateways
 ---
 
-{{ site.kic_product_name }} can manage {{ site.ee_product_name }} instances. To make the {{ site.ee_product_name }} instances licensed,
-you need to provide a license. This guide explains how you can do it.
+{{ site.kic_product_name }} can manage {{ site.ee_product_name }} instances. This guide explains how to apply an enterprise license to running Gateways.
 
 {% if_version gte:3.1.x %}
-## Applying a license using `KongLicense` CRD
+## Applying a license using the KongLicense CRD
 
-In {{ site.kic_product_name }} v3.1 we introduced `KongLicense` (see its [reference](/kubernetes-ingress-controller/{{page.release}}/reference/custom-resources/#konglicense)) CRD that allows dynamic propagation
-of license to all managed {{ site.ee_product_name }} replicas using their Admin API.
+{{ site.kic_product_name }} v3.1 introduced a `KongLicense` CRD ([reference](/kubernetes-ingress-controller/{{page.release}}/reference/custom-resources/#konglicense)) that applies a license to {{ site.ee_product_name }} using the Admin API.
 
 1. Create a file named `license.json` containing your {{site.ee_product_name}} license.
 
-1. Create a `KongLicense` object with `rawLicenseString` field set to your license: 
+1. Create a `KongLicense` object with the `rawLicenseString` field set to your license:
 
    ```bash
    echo "
@@ -28,7 +26,7 @@ of license to all managed {{ site.ee_product_name }} replicas using their Admin 
    " | kubectl apply -f -
    ```
 
-1. Verify the created `KongLicense` was picked up by the {{ site.kic_product_name }}:
+1. Verify that {{ site.kic_product_name }} is using the license:
 
    ```bash
    kubectl describe konglicense kong-license
@@ -60,16 +58,13 @@ of license to all managed {{ site.ee_product_name }} replicas using their Admin 
      Controller Name:        konghq.com/kong-ingress-controller/5b374a9e.konghq.com
    ```
 
-From now on, all Gateways that are managed by the {{ site.kic_product_name }} will be licensed with the provided license.
-Once the license approaches its expiration, you can simply update the `KongLicense` object with a new license string and 
-{{ site.kic_product_name }} will dynamically propagate it to all {{site.ee_product_name}} instances with no downtime.
+All {{ site.base_gateway }} instances that are configured by the {{ site.kic_product_name }} will have the license provided in `KongLicense` applied. To update your license, update the `KongLicense` resource and {{ site.kic_product_name }} will dynamically propagate it to all {{site.ee_product_name}} instances with no downtime. There is no need to restart your Pods when updating a license.
 {% endif_version %}
 
 ## Applying a static license
 
 {% if_version gte:3.1.x %}
-An alternate and less flexible option is to use a static license Secret that will be used to populate {{ site.ee_product_name }}'s
-`KONG_LICENSE_DATA` environment variable.
+An alternative option is to use a static license Secret that will be used to populate {{ site.ee_product_name }}'s `KONG_LICENSE_DATA` environment variable. This option allows you to store the license in Kubernetes secrets, but requires a Pod restart when the value of the secret changes.
 {% endif_version %}
 
 1. Create a file named `license.json` containing your {{site.ee_product_name}} license and store it in a Kubernetes secret:

--- a/app/_src/kubernetes-ingress-controller/license.md
+++ b/app/_src/kubernetes-ingress-controller/license.md
@@ -5,9 +5,72 @@ purpose: |
   How to get your license and apply it to KIC managed Gateways
 ---
 
-{{ site.kic_product_name }} can manage {{ site.ee_product_name }} instances. To deploy {{ site.ee_product_name }} create a Kubernetes secret containing your license key and set the `LICENSE_DATA` environment variable on your {{ site.base_gateway }} pods.
+{{ site.kic_product_name }} can manage {{ site.ee_product_name }} instances. To make the {{ site.ee_product_name }} instances licensed,
+you need to provide a license. This guide explains how you can do it.
 
-## Applying a license
+{% if_version gte:3.1.x %}
+## Applying a license using `KongLicense` CRD
+
+In {{ site.kic_product_name }} v3.1 we introduced `KongLicense` (see its [reference](/kubernetes-ingress-controller/{{page.release}}/reference/custom-resources/#konglicense)) CRD that allows dynamic propagation
+of license to all managed {{ site.ee_product_name }} replicas using their Admin API.
+
+1. Create a file named `license.json` containing your {{site.ee_product_name}} license.
+
+1. Create a `KongLicense` object with `rawLicenseString` field set to your license: 
+
+   ```bash
+   echo "
+   apiVersion: configuration.konghq.com/v1alpha1
+   kind: KongLicense
+   metadata:
+     name: kong-license
+   rawLicenseString: '$(cat ./license.json)'
+   " | kubectl apply -f -
+   ```
+
+1. Verify the created `KongLicense` was picked up by the {{ site.kic_product_name }}:
+
+   ```bash
+   kubectl describe konglicense kong-license
+   ```
+
+   The results should look like this, including the `Programmed` condition with `True` status:
+
+   ```text
+   Name:         kong-license
+   Namespace:
+   Labels:       <none>
+   Annotations:  <none>
+   API Version:  configuration.konghq.com/v1alpha1
+   Enabled:      true
+   Kind:         KongLicense
+   Metadata:
+    Creation Timestamp:  2024-02-06T15:37:58Z
+    Generation:          1
+    Resource Version:    2888
+   Raw License String:   <your-license-string>   
+   Status:
+    Controllers:
+     Conditions:
+      Last Transition Time:  2024-02-06T15:37:58Z
+      Message:
+      Reason:                PickedAsLatest
+      Status:                True
+      Type:                  Programmed
+     Controller Name:        konghq.com/kong-ingress-controller/5b374a9e.konghq.com
+   ```
+
+From now on, all Gateways that are managed by the {{ site.kic_product_name }} will be licensed with the provided license.
+Once the license approaches its expiration, you can simply update the `KongLicense` object with a new license string and 
+{{ site.kic_product_name }} will dynamically propagate it to all {{site.ee_product_name}} instances with no downtime.
+{% endif_version %}
+
+## Applying a static license
+
+{% if_version gte:3.1.x %}
+An alternate and less flexible option is to use a static license Secret that will be used to populate {{ site.ee_product_name }}'s
+`KONG_LICENSE_DATA` environment variable.
+{% endif_version %}
 
 1. Create a file named `license.json` containing your {{site.ee_product_name}} license and store it in a Kubernetes secret:
 


### PR DESCRIPTION
### Description

Adds a section describing `KongLicense` CRD usage to the license guide.

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5570.

### Testing instructions

https://deploy-preview-6910--kongdocs.netlify.app/kubernetes-ingress-controller/unreleased/license/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.



