### PR TITLE
feat(plugins): tracing headers propagation

### DIFF
--- a/app/_hub/kong-inc/opentelemetry/overview/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/overview/_index.md
@@ -208,9 +208,12 @@ The OpenTelemetry plugin supports propagation of the following header formats:
 {% if_plugin_version gte:3.7.x %}
 {% include /md/plugins-hub/tracing-headers-propagation.md %}
 
-Refer to the [Configuration reference](/hub/kong-inc/opentelemetry/configuration/#config-propagation) for a complete overview of the available options and values.
+Refer to the plugin's [configuration reference](/hub/kong-inc/opentelemetry/configuration/#config-propagation) for a complete overview of the available options and values.
 
-**Note:** if any of the `propagation.*` configuration options: `extract`, `clear`, `inject` is configured, the `propagation` configuration takes precedence over the deprecated `header_type` parameter. If none of the `propagation.*` configuration options are set, the `header_type` parameter is still used to determine the propagation behavior.
+
+{:.note}
+> **Note:** If any of the `propagation.*` configuration options (`extract`, `clear`, or `inject`) are configured, the `propagation` configuration takes precedence over the deprecated `header_type` parameter. 
+If none of the `propagation.*` configuration options are set, the `header_type` parameter is still used to determine the propagation behavior.
 {% endif_plugin_version %}
 {% if_plugin_version lte:3.6.x %}
 The plugin detects the propagation format from the headers and will use the appropriate format to propagate the span context.

--- a/app/_hub/kong-inc/opentelemetry/overview/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/overview/_index.md
@@ -192,12 +192,12 @@ The top level span has the following attributes:
 
 ### Propagation
 
-The OpenTelemetry plugin propagates the following headers:
+The OpenTelemetry plugin supports propagation of the following header formats:
 - `w3c`: [W3C trace context](https://www.w3.org/TR/trace-context/)
 - `b3` and `b3-single`: [Zipkin headers](https://github.com/openzipkin/b3-propagation)
 - `jaeger`: [Jaeger headers](https://www.jaegertracing.io/docs/client-libraries/#propagation-format)
 - `ot`: [OpenTracing headers](https://github.com/opentracing/specification/blob/master/rfc/trace_identifiers.md)
-- `datadog`: [Datadog headers](https://docs.datadoghq.com/tracing/trace_collection/library_config/go/#trace-context-propagation-for-distributed-tracing) (Enterprise only)
+- `datadog`: [Datadog headers](https://docs.datadoghq.com/tracing/trace_collection/library_config/go/#trace-context-propagation-for-distributed-tracing)
 {% if_plugin_version gte:3.4.x %}
 - `aws`: [AWS X-Ray header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
 {% endif_plugin_version %}
@@ -205,8 +205,18 @@ The OpenTelemetry plugin propagates the following headers:
 - `gcp`: [GCP X-Cloud-Trace-Context header](https://cloud.google.com/trace/docs/setup#force-trace)
 {% endif_plugin_version %}
 
+{% if_plugin_version gte:3.7.x %}
+{% include /md/plugins-hub/tracing-headers-propagation.md %}
+
+Refer to the [Configuration reference](/hub/kong-inc/opentelemetry/configuration/#config-propagation) for a complete overview of the available options and values.
+
+**Note:** if any of the `propagation.*` configuration options: `extract`, `clear`, `inject` is configured, the `propagation` configuration takes precedence over the deprecated `header_type` parameter. If none of the `propagation.*` configuration options are set, the `header_type` parameter is still used to determine the propagation behavior.
+{% endif_plugin_version %}
+{% if_plugin_version lte:3.6.x %}
 The plugin detects the propagation format from the headers and will use the appropriate format to propagate the span context.
 If no appropriate format is found, the plugin will fallback to the default format, which is `w3c`.
+{% endif_plugin_version %}
+
 
 ### OTLP exporter
 

--- a/app/_hub/kong-inc/zipkin/overview/_index.md
+++ b/app/_hub/kong-inc/zipkin/overview/_index.md
@@ -122,9 +122,11 @@ The Zipkin plugin supports propagation of the following header formats:
 {% if_plugin_version gte:3.7.x %}
 {% include /md/plugins-hub/tracing-headers-propagation.md %}
 
-Refer to the [Configuration reference](/hub/kong-inc/zipkin/configuration/#config-propagation) for a complete overview of the available options and values.
+Refer to the plugin's [configuration reference](/hub/kong-inc/zipkin/configuration/#config-propagation) for a complete overview of the available options and values.
 
-**Note:** if any of the `propagation.*` configuration options: `extract`, `clear`, `inject` is configured, the `propagation` configuration takes precedence over the deprecated `header_type` and `default_header_type` parameters. If none of the `propagation.*` configuration options are set, the `header_type` and `default_header_type` parameters are still used to determine the propagation behavior.
+{:.note}
+> **Note:** If any of the `propagation.*` configuration options (`extract`, `clear`,  or `inject`) are configured, the `propagation` configuration takes precedence over the deprecated `header_type` and `default_header_type` parameters. 
+If none of the `propagation.*` configuration options are set, the `header_type` and `default_header_type` parameters are still used to determine the propagation behavior.
 {% endif_plugin_version %}
 {% if_plugin_version lte:3.6.x %}
 The plugin detects the propagation format from the headers and will use the appropriate format to propagate the span context.

--- a/app/_hub/kong-inc/zipkin/overview/_index.md
+++ b/app/_hub/kong-inc/zipkin/overview/_index.md
@@ -104,6 +104,33 @@ Contains the following tags specific to load balancing:
   * `kong.balancer.state`: An NGINX-specific description of the error, `next/failed` for HTTP failures, or `0` for stream failures.
      Equivalent to `state_name` in OpenResty's balancer's `get_last_failure` function.
 
+### Propagation
+
+The Zipkin plugin supports propagation of the following header formats:
+- `w3c`: [W3C trace context](https://www.w3.org/TR/trace-context/)
+- `b3` and `b3-single`: [Zipkin headers](https://github.com/openzipkin/b3-propagation)
+- `jaeger`: [Jaeger headers](https://www.jaegertracing.io/docs/client-libraries/#propagation-format)
+- `ot`: [OpenTracing headers](https://github.com/opentracing/specification/blob/master/rfc/trace_identifiers.md)
+- `datadog`: [Datadog headers](https://docs.datadoghq.com/tracing/trace_collection/library_config/go/#trace-context-propagation-for-distributed-tracing)
+{% if_plugin_version gte:3.4.x %}
+- `aws`: [AWS X-Ray header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
+{% endif_plugin_version %}
+{% if_plugin_version gte:3.5.x %}
+- `gcp`: [GCP X-Cloud-Trace-Context header](https://cloud.google.com/trace/docs/setup#force-trace)
+{% endif_plugin_version %}
+
+{% if_plugin_version gte:3.7.x %}
+{% include /md/plugins-hub/tracing-headers-propagation.md %}
+
+Refer to the [Configuration reference](/hub/kong-inc/zipkin/configuration/#config-propagation) for a complete overview of the available options and values.
+
+**Note:** if any of the `propagation.*` configuration options: `extract`, `clear`, `inject` is configured, the `propagation` configuration takes precedence over the deprecated `header_type` and `default_header_type` parameters. If none of the `propagation.*` configuration options are set, the `header_type` and `default_header_type` parameters are still used to determine the propagation behavior.
+{% endif_plugin_version %}
+{% if_plugin_version lte:3.6.x %}
+The plugin detects the propagation format from the headers and will use the appropriate format to propagate the span context.
+If no appropriate format is found, the plugin will fallback to the default format, which is `b3`.
+{% endif_plugin_version %}
+
 ### See also
 
 For more information, read the [Kong blog post](https://konghq.com/blog/tracing-with-zipkin-in-kong-2-1-0).

--- a/app/_includes/md/plugins-hub/tracing-headers-propagation.md
+++ b/app/_includes/md/plugins-hub/tracing-headers-propagation.md
@@ -1,0 +1,82 @@
+This plugin offers extensive options for configuring tracing header propagation, providing a high degree of flexibility.
+Users can freely customize which headers are used to extract and inject tracing context. Additionally, they have the ability to configure headers to be cleared after the tracing context extraction process, enabling a high level of customization.
+
+<!--vale off-->
+{% mermaid %}
+flowchart LR
+   id1(Original Request) --> Extract
+   id1(Original Request) -->|"headers (original)"| Extract
+   id1(Original Request) --> Extract
+   subgraph ide1 [Headers Propagation]
+   Extract --> Clear
+   Extract -->|"headers (original)"| Clear
+   Extract --> Clear
+   Clear -->|"headers (filtered)"| Inject
+   end
+   Extract -.->|extracted ctx| id2((tracing logic))
+   id2((tracing logic)) -.->|updated ctx| Inject
+   Inject -->|"headers (updated ctx)"| id3(Updated request)
+{% endmermaid %}
+<!--vale on-->
+
+The examples below demonstrate how the propagation configuration options can be used to achieve various use cases.
+
+#### Extract, clear and inject
+- Extract the tracing context using order of precedence: `w3c` > `b3` > `jaeger` > `ot` > `aws` > `datadog`
+- Clear `b3` and `uber-trace-id` headers after extraction, if present in the request
+- Inject the tracing context using the format: `w3c`
+
+```yaml
+- config:
+    propagation:	
+      extract: [ w3c, b3, jaeger, ot, aws, datadog ]
+      clear: [ b3, uber-trace-id ]
+      inject: [ w3c ]
+```
+
+#### Multiple injection
+- Extract the tracing context from: `b3`
+- Inject the tracing context using the formats: `w3c`, `b3`, `jaeger`, `ot`, `aws`, `datadog`, `gcp`
+
+```yaml
+- config:
+    propagation:	
+      extract: [ b3 ]
+      inject: [ w3c, b3, jaeger, ot, aws, datadog, gcp ]
+```
+
+#### Preserve incoming format
+- Extract the tracing context using order of precedence: `w3c` > `b3` > `jaeger` > `ot` > `aws` > `datadog`
+- Inject the tracing context **in the extracted header type**
+- Default to `w3c` for context injection if none of the `extract` header types were found in the request
+
+```yaml
+- config:
+    propagation:	
+      extract: [ w3c, b3, jaeger, ot, aws, datadog ]
+      inject: [ preserve ]
+      default_format: "w3c"
+```
+
+**Note:** `preserve` can be used with other formats, to specify that the incoming format should be preserved in addition to the others:
+
+```yaml
+- config:
+    propagation:	
+      extract: [ w3c, b3, jaeger, ot, datadog ]
+      inject: [ aws, preserve, datadog ]
+      default_format: "w3c"
+```
+
+#### Ignore incoming headers
+- No tracing context extraction
+- Inject the tracing context using the formats: `b3`, `datadog`
+
+```yaml
+- config:
+    propagation:	
+      extract: [ ]
+      inject: [ b3, datadog ]
+```
+
+**Note:** Some header formats specify different trace and span ID sizes. When the tracing context is extracted and injected from/to headers with different ID sizes, the IDs are truncated or left-padded to align with the target format.

--- a/app/_includes/md/plugins-hub/tracing-headers-propagation.md
+++ b/app/_includes/md/plugins-hub/tracing-headers-propagation.md
@@ -19,9 +19,9 @@ flowchart LR
 {% endmermaid %}
 <!--vale on-->
 
-The examples below demonstrate how the propagation configuration options can be used to achieve various use cases.
+The following examples demonstrate how the propagation configuration options can be used to achieve various use cases.
 
-#### Extract, clear and inject
+#### Extract, clear, and inject
 - Extract the tracing context using order of precedence: `w3c` > `b3` > `jaeger` > `ot` > `aws` > `datadog`
 - Clear `b3` and `uber-trace-id` headers after extraction, if present in the request
 - Inject the tracing context using the format: `w3c`
@@ -58,7 +58,7 @@ The examples below demonstrate how the propagation configuration options can be 
       default_format: "w3c"
 ```
 
-**Note:** `preserve` can be used with other formats, to specify that the incoming format should be preserved in addition to the others:
+`preserve` can also be used with other formats, to specify that the incoming format should be preserved in addition to the others:
 
 ```yaml
 - config:
@@ -79,4 +79,5 @@ The examples below demonstrate how the propagation configuration options can be 
       inject: [ b3, datadog ]
 ```
 
-**Note:** Some header formats specify different trace and span ID sizes. When the tracing context is extracted and injected from/to headers with different ID sizes, the IDs are truncated or left-padded to align with the target format.
+{:.note}
+> **Note:** Some header formats specify different trace and span ID sizes. When the tracing context is extracted and injected from/to headers with different ID sizes, the IDs are truncated or left-padded to align with the target format.


### PR DESCRIPTION
### Description

Documentation for the new (3.7.0.0+) tracing headers propagation module, available to the OpenTelemetry and Zipkin plugins.

### Testing instructions

Preview link: 
https://deploy-preview-7161--kongdocs.netlify.app/hub/kong-inc/opentelemetry/unreleased/#propagation
https://deploy-preview-7161--kongdocs.netlify.app/hub/kong-inc/zipkin/unreleased/#propagation

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

KAG-4105