### PR TITLE
Release: decK 1.36.x

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -364,6 +364,7 @@ nameserver
 nameservers
 namespace
 namespaced
+namespacing
 namespaces
 NAT
 NATs

--- a/app/_data/docs_nav_deck_1.37.x.yml
+++ b/app/_data/docs_nav_deck_1.37.x.yml
@@ -1,10 +1,10 @@
 product: deck
-release: 1.36.x
+release: 1.37.x
 generate: true
 items:
   - title: Introduction
     icon: /assets/images/icons/documentation/icn-flag.svg
-    url: /deck/1.36.x/
+    url: /deck/1.37.x/
     absolute_url: true
     items:
       - text: Terminology

--- a/app/_data/docs_nav_deck_1.37.x.yml
+++ b/app/_data/docs_nav_deck_1.37.x.yml
@@ -1,0 +1,143 @@
+product: deck
+release: 1.36.x
+generate: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    url: /deck/1.36.x/
+    absolute_url: true
+    items:
+      - text: Terminology
+        url: /terminology/
+      - text: Architecture
+        url: /design-architecture/
+      - text: Use Case - Streamlining KongAir APIs
+        url: /use-case/
+      - text: Compatibility Promise
+        url: /compatibility-promise/
+
+  - title: Changelog
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    url: https://github.com/kong/deck/blob/main/CHANGELOG.md
+    absolute_url: true
+
+  - title: Installation
+    icon: /assets/images/icons/documentation/icn-deployment-color.svg
+    url: /installation
+
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: Getting Started with decK
+        url: /guides/getting-started/
+      - text: Backup and Restore
+        url: /guides/backup-restore/
+      - text: Upgrade to Kong Gateway 3.x
+        url: /3.0-upgrade/
+      - text: Configuration as Code and GitOps
+        url: /guides/ci-driven-configuration/
+      - text: APIOps with decK
+        url: /guides/apiops/
+      - text: Distributed Configuration
+        url: /guides/distributed-configuration/
+      - text: Best Practices
+        url: /guides/best-practices/
+      - text: Using decK with Kong Gateway (Enterprise)
+        url: /guides/kong-enterprise/
+      - text: Using decK with Konnect
+        url: /guides/konnect/
+      - text: Run decK with Docker
+        url: /guides/run-with-docker/
+      - text: Using Multiple Files to Store Configuration
+        url: /guides/multi-file-state/
+      - text: De-duplicate Plugin Configuration
+        url: /guides/deduplicate-plugin-configuration/
+      - text: Set Up Object Defaults
+        url: /guides/defaults/
+      - text: Security
+        items:
+          - text: Overview
+            url: /guides/security/
+          - text: Secret Management with decK
+            url: /guides/vaults/
+          - text: Using Environment Variables with decK
+            url: /guides/environment-variables/
+
+  - title: Reference
+    icon: /assets/images/icons/documentation/icn-references-color.svg
+    items:
+      - text: Entities Managed by decK
+        url: /reference/entities/
+      - text: decK CLI
+        url: /reference/deck/
+      - text: deck completion
+        url: /reference/deck_completion/
+      - text: deck file commands
+        items:
+          - text: deck file
+            url: /reference/deck_file/
+          - text: deck file add-plugins
+            url: /reference/deck_file_add-plugins/
+          - text: deck file add-tags
+            url: /reference/deck_file_add-tags/
+          - text: deck file convert
+            url: /reference/deck_file_convert/
+          - text: deck file kong2kic
+            url: /reference/deck_file_kong2kic/
+          - text: deck file lint
+            url: /reference/deck_file_lint/
+          - text: deck file list-tags
+            url: /reference/deck_file_list-tags/
+          - text: deck file merge
+            url: /reference/deck_file_merge/
+          - text: deck file namespace
+            url: /reference/deck_file_namespace/
+          - text: deck file openapi2kong
+            url: /reference/deck_file_openapi2kong/
+          - text: deck file patch
+            url: /reference/deck_file_patch/
+          - text: deck file remove-tags
+            url: /reference/deck_file_remove-tags/
+          - text: deck file render
+            url: /reference/deck_file_render/
+          - text: deck file validate
+            url: /reference/deck_file_validate/
+      - text: deck gateway commands
+        items:
+          - text: deck gateway
+            url: /reference/deck_gateway/
+          - text: deck gateway diff
+            url: /reference/deck_gateway_diff/
+          - text: deck gateway dump
+            url: /reference/deck_gateway_dump/
+          - text: deck gateway ping
+            url: /reference/deck_gateway_ping/
+          - text: deck gateway reset
+            url: /reference/deck_gateway_reset/
+          - text: deck gateway sync
+            url: /reference/deck_gateway_sync/
+          - text: deck gateway validate
+            url: /reference/deck_gateway_validate/
+      - text: deck version
+        url: /reference/deck_version/
+      - text: Deprecated commands
+        items: 
+          - text: deck convert
+            url: /reference/deck_convert/
+          - text: deck diff
+            url: /reference/deck_diff/
+          - text: deck dump
+            url: /reference/deck_dump/
+          - text: deck ping
+            url: /reference/deck_ping/
+          - text: deck reset
+            url: /reference/deck_reset/
+          - text: deck sync
+            url: /reference/deck_sync/
+          - text: deck validate
+            url: /reference/deck_validate/
+      
+
+  - title: FAQ
+    icon: /assets/images/icons/documentation/icn-faq-color.svg
+    url: /faqs/

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -238,9 +238,12 @@
 - release: "1.35.x"
   version: "1.35.0"
   edition: "deck"
