### PR TITLE
Feat: Update get started with Konnect and transit gateway documentation

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -56,6 +56,8 @@
           url: /gateway-manager/data-plane-nodes/parameter-reference/
         - text: Using Custom DP Labels
           url: /gateway-manager/data-plane-nodes/custom-dp-labels
+        - text: Transit Gateways
+          url: /gateway-manager/data-plane-nodes/transit-gateways
     - text: Control Plane Groups
       items:
         - text: Overview

--- a/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
@@ -3,7 +3,7 @@ title: How to configure Transit Gateway
 ---
 
 
-This guide will walk you through connecting your {{site.konnect_short_name}} managed Dedicated Cloud Gateways to AWS Transit Gateway, providing a secure and private channel for your API traffic.
+This guide walks you through connecting your {{site.konnect_short_name}}-managed Dedicated Cloud Gateways to AWS Transit Gateway, providing a secure and private channel for your API traffic.
 
 ## Prerequisites 
 
@@ -22,7 +22,7 @@ This will display a **Transit Gateway ID**, save this.
 
 ### Configure AWS resources access
 
-1. Navigate to the **Resource Access Manager**, then click  **Create Resource Share**. 
+1. Navigate to the **Resource Access Manager**, then click **Create Resource Share**. 
 1. Select **Transit Gateways** as the resource type, and check the box for the transit gateway that you created in the previous section.
 1. Give the Resource Share a name.
 1. Click **Next** and leave the default managed permission settings as they are.
@@ -33,9 +33,9 @@ After creating the resource share, copy the **RAM Share ARN**. You will need thi
 
 ### Configure {{site.konnect_short_name}}
 
-1. From {{site.konnect_short_name}} navigate to the **Gateway Manager**.
-1. Within the **Networks** tab, select the desired network then select **Attach Transit Gateway**.
-1. In the form that appears, enter a **Transit Gateway Name**
+1. From {{site.konnect_short_name}}, navigate to the **Gateway Manager**.
+1. Within the **Networks** tab, select the desired network, then select **Attach Transit Gateway**.
+1. In the form that appears, enter a **Transit Gateway Name**.
 1. Add one or more CIDR blocks that will be forwarded to your AWS Transit Gateway. Ensure these do not overlap with the CIDR of your cloud gateways network.
 1. Paste the **RAM Share ARN** and the **Transit Gateway ID** you saved earlier into the matching fields.
 1. For DNS configuration, add the IP addresses of DNS servers that will resolve to your private domains, along with any domains you want associated with your DNS.
@@ -43,14 +43,14 @@ After creating the resource share, copy the **RAM Share ARN**. You will need thi
 
 ### Accept Transit Gateway attachment request
 
-1. From the **AWS Console > VPC > Transit Gateway Attachments**.
-2. Wait for an attachment request coming from the AWS Account ID you used in {{site.konnect_short_name}}.
+1. From the **AWS Console**, go to  **VPC** > **Transit Gateway Attachments**.
+1. Wait for an attachment request coming from the AWS Account ID you used in {{site.konnect_short_name}}.
 1. Accept the attachment to complete the setup.
 
 Once the transit gateway attachment is successful, add a route where the upstream services are running, and configure the route to forward all traffic for the {{site.konnect_short_name}} managed VPC via the transit gateway. This ensures that traffic from the {{site.konnect_short_name}} data plane reaches the service and the response packets are routed back correctly.
 
 
-## More Information
+## More information
 
 * [Dedicated Cloud Gateways](/konnect/dedicated-cloud-gateways/)
 * [Network Resiliency and availability](/konnect/network-resiliency/)

