### PR TITLE
fix: Updated HTTP method for setting targets health

### DIFF
--- a/app/_src/gateway/how-kong-works/health-checks.md
+++ b/app/_src/gateway/how-kong-works/health-checks.md
@@ -200,7 +200,7 @@ health checker that the target should be enabled again, via an
 Admin API endpoint:
 
 ```bash
-curl -i -X POST http://localhost:8001/upstreams/my_upstream/targets/10.1.2.3:1234/healthy
+curl -i -X PUT http://localhost:8001/upstreams/my_upstream/targets/10.1.2.3:1234/healthy
 ```
 
 Response:


### PR DESCRIPTION
### Description

Updated the HTTP method from POST to PUT for setting targets health. The current doc references a POST method which results in a 405 - Method not allowed error.
 
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

