### PR TITLE
chore: Bump unreleased Gateway version to 3.7

### DIFF
--- a/app/_data/docs_nav_gateway_3.7.x.yml
+++ b/app/_data/docs_nav_gateway_3.7.x.yml
@@ -1,0 +1,693 @@
+product: gateway
+release: 3.7.x
+generate: true
+assume_generated: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    items:
+      - text: Overview of Kong Gateway
+        url: /gateway/3.7.x/
+        absolute_url: true
+      - text: Support
+        items:
+          - text: Version Support Policy
+            url: /support-policy/
+            src: /gateway/support/index
+          - text: Third Party Dependencies
+            url: /support/third-party
+          - text: Browser Support
+            url: /support/browser
+          - text: Vulnerability Patching Process
+            url: /support/vulnerability-patching-process
+          - text: Software Bill of Materials
+            url: /support/sbom
+      - text: Stability
+        url: /stability
+      - text: Release Notes
+        url: /gateway/changelog
+        absolute_url: true
+      - text: Breaking Changes
+        items:
+          - text: Kong Gateway 3.6.x
+            url: /breaking-changes/
+            src: /gateway/breaking-changes/36x
+          - text: Kong Gateway 3.5.x
+            url: /breaking-changes/35x/
+          - text: Kong Gateway 3.4.x
+            url: /breaking-changes/34x/
+          - text: Kong Gateway 3.3.x
+            url: /breaking-changes/33x/
+          - text: Kong Gateway 3.2.x
+            url: /breaking-changes/32x/
+          - text: Kong Gateway 3.1.x
+            url: /breaking-changes/31x/
+          - text: Kong Gateway 3.0.x
+            url: /breaking-changes/30x/
+          - text: Kong Gateway 2.8.x or earlier
+            url: /breaking-changes/28x/
+      - text: Key Concepts
+        items:
+          - text: Services
+            url: /key-concepts/services
+          - text: Routes
+            url: /key-concepts/routes
+          - text: Upstreams
+            url: /key-concepts/upstreams
+          - text: Plugins
+            url: /key-concepts/plugins
+          - text: Consumer Groups
+            url: /key-concepts/consumer-groups
+            src: /gateway/kong-enterprise/consumer-groups/index
+          # - text: Manage Kong Gateway with decK
+          #   url: /key-concepts/manage-kong-with-deck
+      - text: How Kong Works
+        items:
+          - text: Routing Traffic
+            url: /how-kong-works/routing-traffic
+          - text: Load Balancing
+            url: /how-kong-works/load-balancing
+          - text: Health Checks and Circuit Breakers
+            url: /how-kong-works/health-checks
+      - text: Glossary
+        url: /glossary
+
+  - title: Get Started with Kong
+    icon: /assets/images/icons/documentation/icn-learning.svg
+    items:
+      - text: Get Kong
+        url: /get-started/
+      - text: Services and Routes
+        url: /get-started/services-and-routes
+      - text: Rate Limiting
+        url: /get-started/rate-limiting
+      - text: Proxy Caching
+        url: /get-started/proxy-caching
+      - text: Key Authentication
+        url: /get-started/key-authentication
+      - text: Load-Balancing
+        url: /get-started/load-balancing
+      - text: AI Gateway
+        url: /get-started/ai-gateway
+  - title: Kong in Production
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    items:
+      - text: Deployment Topologies
+        items:
+          - text: Overview
+            url: /production/deployment-topologies/
+          - text: Hybrid Mode
+            items:
+            - text: Overview
+              url: /production/deployment-topologies/hybrid-mode/
+            - text: Deploy Kong Gateway in Hybrid mode
+              url: /production/deployment-topologies/hybrid-mode/setup
+          - text: DB-less Deployment
+            url: /production/deployment-topologies/db-less-and-declarative-config
+          - text: Traditional
+            url: /production/deployment-topologies/traditional
+      - text: Installation Options
+        items:
+          - text: Overview
+            url: /install/
+          - text: Kubernetes
+            items:
+              - text: Overview
+                url: /install/kubernetes/
+              - text: Install Kong Gateway
+                url: /install/kubernetes/proxy/
+              - text: Configure the Admin API
+                url: /install/kubernetes/admin/
+              - text: Install Kong Manager
+                url: /install/kubernetes/manager/
+          - text: Docker
+            items:
+              - text: Using docker run
+                url: /install/docker
+              - text: Build your own Docker images
+                url: /install/docker/build-custom-images/
+          - text: Linux
+            items:
+              - text: Amazon Linux
+                url: /install/linux/amazon-linux
+              - text: Debian
+                url: /install/linux/debian
+              - text: Red Hat
+                url: /install/linux/rhel
+              - text: Ubuntu
+                url: /install/linux/ubuntu
+          - text: Post-installation
+            items:
+              - text: Set up a data store
+                url: /install/post-install/set-up-data-store/
+              - text: Apply Enterprise license
+                url: /install/post-install/enterprise-license/
+                generate: false
+              - text: Enable Kong Manager (Enterprise)
+                url: /install/post-install/kong-manager/
+                generate: false
+              - text: Enable Kong Manager (OSS)
+                url: /install/post-install/kong-manager-oss/
+                generate: false
+      - text: Running Kong
+        items:
+          - text: Running Kong as a non-root user
+            url: /production/running-kong/kong-user
+          - text: Securing the Admin API
+            url: /production/running-kong/secure-admin-api
+          - text: Using systemd
+            url: /production/running-kong/systemd
+      - text: Access Control
+        items:
+          - text: Start Kong Gateway Securely
+            url: /production/access-control/start-securely
+          - text: Programatically Creating Admins
+            url: /production/access-control/register-admin-api
+          - text: Enabling RBAC
+            url: /production/access-control/enable-rbac
+      - text: Licenses
+        items:
+          - text: Overview
+            url: /licenses/
+          - text: Download your License
+            url: /licenses/download
+          - text: Deploy Enterprise License
+            url: /licenses/deploy
+          - text: Using the License API
+            url: /licenses/examples
+          - text: Monitor Licenses Usage
+            url: /licenses/report
+            src: /gateway/licenses/report-v2
+      - text: Networking
+        items:
+          - text: Default Ports
+            url: /production/networking/default-ports
+          - text: DNS Considerations
+            url: /production/networking/dns-considerations
+          - text: Network and Firewall
+            url: /production/networking/firewall
+          - text: CP/DP Communication through a Forward Proxy
+            url: /production/networking/cp-dp-proxy
+          - text: PostgreSQL TLS
+            items:
+            - text: Configure PostgreSQL TLS
+              url: /production/networking/configure-postgres-tls
+            - text: Troubleshooting PostgreSQL TLS
+              url: /production/networking/troubleshoot-postgres-tls
+      - text: Kong Configuration File
+        url: /production/kong-conf
+      - text: Environment Variables
+        url: /production/environment-variables
+      - text: Serving a Website and APIs from Kong
+        url: /production/website-api-serving
+      - text: Monitoring
+        items:
+          - text: Overview
+            url: /production/monitoring/
+          - text: Prometheus
+            url: /production/monitoring/prometheus
+          - text: StatsD
+            url: /production/monitoring/statsd
+          - text: Datadog
+            url: /production/monitoring/datadog
+          - text: Health Check Probes
+            url: /production/monitoring/healthcheck-probes
+      - text: Tracing
+        items:
+          - text: Overview
+            url: /production/tracing/
+          - text: Writing a Custom Trace Exporter
+            url: /production/tracing/write-custom-trace-exporter
+          - text: Tracing API Reference
+            url: /production/tracing/api
+      - text: Resource Sizing Guidelines
+        url: /production/sizing-guidelines
+      - text: Security Update Process
+        url: /production/security-update-process
+      - text: Blue-Green Deployments
+        url: /production/blue-green
+      - text: Canary Deployments
+        url: /production/canary
+      - text: Clustering Reference
+        url: /production/clustering
+      - text: Performance Testing
+        items:
+        - text: Performance Testing Benchmarks
+          url: /production/performance/performance-testing
+        - text: Establish a Performance Benchmark
+          url: /production/performance/benchmark
+      - text: Logging and Debugging
+        items:
+          - text: Log Reference
+            url: /production/logging/log-reference
+          - text: Dynamic log level updates
+            url: /production/logging/update-log-level-dynamically
+          - text: Customize Gateway Logs
+            url: /production/logging/customize-gateway-logs
+          - text: Debug Requests
+            url: /production/debug-request
+        url: /production/logging
+      - text: Configure a gRPC service
+        url: /production/configuring-a-grpc-service
+      - text: Use the Expressions Router
+        url: /key-concepts/routes/expressions
+      - text: Upgrade and Migration
+        items:
+          - text: Upgrading Kong Gateway 3.x.x
+            url: /upgrade/
+          - text: Backup and Restore
+            url: /upgrade/backup-and-restore/
+          - text: Upgrade Strategies
+            items:
+              - text: Dual-Cluster Upgrade
+                url: /upgrade/dual-cluster/
+              - text: In-Place Upgrade
+                url: /upgrade/in-place/
+              - text: Blue-Green Upgrade
+                url: /upgrade/blue-green/
+              - text: Rolling Upgrade
+                url: /upgrade/rolling-upgrade/
+          - text: Upgrade from 2.8 LTS to 3.4 LTS
+            url: /upgrade/lts-upgrade/
+          - text: Migrate from OSS to Enterprise
+            url: /migrate-ce-to-ke/
+          - text: Migration Guidelines Cassandra to PostgreSQL
+            url: /migrate-cassandra-to-postgres/
+          - text: Breaking Changes
+            url: /production/breaking-changes/
+            generate: false
+  - title: Kong Gateway Enterprise
+    icon: /assets/images/icons/documentation/icn-enterprise-blue.svg
+    items:
+      - text: Overview
+        url: /kong-enterprise/
+      - text: Secrets Management
+        items:
+          - text: Overview
+            url: /kong-enterprise/secrets-management/
+          - text: Getting Started
+            url: /kong-enterprise/secrets-management/getting-started
+          - text: Secrets Rotation
+            url: /kong-enterprise/secrets-management/secrets-rotation
+          - text: Advanced Usage
+            url: /kong-enterprise/secrets-management/advanced-usage
+          - text: Backends
+            items:
+              - text: Overview
+                url: /kong-enterprise/secrets-management/backends
+              - text: Environment Variables
+                url: /kong-enterprise/secrets-management/backends/env
+              - text: AWS Secrets Manager
+                url: /kong-enterprise/secrets-management/backends/aws-sm
+              - text: Azure Key Vaults
+                url: /kong-enterprise/secrets-management/backends/azure-key-vaults
+              - text: Google Secrets Manager
+                url: /kong-enterprise/secrets-management/backends/gcp-sm
+              - text: Hashicorp Vault
+                url: /kong-enterprise/secrets-management/backends/hashicorp-vault
+          - text: How-To
+            items:
+              - text: Securing the Database with AWS Secrets Manager
+                url: /kong-enterprise/secrets-management/how-to/aws-secrets-manager
+          - text: Reference Format
+            url: /kong-enterprise/secrets-management/reference-format
+      - text: Dynamic Plugin Ordering
+        items:
+          - text: Overview
+            url: /kong-enterprise/plugin-ordering/
+          - text: Get Started with Dynamic Plugin Ordering
+            url: /kong-enterprise/plugin-ordering/get-started
+      - text: Audit Logging
+        url: /kong-enterprise/audit-log
+      - text: Keyring and Data Encryption
+        url: /kong-enterprise/db-encryption
+      - text: Workspaces
+        url: /kong-enterprise/workspaces
+      - text: Consumer Groups
+        url: /kong-enterprise/consumer-groups
+      - text: Event Hooks
+        url: /kong-enterprise/event-hooks
+      - text: Configure Data Plane Resilience
+        url: /kong-enterprise/cp-outage-handling
+      - text: About Control Plane Outage Management
+        url: /kong-enterprise/cp-outage-handling-faq
+      - text: FIPS 140-2
+        items:
+          - text: Overview
+            url: /kong-enterprise/fips-support/
+            src: /gateway/kong-enterprise/fips-support/index
+          - text: Install the FIPS Compliant Package
+            url: /kong-enterprise/fips-support/install
+          - text: FIPS 140-2 Compliant Plugins
+            url: /kong-enterprise/fips-support/plugins
+      - text: Authenticate your Kong Gateway Amazon RDS database with AWS IAM
+        url: /kong-enterprise/aws-iam-auth-to-rds-database
+      - text: Verify Signatures for Signed Kong Images
+        url: /kong-enterprise/signed-images
+
+  - title: Kong Manager
+    icon: /assets/images/icons/documentation/icn-manager-color.svg
+    items:
+      - text: Overview
+        url: /kong-manager/
+      - text: Enable Kong Manager
+        url: /kong-manager/enable
+      - text: Get Started with Kong Manager
+        items:
+          - text: Services and Routes
+            url: /kong-manager/get-started/services-and-routes
+          - text: Rate Limiting
+            url: /kong-manager/get-started/rate-limiting
+          - text: Proxy Caching
+            url: /kong-manager/get-started/proxy-caching
+          - text: Authentication with Consumers
+            url: /kong-manager/get-started/consumers
+          - text: Load Balancing
+            url: /kong-manager/get-started/load-balancing
+      - text: Authentication and Authorization
+        items:
+          - text: Overview
+            url: /kong-manager/auth/
+          - text: Create a Super Admin
+            url: /kong-manager/auth/super-admin
+          - text: Workspaces and Teams
+            url: /kong-manager/auth/workspaces-and-teams
+          - text: Reset Passwords and RBAC Tokens
+            url: /kong-manager/auth/reset-password
+          - text: Basic Auth
+            url: /kong-manager/auth/basic
+          - text: LDAP
+            items:
+              - text: Configure LDAP
+                url: /kong-manager/auth/ldap/configure
+              - text: LDAP Service Directory Mapping
+                url: /kong-manager/auth/ldap/service-directory-mapping
+          - text: OIDC
+            items:
+              - text: Configure OIDC
+                url: /kong-manager/auth/oidc/configure
+              - text: OIDC Authenticated Group Mapping
+                url: /kong-manager/auth/oidc/mapping
+              - text: Migrate from previous configurations
+                url: /kong-manager/auth/oidc/migrate
+          - text: Sessions
+            url: /kong-manager/auth/sessions
+          - text: RBAC
+            items:
+            - text: Overview
+              url: /kong-manager/auth/rbac
+            - text: Enable RBAC
+              url: /kong-manager/auth/rbac/enable
+            - text: Add a Role and Permissions
+              url: /kong-manager/auth/rbac/add-role
+            - text: Create a User
+              url: /kong-manager/auth/rbac/add-user
+            - text: Create an Admin
+              url: /kong-manager/auth/rbac/add-admin
+      - text: Networking Configuration
+        url: /kong-manager/networking
+      - text: Workspaces
+        url: /kong-manager/workspaces
+      - text: Create Consumer Groups
+        url: /kong-manager/consumer-groups
+      - text: Sending Email
+        url: /kong-manager/configuring-to-send-email
+  - title: Kong Manager Open Source
+    icon: /assets/images/icons/documentation/icn-manager-oss-color.svg
+    items:
+      - text: Overview
+        url: /kong-manager-oss/
+      - text: Troubleshooting
+        url: /kong-manager-oss/troubleshoot/
+
+  - title: Develop Custom Plugins
+    icon: /assets/images/icons/documentation/icn-dev-portal-color.svg
+    items:
+      - text: Overview
+        url: /plugin-development/
+      - text: File Structure
+        url: /plugin-development/file-structure
+      - text: Implementing Custom Logic
+        url: /plugin-development/custom-logic
+      - text: Plugin Configuration
+        url: /plugin-development/configuration
+      - text: Accessing the Data Store
+        url: /plugin-development/access-the-datastore
+      - text: Storing Custom Entities
+        url: /plugin-development/custom-entities
+      - text: Caching Custom Entities
+        url: /plugin-development/entities-cache
+      - text: Extending the Admin API
+        url: /plugin-development/admin-api
+      - text: Writing Tests
+        url: /plugin-development/tests
+      - text: (un)Installing your Plugin
+        url: /plugin-development/distribution
+      - text: Proxy-Wasm Filters
+        items:
+          - text: Create a Proxy-Wasm Filter
+            url: /plugin-development/wasm/filter-development-guide
+          - text: Proxy-Wasm Filter Configuration
+            url: /plugin-development/wasm/filter-configuration
+      - text: Plugin Development Kit
+        items:
+        - text: Overview
+          url: /plugin-development/pdk/
+        - text: kong.client
+          url: /plugin-development/pdk/kong.client
+        - text: kong.client.tls
+          url: /plugin-development/pdk/kong.client.tls
+        - text: kong.cluster
+          url: /plugin-development/pdk/kong.cluster
+        - text: kong.ctx
+          url: /plugin-development/pdk/kong.ctx
+        - text: kong.ip
+          url: /plugin-development/pdk/kong.ip
+        - text: kong.jwe
+          url: /plugin-development/pdk/kong.jwe
+        - text: kong.log
+          url: /plugin-development/pdk/kong.log
+        - text: kong.nginx
+          url: /plugin-development/pdk/kong.nginx
+        - text: kong.node
+          url: /plugin-development/pdk/kong.node
+        - text: kong.plugin
+          url: /plugin-development/pdk/kong.plugin
+        - text: kong.request
+          url: /plugin-development/pdk/kong.request
+        - text: kong.response
+          url: /plugin-development/pdk/kong.response
+        - text: kong.router
+          url: /plugin-development/pdk/kong.router
+        - text: kong.service
+          url: /plugin-development/pdk/kong.service
+        - text: kong.service.request
+          url: /plugin-development/pdk/kong.service.request
+        - text: kong.service.response
+          url: /plugin-development/pdk/kong.service.response
+        - text: kong.table
+          url: /plugin-development/pdk/kong.table
+        - text: kong.tracing
+          url: /plugin-development/pdk/kong.tracing
+        - text: kong.vault
+          url: /plugin-development/pdk/kong.vault
+
+        - text: kong.websocket.client
+          url: /plugin-development/pdk/kong.websocket.client
+
+        - text: kong.websocket.upstream
+          url: /plugin-development/pdk/kong.websocket.upstream
+
+      - text: Plugins in Other Languages
+        items:
+          - text: Go
+            url: /plugin-development/pluginserver/go
+          - text: Javascript
+            url: /plugin-development/pluginserver/javascript
+          - text: Python
+            url: /plugin-development/pluginserver/python
+          - text: Running Plugins in Containers
+            url: /plugin-development/pluginserver/plugins-kubernetes
+          - text: External Plugin Performance
+            url: /plugin-development/pluginserver/performance
+  - title: Kong Plugins
+    icon: /assets/images/icons/documentation/icn-api-plugins-color.svg
+    items:
+      - text: Overview
+        url: /kong-plugins/
+      - text: Authentication Reference
+        url: /kong-plugins/authentication/reference
+      - text: Allow Multiple Authentication Plugins
+        url: /kong-plugins/authentication/allowing-multiple-authentication-methods/
+      - text: Plugin Queuing
+        items:
+          - text: Overview
+            url: /kong-plugins/queue
+          - text: Plugin Queuing Reference
+            url: /kong-plugins/queue/reference
+
+  - title: Admin API
+    icon: /assets/images/icons/documentation/icn-admin-api-color.svg
+    items:
+      - text: Overview
+        url: /admin-api/
+        src: /gateway/admin-api/index_latest
+      - text: Declarative Configuration
+        url: /admin-api/declarative-configuration
+      - text: Enterprise API
+        items:
+        - text: Information Routes
+          url: /gateway/api/admin-ee/latest/#/Information/get-endpoints
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Health Routes
+          url: /gateway/api/admin-ee/latest/#/Information/get-status
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Tags
+          url: /gateway/api/admin-ee/latest/#/tags/get-tags
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Debug Routes
+          url: /gateway/api/admin-ee/latest/#/debug/put-debug-cluster-control-planes-nodes-log-level-log_level
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Services
+          url: /gateway/api/admin-ee/latest/#/Services/list-service
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Routes
+          url: /gateway/api/admin-ee/latest/#/Routes/list-route
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Consumers
+          url: /gateway/api/admin-ee/latest/#/Consumers/list-consumer
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Plugins
+          url: /gateway/api/admin-ee/latest/#/Plugins/list-plugins-with-consumer
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Certificates
+          url: /gateway/api/admin-ee/latest/#/Certificates/list-certificate
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: CA Certificates
+          url: /gateway/api/admin-ee/latest/#/CA%20Certificates/list-ca_certificate
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: SNIs
+          url:  /gateway/api/admin-ee/latest/#/SNIs/list-sni-with-certificate
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Upstreams
+          url: /gateway/api/admin-ee/latest/#/Upstreams/list-upstream
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Targets
+          url: /gateway/api/admin-ee/latest/#/Targets/list-target-with-upstream
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Vaults
+          url: /gateway/api/admin-ee/latest/#/Vaults/list-vault
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Keys
+          url: /gateway/api/admin-ee/latest/#/Keys/list-key
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Filter Chains
+          url:  /gateway/api/admin-ee/latest/#/filter-chains/get-filter-chains
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Licenses
+          url: /gateway/api/admin-ee/latest/#/licenses/get-licenses
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Workspaces
+          url: /gateway/api/admin-ee/latest/#/Workspaces/list-workspace
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: RBAC
+          url: /gateway/api/admin-ee/latest/#/rbac/get-rbac-users
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Admins
+          url: /gateway/api/admin-ee/latest/#/admins/get-admins
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Consumer Groups
+          url: /gateway/api/admin-ee/latest/#/consumer_groups/
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Event Hooks
+          url: /gateway/api/admin-ee/latest/#/Event-hooks/get-event-hooks
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Keyring and Data Encryption
+          url: /gateway/api/admin-ee/latest/#/Keyring/get-keyring
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Audit Logs
+          url: /gateway/api/admin-ee/latest/#/audit-logs/get-audit-requests
+          absolute_url: true
+          generate: false
+          target_blank: true
+        - text: Status API
+          url: /gateway/api/status/v1/
+          absolute_url: true
+          generate: false
+          target_blank: true
+      - text: Open Source API
+        url: /gateway/api/admin-oss/latest/
+        absolute_url: true
+        generate: false
+        target_blank: true
+  - title: Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    items:
+      - text: kong.conf
+        url: /reference/configuration
+      - text: Injecting Nginx Directives
+        url: /reference/nginx-directives
+      - text: CLI
+        url: /reference/cli
+      - text: Key Management
+        url: /reference/key-management
+      - text: The Expressions Language
+        items:
+          - text: Overview
+            url: /reference/expressions-language
+          - text: Language References
+            url: /reference/expressions-language/language-references
+          - text: Performance Optimizations
+            url: /reference/expressions-language/performance
+      - text: Rate Limiting Library
+        url: /reference/rate-limiting/
+      - text: WebAssembly
+        url: /reference/wasm
+      - text: FAQ
+        url: /reference/faq

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -142,6 +142,21 @@
     pcre: 8.45
   lua_doc: true
   latest: true
+- release: "3.7.x"
+  ee-version: "3.7.0.0"
+  ce-version: "3.7.0"
+  edition: "gateway"
+  luarocks_version: "3.0.0-0"
+  dependencies:
+    luajit: "2.1-20220411"
+    luarocks: "3.9.1"
+    postgres: "9.5+"
+    openresty: "1.21.4.1"
+    openssl: "1.1.1.q"
+    libyaml: "0.2.5"
+    pcre: 8.45
+  lua_doc: true
+  label: unreleased
 - release: "pre-1.7"
   version: "1.6.0"
   edition: "deck"


### PR DESCRIPTION
### Description

Chore PR to set up next unreleased version.

### Testing instructions

Preview link: https://deploy-preview-6978--kongdocs.netlify.app/gateway/unreleased/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

