### PR TITLE
fix: Metadata file for traceable plugin

### DIFF
--- a/app/_hub/traceableai/traceableai/_metadata/_index.yml
+++ b/app/_hub/traceableai/traceableai/_metadata/_index.yml
@@ -1,7 +1,3 @@
-# This file sets metadata for an individual Kong partner plugin.
-# View the full instructions for documenting a plugin
-# at https://docs.konghq.com/contributing/partner-plugins
-
 name: Traceable.ai
 publisher: Traceable.ai
 categories:
@@ -39,3 +35,7 @@ enterprise: false
 konnect: false
 
 dbless_compatible: yes
+
+search_aliases:
+  - traceable ai
+  - traceableai


### PR DESCRIPTION
### Description

The traceable plugin PR was opened before plugin versioning was changed, so it didn't fail until it got merged into main.

### Testing instructions

Preview link: Check that the traceable plugin appears in the Hub search/landing page.
https://deploy-preview-7054--kongdocs.netlify.app/hub/?search=traceable

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

