### PR TITLE
Update: Add note about Google ACME and DNS requirement

### DIFF
--- a/app/konnect/dev-portal/customization/index.md
+++ b/app/konnect/dev-portal/customization/index.md
@@ -44,6 +44,7 @@ To add a custom URL to Dev Portal, you need:
 
 * A domain and access to configure the domain's DNS `CNAME` records.
 * Your organization's auto-generated default Dev Portal URL.
+* A [CAA DNS](https://datatracker.ietf.org/doc/html/rfc6844) record that allows `pki.goog` only if any pre-existing CAA DNS records are present on the domain.
 
 You can also choose to [self-host the Dev Portal with Netlify](/konnect/dev-portal/customization/netlify/) or any other static hosting service that supports single page applications.
 
@@ -55,6 +56,8 @@ The record will look like this:
 | Type  | Name   | Value                                  |
 |:------|--------|----------------------------------------|
 | CNAME | portal | `https://example.us.portal.konghq.com` |
+
+If your domain has specific CAA DNS records that list authorized certificate authorities/issuers, you'll also need to create a new CAA DNS record to permit [Google Trust Services](https://pki.goog/faq/#caa) as an issuer. If your domain doesn't currently have any CAA DNS records, it means all issuers are implicitly allowed, and there's no need for a new CAA DNS record in that case.
 
 ### Update Dev Portal URL settings {#update-portal}
 


### PR DESCRIPTION
### Description

Added a couple of notes to clarify that a requirement is to also allow Google Trust Services (pki.goog) by adding a CAA DNS record in a situation where a domain is already explicitly using CAA DNS records. 

What is a little complicated by this is that if a domain doesn't include any CAA DNS records then it's all good, but if they even set one CAA DNS record then it implicitly denies all issuers that they did not define, requiring them to add a new one for `pki.goog` since that is the issuer we utilize in Konnect.

Related [Slack thread](https://kongstrong.slack.com/archives/C03NRECFJPM/p1709667853741059?thread_ts=1709667666.887609&cid=C03NRECFJPM).

### Testing instructions

Preview link: 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.