### PR TITLE
Fix: update docker logo on Mesh docs

### DIFF
--- a/app/_src/mesh/install.md
+++ b/app/_src/mesh/install.md
@@ -37,7 +37,7 @@ links to cloud marketplace integrations.
   </a>
 
   <a href="/mesh/{{page.release}}/installation/docker" class="docs-grid-install-block no-description">
-    <img class="install-icon" src="/assets/images/icons/third-party/docker.png" alt="Docker" />
+    <img class="install-icon" src="/assets/images/icons/third-party/docker.svg" alt="Docker" />
     <div class="install-text">Docker</div>
   </a>
 


### PR DESCRIPTION
### Description

Fixing broken link test failure: https://github.com/Kong/docs.konghq.com/actions/runs/8768698057/job/24063340313

The old docker logo was deleted but the Mesh install page is still pointing to it. Changing it to use the latest docker logo instead.

### Testing instructions

Preview link: https://deploy-preview-7285--kongdocs.netlify.app/mesh/latest/install/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

