### PR TITLE
Fix sidenav issues

### DIFF
--- a/app/_assets/stylesheets/sidebar.less
+++ b/app/_assets/stylesheets/sidebar.less
@@ -136,9 +136,15 @@
     }
 
     .sidebar-tree-toggle {
-      position: absolute;
-      right: 0;
       border: none;
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      height: 10px;
+
+      &:hover {
+        background: none;
+      }
     }
 
     .sidebar-label {
@@ -200,7 +206,7 @@
     }
 
     > .sidebar-label {
-      padding: 16px 16px 16px 15px;
+      padding: 16px 0 16px 15px;
     }
   }
 }

--- a/app/_assets/stylesheets/sidebar.less
+++ b/app/_assets/stylesheets/sidebar.less
@@ -141,6 +141,7 @@
       display: flex;
       align-items: center;
       height: 10px;
+      padding: 0 13px 0 0;
 
       &:hover {
         background: none;

--- a/app/_includes/sidebar/item.html
+++ b/app/_includes/sidebar/item.html
@@ -18,13 +18,13 @@
       </a>
     {% else %}
       {% include_cached sidebar/item_label.html icon=include.item.icon label=include.item.label items_size=include.item.items.size %}
+    {% endif %}
 
-        {% if include.item.items.size > 0 %}
-          <button class="sidebar-tree-toggle" aria-label="toggle {{ include.item.label }} subtree">
-            <i class="fa fa-chevron-down"></i>
-          </button>
-        {% endif %}
-      {% endif %}
+    {% if include.item.items.size > 0 %}
+      <button class="sidebar-tree-toggle" aria-label="toggle {{ include.item.label }} subtree" tabindex="-1">
+        <i class="fa fa-chevron-down"></i>
+      </button>
+    {% endif %}
   </span>
 
   {% if include.item.items.size > 0 %}


### PR DESCRIPTION
### Description

* Add a caret symbol to sidebar menus that also have a URL.
* Fixes overlap between long titles and the caret symbol.

### Testing instructions

[long nav titles](https://deploy-preview-7057--kongdocs.netlify.app/mesh/2.6.x/networking/service-discovery/)

before:
<img width="1196" alt="Screenshot 2024-03-08 at 11 05 47" src="https://github.com/Kong/docs.konghq.com/assets/715229/fd45dad9-d26d-4f08-b940-06310d21734a">


after:
<img width="1062" alt="Screenshot 2024-03-08 at 11 05 41" src="https://github.com/Kong/docs.konghq.com/assets/715229/cd61b952-eda4-435a-a845-bdc453884bd0">


[missing caret](https://deploy-preview-7057--kongdocs.netlify.app/gateway/latest/production/logging/log-reference/)

before:
<img width="840" alt="Screenshot 2024-03-08 at 11 05 58" src="https://github.com/Kong/docs.konghq.com/assets/715229/153d24a1-081f-401a-8013-ee03340ef2c9">

after:
<img width="807" alt="Screenshot 2024-03-08 at 11 08 18" src="https://github.com/Kong/docs.konghq.com/assets/715229/10c7ad8b-bdcc-4477-bc36-968acc6fc5d2">


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->
