### PR TITLE
removed "CA" on examples of CP and DP PKI certs

### DIFF
--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
@@ -118,8 +118,8 @@ Certificate:
 ```
 {% endnavtab %}
 
-{% navtab CA Certificate on CP %}
-Here is an example of a CA certificate on a control plane:
+{% navtab Certificate on CP %}
+Here is an example of a certificate on a control plane:
 
 ```
 Certificate:
@@ -169,8 +169,8 @@ Certificate:
 ```
 {% endnavtab %}
 
-{% navtab CA Certificate on DP %}
-Here is an example of a CA certificate on a data plane:
+{% navtab Certificate on DP %}
+Here is an example of a certificate on a data plane:
 
 ```
 Certificate:


### PR DESCRIPTION
### Description

removed "CA" on the certificate examples on CP and DP certificates.  

In PKI we only need to provide a single  "CA certificate" that will issue the certs for CP and CP (The "CA certificate example" does have the "CA: true")  

So the other examples are not "CA certificates" are just Certificates for CP and DP.
