### PR TITLE
Fix: TCL/TCP typo

### DIFF
--- a/app/_src/gateway/how-kong-works/routing-traffic.md
+++ b/app/_src/gateway/how-kong-works/routing-traffic.md
@@ -179,7 +179,7 @@ upstream service untouched, with the exception of various headers such as
 Let's now discuss how {{site.base_gateway}} matches a request against the configured routing
 attributes.
 
-{{site.base_gateway}} supports native proxying of HTTP/HTTPS, TCL/TLS, and GRPC/GRPCS protocols;
+{{site.base_gateway}} supports native proxying of HTTP/HTTPS, TCP/TLS, and GRPC/GRPCS protocols;
 as mentioned earlier, each of these protocols accept a different set of routing
 attributes:
 - `http`: `methods`, `hosts`, `headers`, `paths` (and `snis`, if `https`)

--- a/app/gateway/2.6.x/reference/proxy.md
+++ b/app/gateway/2.6.x/reference/proxy.md
@@ -171,7 +171,7 @@ upstream service untouched, with the exception of various headers such as
 Let's now discuss how Kong matches a request against the configured routing
 attributes.
 
-Kong supports native proxying of HTTP/HTTPS, TCL/TLS, and GRPC/GRPCS protocols;
+Kong supports native proxying of HTTP/HTTPS, TCP/TLS, and GRPC/GRPCS protocols;
 as mentioned earlier, each of these protocols accept a different set of routing
 attributes:
 - `http`: `methods`, `hosts`, `headers`, `paths` (and `snis`, if `https`)

--- a/app/gateway/2.7.x/reference/proxy.md
+++ b/app/gateway/2.7.x/reference/proxy.md
@@ -171,7 +171,7 @@ upstream service untouched, with the exception of various headers such as
 Let's now discuss how Kong matches a request against the configured routing
 attributes.
 
-Kong supports native proxying of HTTP/HTTPS, TCL/TLS, and GRPC/GRPCS protocols;
+Kong supports native proxying of HTTP/HTTPS, TCP/TLS, and GRPC/GRPCS protocols;
 as mentioned earlier, each of these protocols accept a different set of routing
 attributes:
 - `http`: `methods`, `hosts`, `headers`, `paths` (and `snis`, if `https`)

--- a/app/gateway/2.8.x/reference/proxy.md
+++ b/app/gateway/2.8.x/reference/proxy.md
@@ -171,7 +171,7 @@ upstream service untouched, with the exception of various headers such as
 Let's now discuss how Kong matches a request against the configured routing
 attributes.
 
-Kong supports native proxying of HTTP/HTTPS, TCL/TLS, and GRPC/GRPCS protocols;
+Kong supports native proxying of HTTP/HTTPS, TCP/TLS, and GRPC/GRPCS protocols;
 as mentioned earlier, each of these protocols accept a different set of routing
 attributes:
 - `http`: `methods`, `hosts`, `headers`, `paths` (and `snis`, if `https`)


### PR DESCRIPTION
### Description

Doc said "TCL/TLS", should be "TCP/TLS". 

Was reported in docs Slack. Ended up making this fix since it appears in old versioned files, and it's easier/cleaner to quickly search & replace.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

