### PR TITLE
Fix: Reference lua package path location in Exit Transformer plugin

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/overview/_index.md
@@ -190,7 +190,7 @@ end
 1. Create a file named `transform.lua` with the transformation code. The
   following example adds a header, appends "arr!" to any message, and adds
   `error` and `status` fields on the response body. Save this file in a
-   location referenced by the lua_package_path variable.
+   location referenced by the [`lua_package_path`](/gateway/latest/reference/configuration/#lua_package_path) variable.
 
     ```lua
         -- transform.lua

--- a/app/_hub/kong-inc/exit-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/overview/_index.md
@@ -189,7 +189,8 @@ end
 
 1. Create a file named `transform.lua` with the transformation code. The
   following example adds a header, appends "arr!" to any message, and adds
-  `error` and `status` fields on the response body.
+  `error` and `status` fields on the response body. Save this file in a
+   location referenced by the lua_package_path variable.
 
     ```lua
         -- transform.lua


### PR DESCRIPTION
### Description

Original document assumed knowledge about location for reference of .lua files. Added instruction to save file in referenced lua package path location as per https://docs.konghq.com/gateway/latest/plugin-development/distribution/#manually

### Testing instructions

Preview link: https://deploy-preview-6922--kongdocs.netlify.app/hub/kong-inc/exit-transformer/#demonstration

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

