### PR TITLE
docs(api): define ordering of audit log requests

### DIFF
--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -232,6 +232,24 @@ components:
       schema:
         type: string
       description: The unique identifier of the filter chain to retrieve.
+    BeforeAuditLogFilter:
+      name: before_audit_log_filter
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/RequestTimestampFilterSchema'
+      description: |
+        Before filter could be used to request audit log data that was recorded before certain time (exclusive).
+        It can either be a timestamp as Unix Epoch or a string following RFC3339 Schema (without fractions of a second) - ex: '2024-04-25T15:03:24Z'
+    AfterAuditLogFilter:
+      name: after_audit_log_filter
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/RequestTimestampFilterSchema'
+      description: |
+        After filter could be used to request audit log data that was recorded after certain time (inclusive).
+        It can either be a timestamp as Unix Epoch or a string following RFC3339 Schema (without fractions of a second) - ex: '2024-04-25T15:03:24Z'
   schemas:
     UnauthorizedError:
       type: object
@@ -1275,6 +1293,11 @@ components:
           type: array
           items:
             type: string
+    RequestTimestampFilterSchema:
+      oneOf:
+        - type: string
+          pattern: '^(\d+|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$'
+        - type: integer
   responses:
     HTTP401Error:
       content:
@@ -14133,6 +14156,9 @@ paths:
   /audit/requests:
     get:
       summary: List request audit logs
+      parameters:
+        - $ref: '#/components/parameters/befpre_audit_log_filter'
+        - $ref: '#/components/parameters/after_audit_log_filter'
       tags:
         - audit-logs
       responses:
@@ -14148,6 +14174,9 @@ paths:
   /audit/objects:
     get:
       summary: List database audit logs
+      parameters:
+        - $ref: '#/components/parameters/befpre_audit_log_filter'
+        - $ref: '#/components/parameters/after_audit_log_filter'
       responses:
         '200':
           $ref: '#/components/responses/database-audit-log-response'

--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -14143,6 +14143,7 @@ paths:
       operationId: get-audit-requests
       description: |-
         You can access request and database audit logs through the Admin API.
+        The default order of audit log is by request timestamp - latest to oldest.
         For usage examples, see [Audit Logging in Kong Gateway](https://docs.konghq.com/gateway/latest/kong-enterprise/audit-log/).
   /audit/objects:
     get:
@@ -14155,7 +14156,7 @@ paths:
       operationId: get-audit-objects
       tags:
         - audit-logs
-      description: List database audit logs
+      description: List database audit logs (ordered by request timestamp - latest to oldest)
   /event-hooks:
     get:
       summary: List all event hooks
@@ -14779,7 +14780,7 @@ tags:
       A filter chain is the database entity representing one or more WebAssembly filters executed for each request to a particular service or route, each one with its configuration.
     name: filter-chains
   - description: |
-      You can access request and database audit logs through the Admin API.
+      You can access request and database audit logs through the Admin API. The default order of audit log is by request timestamp - latest to oldest.
       <br><br>
       For usage examples, see [Audit Logging in Kong Gateway](https://docs.konghq.com/gateway/latest/admin-api/audit-logs/).
     name: audit-logs


### PR DESCRIPTION
### Description

Audit Log request were previously sorted by `request_id`. With the upcoming changes they'll be sorted by `request_timestamp` descending - which is from latest to oldest.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.


