### PR TITLE
docs(mesh): update MeshGlobalRateLimit and MeshOPA targetref support table

### DIFF
--- a/app/_src/mesh/features/meshglobalratelimit.md
+++ b/app/_src/mesh/features/meshglobalratelimit.md
@@ -108,7 +108,7 @@ TODO: document how to generate and use zone token on universal.-->
 
 ## TargetRef support matrix
 
-{% if_version gte:2.6.x %}
+{% if_version gte:2.7.x %}
 {% tabs targetRef useUrlFragment=false %}
 {% tab targetRef Sidecar %}
 | `targetRef`             | Allowed kinds                         |
@@ -121,7 +121,7 @@ TODO: document how to generate and use zone token on universal.-->
 | `targetRef`             | Allowed kinds                                             |
 | ----------------------- | --------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshGateway`                                     |
-| `from[].targetRef.kind` | `Mesh`                                                    |
+| `to[].targetRef.kind` | `Mesh`                                                    |
 {% endtab %}
 {% endtabs %}
 

--- a/app/_src/mesh/features/meshglobalratelimit.md
+++ b/app/_src/mesh/features/meshglobalratelimit.md
@@ -108,6 +108,26 @@ TODO: document how to generate and use zone token on universal.-->
 
 ## TargetRef support matrix
 
+{% if_version gte:2.6.x %}
+{% tabs targetRef useUrlFragment=false %}
+{% tab targetRef Sidecar %}
+| `targetRef`             | Allowed kinds                         |
+| ----------------------- | ------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`   |
+| `from[].targetRef.kind` | `Mesh`                                |
+{% endtab %}
+
+{% tab targetRef Builtin Gateway %}
+| `targetRef`             | Allowed kinds                                             |
+| ----------------------- | --------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshGateway`                                     |
+| `from[].targetRef.kind` | `Mesh`                                                    |
+{% endtab %}
+{% endtabs %}
+
+{% endif_version %}
+{% if_version lte:2.5.x %}
+
 | TargetRef type    | Top level | To  | From |
 | ----------------- | --------- | --- | ---- |
 | Mesh              | ✅        | ❌  | ✅   |
@@ -115,6 +135,8 @@ TODO: document how to generate and use zone token on universal.-->
 | MeshService       | ✅        | ❌  | ❌   |
 | MeshServiceSubset | ❌        | ❌  | ❌   |
 | MeshGatewayRoute  | ❌        | ❌  | ❌   |
+
+{% endif_version %}
 
 To learn more about the information in this table, see the [matching docs](/mesh/{{page.release}}/policies/targetref).
 

--- a/app/_src/mesh/features/meshopa.md
+++ b/app/_src/mesh/features/meshopa.md
@@ -21,6 +21,24 @@ When the `MeshOPA` policy is applied, the control plane configures the following
 
 ## TargetRef support matrix
 
+{% if_version gte:2.6.x %}
+{% tabs targetRef useUrlFragment=false %}
+{% tab targetRef Sidecar %}
+| `targetRef`           | Allowed kinds                                            |
+| --------------------- | -------------------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
+{% endtab %}
+
+{% tab targetRef Builtin Gateway %}
+| `targetRef`             | Allowed kinds                                             |
+| ----------------------- | --------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshGateway`                                     |
+{% endtab %}
+{% endtabs %}
+
+{% endif_version %}
+{% if_version lte:2.5.x %}
+
 | TargetRef type    | top level | to  | from |
 | ----------------- | --------- | --- | ---- |
 | Mesh              | ✅        | ❌  | ❌   |
@@ -28,6 +46,8 @@ When the `MeshOPA` policy is applied, the control plane configures the following
 | MeshService       | ✅        | ❌  | ❌   |
 | MeshServiceSubset | ✅        | ❌  | ❌   |
 | MeshGatewayRoute  | ❌        | ❌  | ❌   |
+
+{% endif_version %}
 
 To learn more about the information in this table, see the [matching docs](/mesh/{{page.release}}/policies/targetref).
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->

Change the targetRef support table since 2.6 it has a different layout.

**Listener tags are not yet supported because the plugins need to be adjusted**
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

fix: https://github.com/Kong/kong-mesh/issues/5342