### PR TITLE
Chore: Move Gateway 3.2 to sunset versions

### DIFF
--- a/app/_src/gateway/support/browser.md
+++ b/app/_src/gateway/support/browser.md
@@ -22,9 +22,6 @@ Kong supports N-1 versions of Edge, Chrome, Firefox and Safari on desktop plus a
   {% navtab 3.3 %}
     {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.33 %}
   {% endnavtab %}
-  {% navtab 3.2 %}
-    {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.32 %}
-  {% endnavtab %}
   {% navtab 2.8 LTS %}
     {% include_cached gateway-support-browsers.html data=site.data.tables.support.gateway.versions.28 %}
   {% endnavtab %}

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -61,9 +61,6 @@ Kong supports the following versions of {{site.ee_product_name}}:
   {% navtab 3.3 %}
     {% include_cached gateway-support.html version="3.3" data=site.data.tables.support.gateway.versions.33 eol="May 2024" %}
   {% endnavtab %}
-  {% navtab 3.2 %}
-    {% include_cached gateway-support.html version="3.2" data=site.data.tables.support.gateway.versions.32 eol="Feb 2024" %}
-  {% endnavtab %}
   {% navtab 2.8 LTS %}
     {% include_cached gateway-support.html version="2.8 LTS" data=site.data.tables.support.gateway.versions.28  eol="March 2025" %}
   {% endnavtab %}
@@ -75,6 +72,7 @@ These versions have reached the end of full support.
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  3.2.x.x |  2023-02-28   |     2024-02-28      |      2025-02-28       |
 |  3.1.x.x |  2022-12-06   |     2023-12-06      |      2024-12-06       |
 |  3.0.x.x |  2022-09-09   |     2023-09-09      |      2024-09-09       |
 |  2.7.x.x |  2021-12-16   |     2023-02-24      |      2024-08-24       |

--- a/app/_src/gateway/support/third-party.md
+++ b/app/_src/gateway/support/third-party.md
@@ -25,9 +25,6 @@ Unless otherwise noted, Kong supports the last 2 versions any third party tool, 
   {% navtab 3.3 %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.33 %}
   {% endnavtab %}
-  {% navtab 3.2 %}
-    {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.32 %}
-  {% endnavtab %}
   {% navtab 2.8 LTS %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.28 %}
   {% endnavtab %}


### PR DESCRIPTION
### Description

Gateway 3.2.x enters sunset support on Feb 28th. 

Resolves [DOCU-3521](https://konghq.atlassian.net/browse/DOCU-3521).

### Testing instructions

Preview link: https://deploy-preview-7004--kongdocs.netlify.app/gateway/latest/support-policy/
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->



[DOCU-3521]: https://konghq.atlassian.net/browse/DOCU-3521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