### PR TITLE
Release: decK 1.35

### DIFF
--- a/app/_data/docs_nav_deck_1.36.x.yml
+++ b/app/_data/docs_nav_deck_1.36.x.yml
@@ -1,0 +1,139 @@
+product: deck
+release: 1.36.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    url: /deck/1.36.x/
+    absolute_url: true
+    items:
+      - text: Terminology
+        url: /terminology/
+      - text: Architecture
+        url: /design-architecture/
+      - text: Compatibility Promise
+        url: /compatibility-promise/
+
+  - title: Changelog
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    url: https://github.com/kong/deck/blob/main/CHANGELOG.md
+    absolute_url: true
+
+  - title: Installation
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    url: /installation
+
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: Getting Started with decK
+        url: /guides/getting-started/
+      - text: Backup and Restore
+        url: /guides/backup-restore/
+      - text: Upgrade to Kong Gateway 3.x
+        url: /3.0-upgrade/
+      - text: Configuration as Code and GitOps
+        url: /guides/ci-driven-configuration/
+      - text: APIOps with decK
+        url: /guides/apiops/
+      - text: Distributed Configuration
+        url: /guides/distributed-configuration/
+      - text: Best Practices
+        url: /guides/best-practices/
+      - text: Using decK with Kong Gateway (Enterprise)
+        url: /guides/kong-enterprise/
+      - text: Using decK with Konnect
+        url: /guides/konnect/
+      - text: Run decK with Docker
+        url: /guides/run-with-docker/
+      - text: Using Multiple Files to Store Configuration
+        url: /guides/multi-file-state/
+      - text: De-duplicate Plugin Configuration
+        url: /guides/deduplicate-plugin-configuration/
+      - text: Set Up Object Defaults
+        url: /guides/defaults/
+      - text: Security
+        items:
+          - text: Overview
+            url: /guides/security/
+          - text: Secret Management with decK
+            url: /guides/vaults/
+          - text: Using Environment Variables with decK
+            url: /guides/environment-variables/
+
+  - title: Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    items:
+      - text: Entities Managed by decK
+        url: /reference/entities/
+      - text: decK CLI
+        url: /reference/deck/
+      - text: deck completion
+        url: /reference/deck_completion/
+      - text: deck file commands
+        items:
+          - text: deck file
+            url: /reference/deck_file/
+          - text: deck file add-plugins
+            url: /reference/deck_file_add-plugins/
+          - text: deck file add-tags
+            url: /reference/deck_file_add-tags/
+          - text: deck file convert
+            url: /reference/deck_file_convert/
+          - text: deck file lint
+            url: /reference/deck_file_lint/
+          - text: deck file list-tags
+            url: /reference/deck_file_list-tags/
+          - text: deck file merge
+            url: /reference/deck_file_merge/
+          - text: deck file namespace
+            url: /reference/deck_file_namespace/
+          - text: deck file openapi2kong
+            url: /reference/deck_file_openapi2kong/
+          - text: deck file patch
+            url: /reference/deck_file_patch/
+          - text: deck file remove-tags
+            url: /reference/deck_file_remove-tags/
+          - text: deck file render
+            url: /reference/deck_file_render/
+          - text: deck file validate
+            url: /reference/deck_file_validate/
+      - text: deck gateway commands
+        items:
+          - text: deck gateway
+            url: /reference/deck_gateway/
+          - text: deck gateway diff
+            url: /reference/deck_gateway_diff/
+          - text: deck gateway dump
+            url: /reference/deck_gateway_dump/
+          - text: deck gateway ping
+            url: /reference/deck_gateway_ping/
+          - text: deck gateway reset
+            url: /reference/deck_gateway_reset/
+          - text: deck gateway sync
+            url: /reference/deck_gateway_sync/
+          - text: deck gateway validate
+            url: /reference/deck_gateway_validate/
+      - text: deck version
+        url: /reference/deck_version/
+      - text: Deprecated commands
+        items: 
+          - text: deck convert
+            url: /reference/deck_convert/
+          - text: deck diff
+            url: /reference/deck_diff/
+          - text: deck dump
+            url: /reference/deck_dump/
+          - text: deck ping
+            url: /reference/deck_ping/
+          - text: deck reset
+            url: /reference/deck_reset/
+          - text: deck sync
+            url: /reference/deck_sync/
+          - text: deck validate
+            url: /reference/deck_validate/
+      
+
+  - title: FAQ
+    icon: /assets/images/icons/documentation/icn-faq-color.svg
+    url: /faqs/

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -235,9 +235,12 @@
 - release: "1.34.x"
   version: "1.34.0"
   edition: "deck"
-  latest: true
 - release: "1.35.x"
   version: "1.35.0"
+  edition: "deck"
+  latest: true
+- release: "1.36.x"
+  version: "1.36.0"
   edition: "deck"
   label: unreleased
 - edition: "konnect"


### PR DESCRIPTION
### Description

Bump deck version to 1.35 and create an unreleased 1.36 version.

decK 1.35 was released earlier today: https://github.com/Kong/deck/releases/tag/v1.35.0

### Testing instructions

Preview link: https://deploy-preview-7015--kongdocs.netlify.app/deck/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

