### PR TITLE
Chore: change 'outdated' to 'older' in version banner

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -105,7 +105,7 @@ id: documentation
                 {% endif %}
             {% else %}
               <blockquote id="version-notice" class="important">
-                You are browsing documentation for an outdated version.
+                You are browsing documentation for an older version.
             {% endif %}
                 See the <a href="{{ page.canonical_url }}">latest documentation here</a>.
               </blockquote>

--- a/tests/sidebar.test.js
+++ b/tests/sidebar.test.js
@@ -25,9 +25,9 @@ describe("Version Switcher", () => {
   });
 });
 
-describe("Outdated version documentation", () => {
+describe("Older version documentation", () => {
   const oldVersionSelector =
-    'blockquote:contains("You are browsing documentation for an outdated version.") a';
+    'blockquote:contains("You are browsing documentation for an older version.") a';
   const latestGatewayVersion = "2.8.x";
 
   test("does not show on the latest version", async () => {

--- a/tools/admonition-summary/scrape.js
+++ b/tools/admonition-summary/scrape.js
@@ -30,7 +30,7 @@ module.exports = function () {
       const content = el.html().trim();
       if (
         content.startsWith(
-          "You are browsing documentation for an outdated version.",
+          "You are browsing documentation for an older version.",
         )
       ) {
         return;


### PR DESCRIPTION
### Description

When looking at the docs for an older version, the banner currently says "You are browsing documentation for an outdated version." This isn't always true, as our LTS versions are older, but not considered "outdated". Changing the text to reflect this.

### Testing instructions

Preview link: https://deploy-preview-7314--kongdocs.netlify.app/gateway/3.4.x/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

