### PR TITLE
Fix: Links to KIC cli-arguments reference

### DIFF
--- a/app/_data/docs_nav_kic_3.1.x.yml
+++ b/app/_data/docs_nav_kic_3.1.x.yml
@@ -193,7 +193,8 @@ items:
       - text: Annotations
         url: /reference/annotations
       - text: Configuration Options
-        url: /reference/cli-arguments-3.1.x
+        url: /reference/cli-arguments/
+        src: reference/cli-arguments-3.1.x
       - text: Beta Feature Gates
         url: /reference/feature-gates
       - text: FAQ

--- a/app/_data/docs_nav_kic_3.2.x.yml
+++ b/app/_data/docs_nav_kic_3.2.x.yml
@@ -193,7 +193,8 @@ items:
       - text: Annotations
         url: /reference/annotations
       - text: Configuration Options
-        url: /reference/cli-arguments-3.1.x
+        url: /reference/cli-arguments/
+        src: reference/cli-arguments-3.1.x
       - text: Beta Feature Gates
         url: /reference/feature-gates
       - text: FAQ

--- a/app/_src/kubernetes-ingress-controller/reference/cli-arguments-3.1.x.md
+++ b/app/_src/kubernetes-ingress-controller/reference/cli-arguments-3.1.x.md
@@ -116,4 +116,5 @@ and not CLI flags.
 | `--update-status` | `bool` | Indicates if the ingress controller should update the status of resources (e.g. IP/Hostname for v1.Ingress, etc.). | `true` |
 | `--update-status-queue-buffer-size` | `int` | Buffer size of the underlying channels used to update the status of resources. | `8192` |
 | `--watch-namespace` | `strings` | Namespace(s) in comma-separated format (or specify this flag multiple times) to watch for Kubernetes resources. Defaults to all namespaces. | `[]` |
+
 <!-- vale on -->


### PR DESCRIPTION
### Description

Flagged in https://github.com/Kong/docs.konghq.com/actions/runs/7945193457/job/21691549272. Links have no `src`, so they're not being generated properly.

Generator will need adjusting to add a space between the end of the table and `<!--vale off-->`, otherwise the table breaks and looks like this: 
![Screenshot 2024-02-20 at 10 42 57 AM](https://github.com/Kong/docs.konghq.com/assets/54370747/10d3eb74-124b-4b14-9fee-9bc5098e7489)

Ran into a couple other cross-folder issues (kic-v2 vs kubernetes-ingress-controller): 
* Why is https://github.com/Kong/docs.konghq.com/blob/main/app/_src/kic-v2/references/version-compatibility.md being maintained in `kic-v2` and not in the current folder?
* This PR was opened against kic-v2 because the same FAQ page doesn't exist in 3.x: https://github.com/Kong/docs.konghq.com/pull/6403 - should this info be in 3.x?

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

