### PR TITLE
docs(mesh): in Vault docs switch to orphan tokens

### DIFF
--- a/app/_src/mesh/features/vault.md
+++ b/app/_src/mesh/features/vault.md
@@ -176,8 +176,8 @@ vault token create -type=service -orphan -format=json -policy="kmesh-default-dat
 ```
 
 We suggest using an [orphan token](https://developer.hashicorp.com/vault/docs/concepts/tokens#token-hierarchies-and-orphan-tokens)
-to avoid surprising behavior around expiration. Creating them requires root/sudo
-permissions, Therefore you need those permissions to execute the above command. If you understand the
+to avoid surprising behavior around expiration. You need root/sudo
+permissions to execute the previous command. If you understand the
 implications, you can use a non-orphan token as well.
 The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
 

--- a/app/_src/mesh/features/vault.md
+++ b/app/_src/mesh/features/vault.md
@@ -169,7 +169,7 @@ vault policy write kmesh-default-dataplane-proxies kmesh-default-dataplane-proxi
 
 #### Step 4. Configure authentication method:
 
-To authorize {{site.mesh_product_name}} to vault using a token, generate the following orphan token and pass it to mesh:
+To authorize {{site.mesh_product_name}} to vault using a token, generate the following orphan token and pass it to the mesh:
 
 ```sh
 vault token create -type=service -orphan -format=json -policy="kmesh-default-dataplane-proxies" | jq -r ".auth.client_token"

--- a/app/_src/mesh/features/vault.md
+++ b/app/_src/mesh/features/vault.md
@@ -175,10 +175,8 @@ To authorize {{site.mesh_product_name}} to vault using a token, generate the fol
 vault token create -type=service -orphan -format=json -policy="kmesh-default-dataplane-proxies" | jq -r ".auth.client_token"
 ```
 
-We suggest using an [orphan token](https://developer.hashicorp.com/vault/docs/concepts/tokens#token-hierarchies-and-orphan-tokens)
-to avoid surprising behavior around expiration. You need root/sudo
-permissions to execute the previous command. If you understand the
-implications, you can use a non-orphan token as well.
+We suggest using an [orphan token to avoid surprising behavior around expiration in token hierarchies](https://developer.hashicorp.com/vault/docs/concepts/tokens#token-hierarchies-and-orphan-tokens).
+You need root/sudo permissions to execute the previous command.
 The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
 
 {:.note}

--- a/app/_src/mesh/features/vault.md
+++ b/app/_src/mesh/features/vault.md
@@ -169,12 +169,16 @@ vault policy write kmesh-default-dataplane-proxies kmesh-default-dataplane-proxi
 
 #### Step 4. Configure authentication method:
 
-To authorize {{site.mesh_product_name}} to vault using a token, generate the token and pass it to mesh:
+To authorize {{site.mesh_product_name}} to vault using a token, generate the following orphan token and pass it to mesh:
 
 ```sh
-vault token create -format=json -policy="kmesh-default-dataplane-proxies" | jq -r ".auth.client_token"
+vault token create -type=service -orphan -format=json -policy="kmesh-default-dataplane-proxies" | jq -r ".auth.client_token"
 ```
 
+We suggest using an [orphan token](https://developer.hashicorp.com/vault/docs/concepts/tokens#token-hierarchies-and-orphan-tokens)
+to avoid surprising behavior around expiration. Creating them requires root/sudo
+permissions, Therefore you need those permissions to execute the above command. If you understand the
+implications, you can use a non-orphan token as well.
 The output should print a Vault token that you then provide as the `conf.fromCp.auth.token` value of the `Mesh` object.
 
 {:.note}


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
As described in the PR changes, it's likely users want to create orphan tokens to authenticate to vault.

See also https://github.com/Kong/kong-mesh/issues/5412
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-6964--kongdocs.netlify.app/mesh/latest/features/vault/#step-4-configure-authentication-method

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
  - Not applicable to a specific version