### PR TITLE
Update: Plugin compatibility in dedicated cloud gateways

### DIFF
--- a/app/_hub/kong-inc/app-dynamics/_metadata/_index.yml
+++ b/app/_hub/kong-inc/app-dynamics/_metadata/_index.yml
@@ -7,10 +7,14 @@ desc: Integrate Kong with the AppDynamics APM Platform
 free: false
 enterprise: true
 paid: true
-network_config_opts: Self-managed traditional, DB-less, and hybrid
+konnect: true
+cloud_gateways: false
+network_config_opts: traditional, hybrid, konnect hybrid, and db-less
+notes: | 
+   <b>Dedicated Cloud Gateways</b>: This plugin is not supported in Dedicated Cloud Gateways because it depends on a local agent, 
+   and there are no local nodes in Dedicated Cloud Gateways.
 type: plugin
 categories:
   - analytics-monitoring
 bundled: false
 dbless_compatible: 'yes'
-konnect: true

--- a/app/_hub/kong-inc/aws-lambda/_metadata/_index.yml
+++ b/app/_hub/kong-inc/aws-lambda/_metadata/_index.yml
@@ -8,7 +8,7 @@ paid: true
 konnect: true
 network_config_opts: All
 notes: |
-  <b>Dedicated Cloud Gateways</b>: If you use the IAM assumeRole functiuonality with this plugin, 
+  <b>Dedicated Cloud Gateways</b>: If you use the IAM assumeRole functionality with this plugin, 
   it must be configured differently than for hybrid deployments in Konnect.
 categories:
   - serverless

--- a/app/_hub/kong-inc/aws-lambda/_metadata/_index.yml
+++ b/app/_hub/kong-inc/aws-lambda/_metadata/_index.yml
@@ -7,7 +7,9 @@ enterprise: true
 paid: true
 konnect: true
 network_config_opts: All
-notes: --
+notes: |
+  <b>Dedicated Cloud Gateways</b>: If you use the IAM assumeRole functiuonality with this plugin, 
+  it must be configured differently than for hybrid deployments in Konnect.
 categories:
   - serverless
 publisher: Kong Inc.

--- a/app/_hub/kong-inc/file-log/_metadata/_index.yml
+++ b/app/_hub/kong-inc/file-log/_metadata/_index.yml
@@ -6,8 +6,11 @@ dbless_compatible: 'yes'
 free: true
 enterprise: true
 konnect: true
-network_config_opts: All
-notes: --
+cloud_gateways: false
+network_config_opts: traditional, hybrid, konnect hybrid, and db-less
+notes: | 
+   <b>Dedicated Cloud Gateways</b>: This plugin is not supported in Dedicated Cloud Gateways because it depends on a local agent, 
+   and there are no local nodes in Dedicated Cloud Gateways.
 categories:
   - logging
 publisher: Kong Inc.

--- a/app/_hub/kong-inc/prometheus/_metadata/_index.yml
+++ b/app/_hub/kong-inc/prometheus/_metadata/_index.yml
@@ -8,8 +8,11 @@ free: true
 enterprise: true
 paid: true
 konnect: true
-network_config_opts: All
-notes: --
+cloud_gateways: false
+network_config_opts: traditional, hybrid, konnect hybrid, and db-less
+notes: | 
+   <b>Dedicated Cloud Gateways</b>: This plugin is not supported in Dedicated Cloud Gateways because it depends on the 
+   Admin API and the Status API, which aren't accessible in that setup.
 categories:
   - analytics-monitoring
 publisher: Kong Inc.

--- a/app/_hub/kong-inc/syslog/_metadata/_index.yml
+++ b/app/_hub/kong-inc/syslog/_metadata/_index.yml
@@ -3,8 +3,11 @@ dbless_compatible: 'yes'
 free: true
 enterprise: true
 konnect: true
-network_config_opts: All
-notes: --
+cloud_gateways: false
+network_config_opts: traditional, hybrid, konnect hybrid, and db-less
+notes: | 
+   <b>Dedicated Cloud Gateways</b>: This plugin is not supported in Dedicated Cloud Gateways because it depends on a local agent, 
+   and there are no local nodes in Dedicated Cloud Gateways.
 categories:
   - logging
 

