### PR TITLE
Fix links to plugins

### DIFF
--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -55,7 +55,7 @@ breadcrumbs:
   </blockquote>
 {% endif %}
 
-{% if page.extn_publisher == "kong-inc" %}
+{% if page.extn_publisher == "kong-inc" and page.schema.defined? %}
 <blockquote>
   <p>
     <em>Looking for the plugin's configuration parameters? You can find them in the <a href="{{ page.configuration_url }}">{{page.name}} configuration reference</a> doc.</em>


### PR DESCRIPTION
### Description

Render the link to a plugin's configuration page only if it has a schema -this was removed in a [previous PR](https://github.com/Kong/docs.konghq.com/commit/5fbd08aa7fb3388d107bd4d144ae7c941ceb255b#diff-0e2df9b2eb63d24180f8e981ed509cf86eaa9747faef9fa76cb383f931ab2cff)-

#### Note:

A full scan results in the following 404s:
*  /hub/kong-inc/wasm/
*  /hub/kong-inc/enable-app-reg/

Those were introduced as part of https://github.com/Kong/docs.konghq.com/pull/6883/files
@lena-larionova should we set an empty `DocumentationURL` for those? WDYT?

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

