### PR TITLE
Fix: Add missing items from changelog to API specs [skip-ci]

### DIFF
--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -5777,6 +5777,53 @@ info:
   version: 3.6.0
 openapi: 3.0.0
 paths:
+  /:
+    get:
+      summary: Get Kong's instance information
+      tags:
+        - System Information
+      operationId: getRootInfo
+      description: |
+        Returns basic information about the Kong gateway instance, including the version, edition (enterprise or community), a tagline, and the unique node identifier.
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: The version number of the Kong instance.
+                    example: "2.3.3"
+                  edition:
+                    type: string
+                    description: Indicates whether the Kong instance is the Community or Enterprise edition.
+                    example: "enterprise"
+                  tagline:
+                    type: string
+                    description: A tagline or slogan for the Kong instance.
+                    example: "Welcome to Kong"
+                  node_id:
+                    type: string
+                    description: A unique identifier for the node, in UUID format.
+                    pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+                    example: "a74d7c4f-ef83-4bbe-a5e7-3f5409f4a0b9"
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '405':
+          description: Method Not Allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            Server:
+              description: Kong's server tokens.
+              schema:
+                type: string
+                example: "kong/2.3.3"
   /ca_certificates:
     get:
       description: Retrieve a list of all available Certificate Authority (CA) certificates, including the certificate ID, creation date, and other details. You can use query parameters to filter the results by size or tags, for example `/ca-certificates?size=50&tags=enterprise`.

--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -11444,6 +11444,8 @@ paths:
       description: |-
         Retrieve usage information about a node, with some basic information about the connections being processed by the underlying nginx process, the status of the database connection, and node's memory usage.
 
+        This endpoint now listens on `127.0.0.1:8007` by default for status checks. It provides detailed metrics regarding memory usage, worker process stats, database connection status, and server connection metrics.
+
         If you want to monitor the Kong process, since Kong is built on top of nginx, every existing nginx monitoring tool or agent can be used.
         '401': 
           $ref: '#/components/responses/HTTP401Error'

--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -5781,8 +5781,8 @@ paths:
     get:
       summary: Get Kong's instance information
       tags:
-        - System Information
-      operationId: getRootInfo
+        - Information
+      operationId: geInfo
       description: |
         Returns basic information about the Kong gateway instance, including the version, edition (enterprise or community), a tagline, and the unique node identifier.
       responses:
@@ -5810,6 +5810,106 @@ paths:
                     description: A unique identifier for the node, in UUID format.
                     format: uuid
                     example: "a74d7c4f-ef83-4bbe-a5e7-3f5409f4a0b9"
