### PR TITLE
Improved readability and detatched some commands from their output

### DIFF
--- a/app/_src/gateway-operator/guides/autoscaling-kong.md
+++ b/app/_src/gateway-operator/guides/autoscaling-kong.md
@@ -76,7 +76,7 @@ spec:
             limits:
               memory: "1024Mi"
               cpu: "1000m"
-          # Add here any Konnect related environment variables, volumes etc...
+          # Add any Konnect-related configuration here: environment variables, volumes, and so on.
 ' | kubectl apply -f -
 ```
 

--- a/app/_src/gateway-operator/guides/autoscaling-kong.md
+++ b/app/_src/gateway-operator/guides/autoscaling-kong.md
@@ -106,7 +106,7 @@ You can test if the autoscaling works by using a load testing tool (e.g. k6s) to
     export PROXY_IP=$(kubectl get dataplanes.gateway-operator.konghq.com -o jsonpath='{.status.addresses[0].value}' horizontal-autoscaling)
     ```
 
-1. Install [`k6s`](https://k6.io/) then create a configuration file containing the following code:
+1. Install [`k6s`](https://k6.io/), then create a configuration file containing the following code:
 
     ```javascript
     import http from "k6/http";

--- a/app/_src/gateway-operator/guides/autoscaling-kong.md
+++ b/app/_src/gateway-operator/guides/autoscaling-kong.md
@@ -29,6 +29,7 @@ The `scaleUp` configuration states that either 100% of existing replicas, or 5 n
 The `scaleDown` configuration states that 100% of pods may be removed (with a `minReplicas` value of 2).
 
 ```yaml
+echo '
 apiVersion: gateway-operator.konghq.com/v1beta1
 kind: DataPlane
 metadata:
@@ -75,7 +76,8 @@ spec:
             limits:
               memory: "1024Mi"
               cpu: "1000m"
-          # Konnect related environment variables, volumes etc...
+          # Add here any Konnect related environment variables, volumes etc...
+' | kubectl apply -f -
 ```
 
 {:.note}
@@ -84,7 +86,12 @@ spec:
 A `DataPlane` is created when the manifest above is applied. This creates 2 `Pod`s running {{site.base_gateway}}, as well as a `HorizontalPodAutoscaler` which will manage the replica count of those `Pod`s to ensure that the average CPU utilization is around 50%.
 
 ```bash
-$ kubectl get hpa
+kubectl get hpa
+```
+
+The output will show the `HorizontalPodAutoscaler` resource:
+
+```bash
 NAME                     REFERENCE                                           TARGETS   MINPODS   MAXPODS   REPLICAS   AGE
 horizontal-autoscaling   Deployment/dataplane-horizontal-autoscaling-4q72p   2%/50%    2         10        2          30s
 ```
@@ -99,10 +106,9 @@ You can test if the autoscaling works by using a load testing tool (e.g. k6s) to
     export PROXY_IP=$(kubectl get dataplanes.gateway-operator.konghq.com -o jsonpath='{.status.addresses[0].value}' horizontal-autoscaling)
     ```
 
-1. Create a [`k6s`](https://k6.io/) configuration file.
+1. Install [`k6s`](https://k6.io/) then create a configuration file containing the following code:
 
-    ```bash
-    $ cat k6s.js
+    ```javascript
     import http from "k6/http";
     import { check } from "k6";
 
@@ -123,13 +129,17 @@ You can test if the autoscaling works by using a load testing tool (e.g. k6s) to
 1. Start the load test.
 
    ```
-   $ k6 run k6.js
+   k6 run k6.js
    ```
 
 1. Observe the scaling events in the cluster while the test is running.
 
     ```bash
-    $ kubectl get events --field-selector involvedObject.name=horizontal-autoscaling --field-selector involvedObject.kind=HorizontalPodAutoscaler
+    kubectl get events --field-selector involvedObject.name=horizontal-autoscaling --field-selector involvedObject.kind=HorizontalPodAutoscaler
+    ```
+
+    The output will show the scaling events:
+    ```bash
     LAST SEEN   TYPE      REASON                         OBJECT                                           MESSAGE
     3m55s       Normal    SuccessfulRescale              horizontalpodautoscaler/horizontal-autoscaling   New size: 6; reason: cpu resource utilization (percentage of request) above target
     3m25s       Normal    SuccessfulRescale              horizontalpodautoscaler/horizontal-autoscaling   New size: 7; reason: cpu resource utilization (percentage of request) above target
@@ -140,7 +150,10 @@ You can test if the autoscaling works by using a load testing tool (e.g. k6s) to
     The `DataPlane`'s `status` field will also be updated with the number of ready/target replicas:
 
     ```bash
-    $ kubectl get dataplanes.gateway-operator.konghq.com horizontal-autoscaling -o jsonpath-as-json='{.status}'
+    kubectl get dataplanes.gateway-operator.konghq.com horizontal-autoscaling -o jsonpath-as-json='{.status}'
+    ```
+
+    ```json
     [
         {
             ...


### PR DESCRIPTION
### Description

I improved the readability of some commands separating their outputs, facilitating user copy-paste flow when trying out when trying the autoscaling setup, clarified the k6s installation is required before running the command and its javascript test.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.

At least one of these labels must be applied to a PR or the build will fail.
-->

