### PR TITLE
Fix: remove if_version on the Or operator in the table

### DIFF
--- a/app/_src/gateway/reference/expressions-language/language-references.md
+++ b/app/_src/gateway/reference/expressions-language/language-references.md
@@ -138,15 +138,7 @@ Expressions language support a rich set of operators that can be performed on va
 | `not in`       | Not in                | Field value is not inside the constant value                                                                                                                                                                 |
 | `contains`     | Contains              | Field value contains the constant value                                                                                                                                                                      |
 | `&&`           | And                   | Returns `true` if **both** expressions on the left and right side evaluates to `true`                                                                                                                        |
-
-{% if_version lte:3.5.x %}
-| `||` | Or | Returns `true` if **any** expressions on the left and right side evaluates to `true` |
-{% endif_version %}
-
-{% if_version gte:3.6.x %}
-| `\|\|`         | Or                    | Returns `true` if **any** expressions on the left and right side evaluates to `true`                                                                                                                         |
-{% endif_version %}
-
+| `||` | Or | Returns `true` if **any** expressions on the left and right side evaluates to `true` |                                                                                                                    |
 | `(Expression)` | Parenthesis           | Groups expressions together to be evaluated first                                                                                                                                                            |
 
 {% if_version gte:3.6.x %}
@@ -178,7 +170,7 @@ Here are the allowed combination of field types and constant types with each ope
 | `String`                         | `==`, `!=`, `~`, `^=`, `=^`, `contains` | ❌              | ❌        | ❌                                | `~`     | ❌            |
 | `IpAddr`                         | ❌                                       | `in`, `not in` | `==`     | ❌                                | ❌       | ❌            |
 | `Int`                            | ❌                                       | ❌              | ❌        | `==`, `!=`, `>=`, `>`, `<=`, `<` | ❌       | ❌           |
-| `Expression`                     | ❌                                       | ❌              | ❌        | ❌                                | ❌       | `&&`,{% if_version lte:3.5.x inline:true %} `{% raw %}||{% endraw %}`{% endif_version %}{% if_version gte:3.6.x inline:true %} `\|\|`{% endif_version %}  |
+| `Expression`                     | ❌                                       | ❌              | ❌        | ❌                                | ❌       | `&&`, `||`|
 
 
 {:.note}

--- a/app/_src/gateway/reference/expressions-language/language-references.md
+++ b/app/_src/gateway/reference/expressions-language/language-references.md
@@ -141,7 +141,7 @@ Expressions language support a rich set of operators that can be performed on va
 | `||` | Or | Returns `true` if **any** expressions on the left and right side evaluates to `true` |                                                                                                                    |
 | `(Expression)` | Parenthesis           | Groups expressions together to be evaluated first                                                                                                                                                            |
 
-{% if_version gte:3.6.x %}
+{% if_version gte:3.6.x inline:true %}
 | `!`            | Not                   | Negates the result of a parenthesized expression. **Note:** The `!` operator can only be used with parenthesized expression like `!(foo == 1)`, it **cannot** be used with a bare predicate like `! foo == 1` |
 {% endif_version %}
 
@@ -161,9 +161,9 @@ This will match a `http.path` that looks like `/foo`, `/abc/foo`, or `/xfooy`, f
 
 ### Type and operator semantics
 
-Here are the allowed combination of field types and constant types with each operator:
-
-> **Note:** Rows represents field types that display on the left-hand side (LHS) of the predicate where columns represents constant value types that display on the right-hand side (RHS) of the predicate.
+Here are the allowed combination of field types and constant types with each operator.
+In the following table, rows represent field types that display on the left-hand side (LHS) of the predicate, 
+whereas columns represent constant value types that display on the right-hand side (RHS) of the predicate.
 
 | Field (LHS)/Constant (RHS) types | `String`                                | `IpCidr`       | `IpAddr` | `Int`                            | `Regex` | `Expression` |
 |----------------------------------|-----------------------------------------|----------------|----------|----------------------------------|---------|--------------|


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
Remove the `if_version` on OR operator in expression language reference page to let the OR operator (`||`) displayed correctly.
fixes #6972.
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
https://deploy-preview-6975--kongdocs.netlify.app/gateway/latest/reference/expressions-language/language-references/#operators
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

