### PR TITLE
fix(mistral): docs are a copy of llama2

### DIFF
--- a/app/_hub/kong-inc/ai-proxy/how-to/_mistral.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/_mistral.md
@@ -72,6 +72,8 @@ Enable and configure the AI Proxy plugin for Mistral (using `ollama` format in t
 curl -X POST http://localhost:8001/routes/mistral-chat/plugins \
   --data "name=ai-proxy" \
   --data "config.route_type=llm/v1/chat" \
+  --data "config.auth.header_name=Authorization" \
+  --data "config.auth.header_value=Bearer <MISTRAL_AI_KEY>" \
   --data "config.model.provider=mistral" \
   --data "config.model.name=mistral-tiny" \
   --data "config.model.options.mistral_format=openai" \
@@ -89,6 +91,9 @@ plugins:
   - name: ai-proxy
     config:
       route_type: "llm/v1/chat"
+      auth:
+        header_name: "Authorization"
+        header_value: "Bearer <MISTRAL_AI_KEY>"
       model:
         provider: "mistral"
         name: "mistral-tiny"

--- a/app/_hub/kong-inc/ai-proxy/how-to/_mistral.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/_mistral.md
@@ -33,7 +33,7 @@ The `openai` format option follows the same upstream formats as the equivalent
 [OpenAI route type operation](https://github.com/kong/kong/blob/master/spec/fixtures/ai-proxy/oas.yaml) 
 (that is, `llm/v1/chat` or `llm/v1/completions`).
 
-This format should be used when configuring the cloud-based https://mistral.ai/
+This format should be used when configuring the cloud-based [https://mistral.ai/](https://mistral.ai/).
 
 It will transform both `llm/v1/chat` and `llm/v1/completions` type route requests, into the same format.
 

--- a/app/_hub/kong-inc/ai-proxy/how-to/_mistral.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/_mistral.md
@@ -21,21 +21,26 @@ The "upstream" request and response formats are different between various implem
 
 For this provider, the following should be used for the [`config.model.options.mistral_format`](/hub/kong-inc/ai-proxy/configuration/#config-model-options-mistral_format) parameter:
 
-| Mistral Hosting  | `mistral_format` Config Value | Auth Header           |
-|------------------|-----------------------------|-------------------------|
-| OLLAMA           | `ollama`                    | Not required by default |
-| Self-Hosted GGUF | `openai`                    | Not required by default |
-
-### Ollama Format
-
-The `ollama` format option adheres to the `chat` and `chat-completion` request formats,
-as defined in its [API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md).
+| Mistral Hosting  | `mistral_format` Config Value | Auth Header             |
+|------------------|-------------------------------|-------------------------|
+| Mistral.ai       | `openai`                      | `Authorization`         |
+| OLLAMA           | `ollama`                      | Not required by default |
+| Self-Hosted GGUF | `openai`                      | Not required by default |
 
 ### OpenAI Format
 
 The `openai` format option follows the same upstream formats as the equivalent 
 [OpenAI route type operation](https://github.com/kong/kong/blob/master/spec/fixtures/ai-proxy/oas.yaml) 
 (that is, `llm/v1/chat` or `llm/v1/completions`).
+
+This format should be used when configuring the cloud-based https://mistral.ai/
+
+It will transform both `llm/v1/chat` and `llm/v1/completions` type route requests, into the same format.
+
+### Ollama Format
+
+The `ollama` format option adheres to the `chat` and `chat-completion` request formats,
+as defined in its [API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md).
 
 ## Using the plugin with Mistral
 
@@ -68,9 +73,9 @@ curl -X POST http://localhost:8001/routes/mistral-chat/plugins \
   --data "name=ai-proxy" \
   --data "config.route_type=llm/v1/chat" \
   --data "config.model.provider=mistral" \
-  --data "config.model.name=mistral" \
-  --data "config.model.options.mistral_format=ollama" \
-  --data "config.model.options.upstream_url=http://ollama-server.local:11434/v1/chat" \ 
+  --data "config.model.name=mistral-tiny" \
+  --data "config.model.options.mistral_format=openai" \
+  --data "config.model.options.upstream_url=https://api.mistral.ai/v1/chat/completions" \ 
 ```
 {% endnavtab %}
 {% navtab YAML %}
@@ -86,9 +91,9 @@ plugins:
       route_type: "llm/v1/chat"
       model:
         provider: "mistral"
-        name: "mistral"
-        mistral_format: "ollama"
-        upstream_url: "http://ollama-server.local:11434/v1/chat"
+        name: "mistral-tiny"
+        mistral_format: "openai"
+        upstream_url: "https://api.mistral.ai/v1/chat/completions"
 ```
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Description

The `mistral` provider docs are accidentally a copy of the `llama2` docs!

They need to specifically reference cloud-hosted mistral.ai, as the most common usage.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

