### PR TITLE
Fix: Typo in generate changelog GHA

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          title: Automated Changelog update [skip ci]
+          title: Automated Changelog update [skip-ci]
           body: |
             This is a scheduled pull request to update the changelog.
           labels: skip-changelog,review:copyedit


### PR DESCRIPTION
We were creating PRs with `[skip ci]` which should be `[skip-ci]`