### PR TITLE
Fix: Consumer groups links and descriptions

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/overview/_index.md
@@ -183,9 +183,8 @@ to perform more requests than the limit, but there will still be a limit per nod
 {% if_plugin_version gte:3.4.x%}
 ## Rate limiting for consumer groups
 
-As of {{site.base_gateway}} 3.4, you can use the [consumer groups entity](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/25d728a0-cfe3-4cf4-8e90-93a5bb15cfd9#/default/post-consumer_groups) to manage custom rate limiting configurations for
+You can use the [consumer groups entity](/gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups) to manage custom rate limiting configurations for
 subsets of consumers. This is enabled by default **without** using the `/consumer_groups/:id/overrides` endpoint.
-
 
 You can see an example of this in the [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/) guide.
 

--- a/app/_src/gateway/kong-enterprise/index.md
+++ b/app/_src/gateway/kong-enterprise/index.md
@@ -26,7 +26,7 @@ It offers exclusive versions of OSS plugins like the [Rate Limiting Advanced plu
 * [API product tiers](/gateway/{{page.release}}/admin-api/consumer-groups/reference/)
 {% endif_version %}
 {% if_version gte:3.4.x %}
-* [API product tiers](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/be79b812-46d5-4cc1-b757-b5270bf4fa60#/consumer_groups/get-consumer_groups)
+* [API product tiers](/gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups)
 {% endif_version %}
 [Get started with plugins &rarr;](/hub/)
 {% if_version lte:3.4.x %}
@@ -125,22 +125,23 @@ You can configure event hooks through the Admin API.
 
 ## Consumer groups
 
-You can use consumer groups to manage custom rate limiting configuration for subsets of consumers. With consumer groups, you can define any number of rate limiting tiers and
+Consumer groups enable the organization and categorization of consumers (users or applications) within an API ecosystem. 
+By grouping consumers together, you eliminate the need to manage them individually, providing a scalable, 
+efficient approach to managing configurations.
+
+For example, you could use consumer groups to define rate limiting tiers and
 apply them to subsets of consumers, instead of managing each consumer
 individually.
 
-For example, you could define three consumer groups:
-* A "gold tier" with 1000 requests per minute
-* A "silver tier" with 10 requests per second
-* A "bronze tier" with 6 requests per second
-
 {% if_version lte:3.3.x %}
 [Set up consumer groups &rarr;](/hub/kong-inc/rate-limiting-advanced/how-to/)
-[Consumer groups API reference](/gateway/{{page.release}}/admin-api/consumer-groups/reference/)
+
+[Consumer groups API reference &rarr;](/gateway/{{page.release}}/admin-api/consumer-groups/reference/)
 {% endif_version %}
 {% if_version gte:3.4.x %}
-[Set up consumer groups &rarr;](/hub/kong-inc/rate-limiting-advanced/how-to/)
-[Consumer groups API documentation](https://developer.konghq.com/spec/937dcdd7-4485-47dc-af5f-b805d562552f/be79b812-46d5-4cc1-b757-b5270bf4fa60#/consumer_groups/get-consumer_groups)
+[Consumer groups API documentation &rarr;](/gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups)
+
+[Plugins with consumer groups support &rarr;](/hub/plugins/compatibility/#scopes)
 {% endif_version %}
 
 {% if_version gte:3.2.x %}

--- a/app/_src/gateway/kong-enterprise/index.md
+++ b/app/_src/gateway/kong-enterprise/index.md
@@ -134,14 +134,12 @@ apply them to subsets of consumers, instead of managing each consumer
 individually.
 
 {% if_version lte:3.3.x %}
-[Set up consumer groups &rarr;](/hub/kong-inc/rate-limiting-advanced/how-to/)
-
-[Consumer groups API reference &rarr;](/gateway/{{page.release}}/admin-api/consumer-groups/reference/)
+* [Set up consumer groups &rarr;](/hub/kong-inc/rate-limiting-advanced/how-to/)
+* [Consumer groups API reference &rarr;](/gateway/{{page.release}}/admin-api/consumer-groups/reference/)
 {% endif_version %}
 {% if_version gte:3.4.x %}
-[Consumer groups API documentation &rarr;](/gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups)
-
-[Plugins with consumer groups support &rarr;](/hub/plugins/compatibility/#scopes)
+* [Consumer groups API documentation &rarr;](/gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups)
+* [Plugins with consumer groups support &rarr;](/hub/plugins/compatibility/#scopes)
 {% endif_version %}
 
 {% if_version gte:3.2.x %}


### PR DESCRIPTION
### Description

The consumer groups description is outdated on the Kong Enterprise overview, as it describes consumer groups for rate limiting only. This is no longer the case.

https://docs.konghq.com/gateway/latest/kong-enterprise/#consumer-groups

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

