### PR TITLE
Disable slow generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ KONG_PRODUCTS='*:latest'
 ```
  are also possible.
 
+### Skipping slow generators
+
+Unfortunately, the `Sitemap` and `Hub` generators are slow. Even if they don't need to re-render a page,
+they still need to read the files and generate the necessary structures and pages, which takes time.
+You can speed up build times by disabling them and setting the environment variables: `DISABLE_SITEMAP` and `DISABLE_HUB`.
+
+```bash
+DISABLE_SITEMAP=1 DISABLE_HUB=1 make run
+```
+
 ## Plugin contributors
 
 If you have contributed a plugin, you can add a Kong badge to your plugin README.

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ KONG_PRODUCTS='*:latest'
 
 Unfortunately, the `Sitemap` and `Hub` generators are slow. Even if they don't need to re-render a page,
 they still need to read the files and generate the necessary structures and pages, which takes time.
-You can speed up build times by disabling them and setting the environment variables: `DISABLE_SITEMAP` and `DISABLE_HUB`.
+The `Sitemap` generator is disabled by default if `JEKYLL_ENV=development`, so it doesn't run locally.
+Disabling the `Hub` generator can be done by setting the environment variable: `DISABLE_HUB`.
 
 ```bash
-DISABLE_SITEMAP=1 DISABLE_HUB=1 make run
+DISABLE_HUB=1 make run
 ```
 
 ## Plugin contributors

--- a/app/_plugins/generators/plugin_single_source_generator.rb
+++ b/app/_plugins/generators/plugin_single_source_generator.rb
@@ -10,6 +10,7 @@ module PluginSingleSource
     def generate(site)
       site.data['ssg_hub'] = []
 
+      return if ENV['DISABLE_HUB']
       return if ENV['KONG_PRODUCTS'] && !ENV['KONG_PRODUCTS'].include?('hub')
 
       generate_pages(site)

--- a/app/_plugins/generators/sitemap.rb
+++ b/app/_plugins/generators/sitemap.rb
@@ -5,6 +5,8 @@ module Sitemap
     priority :low
 
     def generate(site)
+      return if ENV['DISABLE_SITEMAP']
+
       index = SEO::Index.new(site)
       index.generate
       site.data['sitemap_pages'] = SEO::Sitemap.generate(index)

--- a/app/_plugins/generators/sitemap.rb
+++ b/app/_plugins/generators/sitemap.rb
@@ -5,7 +5,7 @@ module Sitemap
     priority :low
 
     def generate(site)
-      return if ENV['DISABLE_SITEMAP']
+      return if ENV['JEKYLL_ENV'] == 'development'
 
       index = SEO::Index.new(site)
       index.generate


### PR DESCRIPTION
### Description

Add the ability to disable the sitemap and hub generators to reduce local build times.
Generators are run every time a file changes. It takes approximately 16 seconds to run those generators (hub and sitemap) locally, even if the changed file wasn't related to that particular generator.
Disabling them locally significantly reduces the build times.


https://github.com/Kong/docs.konghq.com/assets/715229/7e1275e4-a937-4b6c-9696-853353c10fca

Note: cold start still takes about 87s. The first edit takes longer (17s) because of the `RESET` stage, after that, it only takes  2s.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

