### PR TITLE
fix(kong-manager): add ignored params to the OIDC migration guide

### DIFF
--- a/app/_src/gateway/kong-manager/auth/oidc/migrate.md
+++ b/app/_src/gateway/kong-manager/auth/oidc/migrate.md
@@ -25,6 +25,22 @@ Parameter | Old behavior | New behavior
 [`login_redirect_uri`](#login_redirect_uri) | Optional | Required 
 [`logout_redirect_uri`](#logout_redirect_uri) | Optional | Required
 
+The following parameters are not required and controlled internally, and the provided values for them will be ignored:
+
+- `auth_methods`
+- `login_action`
+- `login_methods`
+- `login_tokens`
+- `logout_methods`
+- `logout_query_arg`
+- `logout_revoke_access_token`
+- `logout_revoke_refresh_token`
+- `logout_revoke`
+- `refresh_tokens`
+- `upstream_access_token_header`
+- `upstream_id_token_header`
+- `upstream_user_info_header` (while `search_user_info` is `true`)
+
 <!-- vale off -->
 ### scopes
 <!-- vale on -->


### PR DESCRIPTION
### Description

This pull request adds the ignored parameters to the migration guide for Kong Manager's OIDC feature.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

