### PR TITLE
chore(kic): update latest to 3.1.3

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -276,7 +276,7 @@
   version: "3.0.2"
   edition: "kubernetes-ingress-controller"
 - release: "3.1.x"
-  version: "3.1.2"
+  version: "3.1.3"
   edition: "kubernetes-ingress-controller"
   latest: true
 - release: "3.2.x"


### PR DESCRIPTION
### Description

Update latest KIC version to 3.1.3 https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v3.1.3

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
