### PR TITLE
Fixes plugin install directions for Dockerfile entrypoint

### DIFF
--- a/app/_src/gateway/plugin-development/distribution.md
+++ b/app/_src/gateway/plugin-development/distribution.md
@@ -144,7 +144,7 @@ ENV KONG_PLUGINS=bundled,example-plugin
 USER kong
 
 # Run kong
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 EXPOSE 8000 8443 8001 8444
 STOPSIGNAL SIGQUIT
 HEALTHCHECK --interval=10s --timeout=10s --retries=10 CMD kong health


### PR DESCRIPTION
### Description

Fixes a minor issue in a sample Dockerfile for plugin distribution.   The example Dockerfile extends a Kong-ee docker image, so the entrypoint needs to match what is delivered by that image. 

