### PR TITLE
Update the description of X-Kong-Upstream-Status header for 3.7.0.0

### DIFF
--- a/app/_src/gateway/reference/configuration.md
+++ b/app/_src/gateway/reference/configuration.md
@@ -1292,7 +1292,9 @@ Accepted values are:
   Admin API request.
 - `X-Kong-Upstream-Status`: The HTTP status code returned by the upstream
   service. This is particularly useful for clients to distinguish upstream
-  statuses if the response is rewritten by a plugin.
+  statuses if the response is rewritten by a plugin.  In the case that the 
+  response is retrieved by a plugin (such as `proxy-cache` plugin) from the
+  cache it holds, the status code always respects to the one in cache.
 {% if_version gte:3.5.x %}
 - `X-Kong-Request-Id`: Unique identifier of the request.
 {% endif_version %}


### PR DESCRIPTION



### Description

A description revise of `X-Kong-Upstream-Status` header. We add a description regarding the value of the header for the case that the response is retrieved from the cache held by a `proxy-cache` plugin
 
FTI-5827

Related-pr:
- https://github.com/Kong/kong/pull/12744
- https://github.com/Kong/kong-ee/pull/8609

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.


