### PR TITLE
feat: Cloud Gateway terminology updates

### DIFF
--- a/app/_includes/md/konnect/konnect-architecture.md
+++ b/app/_includes/md/konnect/konnect-architecture.md
@@ -6,7 +6,7 @@ to manage all service configurations. You can use one or more of the following c
 * {{site.mesh_product_name}}
 
 The control plane propagates those configurations to
-the data plane, which is composed of self-managed or fully-managed data plane 
+the data plane, which is composed of data plane 
 nodes (and proxies in the case of {{site.mesh_product_name}}). The individual nodes can be running either on-premise or in 
 cloud-hosted environments, and each data plane node stores the configuration 
 in-memory. 

--- a/app/_includes/md/konnect/konnect-architecture.md
+++ b/app/_includes/md/konnect/konnect-architecture.md
@@ -6,7 +6,7 @@ to manage all service configurations. You can use one or more of the following c
 * {{site.mesh_product_name}}
 
 The control plane propagates those configurations to
-the data plane, which is composed of self-managed data plane 
+the data plane, which is composed of self-managed or fully-managed data plane 
 nodes (and proxies in the case of {{site.mesh_product_name}}). The individual nodes can be running either on-premise or in 
 cloud-hosted environments, and each data plane node stores the configuration 
 in-memory. 

--- a/app/konnect/gateway-manager/data-plane-nodes/index.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/index.md
@@ -36,7 +36,7 @@ Advanced setup:
 {:.note}
 > **Notes:** 
 > * Gateway Manager includes a feature called Control Plane Launcher which can be used with any of AWS, Azure, or GCP. This feature is currently in tech preview.
-> * Kong does not host data plane nodes. You must install and host your own.
+> * Kong only hosts fully-managed Dedicated Cloud Gateway data plane nodes. You must install and host your own if you want to use a self-managed data plane.
 > * Gateway Manager allows users to select the {{site.base_gateway}} version that they want for their Quickstart scripts (except for cloud provider quickstart scripts for AWS, Azure, and GCP). This allows you to leverage official {{site.konnect_short_name}} scripts to start your gateways while reducing the number of errors due to an invalid script for a certain {{site.base_gateway}} version.
 > * SSH access to Konnect data planes must be done using the cloud provider's tools when using [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html), [Azure](https://learn.microsoft.com/azure/cloud-shell/overview), and [Google Cloud](https://cloud.google.com/compute/docs/instances/ssh) advanced setups. Direct SSH access isn't possible because the keys are randomly generated and not exposed.
 

--- a/app/konnect/gateway-manager/data-plane-nodes/index.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/index.md
@@ -36,7 +36,6 @@ Advanced setup:
 {:.note}
 > **Notes:** 
 > * Gateway Manager includes a feature called Control Plane Launcher which can be used with any of AWS, Azure, or GCP. This feature is currently in tech preview.
-> * Kong only hosts fully-managed Dedicated Cloud Gateway data plane nodes. You must install and host your own if you want to use a self-managed data plane.
 > * Gateway Manager allows users to select the {{site.base_gateway}} version that they want for their Quickstart scripts (except for cloud provider quickstart scripts for AWS, Azure, and GCP). This allows you to leverage official {{site.konnect_short_name}} scripts to start your gateways while reducing the number of errors due to an invalid script for a certain {{site.base_gateway}} version.
 > * SSH access to Konnect data planes must be done using the cloud provider's tools when using [AWS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-methods.html), [Azure](https://learn.microsoft.com/azure/cloud-shell/overview), and [Google Cloud](https://cloud.google.com/compute/docs/instances/ssh) advanced setups. Direct SSH access isn't possible because the keys are randomly generated and not exposed.
 

--- a/app/konnect/gateway-manager/data-plane-nodes/upgrade.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/upgrade.md
@@ -1,15 +1,18 @@
 ---
-title: Upgrade a Data Plane Node to a New Version
+title: Upgrade a Self-managed Data Plane Node to a New Version
 content_type: how-to
 ---
 
-You can upgrade data plane nodes to a new {{site.base_gateway}} version by bringing
+You can upgrade self-managed data plane nodes to a new {{site.base_gateway}} version by bringing
 up new data plane nodes, and then shutting down the old ones. This is the best
 method for high availability, as the new node starts processing data before the
 old node is removed. It is the cleanest and safest way to upgrade with no
 proxy downtime.
 
 We recommend running one major version (2.x or 3.x) of a data plane node per control plane, unless you are in the middle of version upgrades to the data plane. Mixing versions may cause [compatibility issues](/konnect/gateway-manager/version-compatibility).
+
+{:.note}
+> **Note**: If you don't want to manually upgrade data plane nodes, you can use a Dedicated Cloud Gateway. With cloud gateways, Kong fully-manages the data plane and handles upgrades for you.
 
 ## Prerequisites
 

--- a/app/konnect/gateway-manager/data-plane-nodes/upgrade.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: Upgrade a Self-managed Data Plane Node to a New Version
+title: Upgrade a Data Plane Node to a New Version
 content_type: how-to
 ---
 

