### PR TITLE
fix kong mesh navigation

### DIFF
--- a/app/_data/docs_nav_mesh_2.8.x.yml
+++ b/app/_data/docs_nav_mesh_2.8.x.yml
@@ -1,6 +1,6 @@
 generate: true
 assume_generated: true
-release: 2.7.x
+release: 2.8.x
 max_depth: 3
 inherit:
   path: /.repos/kuma/app/_src

--- a/app/_data/docs_nav_mesh_dev.yml
+++ b/app/_data/docs_nav_mesh_dev.yml
@@ -4,7 +4,7 @@ release: 2.7.x
 max_depth: 3
 inherit:
   path: /.repos/kuma/app/_src
-  nav: ../_src/.repos/kuma/app/_data/docs_nav_kuma_2.7.x.yml
+  nav: ../_src/.repos/kuma/app/_data/docs_nav_kuma_dev.yml
   patches:
     - path: [ Introduction ]
       action: modify

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -389,11 +389,7 @@
   endOfLifeDate: "2025-02-01"
   branch: release-2.6
 - edition: mesh
-  version: 2.7.0
-  release: 2.7.x
-  branch: release-2.7
-- edition: mesh
   version: preview
-  release: 2.8.x
+  release: 2.7.x
   branch: master
   label: dev

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -394,6 +394,6 @@
   branch: release-2.7
 - edition: mesh
   version: preview
-  release: dev
+  release: 2.8.x
   branch: master
   label: dev

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -389,7 +389,11 @@
   endOfLifeDate: "2025-02-01"
   branch: release-2.6
 - edition: mesh
-  version: preview
+  version: 2.7.0
   release: 2.7.x
+  branch: release-2.7
+- edition: mesh
+  version: preview
+  release: dev
   branch: master
   label: dev


### PR DESCRIPTION
### Description
Fix to showing correct Kong Mesh versions in docs

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