--- a/app/hub/plugins/compatibility/index.md
+++ b/app/hub/plugins/compatibility/index.md
@@ -33,7 +33,7 @@ with any of the following network configurations:
   * **Hybrid**: Nodes are split into control plane and
 data plane roles. Kong provides and hosts the control plane and a database with
 {{site.konnect_product_name}}, and you provide the {{site.base_gateway}} data plane nodes (no databases required).
-  * [**Dedicated Cloud Gateways:**](/konnect/dedicated-cloud-gateways/) 
+  * [**Dedicated Cloud Gateways:**](/konnect/gateway-manager/dedicated-cloud-gateways/) 
   Kong manages both the control plane and the data plane nodes through {{site.konnect_product_name}}.
 
 {% assign hub = site.data.ssg_hub %}

--- a/app/hub/plugins/compatibility/index.md
+++ b/app/hub/plugins/compatibility/index.md
@@ -29,10 +29,12 @@ with any of the following network configurations:
     nodes, so only control plane nodes require a database
     (available in {{site.ce_product_name}} 2.0 and {{site.ee_product_name}} 2.1 onward).
 
-* **{{site.konnect_short_name}} (Kong-hosted cloud)**: Hybrid deployment. Nodes are split into control plane and
+* **{{site.konnect_short_name}} (Kong-hosted cloud)**: 
+  * **Hybrid**: Nodes are split into control plane and
 data plane roles. Kong provides and hosts the control plane and a database with
 {{site.konnect_product_name}}, and you provide the {{site.base_gateway}} data plane nodes (no databases required).
-
+  * [**Dedicated Cloud Gateways:**](/konnect/dedicated-cloud-gateways/) 
+  Kong manages both the control plane and the data plane nodes through {{site.konnect_product_name}}.
 
 {% assign hub = site.data.ssg_hub %}
 {% assign kong_extns = hub | where: "extn_publisher", "kong-inc" %}
@@ -49,8 +51,9 @@ data plane roles. Kong provides and hosts the control plane and a database with
       <th style="text-align: left; width: 10%">Plugin</th>
       <th style="text-align: center">Traditional</th>
       <th style="text-align: center">DB-less</th>
-      <th style="text-align: center">Hybrid mode</th>
-      <th style="text-align: center">Konnect </th>
+      <th style="text-align: center">Self-managed hybrid</th>
+      <th style="text-align: center">Konnect hybrid </th>
+      <th style="text-align: center">Dedicated Cloud Gateways</th>
       <th style="text-align: left; width: 35%">Notes</th>
   </thead>
   <tbody>
@@ -87,6 +90,13 @@ data plane roles. Kong provides and hosts the control plane and a database with
             <i class="fa fa-check"></i>
           {% elsif plugin.konnect == false %}
             <i class="fa fa-times"></i>
