### PR TITLE
Explain --dump-config gives access via diagnostic server

### DIFF
--- a/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
@@ -202,7 +202,10 @@ in a test environment can help locate potential causes.
 Under normal operation, the controller does not store generated configuration;
 it is only sent to Kong's Admin API. The `--dump-config` flag enables a
 diagnostic mode where the controller also saves generated configuration to a
-temporary file. To use the diagnostic mode:
+temporary file and can be retrieved via web interface of the diagnostic
+server at `host:10256/debug/config`.
+
+To use the diagnostic mode:
 
 1. Set the `--dump-config` flag (or `CONTROLLER_DUMP_CONFIG` environment
    variable) to `true`. Optionally set the `--dump-sensitive-config` flag to

--- a/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
@@ -202,7 +202,7 @@ in a test environment can help locate potential causes.
 Under normal operation, the controller does not store generated configuration;
 it is only sent to Kong's Admin API. The `--dump-config` flag enables a
 diagnostic mode where the controller also saves generated configuration to a
-temporary file and can be retrieved via web interface of the diagnostic
+temporary file. You can retrieve this file via the web interface of the diagnostic
 server at `host:10256/debug/config`.
 
 To use the diagnostic mode:


### PR DESCRIPTION
### Description

Announce reference to the diagnostic sever in the introductory paragraph of the section dedicated to dumping of the configuration. Otherwise, reader reaching the point 3 may feel a bit surprised and confused how the dump will actually be retrieved. IOW, a procedure should be briefly described first, then present details steps.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

