### PR TITLE
Fix: Plugin name and instance_name descriptions

### DIFF
--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -1432,7 +1432,13 @@ components:
               instance_name:
                 type: string
                 description: |
-                  The plugin instance name.
+                  An optional custom name to identify an instance of the plugin, for example `basic-auth_example-service`.
+                  
+                  The instance name shows up in Kong Manager, so it's useful when running the same 
+                  plugin in multiple contexts, for example, on multiple services. You can also use it to access a specific plugin instance
+                  via the Kong Admin API.
+
+                  An instance name must be unique within a workspace for Kong Gateway Enterprise.
                 example: rate-limiting-foo
               config:
                 type: object
@@ -5082,7 +5088,13 @@ components:
               instance_name:
                 type: string
                 description: |
-                  The plugin instance name.
+                  An optional custom name to identify an instance of the plugin, for example `basic-auth_example-service`.
+                  
+                  The instance name shows up in Kong Manager, so it's useful when running the same 
+                  plugin in multiple contexts, for example, on multiple services. You can also use it to access a specific plugin instance
+                  via the Kong Admin API.
+
+                  An instance name must be unique within a workspace for Kong Gateway Enterprise.
                 example: rate-limiting-foo
               config:
                 type: object

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -1471,7 +1471,13 @@ components:
               instance_name:
                 type: string
                 description: |
-                  The Plugin instance name.
+                  An optional custom name to identify an instance of the plugin, for example `basic-auth_example-service`.
+                  
+                  The instance name shows up in Kong Manager, so it's useful when running the same 
+                  plugin in multiple contexts, for example, on multiple services. You can also use it to access a specific plugin instance
+                  via the Kong Admin API.
+
+                  An instance name must be unique globally for Kong Gateway OSS.
                 example: rate-limiting-foo
               config:
                 type: object
@@ -3328,7 +3334,13 @@ components:
               instance_name:
                 type: string
                 description: |
-                  The Plugin instance name.
+                  An optional custom name to identify an instance of the plugin, for example `basic-auth_example-service`.
+                  
+                  The instance name shows up in Kong Manager, so it's useful when running the same 
+                  plugin in multiple contexts, for example, on multiple services. You can also use it to access a specific plugin instance
+                  via the Kong Admin API.
+
+                  An instance name must be unique globally for Kong Gateway OSS.
                 example: rate-limiting-foo
               config:
                 type: object

--- a/app/_includes/plugins/hub-examples/consumer.html
+++ b/app/_includes/plugins/hub-examples/consumer.html
@@ -4,7 +4,7 @@
 {% if include.render_intro_text %}
 The following examples provide some typical configurations for enabling
 the <code>{{ hub_example.plugin_name }}</code> plugin on a
