### PR TITLE
Fix: Upgrade paths

### DIFF
--- a/app/_src/gateway/upgrade/index.md
+++ b/app/_src/gateway/upgrade/index.md
@@ -78,7 +78,7 @@ By default, {{site.base_gateway}} has migration tests between adjacent versions 
 
 1. Between patch releases of the same major and minor version.
 2. Between adjacent minor releases of the same major version.
-3. Between LTS versions.
+3. Between LTS (Long Term Support) versions.
 
     {{site.base_gateway}} maintains LTS versions and guarantees upgrades between adjacent LTS versions.
     The current LTS in the 2.x series is 2.8, and the current LTS in the 3.x series is 3.4.
@@ -93,13 +93,13 @@ The following table outlines various upgrade path scenarios to {{page.release}} 
 | ------------------- | ------------ | ---------------------------- | ---------------- |
 | 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), then upgrade to 3.0.x, and then upgrade to 3.1.x. |
 | 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, then upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 2.x–2.7.x | DB-less | No | upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 2.8.x | Traditional | No | upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 2.8.x | Hybrid | No | upgrade to 3.0.x, and then upgrade to 3.1.1.3. |
-| 2.8.x | DB-less | No | upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 3.0.x | Traditional | Yes | upgrade to 3.1.x. |
-| 3.0.x | Hybrid | Yes | upgrade to 3.1.x. |
-| 3.0.x | DB-less | Yes | upgrade to 3.1.x. |
+| 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, and then upgrade to 3.1.x. |
+| 2.8.x | Traditional | No | Upgrade to 3.0.x, and then upgrade to 3.1.x. |
+| 2.8.x | Hybrid | No | Upgrade to 3.0.x, and then upgrade to 3.1.1.3. |
+| 2.8.x | DB-less | No | Upgrade to 3.0.x, and then upgrade to 3.1.x. |
+| 3.0.x | Traditional | Yes | Upgrade to 3.1.x. |
+| 3.0.x | Hybrid | Yes | Upgrade to 3.1.x. |
+| 3.0.x | DB-less | Yes | Upgrade to 3.1.x. |
 
 {% endif_version %}
 
@@ -109,17 +109,17 @@ The following table outlines various upgrade path scenarios to {{page.release}} 
 | ------------------- | ------------ | ---------------------------- | ---------------- |
 | 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.0.x, upgrade to 3.1.x, and then upgrade to 3.2.x. |
 | 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, upgrade to 3.0.x, upgrade to 3.1.x, and then upgrade to 3.2.x. |
-| 2.x–2.7.x | DB-less | No | upgrade to 3.0.x, upgrade to 3.1.x, and then upgrade to 3.2.x. |
+| 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, upgrade to 3.1.x, and then upgrade to 3.2.x. |
 | 2.8.x | Traditional | No | Upgrade to 3.1.1.3, and then upgrade to 3.2.x. |
 | 2.8.x | Hybrid | No | Upgrade to 3.1.1.3, and then upgrade to 3.2.x. |
 | 2.8.x | DB-less | No | Upgrade to 3.1.1.3, and then upgrade to 3.2.x. |
 | 3.0.x | Traditional | No | Upgrade to 3.1.x, and then upgrade to 3.2.x. |
 | 3.0.x | Hybrid | No | Upgrade to 3.1.x, and then upgrade to 3.2.x. |
 | 3.0.x | DB-less | No | Upgrade to 3.1.x, and then upgrade to 3.2.x. |
-| 3.1.x | Traditional | Yes | upgrade to 3.2.x. |
+| 3.1.x | Traditional | Yes | Upgrade to 3.2.x. |
 | 3.1.0.x-3.1.1.2 | Hybrid | No | Upgrade to 3.1.1.3, and then upgrade to 3.2.x. |
-| 3.1.1.3 | Hybrid | Yes | upgrade to 3.2.x. |
-| 3.1.x | DB-less | Yes | upgrade to 3.2.x. |
+| 3.1.1.3 | Hybrid | Yes | Upgrade to 3.2.x. |
+| 3.1.x | DB-less | Yes | Upgrade to 3.2.x. |
 
 {% endif_version %}
 
@@ -129,20 +129,20 @@ The following table outlines various upgrade path scenarios to {{page.release}} 
 | ------------------- | ------------ | ---------------------------- | ---------------- |
 | 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, and then upgrade to 3.3.x. |
 | 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, and then upgrade to 3.3.x. |
-| 2.x–2.7.x | DB-less | No | upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, and then upgrade to 3.3.x. |
+| 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, and then upgrade to 3.3.x. |
 | 2.8.x | Traditional | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, and then upgrade to 3.3.x. |
 | 2.8.x | Hybrid | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, and then upgrade to 3.3.x. |
 | 2.8.x | DB-less | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, and then upgrade to 3.3.x. |
 | 3.0.x | Traditional | No | Upgrade to 3.1.x, upgrade to 3.2.x, and then upgrade to 3.3.x. |
 | 3.0.x | Hybrid | No | Upgrade to 3.1.x, upgrade to 3.2.x, and then upgrade to 3.3.x. |
 | 3.0.x | DB-less | No | Upgrade to 3.1.x, upgrade to 3.2.x, and then upgrade to 3.3.x. |
-| 3.1.x | Traditional | No | upgrade to 3.2.x, and then upgrade to 3.3.x. |
+| 3.1.x | Traditional | No | Upgrade to 3.2.x, and then upgrade to 3.3.x. |
 | 3.1.0.x-3.1.1.2 | Hybrid | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, and then upgrade to 3.3.x. |
