### PR TITLE
Feat: Add cert expiry to clustering/data-planes output

### DIFF
--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
@@ -608,7 +608,53 @@ curl -i -X GET http://localhost:8001/clustering/data-planes
 
 The output shows all of the connected data plane instances in the cluster:
 
-{% if_version gte:3.5.x %}
+{% if_version gte:3.6.x %}
+```json
+{
+    "data": [
+        {
+            "ip": "172.24.0.10",
+            "updated_at": 1689266492,
+            "config_hash": "595214af5fb356cc569313184c64d9b7",
+            "sync_status": "normal",
+            "version": "3.3.0.0",
+            "id": "10424658-f139-476c-b74f-e0a6e6ec9402",
+            "hostname": "kongDP1",
+            "ttl": 1209593,
+            "last_seen": 1689266492,
+            "labels": {
+                "deployment": "cloud1",
+                "region": "us-east-1"
+            },
+            "cert_details": {
+                "expiry_timestamp": 1897136778,
+            }
+        },
+        {
+            "ip": "172.24.0.11",
+            "updated_at": 1689266472,
+            "config_hash": "595214af5fb356cc569313184c64d9b7",
+            "sync_status": "normal",
+            "version": "3.3.0.0",
+            "id": "3487f520-4f52-4ee5-ad6f-50756822f0c5",
+            "hostname": "kongDP2",
+            "ttl": 1209572,
+            "last_seen": 1689266472,
+            "labels": {
+                "deployment": "cloud2",
+                "region": "us-west-2"
+            },
+            "cert_details": {
+                "expiry_timestamp": 1897136778,
+            }
+        }
+    ],
+    "next": null
+}
+```
+{% endif_version %}
+
+{% if_version eq:3.5.x %}
 ```json
 {
     "data": [


### PR DESCRIPTION
### Description

Cert expiration date has been added to /clustering/data-planes endpoint response. 
Found this during changelog editing.

https://github.com/Kong/kong/issues/11921

### Testing instructions

Preview link: https://deploy-preview-6938--kongdocs.netlify.app/gateway/unreleased/production/deployment-topologies/hybrid-mode/setup/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

