### PR TITLE
fix: Remove inaccurate note in OAuth2 plugin

### DIFF
--- a/app/_hub/kong-inc/oauth2/overview/_index.md
+++ b/app/_hub/kong-inc/oauth2/overview/_index.md
@@ -10,7 +10,6 @@ Add an OAuth 2.0 authentication layer with one of the following grant flows:
 
 {:.important}
 > **Important**: 
-* Using Kong as an identity provider, as is supported by this plugin, is not recommended in production
 * Once applied, any user with a valid credential can access the service.
   To restrict usage to only some of the authenticated users, also add the
   [ACL](/hub/kong-inc/acl/) plugin (not covered here) and create allowed or


### PR DESCRIPTION
### Description

The note was added based on an old ticket that doesn't apply now. The OAuth2 plugin can be run in production. 

### Testing instructions

Preview link: https://deploy-preview-6988--kongdocs.netlify.app/hub/kong-inc/oauth2/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

