### PR TITLE
Fix Gateway > 3.1 docker install instructions

### DIFF
--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -84,7 +84,12 @@ RUN set -ex; \
 {% navtab Ubuntu %}
 ```dockerfile
 
+{% if_version lte:3.0.x %}
 FROM ubuntu:20.04
+{% endif_version %}
+{% if_version gte:3.1.x %}
+FROM ubuntu:22.04
+{% endif_version %}
 
 COPY kong.deb /tmp/kong.deb
 


### PR DESCRIPTION
### Description

Reported by Stu. We link to a Jammy binary for > 3.1, but the Dockerfile was hardcoded to Focal.

### Testing instructions

Preview link: /gateway/latest/install/docker/build-custom-images/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
