### PR TITLE
Add templated KGO PodTemplateSpec examples

### DIFF
--- a/app/_plugins/blocks/kgo_podtemplatespec_example.rb
+++ b/app/_plugins/blocks/kgo_podtemplatespec_example.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class KGOPodtemplatespecExample < Liquid::Block
+    def render(context)
+      spec = super
+
+      config = YAML.safe_load(spec)
+
+      gateway_config_api_version = config['gatewayConfigApiVersion']
+      dp = config['dataplane'].to_yaml.split("\n")[1..].join("\n")
+      cp = config['controlplane'].to_yaml.split("\n")[1..].join("\n")
+
+      <<~TEXT
+        #{dataplane_example(dp) if config['dataplane']}#{' '}
+        #{gateway_config_example(gateway_config_api_version, dp, cp)}
+      TEXT
+    end
+
+    private
+
+    def config_example(field, spec)
+      return '' if spec.empty?
+
+      options = <<~SPEC
+        #{field}:
+          deployment:
+            podTemplateSpec:
+              #{spec.split("\n").map { |line| "      #{line}" }.join("\n").strip}
+      SPEC
+
+      options.split("\n").map { |line| "      #{line}" }.join("\n").strip
+    end
+
+    def gateway_config_example(gateway_config_api_version, dataplane, controlplane)
+      <<~TEXT
+
+        ### Using GatewayConfiguration
+
+        {:.note}
+        > This method is only available when running in [DB-less mode](/gateway-operator/{{ page.release }}/topologies/dbless/)
+
+        The `GatewayConfiguration` resource is a Kong-specific API which allows you to set both `controlPlaneOptions` and `dataPlaneOptions`.
+
+        You can customize both the container image and version.
+        1.  Define the image in the `GatewayConfiguration`.
+            ```yaml
+            kind: GatewayConfiguration
+            apiVersion: gateway-operator.konghq.com/#{gateway_config_api_version}
+            metadata:
+              name: kong
+              namespace: default
+            spec:
+              #{config_example('dataPlaneOptions', dataplane)}
+              #{config_example('controlPlaneOptions', controlplane)}
+            ```
+
+        1.  Reference this configuration in the `GatewayClass` resource for the deployment.
+
+            ```yaml
+            kind: GatewayClass
+            apiVersion: gateway.networking.k8s.io/v1beta1
+            metadata:
+              name: kong
+            spec:
+              controllerName: konghq.com/gateway-operator
+              parametersRef:
+                group: gateway-operator.konghq.com
+                kind: GatewayConfiguration
+                name: kong
+                namespace: default
+            ```
+      TEXT
+    end
+
+    def dataplane_example(spec) # rubocop:disable Metrics/MethodLength
+      return '' if spec.empty?
+
+      <<~TEXT
+        ### Using DataPlane
+
+        {:.note}
+        > This method is only available when running in [hybrid mode](/gateway-operator/{{ page.release }}/topologies/hybrid/)
+
+        The `DataPlane` resource uses the Kubernetes [PodTemplateSpec](/gateway-operator/{{ page.release }}/customization/pod-template-spec/) to define how the Pods should run.
+
+        ```yaml
+        apiVersion: gateway-operator.konghq.com/v1beta1
+        kind: DataPlane
+        metadata:
+          name: dataplane-example
+          namespace: kong
+        spec:
+          deployment:
+            podTemplateSpec:
+              #{spec.split("\n").map { |line| "      #{line}" }.join("\n").strip}
+        ```
+      TEXT
+    end
+  end
+end
+
+Liquid::Template.register_tag('kgo_podtemplatespec_example', Jekyll::KGOPodtemplatespecExample)

--- a/app/_src/gateway-operator/customization/data-plane-image.md
+++ b/app/_src/gateway-operator/customization/data-plane-image.md
@@ -9,72 +9,16 @@ title: Customizing the Data Plane image
 
 You can customize the image of your `DataPlane` using  the `DataPlane` resource or the `GatewayConfiguration` CRD .
 
