### PR TITLE
(fix) Update auth0 instructions to include warning on trailing forward slash in URL

### DIFF
--- a/app/konnect/dev-portal/applications/dynamic-client-registration/auth0.md
+++ b/app/konnect/dev-portal/applications/dynamic-client-registration/auth0.md
@@ -89,7 +89,7 @@ Once you have Auth0 configured, you can configure the Dev Portal to use Auth0 fo
 
 4. Select **New DCR provider** to create an Auth0 configuration. Provide a name for internal use in {{site.konnect_short_name}}. The name and provider type information will not be exposed to Dev Portal developers.
 
-5. Input the **Issuer URL** of your Auth0 tenant, formatted as: `https://AUTH0_TENANT_SUBDOMAIN.us.auth0.com`.  DO NOT have a trailing forward slash in URL.
+5. Input the **Issuer URL** of your Auth0 tenant, formatted as: `https://AUTH0_TENANT_SUBDOMAIN.us.auth0.com`.  Do not include a forward slash at the end of the URL.
 
    {:.note}
    > **Note:** You can find the value for your `AUTH0_TENANT_SUBDOMAIN` by checking the **Tenant Name** under **Settings** > **General**.

--- a/app/konnect/dev-portal/applications/dynamic-client-registration/auth0.md
+++ b/app/konnect/dev-portal/applications/dynamic-client-registration/auth0.md
@@ -89,7 +89,7 @@ Once you have Auth0 configured, you can configure the Dev Portal to use Auth0 fo
 
 4. Select **New DCR provider** to create an Auth0 configuration. Provide a name for internal use in {{site.konnect_short_name}}. The name and provider type information will not be exposed to Dev Portal developers.
 
-5. Input the **Issuer URL** of your Auth0 tenant, formatted as: `https://AUTH0_TENANT_SUBDOMAIN.us.auth0.com`
+5. Input the **Issuer URL** of your Auth0 tenant, formatted as: `https://AUTH0_TENANT_SUBDOMAIN.us.auth0.com`.  DO NOT have a trailing forward slash in URL.
 
    {:.note}
    > **Note:** You can find the value for your `AUTH0_TENANT_SUBDOMAIN` by checking the **Tenant Name** under **Settings** > **General**.


### PR DESCRIPTION
Updated the Issuer URL information, as providing a trailing slash will cause issues.


### Description

When we have trailing slash for issuer URL, it get concatenated which will result in issuer as this https://dev-26uur0y8i4n8x3ez.us.auth0.com//api/v2/". So, informing users via docs will be valuable until if this can be gracefully handled.

### Testing instructions

Following steps mentioned in this docs and just have additional change of including / at the end of issuer url. And try to create an application in Dev Portal, which will fail with "Unable to create one time access token" error.

