### PR TITLE
feat(gateway/oas-validation): OpenAPI 3.1.0 documentation

### DIFF
--- a/app/_hub/kong-inc/oas-validation/overview/_index.md
+++ b/app/_hub/kong-inc/oas-validation/overview/_index.md
@@ -4,13 +4,17 @@ nav_title: Overview
 
 Validate HTTP requests and responses against an OpenAPI Specification.
 
-The plugin supports both Swagger(v2) and OpenAPI(3.0.x) specifications, with the support of JSON Schema [Draft-04](https://json-schema.org/specification-links#draft-4). 
 
-{% if_plugin_version eq:3.7.x %}
+{% if_version lte:3.6.x %}
 
-[OpenAPI 3.1.0](https://www.openapis.org/blog/2021/02/18/openapi-specification-3-1-released) is supported in Kong Gateway 3.7.0.0 with a new JSON Schema validator that supports Draft 2019-09.
+The plugin supports both Swagger (v2) and OpenAPI (3.0.x) specifications, with the support of JSON Schema [Draft-04](https://json-schema.org/specification-links#draft-4). 
 
-{% endif_plugin_version %}
+{% endif_version %}
+{% if_version gte:3.7.x %}
+
+The plugin supports both Swagger (v2) and OpenAPI (3.0.x and 3.1.0) specifications with a JSON Schema validator that supports [Draft 2019-09](https://json-schema.org/specification-links#draft-2019-09-(formerly-known-as-draft-8)).
+
+{% endif_version %}
 
 {% if_plugin_version gte:3.2.x %}
 {:.important .no-icon}
@@ -29,19 +33,19 @@ To enable the plugin, use one of the following methods:
 
 {% endif_plugin_version %}
 
-{% if_plugin_version eq:3.7.x %}
+{% if_version gte:3.7.x %}
 
 ## Supported OpenAPI 3.1.0 specification features
 
 | Category                        | Supported                      | Not supported                                                            |
 |---------------------------------|--------------------------------|--------------------------------------------------------------------------|
-| Request Body                    | application/json               | application/xml</br>multipart/form-data</br>text/plain</br>text/xml</br> |
-| Response Body                   | application/json               | -                                                                        |
-| Request Parameters              | path, query, header, cookie    | -                                                                        |
-| Schema                          | allOf</br>oneOf</br>anyOf</br> | -                                                                        |
-| Parameter Serialization         | style, explode                 | -                                                                        |
+| Request Body                    | `application/json`               | `application/xml`<br>`multipart/form-data`<br>`text/plain`<br>`text/xml`<br> |
+| Response Body                   | `application/json`               | -                                                                        |
+| Request Parameters              | `path`, `query`, `header`, `cookie`    | -                                                                        |
+| Schema                          | `allOf`<br>`oneOf`<br>`anyOf`<br> | -                                                                        |
+| Parameter Serialization         | `style`, `explode `                | -                                                                        |
 
-{% endif_plugin_version %}
+{% endif_version %}
 
 ## Tutorial
 

--- a/app/_hub/kong-inc/oas-validation/overview/_index.md
+++ b/app/_hub/kong-inc/oas-validation/overview/_index.md
@@ -2,9 +2,15 @@
 nav_title: Overview
 ---
 
-Validate HTTP requests and responses based on an API specification. 
-Supports both Swagger v2 and OpenAPI v3 specifications JSON request and response bodies, with support for schema definitions described using JSON Schema draft v4. 
-For JSON Schema draft 4 type schemas, see the [JSON Schema documentation](https://json-schema.org/) for details on the format and examples.
+Validate HTTP requests and responses against an OpenAPI Specification.
+
+The plugin supports both Swagger(v2) and OpenAPI(3.0.x) specifications, with the support of JSONSchema [Draft-04](https://json-schema.org/specification-links#draft-4). 
+
+{% if_plugin_version eq:3.7.x %}
+
+[OpenAPI 3.1.0](https://www.openapis.org/blog/2021/02/18/openapi-specification-3-1-released) is supported in Kong Gateway 3.7.0.0 with a new JSONSchema validator that supports Draft 2019-09.
+
+{% endif_plugin_version %}
 
 {% if_plugin_version gte:3.2.x %}
 {:.important .no-icon}
@@ -20,6 +26,20 @@ To enable the plugin, use one of the following methods:
   * Package install: Set `plugins=bundled,oas-validation` in `kong.conf` before starting Kong
   * Docker: Set `KONG_PLUGINS=bundled,oas-validation` in the environment
   * Kubernetes: Set `KONG_PLUGINS=bundled,oas-validation` using [these instructions](/kubernetes-ingress-controller/latest/guides/setting-up-custom-plugins/#modify-configuration)
+
+{% endif_plugin_version %}
+
+{% if_plugin_version eq:3.7.x %}
+
+## Supported OpenAPI 3.1.0 specification features
+
+| Category                        | Supported                      | Not supported                                                            |
+|---------------------------------|--------------------------------|--------------------------------------------------------------------------|
+| Request Body                    | application/json               | application/xml</br>multipart/form-data</br>text/plain</br>text/xml</br> |
+| Response Body                   | application/json               | -                                                                        |
+| Request Parameters              | path, query, header, cookie    | -                                                                        |
+| Schema                          | allOf</br>oneOf</br>anyOf</br> | -                                                                        |
+| Parameter Serialization         | style, explode                 | -                                                                        |
 
 {% endif_plugin_version %}
 

--- a/app/_hub/kong-inc/oas-validation/overview/_index.md
+++ b/app/_hub/kong-inc/oas-validation/overview/_index.md
@@ -4,11 +4,11 @@ nav_title: Overview
 
 Validate HTTP requests and responses against an OpenAPI Specification.
 
-The plugin supports both Swagger(v2) and OpenAPI(3.0.x) specifications, with the support of JSONSchema [Draft-04](https://json-schema.org/specification-links#draft-4). 
+The plugin supports both Swagger(v2) and OpenAPI(3.0.x) specifications, with the support of JSON Schema [Draft-04](https://json-schema.org/specification-links#draft-4). 
 
 {% if_plugin_version eq:3.7.x %}
 
-[OpenAPI 3.1.0](https://www.openapis.org/blog/2021/02/18/openapi-specification-3-1-released) is supported in Kong Gateway 3.7.0.0 with a new JSONSchema validator that supports Draft 2019-09.
+[OpenAPI 3.1.0](https://www.openapis.org/blog/2021/02/18/openapi-specification-3-1-released) is supported in Kong Gateway 3.7.0.0 with a new JSON Schema validator that supports Draft 2019-09.
 
 {% endif_plugin_version %}
 


### PR DESCRIPTION
### Description

Update document for OAS-Validation plugin about OpenAPI 3.1.0

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-7310--kongdocs.netlify.app/hub/kong-inc/oas-validation/unreleased/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

https://github.com/Kong/kong-ee/pull/7833