-## Using DataPlane
-
-{:.note}
-> This method is only available when running in [hybrid mode](/gateway-operator/{{ page.release }}/topologies/hybrid/)
-
-The `DataPlane` resource uses the Kubernetes [PodTemplateSpec](/gateway-operator/{{ page.release }}/customization/pod-template-spec/) to define how the Pods should run. Set the`spec.deployment.podTemplateSpec.spec.containers[].image` to customize the {{ site.base_gateway }} image.
-
-```yaml
-apiVersion: gateway-operator.konghq.com/v1beta1
-kind: DataPlane
-metadata:
-  name: dataplane-example
-  namespace: kong
-spec:
-  deployment:
-    podTemplateSpec:
-      spec:
-        containers:
-        - name: proxy
-          image: kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
-```
-
-## Using GatewayConfiguration
-
-{:.note}
-> This method is only available when running in [DB-less mode](/gateway-operator/{{ page.release }}/topologies/dbless/)
-
-The `GatewayConfiguration` resource is a Kong-specific API which allows you to set both `controlPlaneOptions` and `dataPlaneOptions`.
-
-You can customize both the container image and version.
-1.  Define the image in the `GatewayConfiguration`.
-    ```yaml
-    kind: GatewayConfiguration
-    apiVersion: gateway-operator.konghq.com/{{ gatewayConfigApiVersion }}
-    metadata:
-      name: kong
-      namespace: default
-    spec:
-      dataPlaneOptions:
-        deployment:
-          podTemplateSpec:
-            spec:
-              containers:
-              - name: proxy
-                image: kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
-      controlPlaneOptions:
-        deployment:
-          podTemplateSpec:
-            spec:
-              containers:
-              - name: controller
-                image: kong/kubernetes-ingress-controller:{{ site.data.kong_latest_KIC.version }}
-    ```
-
-1.  Reference this configuration in the `GatewayClass` resource for the deployment.
-
-    ```yaml
-    kind: GatewayClass
-    apiVersion: gateway.networking.k8s.io/v1beta1
-    metadata:
-      name: kong
-    spec:
-      controllerName: konghq.com/gateway-operator
-      parametersRef:
-        group: gateway-operator.konghq.com
-        kind: GatewayConfiguration
-        name: kong
-        namespace: default
-    ```
+{% kgo_podtemplatespec_example %}
+gatewayConfigApiVersion: {{ gatewayConfigApiVersion }}
+dataplane:
+  spec:
+    containers:
+    - name: proxy
+      image: kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
+controlplane:
+  spec:
+    containers:
+    - name: controller
+      image: kong/kubernetes-ingress-controller:{{ site.data.kong_latest_KIC.version }}
+{% endkgo_podtemplatespec_example %}

--- a/app/_src/gateway-operator/customization/pod-template-spec.md
+++ b/app/_src/gateway-operator/customization/pod-template-spec.md
@@ -2,9 +2,24 @@
 title: Using PodTemplateSpec
 ---
 