--- a/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
@@ -1,0 +1,57 @@
+---
+title: How to configure Transit Gateway
+---
+
+
+This guide will walk you through connecting your {{site.konnect_short_name}} managed Dedicated Cloud Gateways to AWS Transit Gateway, providing a secure and private channel for your API traffic.
+
+## Prerequsites 
+
+Before you start setting up the Transit Gateway with your {{site.konnect_short_name}} Dedicated Cloud Gateways, ensure that you have the following prerequisites:
+
+* A {{site.konnect_short_name}} Cloud Control Plane
+* AWS account with administrative privileges to create resources and manage peering.
+* The **AWS ID** which can be found in {{site.konnect_short_name}} by selecting the desired Network from **Gateway Manager** > **Networks**
+
+## Configure AWS Transit Gateway
+
+1. While logged in to AWS, select the same region as your cloud gateways network. 
+1. Select **VPC** > **Transit Gateways**, then click **Create Transit Gateway**.
+1. Name the transit gateway then click **Create Transit Gateway**. 
+
+This will display a **Transit Gateway ID**, save this. 
+
+### Configure AWS resources access
+
+1. Navigate to the **Resource Access Manager**, then click  **Create Resource Share**. 
+1. Select **Transit Gateways** as the resource type, and check the box for the transit gateway that you created in the previous section.
+1. Give the Resource Share a name.
+1. Click **Next** and leave the default managed permission settings as they are.
+1. On the next screen, select **Allow external accounts** and then choose **AWS Account**. Paste the **AWS ID** you copied from {{site.konnect_short_name}}.
+1. Click **Add**, and review your settings before clicking **Create**.
+
+After creating the resource share, copy the **RAM Share ARN**. You will need this to finish configuration in {{site.konnect_short_name}}
+
+### Configure {{site.konnect_short_name}}
+
+1. From {{site.konnect_short_name}} navigate to the **Gateway Manager**.
+1. Within the **Networks** tab, select the desired network then select **Attach Transit Gateway**.
+1. In the form that appears, enter a **Transit Gateway Name**
+1. Add one or more CIDR blocks that will be forwarded to your AWS Transit Gateway. Ensure these do not overlap with the CIDR of your cloud gateways network.
+1. Paste the **RAM Share ARN** and the **Transit Gateway ID** you saved earlier into the matching fields.
+1. For DNS configuration, add the IP addresses of DNS servers that will resolve to your private domains, along with any domains you want associated with your DNS.
+1. Click **Save**.
+
+### Accept Transit Gateway attachment request
+
+1. From the AWS Console > VPC > Transit Gateway Attachments.
+2. Wait for an attachment request coming from the **AWS Account ID** you used in {{site.konnect_short_name}}
+1. Accept the attachment to complete the setup.
+
+Once the transit gateway attachment is successful, add a route where the upstream services are running, and configure the route to forward all traffic for the {{site.konnect_short_name}} managed VPC via the transit gateway. This ensures that traffic from the {{site.konnect_short_name}} data plane reaches the service and the response packets are routed back correctly.
+
+
+## More Information
+
+* [Dedicated Cloud Gateways](/konnect/dedicated-cloud-gateways/)
+* [Network Resiliency and availbility](/konnect/network-resiliency/)

--- a/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
@@ -54,3 +54,4 @@ Once the transit gateway attachment is successful, add a route where the upstrea
 
 * [Dedicated Cloud Gateways](/konnect/dedicated-cloud-gateways/)
 * [Network Resiliency and availability](/konnect/network-resiliency/)
+* [Getting started with transit gateways - Amazon VPC](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-getting-started.html)

--- a/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
@@ -5,19 +5,18 @@ title: How to configure Transit Gateway
 
 This guide will walk you through connecting your {{site.konnect_short_name}} managed Dedicated Cloud Gateways to AWS Transit Gateway, providing a secure and private channel for your API traffic.
 
-## Prerequsites 
+## Prerequisites 
 
-Before you start setting up the Transit Gateway with your {{site.konnect_short_name}} Dedicated Cloud Gateways, ensure that you have the following prerequisites:
 
-* A {{site.konnect_short_name}} Cloud Control Plane
-* AWS account with administrative privileges to create resources and manage peering.
-* The **AWS ID** which can be found in {{site.konnect_short_name}} by selecting the desired Network from **Gateway Manager** > **Networks**
+* A {{site.konnect_short_name}} control plane
+* An AWS account with administrative privileges to create resources and manage peering
+* The **AWS ID**. You can find this in {{site.konnect_short_name}} by selecting the desired Network from **Gateway Manager** > **Networks**
 
 ## Configure AWS Transit Gateway
 
 1. While logged in to AWS, select the same region as your cloud gateways network. 
 1. Select **VPC** > **Transit Gateways**, then click **Create Transit Gateway**.
-1. Name the transit gateway then click **Create Transit Gateway**. 
+1. Name the transit gateway and then click **Create Transit Gateway**. 
 
 This will display a **Transit Gateway ID**, save this. 
 
@@ -45,7 +44,7 @@ After creating the resource share, copy the **RAM Share ARN**. You will need thi
 ### Accept Transit Gateway attachment request
 
 1. From the AWS Console > VPC > Transit Gateway Attachments.
