### PR TITLE
Update Konnect API links to point to latest

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -455,7 +455,7 @@
 /konnect/api/portal-auth/portal-rbac-guide/ /konnect/dev-portal/access-and-approval/manage-teams/
 #API Redirects
 
-/konnect/identity-management-api/   /konnect/api/identity-management/v2/
+/konnect/identity-management-api/   /konnect/api/identity-management/latest/
 /gateway/*/kong-enterprise/dev-portal/portal-api/ /dev-portal/api/v1/
 
 # STUDIO

--- a/app/konnect/api/identity-management/identity-integration.md
+++ b/app/konnect/api/identity-management/identity-integration.md
@@ -176,5 +176,5 @@ If you were successful, you will receive a `200` response code, and the response
 
 ## More information
 
-* [IdP API documentation](/konnect/api/identity-management/v2/)
+* [IdP API documentation](/konnect/api/identity-management/latest/)
 * [Filtering Reference](/konnect/api/filtering/)

--- a/app/konnect/dev-portal/customization/index.md
+++ b/app/konnect/dev-portal/customization/index.md
@@ -32,9 +32,9 @@ You can completely customize the Dev Portal using the [open source Dev Portal cl
 
 This self-hosted portal provides the following benefits: 
 
-* **Fully customizable:** Use the [example frontend Dev Portal application](https://github.com/Kong/konnect-portal) as a starting point and then customize Dev Portal for your needs using the [Portal API](/konnect/api/portal/v2/) and [Portal SDK](https://www.npmjs.com/package/@kong/sdk-portal-js). You can also integrate the API specs with workflows tailored to your organization's own processes.
+* **Fully customizable:** Use the [example frontend Dev Portal application](https://github.com/Kong/konnect-portal) as a starting point and then customize Dev Portal for your needs using the [Portal API](/konnect/api/portal/latest/) and [Portal SDK](https://www.npmjs.com/package/@kong/sdk-portal-js). You can also integrate the API specs with workflows tailored to your organization's own processes.
 * **Hosting service choice:** When you self-host, you also get to choose which hosting service you use to deploy your Dev Portal. 
-* **Range of customization options:** With the self-hosted Dev Portal, you determine how much you want to customize. You can choose to use the example application right out of the box, or you can use the [Portal API](/konnect/api/portal/v2/) and [Portal SDK](https://www.npmjs.com/package/@kong/sdk-portal-js) for more fine-grained control.
+* **Range of customization options:** With the self-hosted Dev Portal, you determine how much you want to customize. You can choose to use the example application right out of the box, or you can use the [Portal API](/konnect/api/portal/latest/) and [Portal SDK](https://www.npmjs.com/package/@kong/sdk-portal-js) for more fine-grained control.
 
 ## Custom Dev Portal URL
 

--- a/app/konnect/dev-portal/customization/netlify.md
+++ b/app/konnect/dev-portal/customization/netlify.md
@@ -76,7 +76,7 @@ Once your name servers are propagated (this may take a few minutes), your Dev Po
 
 If you want to further customize the example self-hosted Dev Portal, you can edit the settings in your forked copy of the open source {{site.konnect_short_name}} Dev Portal repository. For more information, see the [{{site.konnect_short_name}} Portal repository](https://github.com/Kong/konnect-portal).  
 
-You can also customize your Dev Portal using the [Portal API](/konnect/api/portal/v2/) and [Portal SDK](https://www.npmjs.com/package/@kong/sdk-portal-js). 
+You can also customize your Dev Portal using the [Portal API](/konnect/api/portal/latest/) and [Portal SDK](https://www.npmjs.com/package/@kong/sdk-portal-js). 
 
 ## More information
 

--- a/app/konnect/dev-portal/customization/self-hosted-portal.md
+++ b/app/konnect/dev-portal/customization/self-hosted-portal.md
@@ -13,9 +13,9 @@ You can use the open source Dev Portal to display your APIs to developers on a s
 
 There are several benefits to keep in mind when deciding whether to use a {{site.konnect_short_name}}-hosted or self-hosted Dev Portal. The self-hosted portal provides the following benefits: 
 
-* **Fully customizable:** Use the [example frontend Dev Portal application](https://github.com/Kong/konnect-portal) as a starting point and then customize Dev Portal for your needs using the [Portal API](/konnect/api/portal/v2/). You can also integrate the API specs with workflows tailored to your organization's own processes.
+* **Fully customizable:** Use the [example frontend Dev Portal application](https://github.com/Kong/konnect-portal) as a starting point and then customize Dev Portal for your needs using the [Portal API](/konnect/api/portal/latest/). You can also integrate the API specs with workflows tailored to your organization's own processes.
 * **Hosting platform choice:** When you self-host, you also get to choose which hosting platform you use to deploy your Dev Portal. 
-* **Range of customization options:** With the self-hosted Dev Portal, you determine how much you want to customize. You can choose to use the example application right out of the box, or you can use the [Portal API](/konnect/api/portal/v2/) and [Portal SDK](https://www.npmjs.com/package/@kong/sdk-portal-js) for more fine-grained control.
+* **Range of customization options:** With the self-hosted Dev Portal, you determine how much you want to customize. You can choose to use the example application right out of the box, or you can use the [Portal API](/konnect/api/portal/latest/) and [Portal SDK](https://www.npmjs.com/package/@kong/sdk-portal-js) for more fine-grained control.
 
 ## How the self-hosted Dev Portal works 
 

--- a/app/konnect/gateway-manager/index.md
+++ b/app/konnect/gateway-manager/index.md
@@ -158,7 +158,7 @@ nodes in the control plane the have been accounted for.
 
 To delete a control plane, you can use the Gateway Manager or the 
 {{site.konnect_short_name}} 
-[Control Plane API](/konnect/api/control-planes/v2/).
+[Control Plane API](/konnect/api/control-planes/latest/).
 
 When a control plane is deleted, all associated entities are also deleted.
 This includes all entities configured in the Gateway Manager for this control plane.

--- a/app/konnect/org-management/audit-logging/index.md
+++ b/app/konnect/org-management/audit-logging/index.md
@@ -21,7 +21,7 @@ You can do this by [setting up a webhook](/konnect/org-management/audit-logging/
 log collection service that supports [ArcSight CEF Format](https://docs.centrify.com/Content/IntegrationContent/SIEM/arcsight-cef/arcsight-cef-format.htm) or JSON-formatted data.
 
 Audit logging webhooks can be configured through the {{site.konenct_short_name}} **Organization** menu, or
-using the [Audit Logs API](/konnect/api/audit-logs/v2/).
+using the [Audit Logs API](/konnect/api/audit-logs/latest/).
 Only {{site.konnect_short_name}} org admins can configure and view audit log webhooks. 
 
 ![Audit log webhook](/assets/images/products/konnect/audit-logs/konnect-audit-log-webhook.png)
@@ -38,4 +38,4 @@ See the [audit log reference](/konnect/org-management/audit-logging/reference/) 
 * [Set up an audit log replay job](/konnect/org-management/audit-logging/replay-job/)
 * [Audit log event reference](/konnect/org-management/audit-logging/reference/)
 * [Verify audit log signatures](/konnect/org-management/audit-logging/verify-signatures/)
-* [Audit Logs API](/konnect/api/audit-logs/v2/)
+* [Audit Logs API](/konnect/api/audit-logs/latest/)

--- a/app/konnect/org-management/audit-logging/reference.md
+++ b/app/konnect/org-management/audit-logging/reference.md
@@ -215,4 +215,4 @@ Property | Description
 * [Set up an audit log webhook](/konnect/org-management/audit-logging/webhook/)
 * [Set up an audit log replay job](/konnect/org-management/audit-logging/replay-job/)
 * [Verify audit log signatures](/konnect/org-management/audit-logging/verify-signatures/)
-* [Audit Logs API](/konnect/api/audit-logs/v2/)
+* [Audit Logs API](/konnect/api/audit-logs/latest/)

--- a/app/konnect/org-management/audit-logging/replay-job.md
+++ b/app/konnect/org-management/audit-logging/replay-job.md
@@ -119,4 +119,4 @@ When a replay job is `running`, a request to update the job will return a `409` 
 * [Set up an audit log webhook](/konnect/org-management/audit-logging/webhook/)
 * [Audit log event reference](/konnect/org-management/audit-logging/reference/)
 * [Verify audit log signatures](/konnect/org-management/audit-logging/verify-signatures/)
-* [Audit Logs API](/konnect/api/audit-logs/v2/)
+* [Audit Logs API](/konnect/api/audit-logs/latest/)

--- a/app/konnect/org-management/audit-logging/webhook.md
+++ b/app/konnect/org-management/audit-logging/webhook.md
@@ -191,4 +191,4 @@ false           | `unconfigured` | The webhook for this region has not been conf
 * [Audit log event reference](/konnect/org-management/audit-logging/reference/)
 * [Set up an audit log replay job](/konnect/org-management/audit-logging/replay-job/)
 * [Verify audit log signatures](/konnect/org-management/audit-logging/verify-signatures/)
-* [Audit Logs API](/konnect/api/audit-logs/v2/)
+* [Audit Logs API](/konnect/api/audit-logs/latest/)

--- a/app/konnect/org-management/system-accounts.md
+++ b/app/konnect/org-management/system-accounts.md
@@ -4,7 +4,7 @@ content_type: how-to
 no_version: true
 ---
 
-This guide explains what a system account is, how it varies from a user account, and how to manage a system account using the [{{site.konnect_short_name}} Identity API](/konnect/api/identity-management/v2/). 
+This guide explains what a system account is, how it varies from a user account, and how to manage a system account using the [{{site.konnect_short_name}} Identity API](/konnect/api/identity-management/latest/). 
 
 A system account is a service account in {{site.konnect_short_name}}. Because system accounts are not associated with an email address and a user, they can be used for automation and integrations. 
 

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -277,7 +277,7 @@ You can upload a plugin schema to Konnect and get started with custom plugins in
 ## July 2023
 
 **API Products API released**
-: A new {{site.konnect_short_name}} API for managing API products and versions is now available for external consumption. This API allows you to create and manage API products and versions, upload documentation and specs, and link a version to an existing Gateway service to enable application registration. As a result, you can integrate this API into your automated pipeline to streamline publishing documentation for your products to your third-party developers. Explore the API spec on our [Developer Portal](/konnect/api/api-products/v2/)
+: A new {{site.konnect_short_name}} API for managing API products and versions is now available for external consumption. This API allows you to create and manage API products and versions, upload documentation and specs, and link a version to an existing Gateway service to enable application registration. As a result, you can integrate this API into your automated pipeline to streamline publishing documentation for your products to your third-party developers. Explore the API spec on our [Developer Portal](/konnect/api/api-products/latest/)
 
 **API Products**
 : Introducing a new {{site.konnect_short_name}} module, [API Products](https://cloud.konghq.com/us/api-products/), where technical & non-technical audiences can document their services, link to Gateway services for application registration, and publish API Products to a Developer Portal for consumption. Existing {{site.konnect_short_name}} customers will find that their services in Service Hub have been seamlessly moved to the new API Products UI & API experience.
@@ -293,7 +293,7 @@ With composite runtime groups, organizations can reduce infrastructure costs whi
 * [Set up and manage runtime groups](/konnect/gateway-manager/control-plane-groups/how-to/)
 * [Migrate configuration into a composite runtime group](/konnect/gateway-manager/control-plane-groups/migrate/)
 * [Conflicts in runtime groups](/konnect/gateway-manager/control-plane-groups/conflicts/)
-* [API documentation](/konnect/api/runtime-groups/v2/)
+* [API documentation](/konnect/api/runtime-groups/latest/)
 
 **Analytics for composite runtime groups**
 : Custom reports now support grouping and filtering by composite runtime group.
@@ -323,7 +323,7 @@ For more information, see [About Self-Hosted Dev Portal](/konnect/dev-portal/cus
 
 **Portal Client API**
 : {{site.konnect_short_name}} now supports customers' integration with Dev Portal workflows via public APIs. 
-For more information, see the [Portal Client API spec](/konnect/api/portal/v2/).
+For more information, see the [Portal Client API spec](/konnect/api/portal/latest/).
 
 **Audit logging**
 : Konnect now provides audit logging capability, designed to enhance the security, compliance, debugging and risk management of your core infrastructure. 
@@ -470,7 +470,7 @@ with any of the following backends:
 : {{site.konnect_short_name}} users can now take advantage of the the entire plugin suite offered alongside {{site.base_gateway}} 3.1. For more information about the available plugins. review our [compatibility documentation](/konnect/compatibility/#plugin-compatibility).
 
 **Runtime Groups API**
-: Konnect APIs for runtime groups are now available for external consumption. This set of APIs allow organizations to create and manage runtime groups and manage CP/DP certificates. [View API documentation](/konnect/api/runtime-groups/v2/).
+: Konnect APIs for runtime groups are now available for external consumption. This set of APIs allow organizations to create and manage runtime groups and manage CP/DP certificates. [View API documentation](/konnect/api/runtime-groups/latest/).
 
 ## November 2022
 
@@ -511,7 +511,7 @@ The group still retains its status as the default group, and can't be deleted.
 
 **Konnect APIs for identity management**
 : Konnect APIs for identity management are now available for external consumption. This set of APIs allow organizations to manage users, teams, team memberships, team mappings and role assignments. As a result, customers can leverage our APIs to build custom integrations with their identity provider or ERP systems to manage their users and user’s access to Konnect.
-[IdP API documentation](/konnect/api/identity-management/v2/)
+[IdP API documentation](/konnect/api/identity-management/latest/)
 
 ## October 2022
 


### PR DESCRIPTION
### Description

Some links in our konnect docs point explicitly to v2 of various APIs, when they should be pointing to `latest` to remain evergreen. The only API where this is currently an issue is the identity API, as the latest version is now v3. Updating all versioned links to avoid this issue in the future.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

