### PR TITLE
Fix: Broken ordered list in getting started guide

### DIFF
--- a/app/_src/gateway/get-started/proxy-caching.md
+++ b/app/_src/gateway/get-started/proxy-caching.md
@@ -113,7 +113,10 @@ will potentially be cached.
    |Refresh| The resource was found in cache, but could not satisfy the request, due to Cache-Control behaviors or reaching its hard-coded `cache_ttl` threshold. |
    |Bypass| The request could not be satisfied from cache based on plugin configuration.                                                                         |
 
-### Service level proxy caching
+### Entity-level proxy caching
+
+{% navtabs %}
+{% navtab Service-level %}
 
 The Proxy Cache plugin can be enabled for specific services. The request is the same as above, but the request is sent to the service URL:
 
@@ -127,7 +130,8 @@ curl -X POST http://localhost:8001/services/example_service/plugins \
    --data "config.strategy=memory"
 ```
 
-### Route level proxy caching
+{% endnavtab %}
+{% navtab Route-level %}
 
 The Proxy Caching plugin can be enabled for specific routes. The request is the same as above, but the request is sent to the route URL:
 
@@ -141,31 +145,32 @@ curl -X POST http://localhost:8001/routes/example_route/plugins \
    --data "config.strategy=memory"
 ```
 
-### Consumer level proxy caching
+{% endnavtab %}
+{% navtab Consumer-level %}
 
 In {{site.base_gateway}}, [consumers](/gateway/api/admin-ee/latest/#/Consumers/list-consumer/) are an abstraction that defines a user of a service.
 Consumer-level proxy caching can be used to cache responses per consumer.
 
-1. **Create a consumer**
+1. Create a consumer:
 
-Consumers are created using the consumer object in the Admin API.
+   ```sh
+   curl -X POST http://localhost:8001/consumers/ \
+   --data username=sasha
+   ```
 
-```sh
-curl -X POST http://localhost:8001/consumers/ \
-  --data username=sasha
-```
+2. Enable caching for the consumer:
 
-1. **Enable caching for the consumer**
-
-```sh
-curl -X POST http://localhost:8001/consumers/sasha/plugins \
-   --data "name=proxy-cache" \
-   --data "config.request_method=GET" \
-   --data "config.response_code=200" \
-   --data "config.content_type=application/json" \
-   --data "config.cache_ttl=30" \
-   --data "config.strategy=memory"
-```
+   ```sh
+   curl -X POST http://localhost:8001/consumers/sasha/plugins \
+      --data "name=proxy-cache" \
+      --data "config.request_method=GET" \
+      --data "config.response_code=200" \
+      --data "config.content_type=application/json" \
+      --data "config.cache_ttl=30" \
+      --data "config.strategy=memory"
+   ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Manage cached entities
 


### PR DESCRIPTION
### Description

Fixing broken ordered list and putting the sections into tabs for better flow:

<img width="1062" alt="Screenshot 2024-04-18 at 2 02 59 PM" src="https://github.com/Kong/docs.konghq.com/assets/54370747/243a76cf-3243-4cf9-b772-6ab4a968c10a">

### Testing instructions

Preview link: https://deploy-preview-7260--kongdocs.netlify.app/gateway/latest/get-started/proxy-caching/#entity-level-proxy-caching

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

