### PR TITLE
fix: decK file merge example

### DIFF
--- a/app/_src/deck/reference/deck_file_merge.md
+++ b/app/_src/deck/reference/deck_file_merge.md
@@ -25,7 +25,7 @@ deck file merge [command-specific flags] [global flags] filename [...filename]
 
 ```
 # Merge 3 files
-deck file patch -o merged.yaml file1.yaml file2.yaml file3.yaml
+deck file merge -o merged.yaml file1.yaml file2.yaml file3.yaml
 ```
 
 ## Flags


### PR DESCRIPTION
### Description

`deck file merge` example uses `deck file patch`, where it should be `merge`. 

Parallel PR in decK repo: https://github.com/Kong/deck/pull/1237

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