-The `DataPlane` resource uses the Kubernetes [PodTemplateSpec](/gateway-operator/{{ page.release }}/customization/pod-template-spec/) to define how pods should run. You can customize everything you need to in your deployment using this resource.
+The Kubernetes `PodTemplateSpec` defines how pods should run. You can customize everything you need to in your deployment using this resource.
 
 For more information see the [PodTemplateSpec documentation](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-template-v1/#PodTemplateSpec).
+
+A `PodTemplateSpec` can be provided on both `GatewayConfiguration` and `DataPlane` resources.
+
+## GatewayConfiguration
+
+When using the `GatewayConfiguration` resource, the `ControlPlane` and `DataPlane` resources are configured independently.
+
+* `ControlPlane` pods take their configuration from the `spec.controlPlaneOptions.deployment.podTemplateSpec` field.
+* `DataPlane` pods take their configuration from the `spec.dataPlaneOptions.deployment.podTemplateSpec` field.
+
+## DataPlane
+
+When using the `DataPlane` resource directly, you specify `spec.deployment.podTemplateSpec`.
+
+## Common Usage
 
 Here are some examples for the most common use of `PodTemplateSpec`:
 

--- a/app/_src/gateway-operator/customization/sidecars.md
+++ b/app/_src/gateway-operator/customization/sidecars.md
@@ -2,9 +2,16 @@
 title: Deploying Sidecars
 ---
 
+{% assign gatewayConfigApiVersion = "v1beta1" %}
+{% if_version lte:1.1.x %}
+{% assign gatewayConfigApiVersion = "v1alpha1" %}
+{% endif_version %}
+
 {{ site.kgo_product_name }} uses [PodTemplateSpec](/gateway-operator/{{ page.release }}/customization/pod-template-spec/) to customize deployments.
 
-Here is an example that deploys a [Vector](https://vector.dev/) sidecar alongside the proxy containers:
+Here is an example that deploys a [Vector](https://vector.dev/) sidecar alongside the proxy containers.
+
+## Configure vector.dev
 
 ```yaml
 apiVersion: v1
@@ -20,57 +27,56 @@ data:
     type = "console"
     inputs = [ "proxy_access_log_source" ]
     encoding.codec = "json"
----
-apiVersion: gateway-operator.konghq.com/v1beta1
-kind: DataPlane
-metadata:
-  name: sidecar-example
-spec:
-  deployment:
-    podTemplateSpec:
-      metadata:
-        labels:
-          dataplane-pod-label: example
-        annotations:
-          dataplane-pod-annotation: example
-      spec:
-        volumes:
-        - name: cluster-certificate
-        - name: sidecar-vector-config-volume
-          configMap:
-            name: sidecar-vector-config
-        - name: proxy-logs
-          emptyDir:
-            sizeLimit: 128Mi
-        containers:
-        - name: sidecar
-          image: timberio/vector:0.31.0-debian
-          volumeMounts:
-          - name: sidecar-vector-config-volume
-            mountPath: /etc/vector
-          - name: proxy-logs
-            mountPath: /etc/kong/log/
-          readinessProbe:
-            initialDelaySeconds: 1
-            periodSeconds: 1
-        - name: proxy
-          image: kong:3.4
-          volumeMounts:
-          - name: proxy-logs
-            mountPath: /etc/kong/log/
-          env:
-          - name: KONG_LOG_LEVEL
-            value: debug
-          - name: KONG_PROXY_ACCESS_LOG
-            value: /etc/kong/log/proxy_access.log
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "250m"
-            limits:
-              memory: "1024Mi"
-              cpu: "1000m"
-          readinessProbe:
-            initialDelaySeconds: 1
-            periodSeconds: 1
 ```
+
+## Configure PodTemplateSpec
+
+{% kgo_podtemplatespec_example %}
+gatewayConfigApiVersion: {{ gatewayConfigApiVersion }}
+dataplane:
+  metadata:
+    labels:
+      dataplane-pod-label: example
+    annotations:
+      dataplane-pod-annotation: example
+  spec:
+    volumes:
+    - name: cluster-certificate
+    - name: sidecar-vector-config-volume
+      configMap:
+        name: sidecar-vector-config
+    - name: proxy-logs
+      emptyDir:
+        sizeLimit: 128Mi
+    containers:
+    - name: sidecar
+      image: timberio/vector:0.31.0-debian
+      volumeMounts:
+      - name: sidecar-vector-config-volume
+        mountPath: /etc/vector
+      - name: proxy-logs
+        mountPath: /etc/kong/log/
+      readinessProbe:
+        initialDelaySeconds: 1
+        periodSeconds: 1
+    - name: proxy
+      image: kong:3.4
+      volumeMounts:
+      - name: proxy-logs
+        mountPath: /etc/kong/log/
+      env:
+      - name: KONG_LOG_LEVEL
+        value: debug
+      - name: KONG_PROXY_ACCESS_LOG
+        value: /etc/kong/log/proxy_access.log
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "250m"
+        limits:
+          memory: "1024Mi"
+          cpu: "1000m"
+      readinessProbe:
+        initialDelaySeconds: 1
+        periodSeconds: 1
+{% endkgo_podtemplatespec_example %}


### PR DESCRIPTION
### Description

Add a `kgo_podtemplatespec_example` tag that allows us to show `PodTemplateSpec` for both `DataPlane` and `GatewayConfiguration` use cases without duplication

### Testing instructions

Preview link: https://deploy-preview-7180--kongdocs.netlify.app/gateway-operator/1.2.x/customization/data-plane-image/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
