### PR TITLE
Fix KONG_PRODUCTS so that it filters the right

### DIFF
--- a/app/_plugins/hooks/products_renderer.rb
+++ b/app/_plugins/hooks/products_renderer.rb
@@ -17,7 +17,7 @@ class ProductsRenderer
     return true if page.relative_path.start_with?('assets')
 
     products.any? do |product, _versions|
-      page.relative_path == 'index.html' || page.relative_path.start_with?(product)
+      page.relative_path == 'index.html' || page.relative_path.start_with?("#{product}/")
     end
   end
 
@@ -31,7 +31,7 @@ class ProductsRenderer
       when '*'
         versions.any? { |v| page.dir.start_with?(%r{/(\w|-)+/#{v}/}) }
       else
-        (versions.nil? && page.dir.start_with?("/#{product}")) ||
+        (versions.nil? && page.dir.start_with?("/#{product}/")) ||
           (!versions.nil? && versions.any? { |v| page.dir.start_with?(%r{/#{product}/#{v}}) })
       end
     end


### PR DESCRIPTION
### Description

Prior to this change, KONG_PRODUCTS='gateway:*' was generating both `/gateway/*/` and `/gateway-operator/*/`
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions.

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

