### PR TITLE
Fix: Vale for kgo template

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -14,7 +14,9 @@ WordTemplate = \s(?:%s)\s
 BasedOnStyles = kong
 IgnoredClasses = navtab-titles, plugin_example
 BlockIgnores = (\((http.*://|\.\/|\/).*?\)), \
-{\:.*?}
+{\:.*?}, \
+(?s){% kgo_.*?%}.*?{% endkgo_.*?%}
+
 TokenIgnores = {%.*?%}, \
 {{.*?}}, \
 (?:)(/[(A-Za-z0-9)(\055/)(_)]*/), \


### PR DESCRIPTION
Vale will no longer trigger on

```

{% kgo_podtemplatespec_example %}

{% endkgo_podtemplatespec_example %}
```