### PR TITLE
Adds --populate-env-vars to deck file render command reference

### DIFF
--- a/app/_src/deck/reference/deck_file_render.md
+++ b/app/_src/deck/reference/deck_file_render.md
@@ -38,6 +38,10 @@ deck file render [command-specific flags] [global flags]
 `-o`, `--output-file`
 :  File to which to write Kong's configuration. Use `-` to write to stdout. (Default: `"-"`)
 
+{% if_version gte:1.36.x %}
+`--populate-env-vars`
+:  Populate `DECK_` environment variables in the output file. The default behavior is to mock environment variable values.
+{% endif_version %}
 
 ## Global flags
 


### PR DESCRIPTION
### Description

Adds a new flag reference for the APIOps command `deck file render` introduced in deck 1.36.x