-2. Wait for an attachment request coming from the **AWS Account ID** you used in {{site.konnect_short_name}}
+2. Wait for an attachment request coming from the AWS Account ID you used in {{site.konnect_short_name}}.
 1. Accept the attachment to complete the setup.
 
 Once the transit gateway attachment is successful, add a route where the upstream services are running, and configure the route to forward all traffic for the {{site.konnect_short_name}} managed VPC via the transit gateway. This ensures that traffic from the {{site.konnect_short_name}} data plane reaches the service and the response packets are routed back correctly.
@@ -54,4 +53,4 @@ Once the transit gateway attachment is successful, add a route where the upstrea
 ## More Information
 
 * [Dedicated Cloud Gateways](/konnect/dedicated-cloud-gateways/)
-* [Network Resiliency and availbility](/konnect/network-resiliency/)
+* [Network Resiliency and availability](/konnect/network-resiliency/)

--- a/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/transit-gateways.md
@@ -43,7 +43,7 @@ After creating the resource share, copy the **RAM Share ARN**. You will need thi
 
 ### Accept Transit Gateway attachment request
 
-1. From the AWS Console > VPC > Transit Gateway Attachments.
+1. From the **AWS Console > VPC > Transit Gateway Attachments**.
 2. Wait for an attachment request coming from the AWS Account ID you used in {{site.konnect_short_name}}.
 1. Accept the attachment to complete the setup.
 

