### PR TITLE
chore: Clarify our use of SemVer with Kong Gateway

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -140,7 +140,9 @@ autoscalers
 Autonegotiation
 aws
 backport
+backports
 backported
+backporting
 backtrace
 Bagdi
 bcc

--- a/app/_includes/md/availability-stages.md
+++ b/app/_includes/md/availability-stages.md
@@ -26,4 +26,4 @@ If feature documentation doesn't have a tech preview, alpha, or beta label, then
 
 You can depend on GA features in production environments.
 
-Interfaces are guaranteed to follow a [semantic versioning](https://semver.org/) model for any changes.
+Interfaces follow a [structured versioning model](/gateway/latest/support/) for any changes.

--- a/app/_src/gateway/index.md
+++ b/app/_src/gateway/index.md
@@ -244,8 +244,7 @@ There are a few ways to test out the Gateway's Enterprise features:
 representative will reach out with details to get you started.
 
 ## Support policy
-Kong primarily follows a [semantic versioning](https://semver.org/) (SemVer)
-model for its products.
+Kong follows a structured approach to versioning its products.
 
 For the latest version support information for {{site.ee_product_name}} and
 {{site.mesh_product_name}}, see the [version support policy](/gateway/{{page.release}}/support-policy/).

--- a/app/_src/gateway/support-policy.md
+++ b/app/_src/gateway/support-policy.md
@@ -32,7 +32,11 @@ content-type: reference
 > *Table 1: Version Support for {{site.ee_product_name}}*
 
 ## Types of releases
-Kong primarily follows [semantic versioning](https://semver.org/) (SemVer) with its products. That is, products typically follow a pattern of `{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION}`. {{site.ee_product_name}} additionally has one more decimal point on the right which identifies a sub-patch based on the Kong Community Gateway. For the purposes of this support document:
+Kong adopts a structured approach to versioning its products.
+Products follow a pattern of `{MAJOR}.{MINOR}.{PATCH}.{ENTERPRISE_PATCH}`.
+The `ENTERPRISE_PATCH` segment identifies a sub-patch for {{site.ee_product_name}} based on {{site.ce_product_name}}.
+
+For the purposes of this support document:
 
 * **Major Version** refers to a version of {{site.ee_product_name}} identified by the number to the left of the leftmost decimal point. For example, 2.1.3.0 has Major Version 2 and 1.3.0.0 has Major Version 1.
 

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -3,7 +3,7 @@ title: Kong Gateway Enterprise Version Support
 breadcrumb: Distributions
 ---
 
-Kong primarily follows [semantic versioning](https://semver.org/) (SemVer) with its products, with an added segment for {{site.ee_product_name}} patch releases. Products follow a pattern of `{MAJOR}.{MINOR}.{PATCH}.{ENTERPRISE_PATCH}`. The `ENTERPRISE_PATCH` segment identifies a sub-patch based on the Kong Community Gateway. 
+Kong follows a soft [semantic versioning](https://semver.org/) (SemVer) model with its products, with an added segment for {{site.ee_product_name}} patch releases. Products follow a pattern of `{MAJOR}.{MINOR}.{PATCH}.{ENTERPRISE_PATCH}`. The `ENTERPRISE_PATCH` segment identifies a sub-patch based on the Kong Community Gateway. 
 
 ## Semantic Versioning
 
@@ -21,7 +21,13 @@ For the purposes of this support document:
 
 Kong introduces major functionality and breaking changes by releasing a new major version. Major version releases happen rarely and are usually in response to changes in major industry trends, significant architectural changes or significant internal product innovation. There is no regular release cadence of major versions.
 
-Kong aims to release a new minor version every 10 weeks. Minor versions contain features and bug fixes. Minor versions are backwards compatible within that major version sequence.  Every minor version is supported for a period of 1 year from date of release. This is done by releasing patches that apply to each supported minor version. Customers are encouraged to keep their installations up to date by applying the patches appropriate to their installed version. All patches released by Kong are roll-up patches (for example, patch 1.5 for release version 3.3 includes all the fixes in patches 1.4, 1.3, 1.2, and 1.1).  
+Kong aims to release a new minor version every 10 weeks. Minor versions contain features and bug fixes. Minor versions are backwards compatible within that major version sequence. Every minor version is supported for a period of 1 year from date of release. This is done by releasing patches that apply to each supported minor version. Customers are encouraged to keep their installations up to date by applying the patches appropriate to their installed version. All patches released by Kong are roll-up patches (for example, patch 1.5 for release version 3.3 includes all the fixes in patches 1.4, 1.3, 1.2, and 1.1).
+
+{:.important}
+> **Important:** There can be exceptions to the semantic versioning model. 
+Due to backports, new features and breaking changes are possible at any version level, including patch versions.
+To avoid issues, do not upgrade to any new version automatically, and 
+make sure to review all relevant [changelog entries](/gateway/changelog/) before manually upgrading your deployments.
 
 Kong may designate a specific minor version as a Long-Term Support (LTS) version. Kong provides technical support for the LTS version on a given distribution for the duration of the distribution’s lifecycle, or for 3 years from LTS version release, whichever comes sooner. An LTS version is backwards compatible within its major version sequence. An LTS version receives all security fixes. Additionally, an LTS version may receive certain non-security patches at Kong's discretion. At any time, there will be at least 1 active LTS {{site.ee_product_name}} version.
 

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -26,7 +26,7 @@ Kong introduces major functionality and breaking changes by releasing a new majo
 Kong aims to release a new minor version approximately every 12 weeks. Minor versions contain features and bug fixes. Minor versions are usually¹ backwards compatible within that major version sequence. Every minor version is supported for a period of 1 year from date of release. This is done by releasing patches that apply to each supported minor version. Customers are encouraged to keep their installations up to date by applying the patches appropriate to their installed version. All patches released by Kong are roll-up patches (for example, patch 1.5 for release version 3.3 includes all the fixes in patches 1.4, 1.3, 1.2, and 1.1).
 
 {:.note}
-> (1) **Note:** There can be exceptions to the versioning model. 
+> ¹**Note:** There can be exceptions to the versioning model. 
 Due to backports, new features and breaking changes are possible at any version level, including patch versions.
 To avoid issues, do not upgrade to any new version automatically, and 
 make sure to review all relevant [changelog entries](/gateway/changelog/) before manually upgrading your deployments.

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -3,9 +3,11 @@ title: Kong Gateway Enterprise Version Support
 breadcrumb: Distributions
 ---
 
-Kong follows a soft [semantic versioning](https://semver.org/) (SemVer) model with its products, with an added segment for {{site.ee_product_name}} patch releases. Products follow a pattern of `{MAJOR}.{MINOR}.{PATCH}.{ENTERPRISE_PATCH}`. The `ENTERPRISE_PATCH` segment identifies a sub-patch based on the Kong Community Gateway. 
+Kong adopts a structured approach to versioning its products.
+Products follow a pattern of `{MAJOR}.{MINOR}.{PATCH}.{ENTERPRISE_PATCH}`.
+The `ENTERPRISE_PATCH` segment identifies a sub-patch for {{site.ee_product_name}} based on {{site.ce_product_name}}.
 
-## Semantic Versioning
+## Versioning
 
 For the purposes of this support document:
 
@@ -21,10 +23,10 @@ For the purposes of this support document:
 
 Kong introduces major functionality and breaking changes by releasing a new major version. Major version releases happen rarely and are usually in response to changes in major industry trends, significant architectural changes or significant internal product innovation. There is no regular release cadence of major versions.
 
-Kong aims to release a new minor version every 10 weeks. Minor versions contain features and bug fixes. Minor versions are backwards compatible within that major version sequence. Every minor version is supported for a period of 1 year from date of release. This is done by releasing patches that apply to each supported minor version. Customers are encouraged to keep their installations up to date by applying the patches appropriate to their installed version. All patches released by Kong are roll-up patches (for example, patch 1.5 for release version 3.3 includes all the fixes in patches 1.4, 1.3, 1.2, and 1.1).
+Kong aims to release a new minor version approximately every 12 weeks. Minor versions contain features and bug fixes. Minor versions are usually¹ backwards compatible within that major version sequence. Every minor version is supported for a period of 1 year from date of release. This is done by releasing patches that apply to each supported minor version. Customers are encouraged to keep their installations up to date by applying the patches appropriate to their installed version. All patches released by Kong are roll-up patches (for example, patch 1.5 for release version 3.3 includes all the fixes in patches 1.4, 1.3, 1.2, and 1.1).
 
-{:.important}
-> **Important:** There can be exceptions to the semantic versioning model. 
+{:.note}
+> (1) **Note:** There can be exceptions to the versioning model. 
 Due to backports, new features and breaking changes are possible at any version level, including patch versions.
 To avoid issues, do not upgrade to any new version automatically, and 
 make sure to review all relevant [changelog entries](/gateway/changelog/) before manually upgrading your deployments.

--- a/app/_src/gateway/upgrade-v2.md
+++ b/app/_src/gateway/upgrade-v2.md
@@ -14,7 +14,7 @@ If you experience any issues when running migrations, contact
 
 ## Upgrade path for {{site.base_gateway}} releases
 
-Kong adheres to [semantic versioning](https://semver.org/), which makes a
+Kong follows a structured approach to versioning its products, which makes a
 distinction between major, minor, and patch versions.
 
 The upgrade to {{page.release}} is a **minor** upgrade.

--- a/app/_src/gateway/upgrade-v3.md
+++ b/app/_src/gateway/upgrade-v3.md
@@ -14,7 +14,7 @@ If you experience any issues when running migrations, contact
 
 ## Upgrade path for {{site.base_gateway}} releases
 
-Kong adheres to [semantic versioning](https://semver.org/), which makes a
+Kong follows a structured approach to versioning its products, which makes a
 distinction between major, minor, and patch versions.
 
 The upgrade to 3.0.x is a **major** upgrade.

--- a/app/_src/gateway/upgrade/index.md
+++ b/app/_src/gateway/upgrade/index.md
@@ -52,7 +52,7 @@ Now, let's move on to preparation, starting with determining your upgrade path.
 
 ## Preparation: Review upgrade paths
 
-{{site.base_gateway}} adheres to [semantic versioning](https://semver.org/), which makes a
+{{site.base_gateway}} adheres to a structured approach to versioning its products, which makes a
 distinction between major, minor, and patch versions.
 
 The upgrade from 2.x to 3.x is a **major** upgrade.

--- a/app/gateway/2.6.x/index.md
+++ b/app/gateway/2.6.x/index.md
@@ -164,8 +164,7 @@ There are a few ways to test out the Gateway's Plus or Enterprise features:
 representative will reach out with details to get you started.
 
 ## Support policy
-Kong primarily follows a [semantic versioning](https://semver.org/) (SemVer)
-model for its products.
+Kong follows a structured approach to versioning its products.
 
 For the latest version support information for {{site.ee_product_name}} and
 {{site.mesh_product_name}}, see our [version support policy](/gateway/latest/support-policy/).

--- a/app/gateway/2.6.x/install-and-run/upgrade-enterprise.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade-enterprise.md
@@ -15,7 +15,7 @@ If you experience any issues when running migrations, contact
 
 ## Upgrade path for {{site.base_gateway}} releases
 
-Kong adheres to [semantic versioning](https://semver.org/), which makes a
+Kong follows a structured approach to versioning its products, which makes a
 distinction between major, minor, and patch versions. The upgrade
 path for major and minor versions differs depending on the previous version
 from which you are migrating:

--- a/app/gateway/2.6.x/install-and-run/upgrade-oss.md
+++ b/app/gateway/2.6.x/install-and-run/upgrade-oss.md
@@ -10,7 +10,7 @@ To upgrade to prior versions, find the version number in the
 
 ## Upgrade to 2.6.x
 
-Kong adheres to [semantic versioning](https://semver.org/), which makes a
+Kong adopts a structured versioning approach, which makes a
 distinction between "major", "minor", and "patch" versions. The upgrade path
 will be different depending on which previous version from which you are migrating.
 

--- a/app/gateway/2.7.x/index.md
+++ b/app/gateway/2.7.x/index.md
@@ -164,8 +164,7 @@ There are a few ways to test out the Gateway's Plus or Enterprise features:
 representative will reach out with details to get you started.
 
 ## Support policy
-Kong primarily follows a [semantic versioning](https://semver.org/) (SemVer)
-model for its products.
+Kong follows a structured approach to versioning its products.
 
 For the latest version support information for {{site.ee_product_name}} and
 {{site.mesh_product_name}}, see our [version support policy](/gateway/latest/support-policy/).

--- a/app/gateway/2.7.x/install-and-run/upgrade-enterprise.md
+++ b/app/gateway/2.7.x/install-and-run/upgrade-enterprise.md
@@ -15,7 +15,7 @@ If you experience any issues when running migrations, contact
 
 ## Upgrade path for {{site.base_gateway}} releases
 
-Kong adheres to [semantic versioning](https://semver.org/), which makes a
+Kong follows a structured approach to versioning its products, which makes a
 distinction between major, minor, and patch versions. The upgrade
 path for major and minor versions differs depending on the previous version
 from which you are migrating:

--- a/app/gateway/2.7.x/install-and-run/upgrade-oss.md
+++ b/app/gateway/2.7.x/install-and-run/upgrade-oss.md
@@ -11,7 +11,7 @@ To upgrade to prior versions, find the version number in the
 
 ## Upgrade to 2.7.x
 
-Kong adheres to [semantic versioning](https://semver.org/), which makes a
+Kong adopts a structured versioning approach, which makes a
 distinction between "major", "minor", and "patch" versions. The upgrade path
 will be different depending on which previous version from which you are migrating.
 

--- a/app/gateway/2.8.x/index.md
+++ b/app/gateway/2.8.x/index.md
@@ -170,8 +170,7 @@ There are a few ways to test out the Gateway's Plus or Enterprise features:
 representative will reach out with details to get you started.
 
 ## Support policy
-Kong primarily follows a [semantic versioning](https://semver.org/) (SemVer)
-model for its products.
+Kong follows a structured approach to versioning its products.
 
 For the latest version support information for {{site.ee_product_name}} and
 {{site.mesh_product_name}}, see our [version support policy](/gateway/{{page.release}}/support-policy/).

--- a/app/gateway/2.8.x/install-and-run/upgrade-enterprise.md
+++ b/app/gateway/2.8.x/install-and-run/upgrade-enterprise.md
@@ -15,7 +15,7 @@ If you experience any issues when running migrations, contact
 
 ## Upgrade path for {{site.base_gateway}} releases
 
-Kong adheres to [semantic versioning](https://semver.org/), which makes a
+Kong follows a structured approach to versioning its products, which makes a
 distinction between major, minor, and patch versions. The upgrade
 path for major and minor versions differs depending on the previous version
 from which you are migrating:

--- a/app/gateway/2.8.x/install-and-run/upgrade-oss.md
+++ b/app/gateway/2.8.x/install-and-run/upgrade-oss.md
@@ -42,7 +42,7 @@ configuration, without dropping existing in-flight connections.
 
 ## Upgrade to 2.8.x
 
-Kong adheres to [semantic versioning](https://semver.org/), which makes a
+Kong adopts a structured versioning approach, which makes a
 distinction between "major", "minor", and "patch" versions. The upgrade path
 will be different depending on which previous version from which you are migrating.
 

--- a/app/gateway/2.8.x/support-policy.md
+++ b/app/gateway/2.8.x/support-policy.md
@@ -3,9 +3,11 @@ title: Kong Gateway Enterprise Version Support
 breadcrumb: Distributions
 ---
 
-Kong primarily follows [semantic versioning](https://semver.org/) (SemVer) with its products, with an added segment for {{site.ee_product_name}} patch releases. Products follow a pattern of `{MAJOR}.{MINOR}.{PATCH}.{ENTERPRISE_PATCH}`. The `ENTERPRISE_PATCH` segment identifies a sub-patch based on the Kong Community Gateway. 
+Kong adopts a structured approach to versioning its products.
+Products follow a pattern of `{MAJOR}.{MINOR}.{PATCH}.{ENTERPRISE_PATCH}`.
+The `ENTERPRISE_PATCH` segment identifies a sub-patch for {{site.ee_product_name}} based on {{site.ce_product_name}}.
 
-## Semantic Versioning
+## Versioning
 
 For the purposes of this support document:
 
@@ -21,7 +23,13 @@ For the purposes of this support document:
 
 Kong introduces major functionality and breaking changes by releasing a new major version. Major version releases happen rarely and are usually in response to changes in major industry trends, significant architectural changes or significant internal product innovation. There is no regular release cadence of major versions.
 
-Kong aims to release a new minor version every 10 weeks. Minor versions contain features and bug fixes. Minor versions are backwards compatible within that major version sequence.  Every minor version is supported for a period of 1 year from date of release. This is done by releasing patches that apply to each supported minor version. Customers are encouraged to keep their installations up to date by applying the patches appropriate to their installed version. All patches released by Kong are roll-up patches (for example, patch 1.5 for release version 3.3 includes all the fixes in patches 1.4, 1.3, 1.2, and 1.1).
+Kong aims to release a new minor version approximately every 12 weeks. Minor versions contain features and bug fixes. Minor versions are usually¹ backwards compatible within that major version sequence. Every minor version is supported for a period of 1 year from date of release. This is done by releasing patches that apply to each supported minor version. Customers are encouraged to keep their installations up to date by applying the patches appropriate to their installed version. All patches released by Kong are roll-up patches (for example, patch 1.5 for release version 3.3 includes all the fixes in patches 1.4, 1.3, 1.2, and 1.1).
+
+{:.note}
+> (1) **Note:** There can be exceptions to the versioning model. 
+Due to backports, new features and breaking changes are possible at any version level, including patch versions.
+To avoid issues, do not upgrade to any new version automatically, and 
+make sure to review all relevant [changelog entries](/gateway/changelog/) before manually upgrading your deployments.
 
 Kong may designate a specific minor version as a Long-Term Support (LTS) version. Kong provides technical support for the LTS version on a given distribution for the duration of the distribution’s lifecycle, or for 3 years from LTS version release, whichever comes sooner. An LTS version is backwards compatible within its major version sequence. An LTS version receives all security fixes. Additionally, an LTS version may receive certain non-security patches at Kong's discretion. At any time, there will be at least 1 active LTS {{site.ee_product_name}} version.
 

--- a/app/gateway/2.8.x/support-policy.md
+++ b/app/gateway/2.8.x/support-policy.md
@@ -26,7 +26,7 @@ Kong introduces major functionality and breaking changes by releasing a new majo
 Kong aims to release a new minor version approximately every 12 weeks. Minor versions contain features and bug fixes. Minor versions are usually¹ backwards compatible within that major version sequence. Every minor version is supported for a period of 1 year from date of release. This is done by releasing patches that apply to each supported minor version. Customers are encouraged to keep their installations up to date by applying the patches appropriate to their installed version. All patches released by Kong are roll-up patches (for example, patch 1.5 for release version 3.3 includes all the fixes in patches 1.4, 1.3, 1.2, and 1.1).
 
 {:.note}
-> (1) **Note:** There can be exceptions to the versioning model. 
+> ¹**Note:** There can be exceptions to the versioning model. 
 Due to backports, new features and breaking changes are possible at any version level, including patch versions.
 To avoid issues, do not upgrade to any new version automatically, and 
 make sure to review all relevant [changelog entries](/gateway/changelog/) before manually upgrading your deployments.


### PR DESCRIPTION
### Description

Adding a note to clarify what we deliver in a version, most notably patch versions, to make it clear that it is never safe to upgrade automatically. We can break semver with backports, and it isn't always predicatable.

https://konghq.atlassian.net/browse/DOCU-3717

### Testing instructions

Preview link: https://deploy-preview-7117--kongdocs.netlify.app/gateway/latest/support-policy/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

