### PR TITLE
Chore: add the ability to run vale on modified files locally to make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,6 @@ smoke:
 kill-ports:
 	@JEKYLL_PROCESS=$$(lsof -ti:4000) && kill -9 $$JEKYLL_PROCESS || true
 	@VITE_PROCESS=$$(lsof -ti:3036) && kill -9 $$VITE_PROCESS || true
+
+vale:
+	-git diff --name-only --diff-filter=d HEAD | grep '\.md$$' | xargs vale


### PR DESCRIPTION
Now you can run `make vale` to run vale locally against your modified files. 