### PR TITLE
Fix: ACL doc appearing in 3.5 when it should be in 3.6

### DIFF
--- a/app/_hub/kong-inc/acl/_3.5.x/overview/_index.md
+++ b/app/_hub/kong-inc/acl/_3.5.x/overview/_index.md
@@ -17,4 +17,3 @@ You can't configure an ACL with both `allow` and `deny` configurations. An ACL w
 * [Basic configuration example](/hub/kong-inc/acl/how-to/basic-example/)
 * [Learn how to use the plugin](/hub/kong-inc/acl/how-to/)
 * [ACME plugin API reference](/hub/kong-inc/acl/api/)
-* [Using ACLs with consumer groups](/hub/kong-inc/acl/how-to/consumer-groups/)

--- a/app/_hub/kong-inc/acl/overview/_index.md
+++ b/app/_hub/kong-inc/acl/overview/_index.md
@@ -19,4 +19,6 @@ You can't configure an ACL with both `allow` and `deny` configurations. An ACL w
 * [Basic configuration example](/hub/kong-inc/acl/how-to/basic-example/)
 * [Learn how to use the plugin](/hub/kong-inc/acl/how-to/)
 * [ACME plugin API reference](/hub/kong-inc/acl/api/)
+{% if_plugin_version gte:3.6.x %}
 * [Using ACLs with consumer groups](/hub/kong-inc/acl/how-to/consumer-groups/)
+{% endif_plugin_version %}

--- a/app/_hub/kong-inc/acl/overview/_index.md
+++ b/app/_hub/kong-inc/acl/overview/_index.md
@@ -19,6 +19,4 @@ You can't configure an ACL with both `allow` and `deny` configurations. An ACL w
 * [Basic configuration example](/hub/kong-inc/acl/how-to/basic-example/)
 * [Learn how to use the plugin](/hub/kong-inc/acl/how-to/)
 * [ACME plugin API reference](/hub/kong-inc/acl/api/)
-{% if_plugin_version gte:3.6.x %}
 * [Using ACLs with consumer groups](/hub/kong-inc/acl/how-to/consumer-groups/)
-{% endif_plugin_version %}


### PR DESCRIPTION
ACL Doc was showing [Using ACLs with Consumer Groups](https://docs.konghq.com/hub/kong-inc/acl/how-to/consumer-groups/). in 3.5 it should only be accessible in 3.6+