### PR TITLE
Fix: OR operator hasn't changed in 3.6

### DIFF
--- a/app/_src/gateway/reference/expressions-language/language-references.md
+++ b/app/_src/gateway/reference/expressions-language/language-references.md
@@ -138,19 +138,11 @@ Expressions language support a rich set of operators that can be performed on va
 | `not in`       | Not in                | Field value is not inside the constant value                                                                                                                                                                 |
 | `contains`     | Contains              | Field value contains the constant value                                                                                                                                                                      |
 | `&&`           | And                   | Returns `true` if **both** expressions on the left and right side evaluates to `true`                                                                                                                        |
-
-{% if_version lte:3.5.x %}
 | `||` | Or | Returns `true` if **any** expressions on the left and right side evaluates to `true` |
-{% endif_version %}
-
-{% if_version gte:3.6.x %}
-| `\|\|`         | Or                    | Returns `true` if **any** expressions on the left and right side evaluates to `true`                                                                                                                         |
-{% endif_version %}
-
 | `(Expression)` | Parenthesis           | Groups expressions together to be evaluated first                                                                                                                                                            |
 
-{% if_version gte:3.6.x %}
-| `!`            | Not                   | Negates the result of a parenthesized expression. **Note:** The `!` operator can only be used with parenthesized expression like `!(foo == 1)`, it **cannot** be used with a bare predicate like `! foo == 1` |
+{% if_version gte:3.6.x inline:true %}
+| `!`            | Not                   | Negates the result of a parenthesized expression. <br>**Note:** The `!` operator can only be used with parenthesized expression like `!(foo == 1)`, it **cannot** be used with a bare predicate like `! foo == 1` |
 {% endif_version %}
 
 ### Extended descriptions
@@ -169,17 +161,16 @@ This will match a `http.path` that looks like `/foo`, `/abc/foo`, or `/xfooy`, f
 
 ### Type and operator semantics
 
-Here are the allowed combination of field types and constant types with each operator:
-
-> **Note:** Rows represents field types that display on the left-hand side (LHS) of the predicate where columns represents constant value types that display on the right-hand side (RHS) of the predicate.
+Here are the allowed combination of field types and constant types with each operator.
+In the following table, rows represent field types that display on the left-hand side (LHS) of the predicate, 
+whereas columns represent constant value types that display on the right-hand side (RHS) of the predicate.
 
 | Field (LHS)/Constant (RHS) types | `String`                                | `IpCidr`       | `IpAddr` | `Int`                            | `Regex` | `Expression` |
 |----------------------------------|-----------------------------------------|----------------|----------|----------------------------------|---------|--------------|
 | `String`                         | `==`, `!=`, `~`, `^=`, `=^`, `contains` | ❌              | ❌        | ❌                                | `~`     | ❌            |
 | `IpAddr`                         | ❌                                       | `in`, `not in` | `==`     | ❌                                | ❌       | ❌            |
 | `Int`                            | ❌                                       | ❌              | ❌        | `==`, `!=`, `>=`, `>`, `<=`, `<` | ❌       | ❌           |
-| `Expression`                     | ❌                                       | ❌              | ❌        | ❌                                | ❌       | `&&`,{% if_version lte:3.5.x inline:true %} `{% raw %}||{% endraw %}`{% endif_version %}{% if_version gte:3.6.x inline:true %} `\|\|`{% endif_version %}  |
-
+| `Expression`                     | ❌                                       | ❌              | ❌        | ❌                                | ❌       | `&&`,`||`  |
 
 {:.note}
 > **Notes:** 


### PR DESCRIPTION
### Description

The OR operator (`||`) hasn't changed in 3.6. This change was an accident, as GH-flavored markdown expects `|` characters to be escaped to properly display them, but kramdown/our docs renderer doesn't, so it prints the syntax literally as `\|\|`. Erring in favor of the prod docs (which will mean that it displays incorrectly in GH markdown, but that shouldn't matter).

Fixes https://github.com/Kong/docs.konghq.com/issues/6972.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

