### PR TITLE
kic: extend secrets in plugins guide with configFrom field

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/security/plugin-secrets.md
+++ b/app/_src/kubernetes-ingress-controller/guides/security/plugin-secrets.md
@@ -5,9 +5,19 @@ purpose: |
   How to use a Kubernetes secret to configure a plugin
 ---
 
-## Loading complete plugin's configuration from a secret 
+{{ site.kic_product_name }} allows you to configure {{ site.base_gateway }} plugins using the contents of a Kubernetes secret. {{ site.kic_product_name }} can read secrets in two ways:
 
-{{ site.kic_product_name }} allows you to configure {{ site.base_gateway }} plugins using the contents of a Kubernetes secret. The `configFrom` field in the `KongPlugin` resource allows you to set a `secretKeyRef` pointing to a Kubernetes secret.
+1. Read the complete plugin configuration from a secret
+1. Use `configPatches` to set a single field in a plugin configuration (requires {{ site.kic_product_name }} 3.1+)
+
+{{ site.kic_product_name }} resolves the referenced secrets and sends a complete configuration to {{ site.base_gateway }}.
+
+{:.important}
+> {{ site.kic_product_name }} resolves secrets _before_ sending the configuration to {{ site.base_gateway }}. Anyone with access to the {{ site.base_gateway }} pod can read the configuration, including secrets, from the admin API. To securely fetch secrets at runtime, use [Kong's Vault support](/kubernetes-ingress-controller/{{ page.release }}/guides/security/kong-vault/).
+
+## Read a complete configuration
+
+The `configFrom` field in the `KongPlugin` resource allows you to set a `secretKeyRef` pointing to a Kubernetes secret.
 
 This `KongPlugin` definition points to a secret named `rate-limit-redis` that contains a complete configuration for the plugin:
 
@@ -43,19 +53,18 @@ type: Opaque
 " | kubectl apply -f -
 ```
 
-{{ site.kic_product_name }} resolves the referenced secrets and sends a complete configuration to {{ site.base_gateway }}.
-
-{:.important}
-> {{ site.kic_product_name }} resolves secrets _before_ sending the configuration to {{ site.base_gateway }}. Anyone with access to the {{ site.base_gateway }} pod can read the configuration, including secrets, from the admin API.
-
 {% if_version gte:3.1.x %}
-## Loading a single plugin's configuration's field from a secret 
+## Single field using ConfigPatches
 
-{{ site.kic_product_name }} from version v3.1 allows you to load a single field of a plugin's configuration from a Kubernetes secret.
-`configPatches` field in the `KongPlugin` resource allows you to set a `path` to a field in the `KongPlugin`
+{{ site.kic_product_name }} allows you to populate individual plugin configuration fields from a Kubernetes secret.
+
+The `configPatches` field in the `KongPlugin` resource allows you to set a `path` to a field in the `KongPlugin`
 and a `valueFrom` that points to a Kubernetes secret (and its field) that the configuration field value should be loaded from.
 
-Let's say you have a `KongPlugin` definition that contains a `password` field. 
+In the previous Redis rate-limiting example, only the `redis_password` field is sensitive. Instead of storing the whole configuration in a secret, use `configPatches` to patch a single key:
+
+Create a Kubernetes secret that contains a `password` field.
+
 ```bash
 echo "
 apiVersion: v1
@@ -67,7 +76,7 @@ stringData:
 type: Opaque" | kubectl apply -f -
 ```
 
-You can use the following `KongPlugin` definition to load the `password` field from the `rate-limit-redis` secret.
+Define a new rate-limiting `KongPlugin` resource. The majority of the configuration is provided under the `config` key. The `redis_password` field is populated from the `password` field in the `rate-limit-redis` secret using `configPatches`.
 
 ```bash
 echo "
@@ -89,8 +98,8 @@ configPatches:
 " | kubectl apply -f -
 ```
 
-This way, {{ site.kic_product_name }} resolves the referenced secret and builds the complete configuration for the plugin
-that is sent to {{ site.base_gateway }}. The assembled configuration will look like this:
+{{ site.kic_product_name }} resolves the referenced secret and builds the complete configuration for the plugin
+before sending it to {{ site.base_gateway }}. The complete configuration will look like this:
 
 ```yaml
 minute: 10

--- a/app/_src/kubernetes-ingress-controller/guides/security/plugin-secrets.md
+++ b/app/_src/kubernetes-ingress-controller/guides/security/plugin-secrets.md
@@ -5,6 +5,8 @@ purpose: |
   How to use a Kubernetes secret to configure a plugin
 ---
 
+## Loading complete plugin's configuration from a secret 
+
 {{ site.kic_product_name }} allows you to configure {{ site.base_gateway }} plugins using the contents of a Kubernetes secret. The `configFrom` field in the `KongPlugin` resource allows you to set a `secretKeyRef` pointing to a Kubernetes secret.
 
 This `KongPlugin` definition points to a secret named `rate-limit-redis` that contains a complete configuration for the plugin:
@@ -45,3 +47,55 @@ type: Opaque
 
 {:.important}
 > {{ site.kic_product_name }} resolves secrets _before_ sending the configuration to {{ site.base_gateway }}. Anyone with access to the {{ site.base_gateway }} pod can read the configuration, including secrets, from the admin API.
+
+{% if_version gte:3.1.x %}
+## Loading a single plugin's configuration's field from a secret 
+
+{{ site.kic_product_name }} from version v3.1 allows you to load a single field of a plugin's configuration from a Kubernetes secret.
+`configPatches` field in the `KongPlugin` resource allows you to set a `path` to a field in the `KongPlugin`
+and a `valueFrom` that points to a Kubernetes secret (and its field) that the configuration field value should be loaded from.
+
+Let's say you have a `KongPlugin` definition that contains a `password` field. 
+```bash
+echo "
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rate-limit-redis
+stringData:
+  password: PASSWORD
+type: Opaque" | kubectl apply -f -
+```
+
+You can use the following `KongPlugin` definition to load the `password` field from the `rate-limit-redis` secret.
+
+```bash
+echo "
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+ name: rate-limiting-example
+plugin: rate-limiting
+config: # You can define the non-sensitive part of the config explicitly here.
+  minute: 10
+  policy: redis
+  redis_host: redis-master
+configPatches:
+  - path: redis_password # This is the path to the field in the plugin's configuration this patch will populate.
+    valueFrom:
+      secretKeyRef:
+        name: rate-limit-redis # This is the name of the secret.
+        key: password          # This is the key in the secret.
+" | kubectl apply -f -
+```
+
+This way, {{ site.kic_product_name }} resolves the referenced secret and builds the complete configuration for the plugin
+that is sent to {{ site.base_gateway }}. The assembled configuration will look like this:
+
+```yaml
+minute: 10
+policy: redis
+redis_host: redis-master
+redis_password: PASSWORD
+```
+{% endif_version %}


### PR DESCRIPTION
### Description

Extends `Using Kubernetes Secrets in Plugins` guide to describe the new `configPatches` fields and its usage.
 
Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5572.
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

