### PR TITLE
chore: Set explicit timeouts for all workflows [skip ci]

### DIFF
--- a/.github/workflows/auto-close-kong-issues.yml
+++ b/.github/workflows/auto-close-kong-issues.yml
@@ -7,6 +7,7 @@ jobs:
   auto-close-org-issues:
     name: Auto Close Org Issues
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Generate app token
         id: generate-app-token

--- a/.github/workflows/autogenerated-warning.yml
+++ b/.github/workflows/autogenerated-warning.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check if manual review has been performed
         uses: actions/github-script@v7
@@ -37,6 +38,7 @@ jobs:
     needs: [check]
     if: needs.check.outputs.result == 'false'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: mheap/github-action-required-labels@v5
         env:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check if manual review has been performed
         uses: actions/github-script@v7

--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -6,6 +6,7 @@ jobs:
   prettier-autofix:
     if: github.event.label.name == 'ci:autofix:prettier'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build-changelog:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check if manual review has been performed
         uses: actions/github-script@v7
@@ -88,6 +89,7 @@ jobs:
     if: needs.check.outputs.result == 'false'
     name: Vale
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/require-review-label.yml
+++ b/.github/workflows/require-review-label.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, labeled, unlabeled]
 jobs:
   label:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: mheap/github-action-required-labels@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -75,6 +75,7 @@ jobs:
 
   rspec:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sync-konnect-oas-data.yml
+++ b/.github/workflows/sync-konnect-oas-data.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   update_oas_data:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Fetch OAS Data

--- a/.github/workflows/sync-kuma-submodule.yml
+++ b/.github/workflows/sync-kuma-submodule.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   get-current-do-not-close-pr:
     name: 'Get current do-not-close PR'
+    timeout-minutes: 10
     # Runs for the two dispatch triggers. Also runs for merged pull requests **if** they have the “do-not-close” label.
     if: github.event_name != 'pull_request' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'do-not-close'))
     runs-on: ubuntu-latest
@@ -33,6 +34,7 @@ jobs:
 
   update-submodule:
     name: 'Update submodule'
+    timeout-minutes: 10
     needs: get-current-do-not-close-pr
     if: ${{ ! needs.get-current-do-not-close-pr.outputs.number }} # Do not overwrite the PR if there's a do-not-close label
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -12,6 +12,7 @@ jobs:
   submodule-sync:
     name: Submodule Sync
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Submodule Sync
         uses: mheap/submodule-sync-action@v1


### PR DESCRIPTION
### Description

Setting timeouts for all jobs in our workflows that don't have a timeout. This is to prevent CI from setting the `${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}` timeout variable in our workflows (for example, see https://github.com/Kong/docs.konghq.com/pull/6888).

I set 10 minutes for any label checking jobs, and any jobs that normally take under 1 minute to run (see https://github.com/Kong/docs.konghq.com/actions). Anything longer, I set 30 minutes as the timeout.

### Testing instructions

Preview link: N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

