### PR TITLE
feat: change path to `v1/messages` api for anthropic

### DIFF
--- a/app/_hub/kong-inc/ai-proxy/overview/_index.md
+++ b/app/_hub/kong-inc/ai-proxy/overview/_index.md
@@ -47,7 +47,7 @@ The plugin's [`config.route_type`](/hub/kong-inc/ai-proxy/configuration/#config-
 | Cohere        | `/v1/generate`                                           | `llm/v1/completions` | command                |
 | Azure         | `/openai/deployments/{deployment_name}/chat/completions` | `llm/v1/chat`        | gpt-4                  |
 | Azure         | `/openai/deployments/{deployment_name}/completions`      | `llm/v1/completions` | gpt-3.5-turbo-instruct |
-| Anthropic     | `/v1/complete`                                           | `llm/v1/chat`        | claude-2.1             |
+| Anthropic     | `/v1/messages`                                           | `llm/v1/chat`        | claude-2.1             |
 | Anthropic     | `/v1/complete`                                           | `llm/v1/completions` | claude-2.1             |
 | Llama2        | User-defined                                             | `llm/v1/chat`        | User-defined           |
 | Llama2        | User-defined                                             | `llm/v1/completions` | User-defined           |

--- a/app/_hub/kong-inc/ai-proxy/overview/_index.md
+++ b/app/_hub/kong-inc/ai-proxy/overview/_index.md
@@ -47,7 +47,14 @@ The plugin's [`config.route_type`](/hub/kong-inc/ai-proxy/configuration/#config-
 | Cohere        | `/v1/generate`                                           | `llm/v1/completions` | command                |
 | Azure         | `/openai/deployments/{deployment_name}/chat/completions` | `llm/v1/chat`        | gpt-4                  |
 | Azure         | `/openai/deployments/{deployment_name}/completions`      | `llm/v1/completions` | gpt-3.5-turbo-instruct |
+
+{% if_version gte:3.7.x %}
 | Anthropic     | `/v1/messages`                                           | `llm/v1/chat`        | claude-2.1             |
+{% endif_version %}
+{% if_version lte:3.6.x %}
+| Anthropic     | `/v1/complete`                                           | `llm/v1/chat`        | claude-2.1             |
+{% endif_version %}
+
 | Anthropic     | `/v1/complete`                                           | `llm/v1/completions` | claude-2.1             |
 | Llama2        | User-defined                                             | `llm/v1/chat`        | User-defined           |
 | Llama2        | User-defined                                             | `llm/v1/completions` | User-defined           |


### PR DESCRIPTION
### Description

Anthropic released a new `messages` API, we change the `chat` route_type of Anthropic to the new `messages` API correspondingly. 
This new feature is about to be released in 3.7.0.0, the doc should be updated simultaneously.
The sister [PR](https://github.com/Kong/kong-ee/pull/8747) for kong-ee has already been merged.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
