### PR TITLE
(fix) Revert "Make Docker page show all available base images" + condense Docker install to single row

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -388,8 +388,7 @@ jQuery(function () {
 
   // Handle EE/OSS Sidebar switcher
   const ossEeToggle = $("#oss-ee-toggle");
-  // The amazonlinux check is for the docker install page
-  if ($(".external-trigger").length && getParams.os != "amazonlinux") {
+  if ($(".external-trigger").length) {
     ossEeToggle.show();
   }
 

--- a/app/_data/tables/install_options_34x.yml
+++ b/app/_data/tables/install_options_34x.yml
@@ -9,36 +9,13 @@ columns:
 features:
   - name: "Docker"
     items:
-      - name: "Debian (bullseye-slim)"
+      - name: "Install with Docker"
         oss: true
         enterprise: true
         support: true
-        url: "https://hub.docker.com/r/kong/kong/tags?page=&page_size=&ordering=&name=debian"
-        ee_url: "https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name=debian"
-        icon: /assets/images/icons/third-party/debian-logo.jpg
-      - name: "RHEL (8-ubi)"
-        oss: true
-        enterprise: true
-        support: true
-        url: "https://hub.docker.com/r/kong/kong/tags?page=&page_size=&ordering=&name=rhel"
-        ee_url: "https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name=rhel"
-        icon: /assets/images/icons/third-party/rhel.jpg
-      - name: "Ubuntu"
-        oss: true
-        enterprise: true
-        support: true
-        url: "https://hub.docker.com/_/kong/tags?page=&page_size=&ordering=&name=ubuntu"
-        ee_url: "https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name=ubuntu"
-        icon: /assets/images/icons/third-party/ubuntu.png
-        query_params:
-          oss: "install=oss"
-      - name: "Amazon Linux (2 and 2023)"
-        oss: true
-        enterprise: true
-        support: true
-        url: "https://hub.docker.com/r/kong/kong/tags?page=&page_size=&ordering=&name=amazonlinux"
-        ee_url: "https://hub.docker.com/r/kong/kong-gateway/tags?page=1&name=amazonlinux"
-        icon: /assets/images/icons/third-party/amazon-linux.png
+        url: "/gateway/VERSION/install/docker/?install=oss"
+        ee_url: "/gateway/VERSION/install/docker/"
+        icon: /assets/images/icons/third-party/docker.png
   - name: "Kubernetes"
     items:
       - name: "Kubernetes"

--- a/app/_data/tables/install_options_34x.yml
+++ b/app/_data/tables/install_options_34x.yml
@@ -9,32 +9,35 @@ columns:
 features:
   - name: "Docker"
     items:
-      - name: "Ubuntu"
-        oss: true
-        enterprise: true
-        support: true
-        url: "/gateway/VERSION/install/docker/?install=oss"
-        ee_url: "/gateway/VERSION/install/docker/"
-        icon: /assets/images/icons/third-party/ubuntu.png
       - name: "Debian (bullseye-slim)"
         oss: true
         enterprise: true
         support: true
-        url: "/gateway/VERSION/install/docker/?os=debian&install=oss"
-        ee_url: "/gateway/VERSION/install/docker/?os=debian"
+        url: "https://hub.docker.com/r/kong/kong/tags?page=&page_size=&ordering=&name=debian"
+        ee_url: "https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name=debian"
         icon: /assets/images/icons/third-party/debian-logo.jpg
       - name: "RHEL (8-ubi)"
         oss: true
         enterprise: true
         support: true
-        url: "/gateway/VERSION/install/docker/?os=rhel&install=oss"
-        ee_url: "/gateway/VERSION/install/docker/?os=rhel"
+        url: "https://hub.docker.com/r/kong/kong/tags?page=&page_size=&ordering=&name=rhel"
+        ee_url: "https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name=rhel"
         icon: /assets/images/icons/third-party/rhel.jpg
-      - name: "Amazon Linux (2 and 2023)"
-        oss: false
+      - name: "Ubuntu"
+        oss: true
         enterprise: true
         support: true
-        ee_url: "/gateway/VERSION/install/docker/?os=amazonlinux"
+        url: "https://hub.docker.com/_/kong/tags?page=&page_size=&ordering=&name=ubuntu"
+        ee_url: "https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name=ubuntu"
+        icon: /assets/images/icons/third-party/ubuntu.png
+        query_params:
+          oss: "install=oss"
+      - name: "Amazon Linux (2 and 2023)"
+        oss: true
+        enterprise: true
+        support: true
+        url: "https://hub.docker.com/r/kong/kong/tags?page=&page_size=&ordering=&name=amazonlinux"
+        ee_url: "https://hub.docker.com/r/kong/kong-gateway/tags?page=1&name=amazonlinux"
         icon: /assets/images/icons/third-party/amazon-linux.png
   - name: "Kubernetes"
     items:

--- a/app/_src/gateway/install/docker/index.md
+++ b/app/_src/gateway/install/docker/index.md
@@ -30,15 +30,6 @@ The {{site.base_gateway}} software is governed by the
 * A Docker-enabled system with proper Docker access
 * (Enterprise only) A `license.json` file from Kong
 
-### Choose an image
-
-This page uses the Ubuntu {{ site.base_gateway }} image by default. {{ site.base_gateway }} provides multiple distributions. Select which distribution you would like to use:
-
-<label for="docker-os-ubuntu"><input id="docker-os-ubuntu" type="radio" name="docker-os" class="docker-os-select" style="margin-right: 4px" value="" checked="checked" />Ubuntu</label>
-<label for="docker-os-debian"><input id="docker-os-debian" type="radio" name="docker-os" class="docker-os-select" style="margin-right: 4px" value="debian" />Debian</label>
-<label for="docker-os-rhel"><input id="docker-os-rhel" type="radio" name="docker-os" class="docker-os-select" style="margin-right: 4px" value="rhel" />RHEL</label>
-<label for="docker-os-amazonlinux"><input id="docker-os-amazonlinux" type="radio" name="docker-os" class="docker-os-select" style="margin-right: 4px" value="amazonlinux-2023" />Amazon Linux (Enterprise Only)</label>
-
 Choose a path to install {{site.base_gateway}}:
 * [With a database](#install-kong-gateway-with-a-database): Use a database to
 store Kong entity configurations. Can use the Admin API or declarative
@@ -575,58 +566,3 @@ For troubleshooting license issues, see:
 If you did not receive a `200 OK` status code or need assistance completing
 setup, reach out to your support contact or head over to the
 [Support Portal](https://support.konghq.com/support/s/).
-
-<script>
-
-const eeToggle = document.getElementById("oss-ee-toggle");
-const eeToggleSwitch = document.getElementById("switch-to-version");
-
-let lastSelectedOs = "";
-let eeVersion = "{{page.versions.ee}}";
-let ceVersion = "{{page.versions.ce}}";
-
-const eeCodeBlocks = document.querySelectorAll("[data-panel='kong-gateway'] code");
-const ceCodeBlocks = document.querySelectorAll("[data-panel='kong-gateway-oss'] code");
-
-function createReplacement(os, image){
-    if (os != "" && image == "kong"){
-        image = "kong/kong";
-    }
-    return image + ":" + (image == "kong/kong-gateway" ? eeVersion : ceVersion) + (os.length > 0 ? "-" : "") + os;
-}
-
-function replaceOs(oldOs, newOs){
-    const eeOldOsReplace = createReplacement(oldOs, "kong/kong-gateway");
-    const ceOldOsReplace = createReplacement(oldOs, "kong");
-    const eeNewOsReplace = createReplacement(newOs, "kong/kong-gateway");
-    const ceNewOsReplace = createReplacement(newOs, "kong");
-
-    eeCodeBlocks.forEach(function(n){
-        n.innerHTML = n.innerHTML.replace(eeOldOsReplace, eeNewOsReplace);
-    });
-    ceCodeBlocks.forEach(function(n){
-        n.innerHTML = n.innerHTML.replace(ceOldOsReplace, ceNewOsReplace);
-    });
-
-    lastSelectedOs = newOs;
-}
-
-document.querySelectorAll(".docker-os-select").forEach(function(n){
-    n.addEventListener("click", function(e){
-
-        if (e.target.value == "amazonlinux-2023"){
-            // This text is what to switch to, so OSS = we're looking at enterprise
-            if (eeToggleSwitch.textContent != "OSS") {
-                eeToggleSwitch.click();
-            }
-            eeToggle.style.display = "none";
-        } else {
-            eeToggle.style.display = "flex";
-        }
-        replaceOs(lastSelectedOs , e.target.value);
-    });
-});
-
-const dockerOs = (new URLSearchParams(window.location.search)).get("os");
-document.getElementById("docker-os-" + dockerOs).click();
-</script>


### PR DESCRIPTION
Reverts Kong/docs.konghq.com#7239 and condenses Docker install to single row. Feedback on listing multiple available  platforms was that approach was confusing.

Testing: 
* https://deploy-preview-7251--kongdocs.netlify.app/gateway/latest/install/ > Docker row reads "Install with Docker" and links to OSS / Enterprise install instructions on https://deploy-preview-7251--kongdocs.netlify.app/gateway/latest/install/docker/