### PR TITLE
docs(gateway): adjust references to `ulimit -n`.

### DIFF
--- a/app/_src/gateway/breaking-changes/36x.md
+++ b/app/_src/gateway/breaking-changes/36x.md
@@ -88,11 +88,14 @@ The following is a list of known issues that may be fixed in a future release.
 
 ### Operating system requirements
 
-{{site.base_gateway}} 3.6.0.0 requires a higher [ulimit](https://linux.die.net/man/3/ulimit) to function properly. 
-It will not start properly with a ulimit set to 1024 or lower. We recommend setting the ulimit for your operating system to at least 4096. 
+{{site.base_gateway}} 3.6 requires a higher limit on the number of file descriptions to 
+function properly. It will not start properly with a limit set to 1024 or lower. We 
+recommend using `ulimit` on your operating system to set it to at least 4096 using 
+`ulimit -n 4096`.
 
 **Issue fixed in 3.6.1.0**:
-Although a higher ulimit is recommended in general for {{site.base_gateway}}, you can upgrade to 3.6.1.0 to start with a default of 1024 again.
+Although a higher limit on file descriptors (`uname -n`) is recommended in general for 
+{{site.base_gateway}}, you can upgrade to 3.6.1.0 to start with a default of 1024 again.
 
 ### HTTP/2 requires Content-Length for plugins that read request body
 

--- a/app/_src/gateway/breaking-changes/36x.md
+++ b/app/_src/gateway/breaking-changes/36x.md
@@ -88,7 +88,7 @@ The following is a list of known issues that may be fixed in a future release.
 
 ### Operating system requirements
 
-{{site.base_gateway}} 3.6 requires a higher limit on the number of file descriptions to 
+{{site.base_gateway}} 3.6.0.0 requires a higher limit on the number of file descriptions to 
 function properly. It will not start properly with a limit set to 1024 or lower. We 
 recommend using `ulimit` on your operating system to set it to at least 4096 using 
 `ulimit -n 4096`.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -78,7 +78,8 @@ Decreased the concurrency range of the `lua-resty-timer-ng` library from `[512, 
 
 ### Breaking changes and deprecations
 
-* Kong Gateway 3.6.0.0 requires a ulimit higher than 1024 to function properly. This requirement will be removed in a subsequent version. We recommend setting the ulimit to at least 4096 when running Kong Gateway 3.6.0.0.
+
+* Kong Gateway 3.6.0.0 requires a higher limit on the number of file descriptions than 1024 to function properly. This requirement will be removed in a subsequent version. We recommend setting the `ulimit -n` to at least 4096 when running Kong Gateway 3.6.0.0.
 * To avoid ambiguity with other Wasm-related `nginx.conf` directives, the prefix for Wasm `shm_kv` nginx.conf directives was changed from `nginx_wasm_shm_` to `nginx_wasm_shm_kv_`.
  [#11919](https://github.com/Kong/kong/issues/11919)
 


### PR DESCRIPTION
### Description

The wording of https://github.com/Kong/docs.konghq.com/pull/6984 around `ulimit` is ambiguous; this PR changes it to specifically mention `ulimit -n`.

https://deploy-preview-7058--kongdocs.netlify.app/gateway/latest/breaking-changes/#operating-system-requirements