--- a/app/konnect/getting-started/index.md
+++ b/app/konnect/getting-started/index.md
@@ -50,7 +50,7 @@ In the getting started guide, we will show you how to use a {{site.base_gateway}
 
 {{site.konnect_short_name}} features [Dedicated Cloud Gateways](/konnect/dedicated-cloud-gateways/), allowing for performant, scalable, and highly available global API management infrastructure. These gateways provide multi-region support with one-click provisioning and no downtime for upgrades. Offering scalability to handle varying API traffic workloads and support private networking for secure connections.
 
-Dedicated Cloud Gateways offers [Autopilot mode](/konnect/dedicated-cloud-gateways/#autopilot-mode), to streamlines the management of your API gateway resources by automatically adjusting to traffic and volume. This mode ensures that your infrastructure is prepared to handle traffic as it arrives, scaling resources to maintain consistent performance without manual intervention. 
+Dedicated Cloud Gateways offers [Autopilot mode](/konnect/dedicated-cloud-gateways/#autopilot-mode), to streamline the management of your API gateway resources by automatically adjusting to traffic and volume. This mode ensures that your infrastructure is prepared to handle traffic as it arrives, scaling resources to maintain consistent performance without manual intervention. 
 
 Dedicated Cloud Gateways can [private networking](/konnect/gateway-manager/data-plane-nodes/transit-gateways). Integration with [AWS Transit Gateway](https://aws.amazon.com/transit-gateway/), allows you to connect your networks in a way that supports your organization's security requirements, enabling your {{site.konnect_short_name}} powered API infrastructure to interact with your internal networks and cloud resources securely.
 

--- a/app/konnect/getting-started/index.md
+++ b/app/konnect/getting-started/index.md
@@ -48,11 +48,18 @@ In the getting started guide, we will show you how to use a {{site.base_gateway}
 
 ### Dedicated Cloud Gateways
 
-{{site.konnect_short_name}} features [Dedicated Cloud Gateways](/konnect/dedicated-cloud-gateways/), allowing for performant, scalable, and highly available global API management infrastructure. These gateways provide multi-region support with one-click provisioning and no downtime for upgrades. Offering scalability to handle varying API traffic workloads and support private networking for secure connections.
+{{site.konnect_short_name}} features [Dedicated Cloud Gateways](/konnect/dedicated-cloud-gateways/), allowing for performant, scalable, and highly available global API management infrastructure. 
+These gateways provide:
+* Multi-region support with one-click provisioning
+* No downtime for upgrades
+* Scalability to handle varying API traffic workloads
+* Private networking for secure connections
 
-Dedicated Cloud Gateways offers [Autopilot mode](/konnect/dedicated-cloud-gateways/#autopilot-mode), to streamline the management of your API gateway resources by automatically adjusting to traffic and volume. This mode ensures that your infrastructure is prepared to handle traffic as it arrives, scaling resources to maintain consistent performance without manual intervention. 
+You can run Dedicated Cloud Gateways in [autopilot mode](/konnect/dedicated-cloud-gateways/#autopilot-mode) to streamline the management of your API gateway resources by automatically adjusting to traffic and volume. 
+This mode ensures that your infrastructure is prepared to handle traffic as it arrives, scaling resources to maintain consistent performance without manual intervention. 
 
-Dedicated Cloud Gateways can [private networking](/konnect/gateway-manager/data-plane-nodes/transit-gateways). Integration with [AWS Transit Gateway](https://aws.amazon.com/transit-gateway/), allows you to connect your networks in a way that supports your organization's security requirements, enabling your {{site.konnect_short_name}} powered API infrastructure to interact with your internal networks and cloud resources securely.
+Dedicated Cloud Gateways also support [private networking](/konnect/gateway-manager/data-plane-nodes/transit-gateways). 
+Integration with [AWS Transit Gateway](https://aws.amazon.com/transit-gateway/), allows you to connect your networks in a way that supports your organization's security requirements, enabling your {{site.konnect_short_name}}-powered API infrastructure to interact with your internal networks and cloud resources securely.
 
 
 ### {{site.base_gateway}} entities in {{site.konnect_short_name}}

--- a/app/konnect/getting-started/index.md
+++ b/app/konnect/getting-started/index.md
@@ -46,15 +46,18 @@ In the getting started guide, we will show you how to use a {{site.base_gateway}
 
 > Figure 1: Diagram of {{site.konnect_short_name}} modules. The {{site.konnect_short_name}} environment, hosted by Kong, consists of the {{site.konnect_short_name}} applications, {{site.konnect_short_name}} platform, and control planes. The {{site.base_gateway}}, {{site.mesh_product_name}}, and {{site.kic_product_name}} data plane nodes that are connected with the {{site.konnect_short_name}} platform are self-managed.
 
+### Dedicated Cloud Gateways
+
+{{site.konnect_short_name}} features [Dedicated Cloud Gateways](/konnect/dedicated-cloud-gateways/), allowing for performant, scalable, and highly available global API management infrastructure. These gateways provide multi-region support with one-click provisioning and no downtime for upgrades. Offering scalability to handle varying API traffic workloads and support private networking for secure connections.
+
+Dedicated Cloud Gateways offers [Autopilot mode](/konnect/dedicated-cloud-gateways/#autopilot-mode), to streamlines the management of your API gateway resources by automatically adjusting to traffic and volume. This mode ensures that your infrastructure is prepared to handle traffic as it arrives, scaling resources to maintain consistent performance without manual intervention. 
+
+Dedicated Cloud Gateways can [private networking](/konnect/gateway-manager/data-plane-nodes/transit-gateways). Integration with [AWS Transit Gateway](https://aws.amazon.com/transit-gateway/), allows you to connect your networks in a way that supports your organization's security requirements, enabling your {{site.konnect_short_name}} powered API infrastructure to interact with your internal networks and cloud resources securely.
+
+
 ### {{site.base_gateway}} entities in {{site.konnect_short_name}}
 
-Entities, like services, are self-hosted in {{site.base_gateway}}.
-
-![{{site.konnect_product_name}}](/assets/images/products/konnect/getting-started/konnect-gateway-entities.png)
-
-> Figure 2: Diagram that describes how entities, like services, routes, consumers, and load balancers, are self-hosted by the {{site.base_gateway}} data plane node.
-
-Each self-hosted {{site.base_gateway}} data plane node contains the following entities:
+Each {{site.base_gateway}} data plane node contains the following entities:
 
 * [**Services:**](/gateway/latest/key-concepts/services/) A service is an entity representing an external upstream API or microservice. For example, a data transformation microservice, a billing API, and so on.
 * [**Routes:**](/gateway/latest/key-concepts/routes/) Routes determine how (and if) requests are sent to their services after they reach the gateway. Where a service represents the backend API, a route defines what is exposed to clients. A single service can have many routes. Once a route is matched, the gateway proxies the request to its associated service.


### PR DESCRIPTION
Updates the getting started doc to add an explanation of cloud gateways
Adds a doc that explains how to configure transit gateways. 


https://deploy-preview-7151--kongdocs.netlify.app/

https://deploy-preview-7151--kongdocs.netlify.app/konnect/getting-started/
https://deploy-preview-7151--kongdocs.netlify.app/konnect/gateway-manager/data-plane-nodes/transit-gateways/
