### PR TITLE
Fix a typo

### DIFF
--- a/app/_hub/kong-inc/key-auth/overview/_index.md
+++ b/app/_hub/kong-inc/key-auth/overview/_index.md
@@ -156,7 +156,7 @@ Make a request with the key in the body:
 
 ```bash
 curl http://localhost:8000/{proxy path} \
-    --data 'apikey: {some_key}'
+    --data 'apikey={some_key}'
 ```
 
 **Note:** The `key_in_body` plugin parameter must be set to `true` (default is `false`).


### PR DESCRIPTION
### Description

Fixed a mistake in attaching json data to curl command.  
The `=`, not `:`, must be used to attach the 'body'.

>       -d, --data <data>
>              (HTTP MQTT) Sends the specified data in a POST request to the HTTP server, in the same way that a browser does when a
>              user has filled in an HTML form and presses the submit button. This makes curl pass the data to the server using the
>              content-type application/x-www-form-urlencoded. Compare to -F, --form.
>
>              --data-raw is almost the same but does not have a special interpretation of the @ character. To post data purely
>              binary, you should instead use the --data-binary option. To URL-encode the value of a form field you may use
>              --data-urlencode.
>
>              If any of these options is used more than once on the same command line, the data pieces specified are merged with a
>              separating &-symbol. Thus, using '-d name=daniel -d skill=lousy' would generate a post chunk that looks like
>              'name=daniel&skill=lousy'.
>
>              If you start the data with the letter @, the rest should be a file name to read the data from, or - if you want curl
>              to read the data from stdin. Posting data from a file named 'foobar' would thus be done with -d, --data @foobar. When
>              -d, --data is told to read from a file like that, carriage returns and newlines are stripped out. If you do not want
>              the @ character to have a special interpretation use --data-raw instead.
>
>              The data for this option is passed on to the server exactly as provided on the command line. curl does not convert,
>              change or improve it. It is up to the user to provide the data in the correct form.
>
>              -d, --data can be used several times in a command line
>
>              Examples:
>               curl -d "name=curl" https://example.com
>               curl -d "name=curl" -d "tool=cmdline" https://example.com
>               curl -d @filename https://example.com
>
>              See also --data-binary, --data-urlencode and --data-raw. This option is mutually exclusive to -F, --form and -I,
>              --head and -T, --upload-file.
>               
>man curl


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

