### PR TITLE
Fix {:.warning} in Kong mesh

### DIFF
--- a/app/_plugins/kuma-specific/warning.rb
+++ b/app/_plugins/kuma-specific/warning.rb
@@ -11,10 +11,11 @@ module Jekyll
     def render(context)
       content = Kramdown::Document.new(super).to_html
 
+      # warnings in Kuma map to {:.important} in docs
       <<~TIP
-        <div class="custom-block warning">
+        <blockquote class="important">
           <p>#{content}</p>
-        </div>
+        </blockquote>
       TIP
     end
   end


### PR DESCRIPTION
### Description

The markup we used in the tag was outdated. Change it so that a note is render and update the type of note so that it matches the one in Kuma. (the use a different system)

### Testing instructions

Preview link: https://deploy-preview-7199--kongdocs.netlify.app/mesh/latest/reference/kubernetes-annotations/#kumaiodirect-access-services

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