+          {% endif %}
+        </td>
+        <td style="text-align: center">
+          {% if plugin.cloud_gateways == false or plugin.konnect == false %}
+            <i class="fa fa-times"></i>
+          {% else %}
+            <i class="fa fa-check"></i>
           {% endif %}
         </td>
         <td>

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -50,6 +50,19 @@ The tiers denote plugin pricing. See the [{{site.konnect_short_name}} pricing pa
 
 If you're looking for supported network protocols and entity scopes, see [Plugin Compatibility](/hub/plugins/compatibility/) on the Plugin Hub.
 
+### Considerations for Dedicated Cloud Gateways
+
+There are some limitations for plugins with Dedicated Cloud Gateways:
+
+* Any plugins that depend on a local agent will not work with Dedicated Cloud Gateways.
+* Any plugins that depend on the Status API or on Admin API endpoints will not work.
+* Any plugins or functionality that might depend on IAM assumeRole need to be configured differently. 
+This includes [Data Plane Resilience](/gateway/latest/kong-enterprise/cp-outage-handling/).
+
+See the following table for details on each plugin.
+
+### Plugin tiers
+
 {% assign hub = site.data.ssg_hub %}
 {% assign kong_extns = hub | where: "extn_publisher", "kong-inc" %}
 {% assign categories = site.extensions.categories %}

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -42,9 +42,11 @@ To use [Mesh Manager](/konnect/mesh-manager/), you must also use a compatible ve
 
 There are three tiers of plugins available in {{site.konnect_saas}}:
 
+<!--vale off-->
 * [**Free tier**](https://docs.konghq.com/hub/?tier=free&compatibility=konnect)
 * [**Paid tier**](https://docs.konghq.com/hub/?tier=paid&compatibility=konnect)
 * [**Premium tier**](https://docs.konghq.com/hub/?tier=premium&compatibility=konnect)
+<!--vale on-->
 
 The tiers denote plugin pricing. See the [{{site.konnect_short_name}} pricing page](https://konghq.com/pricing) for more detail. 
 
@@ -56,7 +58,7 @@ There are some limitations for plugins with Dedicated Cloud Gateways:
 
 * Any plugins that depend on a local agent will not work with Dedicated Cloud Gateways.
 * Any plugins that depend on the Status API or on Admin API endpoints will not work.
-* Any plugins or functionality that might depend on IAM assumeRole need to be configured differently. 
+* Any plugins or functionality that depend on AWS IAM `AssumeRole` need to be configured differently. 
 This includes [Data Plane Resilience](/gateway/latest/kong-enterprise/cp-outage-handling/).
 
 See the following table for details on each plugin.

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -42,11 +42,9 @@ To use [Mesh Manager](/konnect/mesh-manager/), you must also use a compatible ve
 
 There are three tiers of plugins available in {{site.konnect_saas}}:
 
-<!--vale off-->
-* [**Free tier**](https://docs.konghq.com/hub/?tier=free&compatibility=konnect)
-* [**Paid tier**](https://docs.konghq.com/hub/?tier=paid&compatibility=konnect)
-* [**Premium tier**](https://docs.konghq.com/hub/?tier=premium&compatibility=konnect)
-<!--vale on-->
+* [**Free tier**](/hub/?tier=free&compatibility=konnect)
+* [**Paid tier**](/hub/?tier=paid&compatibility=konnect)
+* [**Premium tier**](/hub/?tier=premium&compatibility=konnect)
 
 The tiers denote plugin pricing. See the [{{site.konnect_short_name}} pricing page](https://konghq.com/pricing) for more detail. 
 

--- a/app/konnect/gateway-manager/plugins/add-custom-plugin.md
+++ b/app/konnect/gateway-manager/plugins/add-custom-plugin.md
@@ -16,6 +16,9 @@ of update.
 See [Editing or deleting a custom plugin's schema](/konnect/gateway-manager/plugins/update-custom-plugin/) 
 for more information.
 
+{:.note}
+> **Note**: Custom plugins are not supported in Dedicated Cloud Gateways.
+
 ## Prerequisites
 
 * Your custom plugin meets {{site.konnect_short_name}}'s [requirements](/konnect/gateway-manager/plugins/#custom-plugins)

--- a/app/konnect/gateway-manager/plugins/index.md
+++ b/app/konnect/gateway-manager/plugins/index.md
@@ -39,6 +39,9 @@ schema, it creates a plugin configuration object in {{site.konnect_short_name}},
 can access via the Konnect UI or the custom plugins API. This means that {{site.konnect_short_name}}
 only sees a custom plugin's configuration options, and does not see any other data.
 
+{:.note}
+> **Note**: Custom plugins are not supported in Dedicated Cloud Gateways.
+
 To run in {{site.konnect_short_name}}, every custom plugin must meet the following requirements:
 
 * **General requirements:**


### PR DESCRIPTION
### Description
https://konghq.atlassian.net/browse/DOCU-3699
Adding info about plugin compatibility with dedicated cloud gateways. 

This might not be the complete list of incompatible plugins. There is also currently nothing to link to for the differences on configuration for AWS IAM assumeRole.

### Testing instructions

Preview link:
https://deploy-preview-7216--kongdocs.netlify.app/hub/plugins/compatibility/
https://deploy-preview-7216--kongdocs.netlify.app/konnect/compatibility/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

