### PR TITLE
Update: Licensing Admin API updates and Troubleshooting section links

### DIFF
--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -81,7 +81,7 @@ Result:
 For more detail and options, see the
 [Admin API `licenses` endpoint reference](/gateway/latest/licenses/examples).
 
-It is recommended to [restart](https://docs.konghq.com/gateway/latest/production/running-kong/systemd/#restart-kong-gateway) the Kong Gateway nodes after applying or modifying a license.
+It is recommended to [restart](https://docs.konghq.com/gateway/latest/production/running-kong/systemd/#restart-kong-gateway) the Kong Gateway nodes after applying or updating a license.
 
 {% endnavtab %}
 {% navtab Filesystem %}

--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -81,6 +81,8 @@ Result:
 For more detail and options, see the
 [Admin API `licenses` endpoint reference](/gateway/latest/licenses/examples).
 
+It is recommended to [restart](https://docs.konghq.com/gateway/latest/production/running-kong/systemd/#restart-kong-gateway) the Kong Gateway nodes after applying or modifying a license.
+
 {% endnavtab %}
 {% navtab Filesystem %}
 

--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -81,7 +81,7 @@ Result:
 For more detail and options, see the
 [Admin API `licenses` endpoint reference](/gateway/latest/licenses/examples).
 
-It is recommended to [restart](https://docs.konghq.com/gateway/latest/production/running-kong/systemd/#restart-kong-gateway) the Kong Gateway nodes after applying or updating a license.
+We recommend [restarting](/gateway/{{page.release}}/reference/cli/#kong-restart) the {{site.base_gateway}} nodes after applying or updating a license.
 
 {% endnavtab %}
 {% navtab Filesystem %}

--- a/app/_src/gateway/licenses/deploy.md
+++ b/app/_src/gateway/licenses/deploy.md
@@ -11,7 +11,7 @@ to [Enterprise-specific features](/gateway/{{page.release}}/licenses/).
 ## Troubleshooting and support
 
 For troubleshooting license issues, see:
-* [License Troubleshooting](/gateway/latest/licenses/#troubleshooting)
+* [License Troubleshooting](/gateway/{{page.release}}/licenses/#troubleshooting)
 
 For more details and examples, see:
 * [`/licenses` API reference](/gateway/api/admin-ee/latest/#/licenses)

--- a/app/_src/gateway/licenses/deploy.md
+++ b/app/_src/gateway/licenses/deploy.md
@@ -11,6 +11,9 @@ to [Enterprise-specific features](/gateway/{{page.release}}/licenses/).
 ## Troubleshooting and support
 
 For troubleshooting license issues, see:
+* [License Troubleshooting](/gateway/latest/licenses/#troubleshooting)
+
+For more details and examples, see:
 * [`/licenses` API reference](/gateway/api/admin-ee/latest/#/licenses)
 * [`/licenses` API examples](/gateway/{{page.release}}/licenses/examples/)
 

--- a/app/_src/gateway/licenses/examples.md
+++ b/app/_src/gateway/licenses/examples.md
@@ -144,7 +144,9 @@ Response:
 }
 ```
 
-Ensure to [restart](https://docs.konghq.com/gateway/latest/production/running-kong/systemd/#restart-kong-gateway) the Kong Gateway nodes after updating a license.
+Ensure to [restart](/gateway/{{page.release}}/reference/cli/#kong-restart) the {{site.base_gateway}} nodes after updating a license.
+
+
 
 ## Generate license report
 

--- a/app/_src/gateway/licenses/examples.md
+++ b/app/_src/gateway/licenses/examples.md
@@ -144,6 +144,8 @@ Response:
 }
 ```
 
+Ensure to [restart](https://docs.konghq.com/gateway/latest/production/running-kong/systemd/#restart-kong-gateway) the Kong Gateway nodes after updating a license.
+
 ## Generate license report
 
 To generate a report, submit a `GET` request directly to `/license/report`:


### PR DESCRIPTION
### Description

* Added notes about restarting the Kong Gateway nodes/service when updating a license.
* Linked the Troubleshooting documentation from Overview page on the Deploy page.

Added because this was an occasional issue with customers after updating a license where they kept seeing warnings in the logs and Kong Manager UI about an expiring license after updating it.

### Testing instructions

Preview link: 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.