### PR TITLE
Fix: Add missing client-bound access tokens doc to OIDC plugin

### DIFF
--- a/app/_hub/kong-inc/openid-connect/how-to/_cert-bound-access-tokens.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_cert-bound-access-tokens.md
@@ -1,0 +1,128 @@
+---
+title: Certificate-Bound Access Tokens
+nav_title: Certificate-Bound Access Tokens
+---
+
+## Overview
+
+One of the main vulnerabilities of OAuth are bearer tokens. With OAuth, presenting a valid bearer token is enough proof to access a resource.
+This can create problems since the client presenting the token isn't validated as the legitimate user that the token was issued to. 
+
+Certificate-bound access tokens can solve this problem by binding tokens to clients. 
+This ensures the legitimacy of the token because the it requires proof that the sender is authorized to use a particular token to access protected resources. 
+
+To enable certificate-bound access for OpenID Connect, you must ensure that the auth server is set up to generate OAuth 2.0 Mutual TLS certificate-bound access tokens.
+
+If you are configuring this in Keycloak, see the [Keycloak configuration](#prerequisites) section in the prerequisites.
+For alternative auth servers, consult their documentation to configure this functionality.
+
+Some of the instructions in the other how-to guides for OpenID Connect support validation of access tokens using mTLS proof of possession.
+Enabling the [`proof_of_possession_mtls`](/hub/kong-inc/openid-connect/configuration/#config-proof_of_possession_mtls) configuration option in the plugin helps to ensure that the supplied access token
+belongs to the client by verifying its binding with the client certificate provided in the request.
+
+The certificate-bound access tokens are supported by the following auth methods:
+
+- [JWT Access Token Authentication](/hub/kong-inc/openid-connect/how-to/authentication/jwt-access-token/)
+- [Introspection Authentication](/hub/kong-inc/openid-connect/how-to/authentication/introspection/)
+- [Session Authentication](/hub/kong-inc/openid-connect/how-to/authentication/session/)
+
+   Session Authentication is only compatible with certificate-bound access tokens when used along with one of the other supported authentication methods:
+
+    * When the configuration option [`proof_of_possession_auth_methods_validation`](/hub/kong-inc/openid-connect/configuration/#config-proof_of_possession_auth_methods_validation) is set to `false` and other non-compatible methods are enabled, if a valid session is found, the proof of possession validation will only be performed if the session was originally created using one of the compatible methods. 
+    * If multiple `openid-connect` plugins are configured with the `session` auth method, we strongly recommend configuring different values of [`session_secret`](/hub/kong-inc/openid-connect/configuration/#config-session_secret) across plugin instances for additional security. This avoids sessions being shared across plugins and possibly bypassing the proof of possession validation.
+
+The following example shows how to enable this feature for the JWT Access Token Authentication method. Similar steps can be followed for the other methods.
+
+## Demo
+### Prerequisites
+
+Follow these prerequisites to set up a demo Keycloak app and a Kong service and route for testing mTLS client auth.
+
+{% include_cached /md/plugins-hub/oidc-prereqs.md %}
+
+### Configure certificate-bound access tokens
+
+1. Configure {{site.base_gateway}} to use mTLS client certificate authentication. You can do this by configuring the [TLS Handshake Modifier plugin](/hub/kong-inc/tls-handshake-modifier/) or the [Mutual TLS Authentication plugin](/hub/kong-inc/mtls-auth/):
+
+    ```bash
+    http -f post :8001/plugins    \
+    name=tls-handshake-modifier \
+    service.name=openid-connect
+    ```
+    If this is configured correctly, it returns a `200` response and something like the following:
+    ```json
+    {
+        "id": "a7f676e6-580d-4841-80de-de46e1f79eb2",
+        "name": "tls-handshake-modifier",
+        "service": {
+            "id": "5fa9e468-0007-4d7e-9aeb-49ca9edd6ccd"
+        }
+    }
+    ```
+
+1. To enable certificate-bound access tokens, use the [`proof_of_possession_mtls`](/hub/kong-inc/openid-connect/configuration/#config-proof_of_possession_mtls) configuration option:
+
+    ```bash
+    http -f put :8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f4f9 \
+    name=openid-connect                                          \
+    service.name=openid-connect                                  \
+    config.issuer=https://keycloak.test:8440/auth/realms/master  \
+    config.client_id=cert-bound                                  \
+    config.client_secret=cf4c655a-0622-4ce6-a0de-d3353ef0b714    \
+    config.auth_methods=bearer                                   \
+    config.proof_of_possession_mtls=strict
+    ```
+    If this is configured correctly, it returns a `200` response and something like the following:
+    ```json
+    {
+        "id": "5f35b796-ced6-4c00-9b2a-90eef745f4f9",
+        "name": "openid-connect",
+        "service": {
+            "id": "5fa9e468-0007-4d7e-9aeb-49ca9edd6ccd"
+        },
+        "config": {
+            "issuer": "https://keycloak.test:8440/auth/realms/master",
+            "client_id": [ "cert-bound" ],
+            "client_secret": [ "cf4c655a-0622-4ce6-a0de-d3353ef0b714" ],
+            "auth_methods": [ "bearer" ],
+            "proof_of_possession_mtls": "strict",
+        }
+    }
+    ```
+
+1. Obtain the token from the IdP, making sure to modify the following command for your environment:
+    ```bash
+    http --cert client-cert.pem --cert-key client-key.pem                                 \
+    -f post https://keycloak.test:8440/auth/realms/master/protocol/openid-connect/token \
+    client_id=cert-bound                                                                \
+    client_secret=cf4c655a-0622-4ce6-a0de-d3353ef0b714                                  \
+    grant_type=client_credentials
+    ```
+    If this is configured correctly, it returns a `200` response and something like the following:
+    ```json
+    {
+        "access_token": "eyJhbG...",
+    }
+    ```
+
+    The token you obtain should include a claim that consists of the hash of the client certificate:
+    ```json
+    {
+        "exp": 1622556713,
+        "typ": "Bearer",
+        "cnf": {
+            "x5t#S256": "hh_XBS..."
+        }
+    }
+    ```
+
+1. Access the service using the same client certificate and key used to obtain the token:
+    ```bash
+    http --cert client-cert.pem --cert-key client-key.pem \
+    -f post https://kong.test:8443                      \
+    Authorization:"Bearer eyJhbGc..."
+    ```
+    If this is configured correctly, it returns a `200` response:
+    ```http
+    HTTP/1.1 200 OK
+    ```

--- a/app/_hub/kong-inc/openid-connect/how-to/_cert-bound-access-tokens.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_cert-bound-access-tokens.md
@@ -1,6 +1,7 @@
 ---
 title: Certificate-Bound Access Tokens
 nav_title: Certificate-Bound Access Tokens
+minimum_version: 3.6.x
 ---
 
 ## Overview

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
@@ -114,6 +114,8 @@ enabled the OpenID Connect plugin on the service. You can now test the introspec
     curl -I http://localhost:8000/openid-connect -H "Authorization: Bearer <access-token>"
     ```
 
+{% if_plugin_version gte:3.5.x %}
 ## More information
 
 Introspection authentication is also compatible with [certificate-bound access tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens/). 
+{% endif_plugin_version %}

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
@@ -113,3 +113,7 @@ enabled the OpenID Connect plugin on the service. You can now test the introspec
     ```sh
     curl -I http://localhost:8000/openid-connect -H "Authorization: Bearer <access-token>"
     ```
+
+## More information
+
+Introspection authentication is also compatible with [certificate-bound access tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens/). 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_jwt-access-token.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_jwt-access-token.md
@@ -156,3 +156,7 @@ Test out the token by accessing the Kong proxy:
 ```bash
 curl http://localhost:8000?access_token=<token>
 ```
+
+## More information
+
+JWT access token authentication is also compatible with [certificate-bound access tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens/).

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_jwt-access-token.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_jwt-access-token.md
@@ -157,6 +157,8 @@ Test out the token by accessing the Kong proxy:
 curl http://localhost:8000?access_token=<token>
 ```
 
+{% if_plugin_version gte:3.5.x %}
 ## More information
 
 JWT access token authentication is also compatible with [certificate-bound access tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens/).
+{% endif_plugin_version %}

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
@@ -107,3 +107,8 @@ formats:
 {:.note}
 > **Note**: If you want to disable session creation with some grants, you can use the 
 [`config.disable_session`](/hub/kong-inc/openid-connect/configuration/#disable_session) configuration parameter.
+
+## More information
+
+Session authentication is also compatible with [certificate-bound access tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens/). 
+In that case, it must be used along with one of the other supported auth methods.

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
@@ -108,7 +108,9 @@ formats:
 > **Note**: If you want to disable session creation with some grants, you can use the 
 [`config.disable_session`](/hub/kong-inc/openid-connect/configuration/#disable_session) configuration parameter.
 
+{% if_plugin_version gte:3.5.x %}
 ## More information
 
 Session authentication is also compatible with [certificate-bound access tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens/). 
 In that case, it must be used along with one of the other supported auth methods.
+{% endif_plugin_version %}


### PR DESCRIPTION
### Description

The OIDC cert-bound access tokens doc was added in 3.5, but got lost in a rebase. 

Issue reported on Slack.

### Testing instructions

Preview link: https://deploy-preview-7208--kongdocs.netlify.app/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

