### PR TITLE
fix if blocks for license part in KGO

### DIFF
--- a/app/_includes/md/kgo/prerequisites-kic.md
+++ b/app/_includes/md/kgo/prerequisites-kic.md
@@ -39,7 +39,6 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 {:.note}
 > **Note:** This is an enterprise feature. In order to use it you'll need a [license](/gateway-operator/{{ page.release }}/license/)
 > installed in your cluster so that {{ site.kgo_product_name }} can consume it.
-{% endif %}
 
 ```yaml
 echo "
@@ -50,6 +49,7 @@ metadata:
 rawLicenseString: '$(cat ./license.json)'
 " | kubectl apply -f -
 ```
+{% endif %}
 
 {% unless include.disable_accordian %}
 </details>

--- a/app/_src/gateway-operator/get-started/kic/install.md
+++ b/app/_src/gateway-operator/get-started/kic/install.md
@@ -8,7 +8,7 @@ alpha: true
 
 Both {{ site.kgo_product_name }} and {{ site.kic_product_name }} can be configured using the [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api).
 
-You configure your `GatewayClass` and `Gateway` objects in a vendor independent way and {{ site.kgo_product_name }} translates those requirements in to Kong specific configuration.
+You can configure your `GatewayClass` and `Gateway` objects in a vendor independent way and {{ site.kgo_product_name }} translates those requirements in to Kong specific configuration.
 
 This means that CRDs for both the Gateway API and {{ site.kic_product_name }} have to be installed.
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
Fix `{if}` block to introduce licenses when `enterprise` is enabled in the page to introduce prerequisite of installing KGO.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