-  latest: true
 - release: "1.36.x"
-  version: "1.36.0"
+  version: "1.36.1"
+  edition: "deck"
+  latest: true
+- release: "1.37.x"
+  version: "1.37.0"
   edition: "deck"
   label: unreleased
 - edition: "konnect"

--- a/app/_src/deck/reference/deck_file_namespace.md
+++ b/app/_src/deck/reference/deck_file_namespace.md
@@ -4,18 +4,18 @@ source_url: https://github.com/Kong/deck/tree/main/cmd/file_namespace.go
 content_type: reference
 ---
 
-{% if_version gte:1.36.x}
+{% if_version gte:1.36.x %}
 
 Apply a namespace to routes in a decK file by path or hostname.
 
 There are two main ways to namespace APIs:
 
-1. Use path prefixes, all on the same hostname;
-   a. `http://api.acme.com/service1/somepath`
-   b. `http://api.acme.com/service2/somepath`
+1. Use path prefixes, all on the same hostname:
+   1. `http://api.acme.com/service1/somepath`
+   2. `http://api.acme.com/service2/somepath`
 2. Use separate hostnames:
-   a. `http://service1.api.acme.com/somepath`
-   b. `http://service2.api.acme.com/somepath`
+   1. `http://service1.api.acme.com/somepath`
+   2. `http://service2.api.acme.com/somepath`
 
 For hostnames, the `--host` and `--clear-hosts` flags are used. Just using `--host` appends
 to the existing hosts, while adding `--clear-hosts` will effectively replace the existing ones.
