### PR TITLE
fix: Add missing license behavior content from 3.5

### DIFF
--- a/app/_src/gateway/licenses/index.md
+++ b/app/_src/gateway/licenses/index.md
@@ -17,10 +17,11 @@ functionality, {{site.base_gateway}} enforces the presence and validity of a
 
 ## Deploying the license file
 
-* **Hybrid mode deployment:** The license file only needs to be deployed to
-control plane nodes, which distribute the license to the data planes in their
-clusters.
-* **Traditional deployment with no separate control plane:** License files must
+* **Hybrid mode deployment:** The license file must be deployed to each control
+plane and data plane node. Apply the license through the Kong Admin API to the
+control plane. The control plane distributes the license to its data plane nodes.
+This is the only method that applies the license to data planes automatically.
+* **Traditional deployment with no separate control plane:** The license file must
 be deployed to each node running {{site.base_gateway}}.
 
 License file checking is done independently by each node as the Kong process starts; no network connectivity is necessary to execute the license validation process.
@@ -56,15 +57,20 @@ Licenses expire at 00:00 on the date of expiration, relative to the time zone th
 Kong Manager displays a banner with a license expiration warning starting at 15 days before expiration.
 Expiration warnings also appear in [{{site.base_gateway}} logs](#license-expiration-logs).
 
-When a license expires, {{site.base_gateway}} behaves as follows:
+After the license expires, there's a 30 day grace period. During the grace period, the full functionality of the license is available, but a message will be logged once a day, which includes information on when the functionality will no longer be available.
+
+After the grace period, {{site.base_gateway}} behaves as follows:
 
 * Kong Manager and its configuration are accessible and may be changed, however any [Enterprise-specific features](/gateway/{{page.release}}/kong-enterprise/) become read-only.
-* The Admin API is not accessible until the license is either renewed or the subscription is downgraded to free mode.
+* The Admin API allows OSS features to continue working and configured {{site.ee_product_name}} features to continue operating in read-only mode.
 * Proxy traffic, including traffic using Enterprise plugins, continues to be processed as if the license had not expired.
-* Other Enterprise features, such as the Dev Portal, are not accessible.
+* There may be some Enterprise features that are still writable, but they may also change later, so do not rely on this behavior.
 
-If you downgrade to free mode, the Admin API will be unlocked, but Enterprise features such Dev Portal, 
-Enterprise plugins, and others will no longer be accessible.
+The behavior of the different deployment modes is as follows:
+
+- **Traditional:** Nodes will be able to restart/scale as needed.
+- **Hybrid:** Existing data planes or new data planes **can accept** config from a control plane with an expired license.
+- **DB-less and KIC:** New nodes **cannot** come up, restarts will break.
 
 To upload a new license, see [Deploy an Enterprise License](/gateway/{{page.release}}/licenses/deploy/).
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Somehow, likely during a force push, the content from #6266 went missing from the 3.5 release branch, so the content never went live on the public site. This adds that content back in.

**Note:** There is no conditional rendering on purpose. Per the old PR: "Regarding this section of the license file, please remove the conditional rendering, it applies to all Kong versions." see https://github.com/Kong/docs.konghq.com/pull/6266#discussion_r1371001034
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

