### PR TITLE
Fix: replace benchmark redirect with moved url entry

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -83,7 +83,6 @@
 
 # 3.6
 /gateway/3.6.x/production/benchmark/  /gateway/3.6.x/production/performance/benchmark/
-/gateway/latest/production/benchmark/ /gateway/latest/production/performance/benchmark/
 
 # 3.5
 /gateway/latest/kong-enterprise/analytics/* /gateway/3.4.x/kong-enterprise/analytics/:splat

--- a/app/_redirects
+++ b/app/_redirects
@@ -81,6 +81,10 @@
 /gateway/3.5.x/admin-api/admins/reference/   /gateway/api/admin-ee/latest/#/admins/get-admins/
 /gateway/3.5.x/admin-api/*                   /gateway/api/admin-ee/latest/
 
+# 3.6
+/gateway/3.6.x/production/benchmark/  /gateway/3.6.x/production/performance/benchmark/
+/gateway/latest/production/benchmark/ /gateway/latest/production/performance/benchmark/
+
 # 3.5
 /gateway/latest/kong-enterprise/analytics/* /gateway/3.4.x/kong-enterprise/analytics/:splat
 /gateway/latest/kong-enterprise/dev-portal/* /gateway/3.4.x/kong-enterprise/dev-portal/:splat

--- a/app/_redirects
+++ b/app/_redirects
@@ -81,9 +81,6 @@
 /gateway/3.5.x/admin-api/admins/reference/   /gateway/api/admin-ee/latest/#/admins/get-admins/
 /gateway/3.5.x/admin-api/*                   /gateway/api/admin-ee/latest/
 
-# 3.6
-/gateway/3.6.x/production/benchmark /gateway/3.6.x/production/performance/benchmark
-
 # 3.5
 /gateway/latest/kong-enterprise/analytics/* /gateway/3.4.x/kong-enterprise/analytics/:splat
 /gateway/latest/kong-enterprise/dev-portal/* /gateway/3.4.x/kong-enterprise/dev-portal/:splat

--- a/app/moved_urls.yml
+++ b/app/moved_urls.yml
@@ -154,7 +154,8 @@
 /gateway/VERSION/reference/external-plugins/: "/gateway/VERSION/plugin-development/pluginserver/go/"
 /gateway/VERSION/get-started/secure-services/: "/gateway/VERSION/get-started/key-authentication/"
 /gateway/VERSION/install/linux/os-support/: "/gateway/VERSION/support-policy/#supported-versions"
-/gateway/VERSION/install/kubernetes/deployment-options/: /gateway/VERSION/install/kubernetes/
+/gateway/VERSION/install/kubernetes/deployment-options/: "/gateway/VERSION/install/kubernetes/"
+/gateway/VERSION/production/benchmark/: "/gateway/VERSION/production/performance/benchmark/"
 
 # KIC 3.0
 # No new page available


### PR DESCRIPTION
### Description

This URL got flagged as 404ing at /latest/ by google console. Did some digging, realized that it should probably be in moved URLs instead anyway, based on the following rule:
* When a topic is moved and not removed or renamed, we should add an entry to moved URLs instead of redirects.

This _should_ generate the correct redirects automatically.

### Testing instructions

Preview link: 
https://deploy-preview-6983--kongdocs.netlify.app/gateway/3.6.x/production/benchmark/
https://deploy-preview-6983--kongdocs.netlify.app/gateway/latest/production/benchmark/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