+                  hostname:
+                    type: string
+                    description: The hostname of the Kong node.
+                    example: "kong-node.example.com"
+                  timers:
+                    type: object
+                    description: Information about running and pending timers.
+                    properties:
+                      running:
+                        type: integer
+                        description: The number of running timers.
+                        example: 5
+                      pending:
+                        type: integer
+                        description: The number of pending timers.
+                        example: 2
+                  plugins:
+                    type: object
+                    description: Information about plugins.
+                    properties:
+                      available_on_server:
+                        type: object
+                        additionalProperties:
+                          type: object
+                          properties:
+                            version:
+                              type: string
+                              description: The version of the plugin.
+                            priority:
+                              type: integer
+                              description: The priority of the plugin.
+                      enabled_in_cluster:
+                        type: array
+                        items:
+                          type: string
+                        description: A list of distinct plugin names enabled in the cluster.
+                        example: ["jwt", "acl"]
+                  lua_version:
+                    type: string
+                    description: The version of Lua used by the Kong instance.
+                    example: "LuaJIT 2.1.0-beta3"
+                  configuration:
+                    type: object
+                    description: A sanitized version of the Kong configuration, excluding sensitive values.
+                    additionalProperties: true
+                  pids:
+                    type: object
+                    description: Process IDs for the master process and worker processes.
+                    properties:
+                      master:
+                        type: integer
+                        description: The PID of the master process.
+                        example: 4321
+                      workers:
+                        type: array
+                        items:
+                          type: integer
+                        description: An array of worker process PIDs.
+                        example: [1234, 5678]
+              examples:
+                fullExample:
+                  summary: Example response
+                  value: 
+                    configuration:
+                      _debug_pg_ttl_cleanup_interval: 300
+                      admin_acc_logs: "/usr/local/kong/logs/admin_access.log"
+                      admin_access_log: "/dev/stdout"
+                      admin_approved_email: "true"
+                      admin_emails_from: "\"\""
+                      admin_error_log: "/dev/stderr"
+                      admin_gui_access_log: "logs/admin_gui_access.log"
+                      admin_gui_auth_header: "******"
+                      admin_gui_auth_login_attempts: 0
+                      admin_gui_error_log: "logs/admin_gui_error.log"
+                      admin_gui_flags: "{}"
+                      admin_gui_listen:
+                        - "0.0.0.0:8002"
+                        - "0.0.0.0:8445 ssl"
+                      admin_gui_origin: "http://localhost:8002"
+                    edition: "enterprise"
+                    hostname: "8a487998603b"
+                    lua_version: "LuaJIT 2.1.0-20231117"
+                    node_id: "1f257156-5e44-46e2-a618-767f5c7529e3"
+                    pids:
+                      master: 1
+                      workers:
+                        - 2382
+                        - 2383
+                    plugins:
+                      available_on_server:
+                        acl: true
+                        acme: true
+                      disabled_on_server:
+                        application-registration: true
+                      enabled_in_cluster: []
+                    tagline: "Welcome to kong"
+                    timers:
+                      pending: 1
+                      running: 1128
+                    version: "3.6.0.0"
         '401': 
           $ref: '#/components/responses/HTTP401Error'
         '405':

--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -5808,7 +5808,7 @@ paths:
                   node_id:
                     type: string
                     description: A unique identifier for the node, in UUID format.
-                    pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+                    format: uuid
                     example: "a74d7c4f-ef83-4bbe-a5e7-3f5409f4a0b9"
         '401': 
           $ref: '#/components/responses/HTTP401Error'

--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -5784,7 +5784,7 @@ paths:
         - Information
       operationId: geInfo
       description: |
-        Returns basic information about the Kong gateway instance, including the version, edition (enterprise or community), a tagline, and the unique node identifier.
+        Returns detailed information about the Kong gateway instance, including the full Kong configuration, available and unavailable plugins, version, edition (enterprise or community), a tagline, the unique node identifier, and other metadata.
       responses:
         '200':
           description: Success

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -3567,8 +3567,8 @@ paths:
     get:
       summary: Get Kong's instance information
       tags:
-        - System Information
-      operationId: getRootInfo
+        - Information
+      operationId: geInfo
       description: |
         Returns basic information about the Kong gateway instance, including the version, edition (enterprise or community), a tagline, and the unique node identifier.
       responses:
@@ -3596,6 +3596,106 @@ paths:
                     description: A unique identifier for the node, in UUID format.
                     format: uuid
                     example: "a74d7c4f-ef83-4bbe-a5e7-3f5409f4a0b9"
