### PR TITLE
Add documentation on higher ulimit requirement for 3.6.0.0

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -534,6 +534,7 @@ txt
 udpingress
 udpingresses
 UIs
+ulimit
 unary
 unassign
 uncheck

--- a/app/_src/gateway/breaking-changes/36x.md
+++ b/app/_src/gateway/breaking-changes/36x.md
@@ -16,6 +16,9 @@ Review the [changelog](/gateway/changelog/#3600) for all the changes in this rel
 ## General
 If you are using `ngx.var.http_*` in custom code to access HTTP headers, the behavior of that variable changed slightly when the same header is used multiple times in a single request. Previously, it would return the first value only; now it returns all the values, separated by commas. {{site.base_gateway}}'s PDK header getters and setters work as before.
 
+## Operating system requirements
+Kong 3.6 requires a higher [ulimit](https://linux.die.net/man/3/ulimit) to function properly. It will not start properly with a ulimit set to 1024 or lower. It is recommended to set the ulimit for your operating system to at least 4096. Although a higher ulimit is recommended in general for Kong, 3.6.1 will allow you to start with a default of 1024 again.
+
 ## Wasm
 
 To avoid ambiguity with other Wasm-related `nginx.conf` directives, the prefix for Wasm `shm_kv` nginx.conf directives was changed from `nginx_wasm_shm_` to `nginx_wasm_shm_kv_`.

--- a/app/_src/gateway/breaking-changes/36x.md
+++ b/app/_src/gateway/breaking-changes/36x.md
@@ -17,7 +17,9 @@ Review the [changelog](/gateway/changelog/#3600) for all the changes in this rel
 If you are using `ngx.var.http_*` in custom code to access HTTP headers, the behavior of that variable changed slightly when the same header is used multiple times in a single request. Previously, it would return the first value only; now it returns all the values, separated by commas. {{site.base_gateway}}'s PDK header getters and setters work as before.
 
 ## Operating system requirements
-Kong 3.6 requires a higher [ulimit](https://linux.die.net/man/3/ulimit) to function properly. It will not start properly with a ulimit set to 1024 or lower. It is recommended to set the ulimit for your operating system to at least 4096. Although a higher ulimit is recommended in general for Kong, 3.6.1 will allow you to start with a default of 1024 again.
+{{site.base_gateway}} 3.6 requires a higher [ulimit](https://linux.die.net/man/3/ulimit) to function properly. It will not start properly with a ulimit set to 1024 or lower. We recommend setting the ulimit for your operating system to at least 4096. 
+
+Although a higher ulimit is recommended in general for {{site.base_gateway}}, an upcoming 3.6.x patch will allow you to start with a default of 1024 again.
 
 ## Wasm
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -14,7 +14,7 @@ For product versions that have reached the end of sunset support, see the [chang
 
 ### Breaking changes and deprecations
 
-* Kong Gateway 3.6.0.0 requires a ulimit higher than 1024 to function properly. This requirement will be removed in a subsequent version. It is recommended to set ulimit to at least 4096 when running Kong Gateway 3.6.0.0
+* Kong Gateway 3.6.0.0 requires a ulimit higher than 1024 to function properly. This requirement will be removed in a subsequent version. We recommend setting the ulimit to at least 4096 when running Kong Gateway 3.6.0.0.
 * To avoid ambiguity with other Wasm-related `nginx.conf` directives, the prefix for Wasm `shm_kv` nginx.conf directives was changed from `nginx_wasm_shm_` to `nginx_wasm_shm_kv_`.
  [#11919](https://github.com/Kong/kong/issues/11919)
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -14,6 +14,7 @@ For product versions that have reached the end of sunset support, see the [chang
 
 ### Breaking changes and deprecations
 
+* Kong Gateway 3.6.0.0 requires a ulimit higher than 1024 to function properly. This requirement will be removed in a subsequent version. It is recommended to set ulimit to at least 4096 when running Kong Gateway 3.6.0.0
 * To avoid ambiguity with other Wasm-related `nginx.conf` directives, the prefix for Wasm `shm_kv` nginx.conf directives was changed from `nginx_wasm_shm_` to `nginx_wasm_shm_kv_`.
  [#11919](https://github.com/Kong/kong/issues/11919)
 


### PR DESCRIPTION
### Description

Document missing entry for ulimit breaking change.

### Testing instructions

Preview link: https://deploy-preview-6984--kongdocs.netlify.app/gateway/latest/breaking-changes/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

