### PR TITLE
chore: Fix OS EOLs in Gateway support matrix

### DIFF
--- a/app/_data/tables/support/gateway/packages.yml
+++ b/app/_data/tables/support/gateway/packages.yml
@@ -42,6 +42,7 @@ _packages:
     arm: false
     fips: false
     graviton: false
+    eol: June 2024
   centos8: &centos8
     os: CentOS
     version: 8
@@ -49,6 +50,7 @@ _packages:
     arm: false
     fips: false
     graviton: false
+    eol: December 2021
   debian8: &debian8
     os: Debian
     version: 8
@@ -128,6 +130,7 @@ _packages:
     arm: false
     fips: false
     graviton: false
+    eol: April 2023
   ubuntu2004: &ubuntu2004
     os: Ubuntu
     version: 20.04

--- a/app/_data/tables/support/gateway/versions/28.yml
+++ b/app/_data/tables/support/gateway/versions/28.yml
@@ -15,15 +15,12 @@ distributions:
     docker: true
   - <<: *centos7
     docker: true
-    eol: June 2024
-  - <<: *centos8
-    eol: December 2021
+  - *centos8
   - <<: *debian10
     docker: true
     eol: June 2024
   - *debian11
-  - <<: *ubuntu1804
-    eol: April 2023
+  - *ubuntu1804
   - *ubuntu2004
   - <<: *ubuntu2204
     docker: true

--- a/app/_data/tables/support/gateway/versions/32.yml
+++ b/app/_data/tables/support/gateway/versions/32.yml
@@ -16,15 +16,16 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - *debian10
+  - <<: *debian10
+    eol: June 2024
   - <<: *debian11
     docker: true
-  - *rhel7
+  - <<: *rhel7
+    eol: June 2024
   - <<: *rhel8
     docker: true
     fips: true
-  - <<: *ubuntu1804
-    eol: April 2023
+  - *ubuntu1804
   - <<: *ubuntu2004
     arm: false
     docker: false

--- a/app/_data/tables/support/gateway/versions/33.yml
+++ b/app/_data/tables/support/gateway/versions/33.yml
@@ -16,15 +16,16 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - *debian10
+  - <<: *debian10
+    eol: June 2024
   - <<: *debian11
     docker: true
-  - *rhel7
+  - <<: *rhel7
+    eol: June 2024
   - <<: *rhel8
     docker: true
     fips: true
-  - <<: *ubuntu1804
-    eol: April 2023
+  - *ubuntu1804
   - <<: *ubuntu2004
     arm: false
     docker: false

--- a/app/_data/tables/support/gateway/versions/33.yml
+++ b/app/_data/tables/support/gateway/versions/33.yml
@@ -16,12 +16,10 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - <<: *debian10
-    eol: June 2024
+  - *debian10
   - <<: *debian11
     docker: true
-  - <<: *rhel7
-    eol: June 2024
+  - *rhel7
   - <<: *rhel8
     docker: true
     fips: true

--- a/app/_data/tables/support/gateway/versions/34.yml
+++ b/app/_data/tables/support/gateway/versions/34.yml
@@ -16,6 +16,7 @@ distributions:
   - <<: *debian10
     eol: June 2024
   - <<: *debian11
+    eol: June 2026
     docker: true
     arm: true
     graviton: true
@@ -23,7 +24,8 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - *rhel7
+  - <<: *rhel7
+    eol: June 2024
   - <<: *rhel8
     docker: false
     fips: true
@@ -35,7 +37,7 @@ distributions:
     arm: false
     docker: false
     fips: true
-    eol: May 2025
+    eol: April 2025
   - <<: *ubuntu2204
     arm: true
     graviton: true

--- a/app/_data/tables/support/gateway/versions/35.yml
+++ b/app/_data/tables/support/gateway/versions/35.yml
@@ -23,7 +23,8 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - *rhel7
+  - <<: *rhel7
+    eol: June 2024
   - <<: *rhel8
     docker: false
     fips: true

--- a/app/_data/tables/support/gateway/versions/36.yml
+++ b/app/_data/tables/support/gateway/versions/36.yml
@@ -22,7 +22,8 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - *rhel7
+  - <<: *rhel7
+    eol: June 2024
   - <<: *rhel8
     docker: false
     fips: true


### PR DESCRIPTION
### Description

OS End of Life dates are only listed in our support matrix if the EOL is sooner than the EOL of the Gateway version. We were missing these dates in a few places. 

### Testing instructions

Preview link: https://deploy-preview-7008--kongdocs.netlify.app/gateway/latest/support-policy/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