+                  hostname:
+                    type: string
+                    description: The hostname of the Kong node.
+                    example: "kong-node.example.com"
+                  timers:
+                    type: object
+                    description: Information about running and pending timers.
+                    properties:
+                      running:
+                        type: integer
+                        description: The number of running timers.
+                        example: 5
+                      pending:
+                        type: integer
+                        description: The number of pending timers.
+                        example: 2
+                  plugins:
+                    type: object
+                    description: Information about plugins.
+                    properties:
+                      available_on_server:
+                        type: object
+                        additionalProperties:
+                          type: object
+                          properties:
+                            version:
+                              type: string
+                              description: The version of the plugin.
+                            priority:
+                              type: integer
+                              description: The priority of the plugin.
+                      enabled_in_cluster:
+                        type: array
+                        items:
+                          type: string
+                        description: A list of distinct plugin names enabled in the cluster.
+                        example: ["jwt", "acl"]
+                  lua_version:
+                    type: string
+                    description: The version of Lua used by the Kong instance.
+                    example: "LuaJIT 2.1.0-beta3"
+                  configuration:
+                    type: object
+                    description: A sanitized version of the Kong configuration, excluding sensitive values.
+                    additionalProperties: true
+                  pids:
+                    type: object
+                    description: Process IDs for the master process and worker processes.
+                    properties:
+                      master:
+                        type: integer
+                        description: The PID of the master process.
+                        example: 4321
+                      workers:
+                        type: array
+                        items:
+                          type: integer
+                        description: An array of worker process PIDs.
+                        example: [1234, 5678]
+              examples:
+                fullExample:
+                  summary: Example response
+                  value: 
+                    configuration:
+                      _debug_pg_ttl_cleanup_interval: 300
+                      admin_acc_logs: "/usr/local/kong/logs/admin_access.log"
+                      admin_access_log: "/dev/stdout"
+                      admin_approved_email: "true"
+                      admin_emails_from: "\"\""
+                      admin_error_log: "/dev/stderr"
+                      admin_gui_access_log: "logs/admin_gui_access.log"
+                      admin_gui_auth_header: "******"
+                      admin_gui_auth_login_attempts: 0
+                      admin_gui_error_log: "logs/admin_gui_error.log"
+                      admin_gui_flags: "{}"
+                      admin_gui_listen:
+                        - "0.0.0.0:8002"
+                        - "0.0.0.0:8445 ssl"
+                      admin_gui_origin: "http://localhost:8002"
+                    edition: "enterprise"
+                    hostname: "8a487998603b"
+                    lua_version: "LuaJIT 2.1.0-20231117"
+                    node_id: "1f257156-5e44-46e2-a618-767f5c7529e3"
+                    pids:
+                      master: 1
+                      workers:
+                        - 2382
+                        - 2383
+                    plugins:
+                      available_on_server:
+                        acl: true
+                        acme: true
+                      disabled_on_server:
+                        application-registration: true
+                      enabled_in_cluster: []
+                    tagline: "Welcome to kong"
+                    timers:
+                      pending: 1
+                      running: 1128
+                    version: "3.6.0.0"
         '401': 
           $ref: '#/components/responses/HTTP401Error'
         '405':

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -3586,7 +3586,7 @@ paths:
                   edition:
                     type: string
                     description: Indicates whether the Kong instance is the Community or Enterprise edition.
-                    example: "community"
+                    example: "Community"
                   tagline:
                     type: string
                     description: A tagline or slogan for the Kong instance.
@@ -3663,6 +3663,7 @@ paths:
                       _debug_pg_ttl_cleanup_interval: 300
                       admin_acc_logs: "/usr/local/kong/logs/admin_access.log"
                       admin_access_log: "/dev/stdout"
+                    edition: "enterprise"
                     hostname: "b8f553cfbd0c"
                     lua_version: "LuaJIT 2.1.0-20230410"
                     node_id: "39bfa49d-3394-4f8e-b9db-94b786bc4e5f"

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -3570,7 +3570,7 @@ paths:
         - Information
       operationId: geInfo
       description: |
-        Returns basic information about the Kong gateway instance, including the version, edition (enterprise or community), a tagline, and the unique node identifier.
+        Returns detailed information about the Kong gateway instance, including the full Kong configuration, available and unavailable plugins, version, edition (enterprise or community), a tagline, the unique node identifier, and other metadata.
       responses:
         '200':
           description: Success

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -3563,6 +3563,53 @@ info:
   version: 3.6.0
 openapi: 3.0.0
 paths:
