### PR TITLE
Update default-ports.md

### DIFF
--- a/app/_src/gateway/production/networking/default-ports.md
+++ b/app/_src/gateway/production/networking/default-ports.md
@@ -9,24 +9,27 @@ By default, {{site.base_gateway}} listens on the following ports:
 | [`:8443`](/gateway/{{page.release}}/reference/configuration/#proxy_listen)      | HTTPS    | Takes incoming HTTPS traffic from **Consumers**, and forwards it to upstream **Services**. | All tiers and modes |
 | [`:8001`](/gateway/{{page.release}}/reference/configuration/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. | All tiers and modes |
 | [`:8444`](/gateway/{{page.release}}/reference/configuration/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. | All tiers and modes |
-| [`:8005`](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
-| [`:8006`](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. |
-| [`:8007`](/gateway/{{page.release}}/reference/configuration/#status_listen)     | HTTP     | Status listener. Listens for calls from the command line over HTTP. | All tiers and modes |
-{{site.ee_product_name}} tier |
-{% if_version lte:3.3.x %}
 
+{% if_version lte:3.3.x inline:true %}
 | [`:8002`](/gateway/{{page.release}}/reference/configuration/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. | {{site.base_gateway}} free mode |
 | [`:8445`](/gateway/{{page.release}}/reference/configuration/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. | {{site.base_gateway}} free mode |
 {% endif_version %}
-{% if_version gte:3.4.x %}
-
+{% if_version gte:3.4.x inline:true %}
 | [`:8002`](/gateway/{{page.release}}/reference/configuration/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. | All tiers and modes |
 | [`:8445`](/gateway/{{page.release}}/reference/configuration/#admin_gui_listen)  | HTTPS    | Kong Manager (GUI). Listens for HTTPS traffic. | All tiers and modes |
 {% endif_version %}
+| [`:8005`](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
+| [`:8006`](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | All tiers and modes |
+
+{% if_version gte:3.6.x inline:true %}
+| [`:8007`](/gateway/{{page.release}}/reference/configuration/#status_listen)     | HTTP     | Status listener. Listens for calls from the command line over HTTP. | {{site.ee_product_name}} tier|
+{% endif_version %}
+{% if_version lte:3.4.x inline:true %}
 | [`:8003`](/gateway/{{page.release}}/reference/configuration/#portal_gui_listen) | HTTP     | Dev Portal. Listens for HTTP traffic, assuming Dev Portal is **enabled**. | {{site.ee_product_name}} tier |
 | [`:8446`](/gateway/{{page.release}}/reference/configuration/#portal_gui_listen) | HTTPS    | Dev Portal. Listens for HTTPS traffic, assuming Dev Portal is **enabled**.  | {{site.ee_product_name}} tier |
 | [`:8004`](/gateway/{{page.release}}/reference/configuration/#portal_api_listen) | HTTP     | Dev Portal `/files` traffic over HTTP, assuming the Dev Portal is **enabled**. | {{site.ee_product_name}} tier |
 | [`:8447`](/gateway/{{page.release}}/reference/configuration/#portal_api_listen) | HTTPS    | Dev Portal `/files` traffic over HTTPS, assuming the Dev Portal is **enabled**. | {{site.ee_product_name}} tier |
+{% endif_version %}
 
 {:.note}
 > **Note:** {{site.base_gateway}} free mode and Enterprise tier are not available for

--- a/app/_src/gateway/production/networking/default-ports.md
+++ b/app/_src/gateway/production/networking/default-ports.md
@@ -10,7 +10,9 @@ By default, {{site.base_gateway}} listens on the following ports:
 | [`:8001`](/gateway/{{page.release}}/reference/configuration/#admin_api_uri)     | HTTP     | Admin API. Listens for calls from the command line over HTTP. | All tiers and modes |
 | [`:8444`](/gateway/{{page.release}}/reference/configuration/#admin_api_uri)     | HTTPS    | Admin API. Listens for calls from the command line over HTTPS. | All tiers and modes |
 | [`:8005`](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for traffic from Data Planes. | All tiers and modes |
-| [`:8006`](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | {{site.ee_product_name}} tier |
+| [`:8006`](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. |
+| [`:8007`](/gateway/{{page.release}}/reference/configuration/#status_listen)     | HTTP     | Status listener. Listens for calls from the command line over HTTP. | All tiers and modes |
+{{site.ee_product_name}} tier |
 {% if_version lte:3.3.x %}
 
 | [`:8002`](/gateway/{{page.release}}/reference/configuration/#admin_gui_listen)  | HTTP     | Kong Manager (GUI). Listens for HTTP traffic. | {{site.base_gateway}} free mode |


### PR DESCRIPTION
### Description

Added the default status listen port.  It is 8007 now, but used to be 8100 in previous releases.  Might be worthwhile to find out when this change was made.

### Testing instructions

Preview link: https://deploy-preview-7053--kongdocs.netlify.app/gateway/latest/production/networking/default-ports/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

