### PR TITLE
docs(mesh): remove beta for MeshOPA and MeshGlobalRateLimiting since 2.6

### DIFF
--- a/app/_src/mesh/features/meshglobalratelimit.md
+++ b/app/_src/mesh/features/meshglobalratelimit.md
@@ -1,8 +1,16 @@
 ---
+{% if_version gte:2.6.x %}
+title: MeshGlobalRateLimit Policy
+content_type: reference
+beta: false
+badge: enterprise
+{% endif_version %}
+{% if_version lte:2.5.x %}
 title: MeshGlobalRateLimit Policy (beta)  
 content_type: reference
 beta: true
 badge: enterprise
+{% endif_version %}
 ---
 
 This policy adds Global Rate Limit support for {{site.mesh_product_name}}.

--- a/app/_src/mesh/features/meshopa.md
+++ b/app/_src/mesh/features/meshopa.md
@@ -1,7 +1,14 @@
 ---
+{% if_version gte:2.6.x %}
+title: MeshOPA - OPA Policy Integration
+content_type: reference
+beta: false
+{% endif_version %}
+{% if_version lte:2.5.x %}
 title: MeshOPA (beta) - OPA Policy Integration
 content_type: reference
 beta: true
+{% endif_version %}
 ---
 
 {:.warning}


### PR DESCRIPTION
### Description

Since 2.6 these policies are not Beta anymore
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