--- a/app/konnect/gateway-manager/index.md
+++ b/app/konnect/gateway-manager/index.md
@@ -149,17 +149,11 @@ You cannot delete the default control plane.
 A data plane node is a single {{site.base_gateway}} instance. 
 Data plane nodes service traffic for the control plane. 
 
-You can deploy your data plane nodes in one of the following ways:
-* Self-managed nodes, hosted either on your own systems or in 
-an external cloud provider
-* Fully-managed dedicated cloud gateway nodes
+You can deploy your data plane nodes in the following ways:
+* **Fully-managed**: Dedicated Cloud Gateways data plane nodes are completely managed by Kong in the cloud provider of your choice. You maintain control over the size and location of the gateway infrastructure, while Kong oversees the management of each instance and the entire cluster for you. You can use the Dedicated Cloud Gateways wizard in Gateway Manager to provision a {{site.base_gateway}} data plane node in a cloud provider.
+* **Self-managed**: The data plane nodes are hosted either on your own systems or in  an external cloud provider. You can use the script in Gateway Manager to provision a {{site.base_gateway}} data plane node in a Docker container running Linux, on MacOS, or on Windows. 
 
-The Gateway Manager simplifies self-managed data plane node deployment 
-by providing a script to provision a {{site.base_gateway}} data plane node in a 
-Docker container running Linux, on MacOS, or on Windows. 
-
-You can also choose to manually configure data plane nodes on various platforms, including cloud providers.
-See the [data plane node installation options](/konnect/gateway-manager/data-plane-nodes/) for more detail.
+See the [data plane node installation options](/konnect/gateway-manager/data-plane-nodes/) for more information.
 
 ## Plugins
 

--- a/app/konnect/gateway-manager/index.md
+++ b/app/konnect/gateway-manager/index.md
@@ -149,9 +149,10 @@ You cannot delete the default control plane.
 A data plane node is a single {{site.base_gateway}} instance. 
 Data plane nodes service traffic for the control plane. 
 
-Kong only hosts fully-managed Dedicated Cloud Gateway data plane nodes.
-You must deploy your own nodes if you want to self-manage them, either on your own systems or in 
-an external cloud provider.
+You can deploy your data plane nodes in one of the following ways:
+* Self-managed nodes, hosted either on your own systems or in 
+an external cloud provider
+* Fully-managed dedicated cloud gateway nodes
 
 The Gateway Manager simplifies self-managed data plane node deployment 
 by providing a script to provision a {{site.base_gateway}} data plane node in a 

--- a/app/konnect/gateway-manager/index.md
+++ b/app/konnect/gateway-manager/index.md
@@ -45,7 +45,7 @@ Control planes come in three types:
     This means that teams within a group share a cluster of {{site.base_gateway}} data 
     plane nodes, where each team has its own segregated configuration.
 
-* [**Kong Ingress Controller**](/konnect/gateway-manager/kic/)
+* [**{{site.kic_product_name}}**](/konnect/gateway-manager/kic/)
     Monitor the configuration of Kubernetes-based {{site.base_gateway}} data plane nodes.
 
 You can find a list of all control planes in your organization

--- a/app/konnect/gateway-manager/index.md
+++ b/app/konnect/gateway-manager/index.md
@@ -149,11 +149,11 @@ You cannot delete the default control plane.
 A data plane node is a single {{site.base_gateway}} instance. 
 Data plane nodes service traffic for the control plane. 
 
-Kong does not host data plane nodes.
-You must deploy your own nodes, either on your own systems or in 
+Kong only hosts fully-managed Dedicated Cloud Gateway data plane nodes.
+You must deploy your own nodes if you want to self-manage them, either on your own systems or in 
 an external cloud provider.
 
-The Gateway Manager simplifies data plane node deployment 
+The Gateway Manager simplifies self-managed data plane node deployment 
 by providing a script to provision a {{site.base_gateway}} data plane node in a 
 Docker container running Linux, on MacOS, or on Windows. 
 

--- a/app/konnect/getting-started/index.md
+++ b/app/konnect/getting-started/index.md
@@ -28,7 +28,7 @@ title: Get started with Konnect
 
 ## About {{site.konnect_short_name}}
 
-{{site.konnect_short_name}} is an API lifecycle management platform that lets you build modern applications better, faster, and more securely. The control plane is hosted in the cloud by Kong, while the data plane is managed by you within your preferred network environment. All of this is powered by {{site.base_gateway}} — Kong's lightweight, fast, and flexible API gateway. 
+{{site.konnect_short_name}} is an API lifecycle management platform that lets you build modern applications better, faster, and more securely. The control plane is hosted in the cloud by Kong, while the data plane is managed by you or Kong within your preferred network environment. All of this is powered by {{site.base_gateway}} — Kong's lightweight, fast, and flexible API gateway. 
 
 {{site.konnect_short_name}} can help you with the following use cases:
 

