### PR TITLE
Fix: Clear up filtering endpoints issue

### DIFF
--- a/app/konnect/api/filtering.md
+++ b/app/konnect/api/filtering.md
@@ -5,9 +5,7 @@ content-type: reference
 
 
 
-The Konnect API supports the ability to filter over selected collections and
-only return results that you are interested in.
-This reference document explains how filtering works in {{site.konnect_short_name}} APIs.
+The Konnect APIs supports the ability to filter over selected collections and only return results that you are interested in. This reference document explains how filtering generally works across {{site.konnect_short_name}} APIs. Every filter operations described here may not be available in every {{site.konnect_short_name}} API. Specific APIs may support a subset of these options. For accurate information on available filters for each API endpoint, always refer to the [individual API specification](/api/). 
 
 ### Available fields
 

--- a/app/konnect/api/filtering.md
+++ b/app/konnect/api/filtering.md
@@ -5,7 +5,11 @@ content-type: reference
 
 
 
-The Konnect APIs supports the ability to filter over selected collections and only return results that you are interested in. This reference document explains how filtering generally works across {{site.konnect_short_name}} APIs. Every filter operations described here may not be available in every {{site.konnect_short_name}} API. Specific APIs may support a subset of these options. For accurate information on available filters for each API endpoint, always refer to the [individual API specification](/api/). 
+The {{site.konnect_short_name}} APIs support the ability to filter over selected collections and only return results that you are interested in. 
+This reference document explains how filtering generally works across {{site.konnect_short_name}} APIs. 
+
+Not every filter operation described here is available in every {{site.konnect_short_name}} API. Specific APIs may support a subset of these options. 
+For the most accurate information on available filters for each API endpoint, always refer to the [individual API specification](/api/).
 
 ### Available fields
 


### PR DESCRIPTION
https://konghq.atlassian.net/browse/DOCU-3783

Rewords the introduction paragraph to explicitly mention that the filtering options aren't present in every API, and that a reader should review the API spec for the most accurate info. 