### PR TITLE
kic: add section about events for cluster scoped resources

### DIFF
--- a/app/_src/kubernetes-ingress-controller/production/observability/events.md
+++ b/app/_src/kubernetes-ingress-controller/production/observability/events.md
@@ -93,3 +93,41 @@ type: Warning
 resource, so you may see multiple Events for a single resource with different
 messages. The message describes the reason the resource is invalid. In this
 case, it's because gRPC routes cannot use HTTP methods.
+
+### Events for cluster scoped resources
+
+Kubernetes Events are namespaced and created in the same namespace as the involved object.
+Cluster scoped objects are handled differently due to not being assigned to a particular namespace.
+
+`kubectl` and Kubernetes libraries like `client-go`, assign `default` namespace to
+Events that involve cluster scoped resources.
+
+Assuming that you've defined the following `KongClusterPlugin` which has an incorrect schema:
+
+```yaml
+apiVersion: configuration.konghq.com/v1
+kind: KongClusterPlugin
+config:
+  config:
+    latency_metrics: true
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: kong
+  labels:
+    global: "true"
+  name: prometheus
+plugin: prometheus
+```
+
+you can find the relevant Event in `default` namespace using the following `kubectl` command:
+
+```bash
+kubectl get events --field-selector involvedObject.name=prometheus -n default
+```
+
+which could yield the following output:
+
+```bash
+LAST SEEN   TYPE      REASON                         OBJECT                         MESSAGE
+2s          Warning   KongConfigurationApplyFailed   kongclusterplugin/prometheus   invalid config.config: unknown field
+```

--- a/app/_src/kubernetes-ingress-controller/production/observability/events.md
+++ b/app/_src/kubernetes-ingress-controller/production/observability/events.md
@@ -96,13 +96,13 @@ case, it's because gRPC routes cannot use HTTP methods.
 
 ### Events for cluster scoped resources
 
-Kubernetes Events are namespaced and created in the same namespace as the involved object.
-Cluster scoped objects are handled differently due to not being assigned to a particular namespace.
+Kubernetes events are namespaced and created in the same namespace as the involved object.
+Cluster scoped objects are handled differently because they aren't assigned to a particular namespace.
 
-`kubectl` and Kubernetes libraries like `client-go`, assign `default` namespace to
-Events that involve cluster scoped resources.
+`kubectl` and Kubernetes libraries, like `client-go`, assign the `default` namespace to
+events that involve cluster scoped resources.
 
-Assuming that you've defined the following `KongClusterPlugin` which has an incorrect schema:
+For example, if you defined the following `KongClusterPlugin`, which has an incorrect schema:
 
 ```yaml
 apiVersion: configuration.konghq.com/v1
@@ -119,13 +119,13 @@ metadata:
 plugin: prometheus
 ```
 
-you can find the relevant Event in `default` namespace using the following `kubectl` command:
+You can find the relevant event in the `default` namespace using the following `kubectl` command:
 
 ```bash
 kubectl get events --field-selector involvedObject.name=prometheus -n default
 ```
 
-which could yield the following output:
+This could output the following:
 
 ```bash
 LAST SEEN   TYPE      REASON                         OBJECT                         MESSAGE


### PR DESCRIPTION
### Description

Adds a section about Events for cluster scoped resources

Relevant KIC issue: https://github.com/Kong/kubernetes-ingress-controller/issues/5847

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

