### PR TITLE
Feat: Topology diagrams for gateway docs

### DIFF
--- a/app/_includes/md/gateway/deployment-topologies.md
+++ b/app/_includes/md/gateway/deployment-topologies.md
@@ -14,7 +14,7 @@ A --- B & B2
 end
 
 id1 --Kong proxy 
-configuration---> C & D & E
+configuration---> id2 & id3
 
 subgraph id2 [Self-managed on-premise node]
 C
@@ -51,7 +51,7 @@ A---B
 end
 
 B --Kong proxy 
-configuration---> C & D & E
+configuration---> id2 & id3
 
 subgraph id2 [Self-managed on-premise node]
 C

--- a/app/_includes/md/gateway/deployment-topologies.md
+++ b/app/_includes/md/gateway/deployment-topologies.md
@@ -1,0 +1,118 @@
+{% if include.topology == "konnect" %}
+<!--vale off -->
+{% mermaid %}
+flowchart TD
+A(Dev Portal &bull; Gateway Manager &bull; Analytics &bull; Service Hub)
+B(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> Control plane \n #40;{{site.base_gateway}} instance#41;)
+B2(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> Control plane \n #40;{{site.base_gateway}} instance#41;)
+C(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 3\n #40;{{site.base_gateway}} instance#41;)
+D(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 1\n #40;{{site.base_gateway}} instance#41;)
+E(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 2\n #40;{{site.base_gateway}} instance#41;)
+
+subgraph id1 [Konnect]
+A --- B & B2
+end
+
+id1 --Kong proxy 
+configuration---> C & D & E
+
+subgraph id2 [Self-managed on-premise node]
+C
+end
+
+subgraph id3 [Self-managed cloud nodes]
+D
+E
+end
+
+style id1 stroke-dasharray:3,rx:10,ry:10
+style id2 stroke-dasharray:3,rx:10,ry:10
+style id3 stroke-dasharray:3,rx:10,ry:10
+style B stroke:none,fill:#0E44A2,color:#fff
+style B2 stroke:none,fill:#0E44A2,color:#fff
+
+{% endmermaid %}
+<!-- vale on-->
+{% endif %}
+
+{% if include.topology == "hybrid" %}
+<!--vale off -->
+{% mermaid %}
+flowchart TD
+
+A[(Database)]
+B(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> Control plane \n #40;{{site.base_gateway}} instance#41;)
+C(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 3\n #40;{{site.base_gateway}} instance#41;)
+D(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 1\n #40;{{site.base_gateway}} instance#41;)
+E(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 2\n #40;{{site.base_gateway}} instance#41;)
+
+subgraph id1 [Self-managed control plane node]
+A---B
+end
+
+B --Kong proxy 
+configuration---> C & D & E
+
+subgraph id2 [Self-managed on-premise node]
+C
+end
+
+subgraph id3 [Self-managed cloud nodes]
+D
+E
+end
+
+style id1 stroke-dasharray:3,rx:10,ry:10
+style id2 stroke-dasharray:3,rx:10,ry:10
+style id3 stroke-dasharray:3,rx:10,ry:10
+style B stroke:none,fill:#0E44A2,color:#fff
+
+{% endmermaid %}
+<!-- vale on-->
+{% endif %}
+
+{% if include.topology == "traditional" %}
+
+<!--vale off -->
+{% mermaid %}
+flowchart TD
+
+A[(Database)]
+B(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> {{site.base_gateway}} instance)
+C(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> {{site.base_gateway}} instance)
+D(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> {{site.base_gateway}} instance)
+
+A <---> B & C & D
+
+style B stroke:none,fill:#0E44A2,color:#fff
+style C stroke:none,fill:#0E44A2,color:#fff
+style D stroke:none,fill:#0E44A2,color:#fff
+
+{% endmermaid %}
+<!-- vale on-->
+{% endif %}
+
+{% if include.topology == "dbless" %}
+<!--vale off -->
+{% mermaid %}
+flowchart TD
+
+A(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> {{site.base_gateway}} instance)
+B(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> {{site.base_gateway}} instance)
+C(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> {{site.base_gateway}} instance)
+
+A2(fa:fa-file kong1.yml)
+B2(fa:fa-file kong2.yml)
+C2(fa:fa-file kong3.yml)
+
+A2 --> A
+B2 --> B
+C2 --> C
+
+style A stroke:none,fill:#0E44A2,color:#fff
+style B stroke:none,fill:#0E44A2,color:#fff
+style C stroke:none,fill:#0E44A2,color:#fff
+
+{% endmermaid %}
+<!-- vale on-->
+{% endif %}

--- a/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+++ b/app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
@@ -11,6 +11,11 @@ specify the use of the database and its [various settings](/gateway/{{page.relea
 We call this DB-less mode. When running {{site.base_gateway}} DB-less, the configuration of 
 entities is done in a second configuration file, in YAML or JSON, using declarative configuration.
 
+{% include_cached /md/gateway/deployment-topologies.md topology='dbless' %}
+
+> _Figure 1: In DB-less mode, configuration is applied via YAML files. 
+{{ site.base_gateway }} nodes aren't connected to a database, or to each other._
+
 The combination of DB-less mode and declarative configuration has a number
 of benefits:
 

--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/index.md
@@ -15,39 +15,10 @@ of the CP nodes, and only the CP nodes are directly connected to a database.
 Instead of accessing the database contents directly, the DP nodes maintain a 
 connection with CP nodes to receive the latest configuration.
 
-<!--vale off -->
-{% mermaid %}
-flowchart LR
+{% include_cached /md/gateway/deployment-topologies.md topology='hybrid' %}
 
-A[(Database)]
-B(<img src="/assets/images/logos/kogo-white.svg" style="max-height:20px" class="no-image-expand"/> Control plane \n #40;{{site.base_gateway}} instance#41;)
-C(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 3\n #40;{{site.base_gateway}} instance#41;)
-D(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 1\n #40;{{site.base_gateway}} instance#41;)
-E(<img src="/assets/images/logos/KogoBlue.svg" style="max-height:20px" class="no-image-expand"/> Data plane 2\n #40;{{site.base_gateway}} instance#41;)
-
-subgraph id1 [cloud node]
-A---B
-end
-
-B --Kong proxy 
-configuration---> C & D & E
-
-subgraph id2 [on-premise node]
-C
-end
-
-subgraph id3 [cloud nodes]
-D
-E
-end
-
-style id1 stroke-dasharray:3,rx:10,ry:10
-style id2 stroke-dasharray:3,rx:10,ry:10
-style id3 stroke-dasharray:3,rx:10,ry:10
-style B stroke:none,fill:#0E44A2,color:#fff
-
-{% endmermaid %}
-<!-- vale on-->
+> _Figure 2: In self-managed hybrid mode, the control plane and data planes are hosted on different nodes. 
+The control plane connects to the database, and the data planes receive configuration from the control plane._
 
 When you create a new data plane node, it establishes a connection to the
 control plane. The control plane listens on port `8005` for connections and

--- a/app/_src/gateway/production/deployment-topologies/index.md
+++ b/app/_src/gateway/production/deployment-topologies/index.md
@@ -20,6 +20,11 @@ The following sections briefly describe each mode.
 
 {{ site.konnect_short_name }} is a hybrid mode deployment, where Kong hosts the control plane for you. This means that you get all of the benefits of a hybrid mode deployment without needing to run multiple control plane nodes yourself.
 
+{% include_cached /md/gateway/deployment-topologies.md topology='konnect' %}
+<!-- vale on-->
+
+> _Figure 1: In {{ site.konnect_short_name }}, Kong hosts your control planes and all of the related applications: Dev Portal, Gateway Manager, Analytics, Service Hub, and so on. You attach data planes to {{ site.konnect_short_name }} to process traffic, which get all of their configuration from the control planes._
+
 Configuration changes can be made using the {{ site.konnect_short_name }} UI and configuration wizards, or applied in an automated way using [decK](/deck/latest/).
 
 As with self-managed hybrid mode, your data plane nodes will continue to process traffic even if the control plane is offline. In addition, you no longer need to worry about securing the control plane because {{site.base_gateway}} does it for you.
@@ -36,6 +41,10 @@ plane (DP), which serves traffic for the proxy. Many DP nodes are connected to a
 traditional deployment method, the DP nodes maintain connection with CP nodes,
 and receive the latest configuration in real-time.
 
+{% include_cached /md/gateway/deployment-topologies.md topology='hybrid' %}
+
+> _Figure 2: In self-managed hybrid mode, the control plane and data planes are hosted on different nodes. The control plane connects to the database, and the data planes receive configuration from the control plane._
+
 Hybrid mode deployments have the following benefits:
 
 * Users can deploy groups of data planes in different data centers, geographies, or zones without needing a local clustered database for each DP group.
@@ -48,6 +57,10 @@ Hybrid mode deployments have the following benefits:
 In [traditional mode](/gateway/{{page.release}}/production/deployment-topologies/traditional/), {{site.base_gateway}} requires a database to store configured entities such as routes, services, and plugins.
 See [supported databases](/gateway/{{page.release}}/support/third-party/#data-stores).
 
+{% include_cached /md/gateway/deployment-topologies.md topology='traditional' %}
+
+> _Figure 3: In a traditional deployment, all {{site.base_gateway}} nodes connect to the database. Each node manages its own configuration._
+
 Running {{ site.base_gateway }} in traditional mode is the simplest way to get started with Kong, and it is the only deployment topology that supports plugins that require a database, like rate-limiting with the cluster strategy, or OAuth2. However, there are some downsides too.
 
 When running in traditional mode, every {{ site.base_gateway }} node runs as both a Control Plane (CP) and Data Plane (DP). This means that if **any** of your nodes are compromised, the entire running gateway configuration is compromised. In contrast, [hybrid mode](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/) has distinct CP and DP nodes reducing the attack surface.
@@ -59,6 +72,11 @@ You can use the [Admin API](/gateway/{{page.release}}/admin-api/) or declarative
 ## DB-less and declarative mode
 
 You can enable [DB-less mode](/gateway/{{page.release}}/production/deployment-topologies/db-less-and-declarative-config/) to reduce complexity of and create more flexible deployment patterns. In this mode, configured entities such as routes, services and plugins are stored in-memory on the node.
+
+{% include_cached /md/gateway/deployment-topologies.md topology='dbless' %}
+
+> _Figure 4: In DB-less mode, configuration is applied via YAML files. 
+{{ site.base_gateway }} nodes aren't connected to a database, or to each other._
 
 When running in DB-less mode, configuration is provided to {{ site.base_gateway }} using a second file. This file contains your configuration in YAML or JSON format using Kong's declarative configuration syntax.
 

--- a/app/_src/gateway/production/deployment-topologies/traditional/index.md
+++ b/app/_src/gateway/production/deployment-topologies/traditional/index.md
@@ -10,6 +10,11 @@ configuration since they point to the same database. Kong nodes pointing to the
 You need a load balancer in front of your Kong cluster to distribute traffic
 across your available nodes.
 
+{% include_cached /md/gateway/deployment-topologies.md topology='traditional' %}
+
+> _Figure 1: In a traditional deployment, all {{site.base_gateway}} nodes connect to the database. 
+Each node manages its own configuration._
+
 ## What a Kong cluster does and doesn't do
 
 **Having a Kong cluster does not mean that your clients traffic will be


### PR DESCRIPTION
### Description

Adding topology diagrams based on a couple of slide decks of similar diagrams, converted into mermaid format.

https://konghq.atlassian.net/browse/DOCU-2482

### Testing instructions

Preview links:
https://deploy-preview-7059--kongdocs.netlify.app/gateway/latest/production/deployment-topologies/
https://deploy-preview-7059--kongdocs.netlify.app/gateway/latest/production/deployment-topologies/hybrid-mode/
https://deploy-preview-7059--kongdocs.netlify.app/gateway/latest/production/deployment-topologies/traditional/
https://deploy-preview-7059--kongdocs.netlify.app/gateway/latest/production/deployment-topologies/db-less-and-declarative-config/
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

