### PR TITLE
kgo: update version compat table for 1.2

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -300,7 +300,7 @@
   version: "3.0.2"
   edition: "kubernetes-ingress-controller"
 - release: "3.1.x"
-  version: "3.1.0"
+  version: "3.1.2"
   edition: "kubernetes-ingress-controller"
   latest: true
 - release: "3.2.x"
@@ -314,7 +314,7 @@
   version: 1.1.0
   release: 1.1.x
 - edition: gateway-operator
-  version: 1.2.0
+  version: 1.2.1
   release: 1.2.x
   latest: true
 - edition: gateway-operator

--- a/app/_src/gateway-operator/reference/version-compatibility.md
+++ b/app/_src/gateway-operator/reference/version-compatibility.md
@@ -8,23 +8,25 @@ The following table presents the general compatibility of {{site.kgo_product_nam
 
 ## Kubernetes
 
-| {{site.kgo_product_name}}        |            1.0.x            |            1.1.x            |
-|:---------------------------------|:---------------------------:|:---------------------------:|
-| {{ site.kic_product_name }} 2.11 | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| {{ site.kic_product_name }} 2.12 | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| {{ site.kic_product_name }} 3.0  | <i class="fa fa-times"></i> | <i class="fa fa-check"></i> |
+| {{site.kgo_product_name}}        |            1.0.x            |            1.1.x            |            1.2.x            |
+|:---------------------------------|:---------------------------:|:---------------------------:|:---------------------------:|
+| {{ site.kic_product_name }} 2.11 | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> |
+| {{ site.kic_product_name }} 2.12 | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> |
+| {{ site.kic_product_name }} 3.0  | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-times"></i> |
+| {{ site.kic_product_name }} 3.1  | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 ### General
 
 The following table presents the general compatibility of {{site.kgo_product_name}} with specific Kubernetes versions.
 Users should expect all the combinations marked with <i class="fa fa-check"></i> to work and to be supported.
 
-| {{site.kgo_product_name}} |            1.0.x            |            1.1.x            |
-|:--------------------------|:---------------------------:|:---------------------------:|
-| Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.26           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.27           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Kubernetes 1.28           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| {{site.kgo_product_name}} |            1.0.x            |            1.1.x            |            1.2.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|
+| Kubernetes 1.25           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.26           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.27           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.28           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Kubernetes 1.29           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 ### Gateway API
 
@@ -33,10 +35,10 @@ As {{site.kgo_product_name}} implements Gateway API features using the upstream
 project, which defines [its own compatibility declarations][gateway-api-supported-versions], the expected compatibility
 of Gateway API features might be limited to those.
 
-| {{site.kgo_product_name}} |            1.0.x            |            1.1.x            |
-|:--------------------------|:---------------------------:|:---------------------------:|
-| Gateway API 0.8.1         | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
-| Gateway API 1.0.0         | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| {{site.kgo_product_name}} |            1.0.x            |            1.1.x            |            1.2.x            |
+|:--------------------------|:---------------------------:|:---------------------------:|:---------------------------:|
+| Gateway API 0.8.1         | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
+| Gateway API 1.0.0         | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
 [gateway-api]: https://github.com/kubernetes-sigs/gateway-api
 [gateway-api-supported-versions]:https://gateway-api.sigs.k8s.io/concepts/versioning/#supported-versions


### PR DESCRIPTION
### Description

Update version compat matrix for KGO 1.2.

Also bump KIC latest to 3.1.2 and KGO to 1.2.1 to have up to date latest versions referenced in guides.

<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

