### PR TITLE
Fix: Replace `plain` with `plaintext` for syntax highlighting

### DIFF
--- a/app/_src/gateway/plugin-development/pdk/kong.log.md
+++ b/app/_src/gateway/plugin-development/pdk/kong.log.md
@@ -48,13 +48,13 @@ Writes a log line to the location specified by the current Nginx
  Produced log lines have the following format when logging is invoked from
  within the core:
 
- ``` plain
+ ```plaintext
  [kong] %file_src:%line_src %message
  ```
 
  In comparison, log lines produced by plugins have the following format:
 
- ``` plain
+ ```plaintext
  [kong] %file_src:%line_src [%namespace] %message
  ```
 
@@ -67,20 +67,20 @@ Writes a log line to the location specified by the current Nginx
 
  For example, the following call:
 
- ``` lua
+ ```plaintext
  kong.log("hello ", "world")
  ```
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (for example, `key-auth`) it would include the
  namespace prefix:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -128,14 +128,14 @@ Similar to `kong.log()`, but the produced log has the severity given by
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (for example, `key-auth`) it would include the
  namespace prefix:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -189,14 +189,14 @@ Write a deprecation log line (similar to `kong.log.warn`).
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (for example, `key-auth`) it would include the
  namespace prefix:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -208,7 +208,7 @@ Write a deprecation log line (similar to `kong.log.warn`).
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 hello world (deprecated after 2.5.0, scheduled for removal in 3.0.0), client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -263,7 +263,7 @@ Like `kong.log()`, this function produces a log with a `notice` level
  When writing logs, `kong.log.inspect()` always uses its own format, defined
  as:
 
- ``` plain
+ ```plaintext
  %file_src:%func_name:%line_src %message
  ```
 

--- a/app/gateway/2.6.x/pdk/kong.log.md
+++ b/app/gateway/2.6.x/pdk/kong.log.md
@@ -52,13 +52,13 @@ Write a log line to the location specified by the current Nginx
  Produced log lines have the following format when logging is invoked from
  within the core:
 
- ``` plain
+ ```plaintext
  [kong] %file_src:%line_src %message
  ```
 
  In comparison, log lines produced by plugins have the following format:
 
- ``` plain
+ ```plaintext
  [kong] %file_src:%line_src [%namespace] %message
  ```
 
@@ -77,14 +77,14 @@ Write a log line to the location specified by the current Nginx
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (e.g. `key-auth`) it would include the
  namespace prefix, like so:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -133,14 +133,14 @@ Similar to `kong.log()`, but the produced log will have the severity given by
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (e.g. `key-auth`) it would include the
  namespace prefix, like so:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -193,7 +193,7 @@ Like `kong.log()`, this function will produce a log with the `notice` level,
  When writing logs, `kong.log.inspect()` always uses its own format, defined
  as:
 
- ``` plain
+ ```plaintext
  %file_src:%func_name:%line_src %message
  ```
 

--- a/app/gateway/2.7.x/pdk/kong.log.md
+++ b/app/gateway/2.7.x/pdk/kong.log.md
@@ -50,13 +50,13 @@ Write a log line to the location specified by the current Nginx
  Produced log lines have the following format when logging is invoked from
  within the core:
 
- ``` plain
+ ```plaintext
  [kong] %file_src:%line_src %message
  ```
 
  In comparison, log lines produced by plugins have the following format:
 
- ``` plain
+ ```plaintext
  [kong] %file_src:%line_src [%namespace] %message
  ```
 
@@ -75,14 +75,14 @@ Write a log line to the location specified by the current Nginx
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (e.g. `key-auth`) it would include the
  namespace prefix, like so:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -131,14 +131,14 @@ Similar to `kong.log()`, but the produced log will have the severity given by
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (e.g. `key-auth`) it would include the
  namespace prefix, like so:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -193,14 +193,14 @@ Write a deprecation log line (similar to `kong.log.warn`).
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (e.g. `key-auth`) it would include the
  namespace prefix, like so:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -212,7 +212,7 @@ Write a deprecation log line (similar to `kong.log.warn`).
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 hello world (deprecated after 2.5.0, scheduled for removal in 3.0.0), client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -268,7 +268,7 @@ Like `kong.log()`, this function will produce a log with the `notice` level,
  When writing logs, `kong.log.inspect()` always uses its own format, defined
  as:
 
- ``` plain
+ ```plaintext
  %file_src:%func_name:%line_src %message
  ```
 

--- a/app/gateway/2.8.x/pdk/kong.log.md
+++ b/app/gateway/2.8.x/pdk/kong.log.md
@@ -48,13 +48,13 @@ Writes a log line to the location specified by the current Nginx
  Produced log lines have the following format when logging is invoked from
  within the core:
 
- ``` plain
+ ```plaintext
  [kong] %file_src:%line_src %message
  ```
 
  In comparison, log lines produced by plugins have the following format:
 
- ``` plain
+ ```plaintext
  [kong] %file_src:%line_src [%namespace] %message
  ```
 
@@ -73,14 +73,14 @@ Writes a log line to the location specified by the current Nginx
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (for example, `key-auth`) it would include the
  namespace prefix:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [notice] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -128,14 +128,14 @@ Similar to `kong.log()`, but the produced log has the severity given by
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (for example, `key-auth`) it would include the
  namespace prefix:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [error] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -189,14 +189,14 @@ Write a deprecation log line (similar to `kong.log.warn`).
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
  If invoked from within a plugin (for example, `key-auth`) it would include the
  namespace prefix:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 [key-auth] hello world, client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -208,7 +208,7 @@ Write a deprecation log line (similar to `kong.log.warn`).
 
  would, within the core, produce a log line similar to:
 
- ``` plain
+ ```plaintext
  2017/07/09 19:36:25 [warn] 25932#0: *1 [kong] some_file.lua:54 hello world (deprecated after 2.5.0, scheduled for removal in 3.0.0), client: 127.0.0.1, server: localhost, request: "GET /log HTTP/1.1", host: "localhost"
  ```
 
@@ -263,7 +263,7 @@ Like `kong.log()`, this function produces a log with a `notice` level
  When writing logs, `kong.log.inspect()` always uses its own format, defined
  as:
 
- ``` plain
+ ```plaintext
  %file_src:%func_name:%line_src %message
  ```
 


### PR DESCRIPTION
### Description

The syntax highlighter doesn't recognize `plain`, so it breaks the codeblock. The copy code icon scrolls with the text:

![Screenshot 2024-04-09 at 8 55 54 AM](https://github.com/Kong/docs.konghq.com/assets/54370747/75f3d010-70d6-4c9d-80aa-ccc3fd0504d5)

(source: https://docs.konghq.com/gateway/latest/plugin-development/pdk/kong.log/)

Reported on Slack.

### Testing instructions

Preview link: https://deploy-preview-7196--kongdocs.netlify.app/gateway/latest/plugin-development/pdk/kong.log/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

