### PR TITLE
document HTTP/2 compatibility breaking change for 3.6

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -441,6 +441,8 @@ regexes
 rego
 reinstall
 reinstallation
+remediation
+remediations
 repo
 requery
 Resty

--- a/app/_src/gateway/breaking-changes/36x.md
+++ b/app/_src/gateway/breaking-changes/36x.md
@@ -13,43 +13,30 @@ or custom plugins, for example.
 
 Review the [changelog](/gateway/changelog/#3600) for all the changes in this release.
 
-## General
+## Breaking changes and deprecations
+
+### General
 
 If you are using `ngx.var.http_*` in custom code to access HTTP headers, the behavior of that variable changed slightly when the same header is used multiple times in a single request. Previously, it would return the first value only; now it returns all the values, separated by commas. {{site.base_gateway}}'s PDK header getters and setters work as before.
 
-## Operating system requirements
-
-{{site.base_gateway}} 3.6.0.0 requires a higher [ulimit](https://linux.die.net/man/3/ulimit) to function properly. 
-It will not start properly with a ulimit set to 1024 or lower. We recommend setting the ulimit for your operating system to at least 4096. 
-
-Although a higher ulimit is recommended in general for {{site.base_gateway}}, you can upgrade to 3.6.1.0 to start with a default of 1024 again.
-
-## HTTP/2 requires Content-Length for plugins that read request body
-
-Kong 3.6.x has introduced a regression for plugins that read the body of incoming requests. Clients must specify a Content-Length header that represents the length of the request body. Not including this header, or relying on Transfer-Encoding: chunked will result in an HTTP response with error code 500.
-
-Currently known affected plugins: [jq](https://docs.konghq.com/hub/kong-inc/jq/), [Request Size Limiting](https://docs.konghq.com/hub/kong-inc/request-size-limiting/), [Request Validator](https://docs.konghq.com/hub/kong-inc/request-validator/), [AI Request Transformer](https://docs.konghq.com/hub/kong-inc/ai-request-transformer/), [Request Transformer](https://docs.konghq.com/hub/kong-inc/request-transformer/), [Request Transformer Advanced](https://docs.konghq.com/hub/kong-inc/request-transformer-advanced/)
-
-Kong is currently investigating potential remediations.
-
-## Wasm
+### Wasm
 
 To avoid ambiguity with other Wasm-related `nginx.conf` directives, the prefix for Wasm `shm_kv` nginx.conf directives was changed from `nginx_wasm_shm_` to `nginx_wasm_shm_kv_`.
  [#11919](https://github.com/Kong/kong/issues/11919)
 
-## Admin API
+### Admin API
 
 The listing endpoints for consumer groups (`/consumer_groups`) and consumers (`/consumers`) now respond
 with paginated results. The JSON key for the list has been changed to `data` instead of `consumer_groups`
 or `consumers`.
 
-## Configuration changes
+### Configuration changes
 
 The default value of the [`dns_no_sync`](/gateway/{{page.release}}/reference/configuration/#dns_no_sync) option has been changed to `off`.
 
-## TLS changes
+### TLS changes
 
-### 3.6.0.0
+#### 3.6.0.0
 
 The recent OpenResty bump includes TLS 1.3 and deprecates TLS 1.1. 
 If you still need to support TLS 1.1, set the [`ssl_cipher_suite`](/gateway/latest/reference/configuration/#ssl_cipher_suite) setting to `old`.
@@ -63,11 +50,11 @@ As a result, the following are prohibited:
 * SSL version 3
 Additionally, compression is disabled.
 
-### 3.6.1.0
+#### 3.6.1.0
 
 TLSv1.1 and lower is now disabled by default in OpenSSL 3.x.
 
-## Kong Manager Enterprise
+### Kong Manager Enterprise
 
 As of {{site.base_gateway}} 3.6, Kong Manager uses the session management mechanism in the OpenID Connect plugin.
 `admin_gui_session_conf` is no longer required when authenticating with OIDC. Instead, session-related
@@ -75,7 +62,7 @@ configuration parameters are set in `admin_gui_auth_conf` (like `session_secret`
 
 See the [migration guide](/gateway/{{page.release}}/kong-manager/auth/oidc/migrate/) for more information.
 
-## Plugin changes
+### Plugin changes
 
 * [**ACME**](/hub/kong-inc/acme/) (`acme`), [**Rate Limiting**](/hub/kong-inc/rate-limiting/) (`rate-limiting`), and [**Response Rate Limiting**](/hub/kong-inc/response-ratelimiting/) (`response-ratelimiting`)
   * Standardized Redis configuration across plugins. The Redis configuration now follows a common schema that is shared across other plugins.
@@ -94,3 +81,31 @@ configuration field to construct the request path when requesting the Azure API.
 
 * [**SAML**](/hub/kong-inc/saml) (`saml`)
   * Adjusted the priority of the SAML plugin to 1010 to correct the integration between the SAML plugin and other consumer-based plugins.
+ 
+## Known issues
+
+The following is a list of known issues that may be fixed in a future release.
+
+### Operating system requirements
+
+{{site.base_gateway}} 3.6.0.0 requires a higher [ulimit](https://linux.die.net/man/3/ulimit) to function properly. 
+It will not start properly with a ulimit set to 1024 or lower. We recommend setting the ulimit for your operating system to at least 4096. 
+
+**Issue fixed in 3.6.1.0**:
+Although a higher ulimit is recommended in general for {{site.base_gateway}}, you can upgrade to 3.6.1.0 to start with a default of 1024 again.
+
+### HTTP/2 requires Content-Length for plugins that read request body
+
+Kong 3.6.x has introduced a regression for plugins that read the body of incoming requests. 
+Clients must specify a `Content-Length` header that represents the length of the request body. 
+Not including this header, or relying on `Transfer-Encoding: chunked` will result in an HTTP response with the error code 500.
+
+Currently known affected plugins: 
+* [jq](/hub/kong-inc/jq/)
+* [Request Size Limiting](/hub/kong-inc/request-size-limiting/)
+* [Request Validator](/hub/kong-inc/request-validator/)
+* [AI Request Transformer](/hub/kong-inc/ai-request-transformer/)
+* [Request Transformer](/hub/kong-inc/request-transformer/)
+* [Request Transformer Advanced](/hub/kong-inc/request-transformer-advanced/)
+
+Kong is currently investigating potential remediations.

--- a/app/_src/gateway/breaking-changes/36x.md
+++ b/app/_src/gateway/breaking-changes/36x.md
@@ -28,7 +28,7 @@ Although a higher ulimit is recommended in general for {{site.base_gateway}}, yo
 
 Kong 3.6.x has introduced a regression for plugins that read the body of incoming requests. Clients must specify a Content-Length header that represents the length of the request body. Not including this header, or relying on Transfer-Encoding: chunked will result in an HTTP response with error code 500.
 
-Currently known affected plugins: [jq](https://docs.konghq.com/hub/kong-inc/jq/), [Request Size Limiting](https://docs.konghq.com/hub/kong-inc/request-size-limiting/)
+Currently known affected plugins: [jq](https://docs.konghq.com/hub/kong-inc/jq/), [Request Size Limiting](https://docs.konghq.com/hub/kong-inc/request-size-limiting/), [Request Validator](https://docs.konghq.com/hub/kong-inc/request-validator/), [AI Request Transformer](https://docs.konghq.com/hub/kong-inc/ai-request-transformer/), [Request Transformer](https://docs.konghq.com/hub/kong-inc/request-transformer/), [Request Transformer Advanced](https://docs.konghq.com/hub/kong-inc/request-transformer-advanced/)
 
 Kong is currently investigating potential remediations.
 

--- a/app/_src/gateway/breaking-changes/36x.md
+++ b/app/_src/gateway/breaking-changes/36x.md
@@ -24,6 +24,14 @@ It will not start properly with a ulimit set to 1024 or lower. We recommend sett
 
 Although a higher ulimit is recommended in general for {{site.base_gateway}}, you can upgrade to 3.6.1.0 to start with a default of 1024 again.
 
+## HTTP/2 requires Content-Length for plugins that read request body
+
+Kong 3.6.x has introduced a regression for plugins that read the body of incoming requests. Clients must specify a Content-Length header that represents the length of the request body. Not including this header, or relying on Transfer-Encoding: chunked will result in an HTTP response with error code 500.
+
+Currently known affected plugins: [jq](https://docs.konghq.com/hub/kong-inc/jq/), [Request Size Limiting](https://docs.konghq.com/hub/kong-inc/request-size-limiting/)
+
+Kong is currently investigating potential remediations.
+
 ## Wasm
 
 To avoid ambiguity with other Wasm-related `nginx.conf` directives, the prefix for Wasm `shm_kv` nginx.conf directives was changed from `nginx_wasm_shm_` to `nginx_wasm_shm_kv_`.


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-7005--kongdocs.netlify.app/gateway/latest/breaking-changes/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