@@ -56,6 +56,8 @@ deck file namespace [command-specific flags] [global flags] filename [...filenam
 ```
 
 ## Examples
+
+{% if_version gte:1.36.x %}
 
 ```sh
 # Apply namespace to a deckfile, path and host:

--- a/app/_src/deck/reference/deck_file_namespace.md
+++ b/app/_src/deck/reference/deck_file_namespace.md
@@ -4,6 +4,34 @@ source_url: https://github.com/Kong/deck/tree/main/cmd/file_namespace.go
 content_type: reference
 ---
 
+{% if_version gte:1.36.x}
+
+Apply a namespace to routes in a decK file by path or hostname.
+
+There are two main ways to namespace APIs:
+
+1. Use path prefixes, all on the same hostname;
+   a. `http://api.acme.com/service1/somepath`
+   b. `http://api.acme.com/service2/somepath`
+2. Use separate hostnames:
+   a. `http://service1.api.acme.com/somepath`
+   b. `http://service2.api.acme.com/somepath`
+
+For hostnames, the `--host` and `--clear-hosts` flags are used. Just using `--host` appends
+to the existing hosts, while adding `--clear-hosts` will effectively replace the existing ones.
+For path prefixes, the `--path-prefix` flag is used. Combining them is possible.
+
+**Note on path-prefixing**: To remain transparent to the backend services, the added path
+prefix must be removed from the path before the request is routed to the service.
+To remove the prefix, the following approaches are used (in order):
+1. If the route has `strip_path=true`, then the added prefix will already be stripped.
+2. If the related service has a `path` property that matches the prefix, then the
+  `service.path` property is updated to remove the prefix.
+3. A `pre-function` plugin will be added to remove the prefix from the path.
+
+{% endif_version %}
+
+{% if_version lte:1.35.x %}
 Apply a namespace to routes in a decK file by prefixing the path.
 
 By prefixing paths with a specific segment, colliding paths to services can be
@@ -19,6 +47,8 @@ following approaches are used:
   `service.path` property is updated to remove the prefix.
 - A `pre-function` plugin will be added to remove the prefix from the path.
 
+{% endif_version %}
+
 ## Syntax
 
 ```sh
@@ -28,11 +58,59 @@ deck file namespace [command-specific flags] [global flags] filename [...filenam
 ## Examples
 
 ```sh
+# Apply namespace to a deckfile, path and host:
+deck file namespace --path-prefix=/kong --host=konghq.com --state=deckfile.yaml
+
+# Apply namespace to a deckfile, and write to a new file
+# Example file 'kong.yaml':
+routes:
+- paths:
+  - ~/tracks/system$
+  strip_path: true
+- paths:
+  - ~/list$
+  strip_path: false
+
+# Apply namespace to the deckfile, and write to stdout:
+cat kong.yaml | deck file namespace --path-prefix=/kong
+
+# Output:
+routes:
+- paths:
+  - ~/kong/tracks/system$
+  strip_path: true
+  hosts:
+  - konghq.com
+- paths:
+  - ~/kong/list$
+  strip_path: false
+  hosts:
+  - konghq.com
+  plugins:
+  - name: pre-function
+    config:
+      access:
+      - "local ns='/kong' -- this strips the '/kong' namespace from the path\nlocal <more code here>"
+
+```
+{% endif_version %}
+{% if_version lte:1.35.x %}
+
+```sh
 # Apply namespace to a decK file
 cat kong.yml | deck file namespace --path-prefix=/kong
 ```
+{% endif_version %}
 
 ## Flags
+
+`--allow-empty-selectors`
+:  Do not error out if the selectors return empty (Default: `false`)
+
+{% if_version gte:1.36.x %}
+`-c`, `--clear-hosts`
+:  Clear existing hosts. (Default: `false`)
+{% endif_version %}
 
 `--format`
 : Output format: yaml or json. (Default: `"yaml"`)
@@ -40,8 +118,16 @@ cat kong.yml | deck file namespace --path-prefix=/kong
 `-h`, `--help`
 :  Help for patch.
 
+{% if_version gte:1.36.x %}
+`--host`
+:  Hostname to add for host-based namespacing. Repeat for multiple hosts.
+{% endif_version %}
+
 `--output-file, -o`
 : Output file to write. Use - to write to stdout. (Default: `"-"`)
+
+`--path-prefix, -p`
+: The path-based namespace to apply.
 
 `--selector`
 : JSON pointer identifying an element to patch. Repeat for multiple selectors. Defaults to selecting all routes.
@@ -49,11 +135,6 @@ cat kong.yml | deck file namespace --path-prefix=/kong
 `--state, -s`
 : DecK spec file to process. Use `-` to read from stdin. (Default: `"-"`)
 
-`--path-prefix, -p`
-: The path-based namespace to apply.
-
-`--allow-empty-selectors`
-: Do not error out if the selectors return empty.
 
 ## Global flags
 


### PR DESCRIPTION
### Description

Doc updates for decK 1.36 + generate an unreleased 1.37 version.

Release went out three weeks ago.

https://github.com/Kong/deck/releases

### Testing instructions

Preview link: https://deploy-preview-7186--kongdocs.netlify.app/deck/latest/reference/deck_file_namespace/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

