### PR TITLE
Fix: Spacing on Gateway Docker install page

### DIFF
--- a/app/_src/gateway/install/docker/index.md
+++ b/app/_src/gateway/install/docker/index.md
@@ -123,6 +123,7 @@ kong:{{page.versions.ce}} kong migrations bootstrap
     In order, this is the Kong Gateway container name and tag, followed by the
     command to Kong to prepare the Postgres database.
 <!-- vale on -->
+
 ### Start {{site.base_gateway}}
 
 {% include_cached /md/admin-listen.md desc='long' release=page.release %}


### PR DESCRIPTION
### Description

Fixing this issue with the "Start Kong Gateway" heading:
![Screenshot 2024-04-03 at 7 47 11 AM](https://github.com/Kong/docs.konghq.com/assets/54370747/36452e40-399f-465c-acf7-911411ce1f04)


### Testing instructions

Preview link: https://deploy-preview-7162--kongdocs.netlify.app/gateway/3.6.x/install/docker/
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

