### PR TITLE
Fix: Move StatsD plugins to Analytics and Monitoring category

### DIFF
--- a/app/_hub/kong-inc/statsd-advanced/_metadata.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata.yml
@@ -7,6 +7,6 @@ konnect: true
 network_config_opts: All
 notes: --
 categories:
-  - logging
+  - analytics-monitoring
 publisher: Kong Inc.
 desc: (Deprecated) Send metrics to StatsD with more flexible options

--- a/app/_hub/kong-inc/statsd/_metadata.yml
+++ b/app/_hub/kong-inc/statsd/_metadata.yml
@@ -8,6 +8,6 @@ konnect: true
 network_config_opts: All
 notes: --
 categories:
-  - logging
+  - analytics-monitoring
 publisher: Kong Inc.
 desc: Send metrics to StatsD


### PR DESCRIPTION
### Description

StatsD and StatsD Advanced are incorrectly categorized as Logging plugins, when they should be under Analytics and Monitoring.

See their categorization in Konnect:

<img width="1208" alt="Screenshot 2024-02-14 at 1 24 08 PM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/c85a5192-47e9-497a-8fad-8576541a7fb4">


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