-| 3.1.1.3 | Hybrid | No | upgrade to 3.2.x, and then upgrade to 3.3.x. |
-| 3.1.x | DB-less | No | upgrade to 3.2.x, and then upgrade to 3.3.x. |
-| 3.2.x | Traditional | Yes | upgrade to 3.3.x. |
-| 3.2.x | Hybrid | Yes | upgrade to 3.3.x. |
-| 3.2.x | DB-less | Yes | upgrade to 3.3.x. |
+| 3.1.1.3 | Hybrid | No | Upgrade to 3.2.x, and then upgrade to 3.3.x. |
+| 3.1.x | DB-less | No | Upgrade to 3.2.x, and then upgrade to 3.3.x. |
+| 3.2.x | Traditional | Yes | Upgrade to 3.3.x. |
+| 3.2.x | Hybrid | Yes | Upgrade to 3.3.x. |
+| 3.2.x | DB-less | Yes | Upgrade to 3.3.x. |
 
 {% endif_version %}
 
@@ -150,22 +150,22 @@ The following table outlines various upgrade path scenarios to {{page.release}} 
 
 | **Current version** | **Topology** | **Direct upgrade possible?** | **Upgrade path** |
 | ------------------- | ------------ | ---------------------------- | ---------------- |
-| 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 2.x–2.7.x | DB-less | No | upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 2.8.x | Traditional | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 2.8.x | Hybrid | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 2.8.x | DB-less | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.0.x | Traditional | No | Upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.0.x | Hybrid | No | Upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.0.x | DB-less | No | Upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.1.x | Traditional | No | upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.1.0.x-3.1.1.2 | Hybrid | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.1.1.3 | Hybrid | No | upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.1.x | DB-less | No | upgrade to 3.2.x, upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.2.x | Traditional | No | upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.2.x | Hybrid | No | upgrade to 3.3.x, and then Upgrade to 3.4.x. |
-| 3.2.x | DB-less | No | upgrade to 3.3.x, and then Upgrade to 3.4.x. |
+| 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 2.8.x | Traditional | Yes | [Directly upgrade to 3.4.x (LTS to LTS upgrade)](/gateway/{{page.release}}/upgrade/lts-upgrade/). |
+| 2.8.x | Hybrid | Yes | [Directly upgrade to 3.4.x (LTS to LTS upgrade)](/gateway/{{page.release}}/upgrade/lts-upgrade/) |
+| 2.8.x | DB-less | Yes | [Directly upgrade to 3.4.x (LTS to LTS upgrade)](/gateway/{{page.release}}/upgrade/lts-upgrade/) |
+| 3.0.x | Traditional | No | Upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.0.x | Hybrid | No | Upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.0.x | DB-less | No | Upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.1.x | Traditional | No | Upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.1.0.x-3.1.1.2 | Hybrid | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.1.1.3 | Hybrid | No | Upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.1.x | DB-less | No | Upgrade to 3.2.x, upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.2.x | Traditional | No | Upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.2.x | Hybrid | No | Upgrade to 3.3.x, and then upgrade to 3.4.x. |
+| 3.2.x | DB-less | No | Upgrade to 3.3.x, and then upgrade to 3.4.x. |
 | 3.3.x | Traditional | Yes | Upgrade to 3.4.x. |
 | 3.3.x | Hybrid | Yes | Upgrade to 3.4.x. |
 | 3.3.x | DB-less | Yes | Upgrade to 3.4.x. |
@@ -179,8 +179,9 @@ The following table outlines various upgrade path scenarios to {{page.release}} 
 | 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.4.x, and then upgrade to 3.5.x. |
 | 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, upgrade to 3.4.x, and then upgrade to 3.5.x. |
 | 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x upgrade to 3.4.x, and then upgrade to 3.5.x. |
-| 2.8.x | Hybrid | No | Upgrade to 3.4.x, and then upgrade to 3.5.x. |
-| 2.8.x | DB-less | No | Upgrade to 3.4.x, and then upgrade to 3.5.x. |
+| 2.8.x | Traditional | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), and then upgrade to 3.5.x. |
+| 2.8.x | Hybrid | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), and then upgrade to 3.5.x. |
+| 2.8.x | DB-less | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), and then upgrade to 3.5.x. |
 | 3.0.x | Traditional | No | Upgrade to 3.4.x, and then upgrade to 3.5.x. |
 | 3.0.x | Hybrid | No | Upgrade to 3.4.x, and then upgrade to 3.5.x. |
 | 3.0.x | DB-less | No | Upgrade to 3.4.x, and then upgrade to 3.5.x. |
@@ -206,8 +207,9 @@ The following table outlines various upgrade path scenarios to {{page.release}} 
 | 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
 | 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
 | 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
-| 2.8.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
-| 2.8.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 2.8.x | Traditional | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 2.8.x | Hybrid | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), upgrade to 3.5.x, and then upgrade to 3.6.x. |
+| 2.8.x | DB-less | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), upgrade to 3.5.x, and then upgrade to 3.6.x. |
 | 3.0.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
 | 3.0.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |
 | 3.0.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, and then upgrade to 3.6.x. |


### PR DESCRIPTION
### Description

Fixing two errors:
* In 3.4, the 2.8 -> 3.4 path should be a direct upgrade, since they're both LTS versions
* The "Traditional mode" 2.8.x row is missing in 3.5.x and 3.6.x

Also fixing up some copy/paste formatting.

Issue reported on Slack.

### Testing instructions

Preview link: 
https://deploy-preview-7267--kongdocs.netlify.app/gateway/latest/upgrade/#guaranteed-upgrade-paths
https://deploy-preview-7267--kongdocs.netlify.app/gateway/3.4.x/upgrade/#guaranteed-upgrade-paths
https://deploy-preview-7267--kongdocs.netlify.app/gateway/3.5.x/upgrade/#guaranteed-upgrade-paths

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

