### PR TITLE
kic: fix kongCredType leftover

### DIFF
--- a/app/_src/kubernetes-ingress-controller/concepts/ingress.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/ingress.md
@@ -76,9 +76,10 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: alice-key
+  labels:
+    konghq.com/credential: key-auth
 stringData:
   key: bylkogdatomoryakom
-  kongCredType: key-auth
 
 ---
 


### PR DESCRIPTION
### Description

In https://github.com/Kong/docs.konghq.com/pull/6556#issuecomment-1978543101 @mloskot has noticed there's one more leftover of `kongCredType` usage. Let's convert it to the new label.

### Testing instructions

Preview link: https://deploy-preview-7040--kongdocs.netlify.app/kubernetes-ingress-controller/latest/concepts/ingress/#examples
