### PR TITLE
add more info about cache key generation in proxy-cache-advanced

### DIFF
--- a/app/_hub/kong-inc/proxy-cache-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/overview/_index.md
@@ -38,7 +38,9 @@ key = md5(UUID | method | request | query_params | headers | consumer_groups)
 ```
 
 Where `method` is defined via the OpenResty `ngx.req.get_method()` call, `request` is defined via the Nginx `$request` variable.
-`query_params` and `headers` are controlled via configuration parameters `vary_query_params` and `vary_headers`.
+You can control `query_params` and `headers` via the configuration parameters 
+[`vary_query_params`](/hub/kong-inc/proxy-cache-advanced/configuration/#config-vary_query_params) and 
+[`vary_headers`](/hub/kong-inc/proxy-cache-advanced/configuration/#config-vary_headers).
 
 Kong will return the cache key associated with a given request as the `X-Cache-Key` response header.
 It is also possible to precalculate the cache key for a given request as noted above.

--- a/app/_hub/kong-inc/proxy-cache-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/proxy-cache-advanced/overview/_index.md
@@ -34,10 +34,12 @@ Currently the cache key format is hard-coded and cannot be adjusted. Internally,
 represented as a hexadecimal-encoded MD5 sum of the concatenation of the constituent parts calculated as follows:
 
 ```
-key = md5(UUID | method | request)
+key = md5(UUID | method | request | query_params | headers | consumer_groups)
 ```
 
-Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `request` is defined via the Nginx `$request` variable.
+Where `method` is defined via the OpenResty `ngx.req.get_method()` call, `request` is defined via the Nginx `$request` variable.
+`query_params` and `headers` are controlled via configuration parameters `vary_query_params` and `vary_headers`.
+
 Kong will return the cache key associated with a given request as the `X-Cache-Key` response header.
 It is also possible to precalculate the cache key for a given request as noted above.
 


### PR DESCRIPTION
### Description

Adding more info about how cache key is generated based on
https://github.com/Kong/kong-ee/blob/3.6.0.0/plugins-ee/proxy-cache-advanced/kong/plugins/proxy-cache-advanced/cache_key.lua#L110-L122

Preview: https://deploy-preview-6982--kongdocs.netlify.app/hub/kong-inc/proxy-cache-advanced/#cache-key


