### PR TITLE
docs(api): describe before & after filters of audit log

### DIFF
--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -232,6 +232,24 @@ components:
       schema:
         type: string
       description: The unique identifier of the filter chain to retrieve.
+    BeforeAuditLogFilter:
+      name: before_audit_log_filter
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/RequestTimestampFilterSchema'
+      description: |
+        Before filter could be used to request audit log data that was recorded before certain time (exclusive).
+        It can either be a timestamp as Unix Epoch or a string following RFC3339 Schema (without fractions of a second) - ex: '2024-04-25T15:03:24Z'
+    AfterAuditLogFilter:
+      name: after_audit_log_filter
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/RequestTimestampFilterSchema'
+      description: |
+        After filter could be used to request audit log data that was recorded after certain time (inclusive).
+        It can either be a timestamp as Unix Epoch or a string following RFC3339 Schema (without fractions of a second) - ex: '2024-04-25T15:03:24Z'
   schemas:
     UnauthorizedError:
       type: object
@@ -1275,6 +1293,11 @@ components:
           type: array
           items:
             type: string
+    RequestTimestampFilterSchema:
+      oneOf:
+        - type: string
+          pattern: '^(\d+|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$'
+        - type: integer
   responses:
     HTTP401Error:
       content:
@@ -14133,6 +14156,9 @@ paths:
   /audit/requests:
     get:
       summary: List request audit logs
+      parameters:
+        - $ref: '#/components/parameters/befpre_audit_log_filter'
+        - $ref: '#/components/parameters/after_audit_log_filter'
       tags:
         - audit-logs
       responses:
@@ -14148,6 +14174,9 @@ paths:
   /audit/objects:
     get:
       summary: List database audit logs
+      parameters:
+        - $ref: '#/components/parameters/befpre_audit_log_filter'
+        - $ref: '#/components/parameters/after_audit_log_filter'
       responses:
         '200':
           $ref: '#/components/responses/database-audit-log-response'


### PR DESCRIPTION
### Description

Audit Log endpoints (`/audit/requests` and `/audit/objects`) right now accept `before` and `after` parameters that allow a user to search through audit log endpoints

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