--- a/app/konnect/getting-started/index.md
+++ b/app/konnect/getting-started/index.md
@@ -28,7 +28,7 @@ title: Get started with Konnect
 
 ## About {{site.konnect_short_name}}
 
-{{site.konnect_short_name}} is an API lifecycle management platform that lets you build modern applications better, faster, and more securely. The control plane is hosted in the cloud by Kong, while the data plane is managed by you or Kong within your preferred network environment. All of this is powered by {{site.base_gateway}} — Kong's lightweight, fast, and flexible API gateway. 
+{{site.konnect_short_name}} streamlines the API lifecycle management process, empowering you to develop modern applications with enhanced speed, improved security, and greater efficiency. It uniquely combines a control plane, managed by Kong and hosted in the cloud, with the versatility of managing the data plane on your terms — either self-managed or through Kong, within your preferred network environment. At the heart of this platform is {{site.base_gateway}}, Kong's innovative, high-performance, and adaptable API gateway, designed to meet your application development needs with agility and reliability.
 
 {{site.konnect_short_name}} can help you with the following use cases:
 

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -10,7 +10,7 @@ breadcrumb: Overview
 management platform designed from the ground up for the cloud native era
 and delivered as a service. This platform lets you build modern applications
 better, faster, and more securely. The control plane is hosted
-in the cloud by Kong, while the data plane is managed by you within your
+in the cloud by Kong, while the data plane is managed by you or Kong within your
 preferred network environment. All of this is powered by {{site.base_gateway}} — Kong's
 lightweight, fast, and flexible API gateway. 
 

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -78,7 +78,7 @@ across the organization’s applications.
 collaborate and manage their own set of data plane nodes and services without
 the risk of impacting other teams and projects. Gateway Manager instantly
 provisions a hosted {{site.base_gateway}} control plane and supports securely
-attaching self-hosted nodes running in cloud or hybrid environments, or using fully-managed data plane nodes.
+attaching data plane nodes.
 
 Through the Gateway Manager, increase the security of your APIs with out-of-the-box enterprise and community plugins, including OpenID Connect, Open Policy Agent, Mutual TLS, and more.
 

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -10,8 +10,7 @@ breadcrumb: Overview
 management platform designed from the ground up for the cloud native era
 and delivered as a service. This platform lets you build modern applications
 better, faster, and more securely. The control plane is hosted
-in the cloud by Kong, while the data plane is managed by you or Kong in your
-preferred network environment. All of this is powered by {{site.base_gateway}} — Kong's
+in the cloud by Kong, while you can choose to either host the data plane yourself in your preferred network environment or let Kong manage it for you in the cloud. All of this is powered by {{site.base_gateway}} — Kong's
 lightweight, fast, and flexible API gateway. 
 
 <p align="center">

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -10,7 +10,7 @@ breadcrumb: Overview
 management platform designed from the ground up for the cloud native era
 and delivered as a service. This platform lets you build modern applications
 better, faster, and more securely. The control plane is hosted
-in the cloud by Kong, while the data plane is managed by you or Kong within your
+in the cloud by Kong, while the data plane is managed by you or Kong in your
 preferred network environment. All of this is powered by {{site.base_gateway}} — Kong's
 lightweight, fast, and flexible API gateway. 
 
@@ -79,7 +79,7 @@ across the organization’s applications.
 collaborate and manage their own set of data plane nodes and services without
 the risk of impacting other teams and projects. Gateway Manager instantly
 provisions a hosted {{site.base_gateway}} control plane and supports securely
-attaching data plane nodes from your cloud or hybrid environments.
+attaching data plane nodes from your fully-managed cloud, or self-managed cloud and hybrid environments.
 
 Through the Gateway Manager, increase the security of your APIs with out-of-the-box enterprise and community plugins, including OpenID Connect, Open Policy Agent, Mutual TLS, and more.
 

--- a/app/konnect/index.md
+++ b/app/konnect/index.md
@@ -79,7 +79,7 @@ across the organization’s applications.
 collaborate and manage their own set of data plane nodes and services without
 the risk of impacting other teams and projects. Gateway Manager instantly
 provisions a hosted {{site.base_gateway}} control plane and supports securely
-attaching data plane nodes from your fully-managed cloud, or self-managed cloud and hybrid environments.
+attaching self-hosted nodes running in cloud or hybrid environments, or using fully-managed data plane nodes.
 
 Through the Gateway Manager, increase the security of your APIs with out-of-the-box enterprise and community plugins, including OpenID Connect, Open Policy Agent, Mutual TLS, and more.
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
We are now calling the original way of deploying ‘self-managed’, and cloud gateways are now referred to as fully-managed, or dedicated cloud instances. Update the Konnect documentation to ensure that we are referring to self-managed control planes across the docs.

I manually went through the docs to look for spots to update since there weren't any great search terms to find/replace in the docs set.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3701
### Testing instructions

Preview link: https://deploy-preview-7093--kongdocs.netlify.app/konnect/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

