### PR TITLE
Get Started: httpbin.org doesn't return a content-type charset

### DIFF
--- a/app/_src/gateway/get-started/index.md
+++ b/app/_src/gateway/get-started/index.md
@@ -74,7 +74,7 @@ This script uses Docker to run {{site.base_gateway}} and a [PostgreSQL](https://
    ```text
    HTTP/1.1 200 OK
    Date: Mon, 22 Aug 2022 19:25:49 GMT
-   Content-Type: application/json; charset=utf-8
+   Content-Type: application/json
    Connection: keep-alive
    Access-Control-Allow-Origin: *
    Content-Length: 11063

--- a/app/_src/gateway/get-started/proxy-caching.md
+++ b/app/_src/gateway/get-started/proxy-caching.md
@@ -60,7 +60,7 @@ will potentially be cached.
      --data "name=proxy-cache" \
      --data "config.request_method=GET" \
      --data "config.response_code=200" \
-     --data "config.content_type=application/json; charset=utf-8" \
+     --data "config.content_type=application/json" \
      --data "config.cache_ttl=30" \
      --data "config.strategy=memory"
    ```
@@ -69,7 +69,7 @@ will potentially be cached.
 
    This Admin API request configured a Proxy Cache plugin for all `GET` requests that resulted
    in response codes of `200` and *response* `Content-Type` headers that *equal*
-   `application/json; charset=utf-8`. `cache_ttl` instructed the plugin to flush values after 30 seconds.
+   `application/json`. `cache_ttl` instructed the plugin to flush values after 30 seconds.
 
    The final option `config.strategy=memory` specifies the backing data store for cached responses. More
    information on `strategy` can be found in the [parameter reference](/hub/kong-inc/proxy-cache/)
@@ -122,7 +122,7 @@ curl -X POST http://localhost:8001/services/example_service/plugins \
    --data "name=proxy-cache" \
    --data "config.request_method=GET" \
    --data "config.response_code=200" \
-   --data "config.content_type=application/json; charset=utf-8" \
+   --data "config.content_type=application/json" \
    --data "config.cache_ttl=30" \
    --data "config.strategy=memory"
 ```
@@ -136,7 +136,7 @@ curl -X POST http://localhost:8001/routes/example_route/plugins \
    --data "name=proxy-cache" \
    --data "config.request_method=GET" \
    --data "config.response_code=200" \
-   --data "config.content_type=application/json; charset=utf-8" \
+   --data "config.content_type=application/json" \
    --data "config.cache_ttl=30" \
    --data "config.strategy=memory"
 ```
@@ -162,7 +162,7 @@ curl -X POST http://localhost:8001/consumers/sasha/plugins \
    --data "name=proxy-cache" \
    --data "config.request_method=GET" \
    --data "config.response_code=200" \
-   --data "config.content_type=application/json; charset=utf-8" \
+   --data "config.content_type=application/json" \
    --data "config.cache_ttl=30" \
    --data "config.strategy=memory"
 ```


### PR DESCRIPTION
### Description

Fix proxy caching getting started guide after the move from mockbin to httpbin

### Testing instructions

Preview link: [/gateway/latest/get-started/proxy-caching/](https://deploy-preview-7258--kongdocs.netlify.app/gateway/latest/get-started/proxy-caching/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
