### PR TITLE
docs(gateway): update SSL configuration

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -1058,7 +1058,13 @@ built with. This value is ignored if `ssl_cipher_suite` is not `custom`.
 
 See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols
 
-**Default:** `TLSv1.1 TLSv1.2 TLSv1.3`
+**Default:**
+
+- if `ssl_cipher_suite` is `modern`, the default value would be `TLSv1.3`
+- if `ssl_cipher_suite` is `intermediate`, the default value would be `TLSv1.2 TLSv1.3`
+- if `ssl_cipher_suite` is `old`, the default value would be `TLSv1 TLSv1.1 TLSv1.2 TLSv1.3`
+- if `ssl_cipher_suite` is `custom`, the default value would be the value of environment variable `KONG_SSL_PROTOCOLS` if it is set.
+- Otherwise, the default value would be `TLSv1.2 TLSv1.3`.
 
 
 ### ssl_prefer_server_ciphers


### PR DESCRIPTION
### Description

Both the Kong CE and EE master branches have been modified to the default configuration of `ssl_protocols` and the configuration of `ssl_cipher_suite`. Please refer to the kong PR [#12420](https://github.com/Kong/kong/pull/12420).

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

