### PR TITLE
feat(SLSA/provenance): publish provenance to central notary repository

### DIFF
--- a/app/_src/gateway/kong-enterprise/provenance-verification.md
+++ b/app/_src/gateway/kong-enterprise/provenance-verification.md
@@ -43,6 +43,16 @@ For both examples, you need to:
    regctl manifest digest <image>:<tag>
    ```
 
+{% if_version gte:3.7.x %}
+
+5. Set the `COSIGN_REPOSITORY` environment variable:
+
+   ```sh
+   export COSIGN_REPOSITORY=kong/notary
+   ```
+
+{% endif_version %}
+
 {:.important .no-icon}
 > The GitHub owner is case-sensitive (`Kong/kong-ee` vs `kong/kong-ee`).
 


### PR DESCRIPTION
### Description
- PR aims to publish provenance signatures into a single central `kong/notary` repository instead of image repository. 
- This will require users performing an additional step starting GW 3.7.x for verifying provenance 
- Aims to provide a similar ux flow for provenance verification similar to verifying image signatures 
- This change is added in a `condition block` to avoid breaking any previous UX prior to 3.7.x for provenance verification

### Dependency
This PR features a change starting from GW release for 3.7.x that should include the GW PR: https://github.com/Kong/kong-ee/pull/8814 and https://github.com/Kong/kong-ee/pull/8816


<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