-[consumer](/gateway/latest/admin-api/#consumer-object).
+[consumer](/gateway/api/admin-ee/latest/#/Consumers).
 {% endif %}
 
 {% navtabs %}

--- a/app/_includes/plugins/hub-examples/consumer_groups.html
+++ b/app/_includes/plugins/hub-examples/consumer_groups.html
@@ -4,7 +4,7 @@
 {% if include.render_intro_text %}
 The following examples provide some typical configurations for enabling
 the <code>{{ hub_example.plugin_name }}</code> plugin on a
-[consumer group](/gateway/latest/admin-api/consumer-groups/reference/).
+[consumer group](/gateway/api/admin-ee/latest/#/consumer_groups).
 {% endif %}
 
 {% navtabs %}

--- a/app/_includes/plugins/hub-examples/global.html
+++ b/app/_includes/plugins/hub-examples/global.html
@@ -16,7 +16,7 @@ considered _global_, and will be run on every request.
 {% endunless %}
 
 Read the
-[Plugin Reference](/gateway/latest/admin-api/#add-plugin) and the [Plugin Precedence](/gateway/latest/admin-api/#precedence)
+[Plugin Reference](/gateway/api/admin-ee/latest/#/Plugins) and the [Plugin Precedence](/gateway/latest/kong-plugins/#precedence)
 sections for more information. 
 
 The following examples provide some typical configurations for enabling

--- a/app/_includes/plugins/hub-examples/route.html
+++ b/app/_includes/plugins/hub-examples/route.html
@@ -4,7 +4,7 @@
 {% if include.render_intro_text %}
 The following examples provide some typical configurations for enabling
 the <code>{{ hub_example.plugin_name }}</code> plugin on a
-[route](/gateway/latest/admin-api/#route-object).
+[route](/gateway/api/admin-ee/latest/#/Routes).
 {% endif %}
 
 {% navtabs %}

--- a/app/_includes/plugins/hub-examples/service.html
+++ b/app/_includes/plugins/hub-examples/service.html
@@ -4,7 +4,7 @@
 {% if include.render_intro_text %}
 The following examples provide some typical configurations for enabling
 the <code>{{ hub_example.plugin_name }}</code> plugin on a
-[service](/gateway/latest/admin-api/#service-object).
+[service](/gateway/api/admin-ee/latest/#/Services).
 {% endif %}
 
 {% navtabs %}

--- a/app/_includes/plugins/schema.html
+++ b/app/_includes/plugins/schema.html
@@ -3,7 +3,7 @@
 <ul class="fields">
   <li class="field">
     <div class="field-overview">
-      <h4 id="name">name</h4>
+      <h4 id="name">name or plugin</h4>
     </div>
     <div class="field-attributes">
       <span><strong>string</strong></span>
@@ -13,7 +13,12 @@
       {% capture plugin_name %}
         {%- if page.reference_param_name != nil -%}{{ page.reference_param_name }}{%- else -%}{{ page.extn_slug }}{%- endif -%}
       {% endcapture %}
-      <p class="field-description">The name of the plugin, in this case <code>{{ plugin_name }}</code>.</p>
+      <p class="field-description">The name of the plugin, in this case <code>{{ plugin_name }}</code>.
+        <ul>
+          <li>If using the Kong Admin API, Konnect API, declarative configuration, or decK files, the field is <code>name</code>.</li>
+          <li>If using the KongPlugin object in Kubernetes, the field is <code>plugin</code>.</li>
+        </ul>
+      </p>
     </div>
   </li>
 
@@ -28,7 +33,18 @@
       <div class="field-description-and-children">
         <p class="field-description">
           An optional custom name to identify an instance of the plugin, for example <code>{{ page.extn_slug }}_my-service</code>.
-          Useful when running the same plugin in multiple contexts, for example, on multiple services.
+        </p>
+        <p class="field-description">
+          The instance name shows up in Kong Manager and in {{site.konnect_short_name}}, so it's useful when running the same 
+          plugin in multiple contexts, for example, on multiple services. You can also use it to access a specific plugin instance
+          via the Kong Admin API.
+        </p>
+        <p class="field-description">
+          An instance name must be unique within the following context:
+          <ul>
+            <li>Within a workspace for {{site.ee_product_name}}</li>
+            <li>Within a control plane or control plane group for {{site.konnect_short_name}}</li>
+            <li>Globally for {{site.ce_product_name}}</li>
         </p>
       </div>
     </li>
@@ -48,8 +64,8 @@
       <div class="field-description-and-children">
         <p class="field-description">
           The name or ID of the service the plugin targets.
-          Set one of these parameters if adding the plugin to a service through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          Not required if using <code>/services/SERVICE_NAME|ID/plugins</code>.
+          Set one of these parameters if adding the plugin to a service through the top-level <a href="/gateway/api/admin-ee/latest/#/Plugins/create-plugin"><code>/plugins</code> endpoint.</a>
+          Not required if using <code>/services/{serviceName|Id}/plugins</code>.
         </p>
       </div>
     </li>
@@ -66,8 +82,8 @@
       <div class="field-description-and-children">
         <p class="field-description">
           The name or ID of the route the plugin targets.
-          Set one of these parameters if adding the plugin to a route through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          Not required if using <code>/routes/ROUTE_NAME|ID/plugins</code>.
+          Set one of these parameters if adding the plugin to a route through the top-level <a href="/gateway/api/admin-ee/latest/#/Plugins/create-plugin"><code>/plugins</code> endpoint.</a>
+          Not required if using <code>/routes/{routeName|Id}/plugins</code>.
         </p>
       </div>
     </li>
@@ -84,8 +100,8 @@
       <div class="field-description-and-children">
         <p class="field-description">
           The name or ID of the consumer the plugin targets.
-          Set one of these parameters if adding the plugin to a consumer through the top-level <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          Not required if using <code>/consumers/CONSUMER_NAME|ID/plugins</code>.
+          Set one of these parameters if adding the plugin to a consumer through the top-level <a href="/gateway/api/admin-ee/latest/#/Plugins/create-plugin"><code>/plugins</code> endpoint.</a>
+          Not required if using <code>/consumers/{consumerName|Id}/plugins</code>.
         </p>
       </div>
     </li>
@@ -102,8 +118,8 @@
       <div class="field-description-and-children">
         <p class="field-description">
           The name or ID of the consumer group the plugin targets.
-          If set, the plugin will activate only for requests where the specified group has been authenticated <a href="/gateway/latest/admin-api/#add-plugin"><code>/plugins</code> endpoint.</a>
-          Not required if using <code>/consumer_groups/{CONSUMER_GROUP_NAME|ID}/plugins</code>.
+          If set, the plugin will activate only for requests where the specified group has been authenticated <a href="/gateway/api/admin-ee/latest/#/Plugins/create-plugin"><code>/plugins</code> endpoint.</a>
+          Not required if using <code>/consumer_groups/{consumerGroupName|Id}/plugins</code>.
         </p>
       </div>
     </li>


### PR DESCRIPTION
### Description

Fixing some minor issues with plugin schema & example docs:
* Description for the `name` field
* Description for the `instance_name` field
* Outdated links to the Admin API from the plugin config descriptions and plugin examples
* Standardize name variables in API URLs (`{serviceName}` etc)

https://konghq.atlassian.net/browse/DOCU-1498
https://konghq.atlassian.net/browse/DOCU-3412
https://konghq.atlassian.net/browse/DOCU-3706

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

