### PR TITLE
fix: Use consistent names in Mocking plugin example

### DIFF
--- a/app/_hub/kong-inc/mocking/overview/_index.md
+++ b/app/_hub/kong-inc/mocking/overview/_index.md
@@ -57,11 +57,11 @@ paths:
           content:
             application/json:
               examples:
-                Jessica:
+                Hao:
                   value:
                     id: 10
                     name: Hao
-                Ron:
+                Sasha:
                   value:
                     id: 20
                     name: Sasha


### PR DESCRIPTION
### Description

Fixes https://konghq.atlassian.net/browse/DOCU-3284.

Examples were using two sets of names, Ron and Jessica, and Hao and Sasha. The latter two are carried through the rest of the topic; the first two don't appear anywhere else, and feel like they might be left over from a previous version of the example .

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

