### PR TITLE
chore: Add step to stop kong before uninstalling

### DIFF
--- a/app/_src/gateway/install/linux/amazon-linux.md
+++ b/app/_src/gateway/install/linux/amazon-linux.md
@@ -131,6 +131,11 @@ get the most out of {{site.base_gateway}}.
 
 ## Uninstall package
 
+Stop {{site.base_gateway}}:
+```
+kong stop
+```
+
 {% navtabs_ee %}
 {% navtab Kong Gateway %}
 To uninstall the package, run: 

--- a/app/_src/gateway/install/linux/debian.md
+++ b/app/_src/gateway/install/linux/debian.md
@@ -143,6 +143,11 @@ get the most out of {{site.base_gateway}}.
 
 ## Uninstall package
 
+Stop {{site.base_gateway}}:
+```
+kong stop
+```
+
 {% navtabs_ee %}
 {% navtab Kong Gateway %}
 To uninstall the package, run: 

--- a/app/_src/gateway/install/linux/rhel.md
+++ b/app/_src/gateway/install/linux/rhel.md
@@ -138,6 +138,11 @@ get the most out of {{site.base_gateway}}.
 
 ## Uninstall package
 
+Stop {{site.base_gateway}}:
+```
+kong stop
+```
+
 {% navtabs_ee %}
 {% navtab Kong Gateway %}
 To uninstall the package, run: 

--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -224,6 +224,11 @@ get the most out of {{site.base_gateway}}.
 
 ## Uninstall package
 
+Stop {{site.base_gateway}}:
+```
+kong stop
+```
+
 {% navtabs_ee %}
 {% navtab Kong Gateway %}
 To uninstall the package, run: 


### PR DESCRIPTION
### Description

Add a step to stop Kong before trying to uninstall it to prevent errors, per https://konghq.atlassian.net/browse/DOCU-253

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

