### PR TITLE
Changed from: Any to from: All

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/services/cross-namespace.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/cross-namespace.md
@@ -98,7 +98,7 @@ spec:
         from: All
 ```
 
-Listeners can allow routes in their own namespace (`from: Same`), any namespace (`from: Any`), or a
+Listeners can allow routes in their own namespace (`from: Same`), all namespaces (`from: All`), or a
 labeled set of namespaces (`from: Selector`).
 
 ## Deploy a Service and HTTPRoute


### PR DESCRIPTION
"Any" is not a valid value, it should be "All":
spec.listeners[0].allowedRoutes.namespaces.from: Unsupported value: "Any": supported values: "All", "Selector", "Same", <nil>


### Description

<!-- What did you change and why? -->
Fixed an apparent mistake in the docs where it said "Any", but meant "All"
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->
