### PR TITLE
feat(openid-connect): fapi docs

### DIFF
--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -1,0 +1,48 @@
+---
+title: Financial-Grade API (FAPI)
+nav_title: Financial-Grade API (FAPI)
+minimum_version: 3.7.x
+---
+
+## Overview
+
+The OpenID Connect plugin supports various features of the FAPI standard, aimed to protect APIs that expose high-value and sensitive data.
+
+### Pushed Authorization Requests (PAR)
+
+With PAR enabled, Kong (OAuth client) sends the payload of an authorization request to the IdP. As a result, it obtains a `request_uri` value. This value is used by the client in a call to the authorization endpoint as a reference to obtain the authorization request payload data.
+
+For more information refer to the [Configuration reference](/hub/kong-inc/openid-connect/configuration/#config-pushed_authorization_request_endpoint)
+
+### JWT-Secured Authorization requests (JAR)
+
+With JAR enabled, when sending requests to the authorization endpoint, Kong provides request parameters in a JSON Web Token (JWT) instead of using a query string, which allows the request data to be signed with JSON Web Signature (JWS).
+
+For more information refer to the [Configuration reference](/hub/kong-inc/openid-connect/configuration/#config-require_signed_request_object)
+
+### JWT-Secured Authorization Response Mode (JARM)
+
+With JARM enabled, Kong requests the authorization server to return the authorization response parameters encoded in a JWT, which allows the response data to be signed with JSON Web Signature (JWS).
+
+JARM can be enabled by setting the `response_mode` configuration option to any of the following available values: `query.jwt`, `form_post.jwt`, `fragment.jwt`, `jwt`.
+
+For more information refer to the [Configuration reference](/hub/kong-inc/openid-connect/configuration/#config-response_mode)
+
+### Certificate-Bound Access Tokens
+
+Certificate-bound access tokens allow binding tokens to clients. This guarantees the authenticity of the token by verifying whether the sender is authorized to use it for accessing protected resources.
+
+For more information refer to the [dedicated section](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens).
+
+### Mutual TLS (mTLS) Client Authentication and Certificate-Bound Access Tokens
+
+When mTLS client authentication is enabled, Kong establishes mTLS connections with the IdP using the configured X.509 certificate as client credentials.
+If the authorization server is configured to bind the client certificate with the issued access token, Kong can validate the access token using mTLS proof of possession.
+
+For more information refer to the dedicated sections of [mTLS Client Authentication](/hub/kong-inc/openid-connect/how-to/client-authentication/mtls) and [Certificate-Bound Access Tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens).
+
+### Demonstrating Proof-of-Possession (DPoP)
+
+Demonstrating Proof of Possession (DPoP) is an application-level mechanism for proving the sender's ownership of OAuth access and refresh tokens. With DPoP a client can prove the possession of a public/private key pair associated with a token, using a header. The header contains a signed JWT that includes a reference to the associated access token.
+
+When DPoP is enabled, Kong validates the DPoP header in the request to ensure that the sender is authorized to use the access token.

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -15,7 +15,7 @@ For more information, refer to the [configuration reference for the `pushed_auth
 
 ### JWT-Secured Authorization Requests (JAR)
 
-With JAR enabled, when sending requests to the authorization endpoint, Kong provides request parameters in a JSON Web Token (JWT) instead of using a query string, which allows the request data to be signed with JSON Web Signature (JWS).
+With JAR enabled, when sending requests to the authorization endpoint, Kong provides request parameters in a JSON Web Token (JWT) instead of using a query string. This allows the request data to be signed with JSON Web Signature (JWS).
 
 For more information refer to the [Configuration reference](/hub/kong-inc/openid-connect/configuration/#config-require_signed_request_object)
 

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -31,7 +31,7 @@ For more information, refer to the [configuration reference for the `response_mo
 
 Certificate-bound access tokens allow binding tokens to clients. This guarantees the authenticity of the token by verifying whether the sender is authorized to use it for accessing protected resources.
 
-For more information refer to the [dedicated section](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens).
+For more information, refer to the [guide on certificate-bound access tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens).
 
 ### Mutual TLS (mTLS) Client Authentication and Certificate-Bound Access Tokens
 

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -4,7 +4,6 @@ nav_title: Financial-Grade API (FAPI)
 minimum_version: 3.7.x
 ---
 
-## Overview
 
 The OpenID Connect plugin supports various features of the FAPI standard, aimed to protect APIs that expose high-value and sensitive data.
 

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -13,7 +13,7 @@ With PAR enabled, Kong (OAuth client) sends the payload of an authorization requ
 
 For more information, refer to the [configuration reference for the `pushed_authorization_request_endpoint` parameter](/hub/kong-inc/openid-connect/configuration/#config-pushed_authorization_request_endpoint).
 
-### JWT-Secured Authorization requests (JAR)
+### JWT-Secured Authorization Requests (JAR)
 
 With JAR enabled, when sending requests to the authorization endpoint, Kong provides request parameters in a JSON Web Token (JWT) instead of using a query string, which allows the request data to be signed with JSON Web Signature (JWS).
 

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -17,7 +17,7 @@ For more information, refer to the [configuration reference for the `pushed_auth
 
 With JAR enabled, when sending requests to the authorization endpoint, Kong provides request parameters in a JSON Web Token (JWT) instead of using a query string. This allows the request data to be signed with JSON Web Signature (JWS).
 
-For more information refer to the [Configuration reference](/hub/kong-inc/openid-connect/configuration/#config-require_signed_request_object)
+For more information, refer to the [configuration reference for the `require_signed_request_object` parameter](/hub/kong-inc/openid-connect/configuration/#config-require_signed_request_object).
 
 ### JWT-Secured Authorization Response Mode (JARM)
 

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -11,7 +11,7 @@ The OpenID Connect plugin supports various features of the FAPI standard, aimed 
 
 With PAR enabled, Kong (OAuth client) sends the payload of an authorization request to the IdP. As a result, it obtains a `request_uri` value. This value is used by the client in a call to the authorization endpoint as a reference to obtain the authorization request payload data.
 
-For more information refer to the [Configuration reference](/hub/kong-inc/openid-connect/configuration/#config-pushed_authorization_request_endpoint)
+For more information, refer to the [configuration reference for the `pushed_authorization_request_endpoint` parameter](/hub/kong-inc/openid-connect/configuration/#config-pushed_authorization_request_endpoint).
 
 ### JWT-Secured Authorization requests (JAR)
 

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -11,13 +11,13 @@ The OpenID Connect plugin supports various features of the FAPI standard, aimed 
 
 With PAR enabled, Kong (OAuth client) sends the payload of an authorization request to the IdP. As a result, it obtains a `request_uri` value. This value is used by the client in a call to the authorization endpoint as a reference to obtain the authorization request payload data.
 
-For more information, refer to the [configuration reference for the `pushed_authorization_request_endpoint` parameter](/hub/kong-inc/openid-connect/configuration/#config-pushed_authorization_request_endpoint).
+For more information, refer to the configuration reference for the [`pushed_authorization_request_endpoint` parameter](/hub/kong-inc/openid-connect/configuration/#config-pushed_authorization_request_endpoint).
 
 ### JWT-Secured Authorization Requests (JAR)
 
 With JAR enabled, when sending requests to the authorization endpoint, Kong provides request parameters in a JSON Web Token (JWT) instead of using a query string. This allows the request data to be signed with JSON Web Signature (JWS).
 
-For more information, refer to the [configuration reference for the `require_signed_request_object` parameter](/hub/kong-inc/openid-connect/configuration/#config-require_signed_request_object).
+For more information, refer to the configuration reference for the [`require_signed_request_object` parameter](/hub/kong-inc/openid-connect/configuration/#config-require_signed_request_object).
 
 ### JWT-Secured Authorization Response Mode (JARM)
 
@@ -25,7 +25,7 @@ With JARM enabled, Kong requests the authorization server to return the authoriz
 
 JARM can be enabled by setting the `response_mode` configuration option to any of the following available values: `query.jwt`, `form_post.jwt`, `fragment.jwt`, `jwt`.
 
-For more information, refer to the [configuration reference for the `response_mode` parameter](/hub/kong-inc/openid-connect/configuration/#config-response_mode).
+For more information, refer to the configuration reference for the [`response_mode` parameter](/hub/kong-inc/openid-connect/configuration/#config-response_mode).
 
 ### Certificate-Bound Access Tokens
 
@@ -38,12 +38,12 @@ For more information, refer to the [guide on certificate-bound access tokens](/h
 When mTLS client authentication is enabled, Kong establishes mTLS connections with the IdP using the configured X.509 certificate as client credentials.
 If the authorization server is configured to bind the client certificate with the issued access token, Kong can validate the access token using mTLS proof of possession.
 
-For more information, refer the guides on [mTLS Client Authentication](/hub/kong-inc/openid-connect/how-to/client-authentication/mtls) and [Certificate-Bound Access Tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens).
+For more information, refer to the guides on [mTLS Client Authentication](/hub/kong-inc/openid-connect/how-to/client-authentication/mtls) and [Certificate-Bound Access Tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens).
 
 ### Demonstrating Proof-of-Possession (DPoP)
 
-Demonstrating Proof of Possession (DPoP) is an application-level mechanism for proving the sender's ownership of OAuth access and refresh tokens. With DPoP a client can prove the possession of a public/private key pair associated with a token, using a header. The header contains a signed JWT that includes a reference to the associated access token.
+Demonstrating Proof of Possession (DPoP) is an application-level mechanism for proving the sender's ownership of OAuth access and refresh tokens. With DPoP, a client can prove the possession of a public/private key pair associated with a token, using a header. The header contains a signed JWT that includes a reference to the associated access token.
 
 When DPoP is enabled, Kong validates the DPoP header in the request to ensure that the sender is authorized to use the access token.
 
-For more information, refer the guide on [Demonstrating Proof-of-Possession](/hub/kong-inc/openid-connect/how-to/demonstrating_proof_of_possession/).
+For more information, refer to the guide on [Demonstrating Proof-of-Possession](/hub/kong-inc/openid-connect/how-to/demonstrating_proof_of_possession/).

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -38,7 +38,7 @@ For more information, refer to the [guide on certificate-bound access tokens](/h
 When mTLS client authentication is enabled, Kong establishes mTLS connections with the IdP using the configured X.509 certificate as client credentials.
 If the authorization server is configured to bind the client certificate with the issued access token, Kong can validate the access token using mTLS proof of possession.
 
-For more information refer to the dedicated sections of [mTLS Client Authentication](/hub/kong-inc/openid-connect/how-to/client-authentication/mtls) and [Certificate-Bound Access Tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens).
+For more information, refer the guides on [mTLS Client Authentication](/hub/kong-inc/openid-connect/how-to/client-authentication/mtls) and [Certificate-Bound Access Tokens](/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens).
 
 ### Demonstrating Proof-of-Possession (DPoP)
 

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -45,3 +45,5 @@ For more information, refer the guides on [mTLS Client Authentication](/hub/kong
 Demonstrating Proof of Possession (DPoP) is an application-level mechanism for proving the sender's ownership of OAuth access and refresh tokens. With DPoP a client can prove the possession of a public/private key pair associated with a token, using a header. The header contains a signed JWT that includes a reference to the associated access token.
 
 When DPoP is enabled, Kong validates the DPoP header in the request to ensure that the sender is authorized to use the access token.
+
+For more information, refer the guide on [Demonstrating Proof-of-Possession](/hub/kong-inc/openid-connect/how-to/demonstrating_proof_of_possession/).

--- a/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_fapi.md
@@ -25,7 +25,7 @@ With JARM enabled, Kong requests the authorization server to return the authoriz
 
 JARM can be enabled by setting the `response_mode` configuration option to any of the following available values: `query.jwt`, `form_post.jwt`, `fragment.jwt`, `jwt`.
 
-For more information refer to the [Configuration reference](/hub/kong-inc/openid-connect/configuration/#config-response_mode)
+For more information, refer to the [configuration reference for the `response_mode` parameter](/hub/kong-inc/openid-connect/configuration/#config-response_mode).
 
 ### Certificate-Bound Access Tokens
 


### PR DESCRIPTION
### Description

This PR adds a page to summarize/link all the FAPI-related features that the OpenID Connect plugin provides.

https://konghq.atlassian.net/browse/DOCU-3627

### Testing instructions

Preview link: https://deploy-preview-7236--kongdocs.netlify.app/hub/kong-inc/openid-connect/unreleased/how-to/fapi/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