+  /:
+    get:
+      summary: Get Kong's instance information
+      tags:
+        - System Information
+      operationId: getRootInfo
+      description: |
+        Returns basic information about the Kong gateway instance, including the version, edition (enterprise or community), a tagline, and the unique node identifier.
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: The version number of the Kong instance.
+                    example: "2.3.3"
+                  edition:
+                    type: string
+                    description: Indicates whether the Kong instance is the Community or Enterprise edition.
+                    example: "enterprise"
+                  tagline:
+                    type: string
+                    description: A tagline or slogan for the Kong instance.
+                    example: "Welcome to Kong"
+                  node_id:
+                    type: string
+                    description: A unique identifier for the node, in UUID format.
+                    format: uuid
+                    example: "a74d7c4f-ef83-4bbe-a5e7-3f5409f4a0b9"
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '405':
+          description: Method Not Allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            Server:
+              description: Kong's server tokens.
+              schema:
+                type: string
+                example: "kong/2.3.3"  
   /ca_certificates:
     get:
       description: Retrieve a list of all available Certificate Authority (CA) certificates, including the certificate ID, creation date, and other details. You can use query parameters to filter the results by size or tags, for example `/ca-certificates?size=50&tags=enterprise`.

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -3663,7 +3663,7 @@ paths:
                       _debug_pg_ttl_cleanup_interval: 300
                       admin_acc_logs: "/usr/local/kong/logs/admin_access.log"
                       admin_access_log: "/dev/stdout"
-                    edition: "enterprise"
+                    edition: "community"
                     hostname: "b8f553cfbd0c"
                     lua_version: "LuaJIT 2.1.0-20230410"
                     node_id: "39bfa49d-3394-4f8e-b9db-94b786bc4e5f"

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -3586,7 +3586,7 @@ paths:
                   edition:
                     type: string
                     description: Indicates whether the Kong instance is the Community or Enterprise edition.
-                    example: "enterprise"
+                    example: "community"
                   tagline:
                     type: string
                     description: A tagline or slogan for the Kong instance.
@@ -3656,46 +3656,30 @@ paths:
                         description: An array of worker process PIDs.
                         example: [1234, 5678]
               examples:
-                fullExample:
-                  summary: Example response
-                  value: 
+                openSourceExample:
+                  summary: Open Source Edition Example Response
+                  value:
                     configuration:
                       _debug_pg_ttl_cleanup_interval: 300
                       admin_acc_logs: "/usr/local/kong/logs/admin_access.log"
                       admin_access_log: "/dev/stdout"
-                      admin_approved_email: "true"
-                      admin_emails_from: "\"\""
-                      admin_error_log: "/dev/stderr"
-                      admin_gui_access_log: "logs/admin_gui_access.log"
-                      admin_gui_auth_header: "******"
-                      admin_gui_auth_login_attempts: 0
-                      admin_gui_error_log: "logs/admin_gui_error.log"
-                      admin_gui_flags: "{}"
-                      admin_gui_listen:
-                        - "0.0.0.0:8002"
-                        - "0.0.0.0:8445 ssl"
-                      admin_gui_origin: "http://localhost:8002"
-                    edition: "enterprise"
-                    hostname: "8a487998603b"
-                    lua_version: "LuaJIT 2.1.0-20231117"
-                    node_id: "1f257156-5e44-46e2-a618-767f5c7529e3"
+                    hostname: "b8f553cfbd0c"
+                    lua_version: "LuaJIT 2.1.0-20230410"
+                    node_id: "39bfa49d-3394-4f8e-b9db-94b786bc4e5f"
                     pids:
                       master: 1
-                      workers:
-                        - 2382
-                        - 2383
+                      workers: [1278, 1279, 1280, 1281, 1282, 1283, 1284, 1285]
                     plugins:
                       available_on_server:
-                        acl: true
-                        acme: true
-                      disabled_on_server:
-                        application-registration: true
+                        acl:
+                          priority: 950
+                          version: "3.6.0"
                       enabled_in_cluster: []
                     tagline: "Welcome to kong"
                     timers:
                       pending: 1
-                      running: 1128
-                    version: "3.6.0.0"
+                      running: 145
+                    version: "3.6.0"
         '401': 
           $ref: '#/components/responses/HTTP401Error'
         '405':


### PR DESCRIPTION
* Added the Kong Gateway edition to the root endpoint (`/`) of the Admin API.
 [#12097](https://github.com/Kong/kong/issues/12097)

* Enabled `status_listen` on `127.0.0.1:8007` by default.
 [#12304](https://github.com/Kong/kong/issues/12304)