### PR TITLE
Add paragraph to explain queue parameter scope

### DIFF
--- a/app/_hub/kong-inc/datadog/overview/_index.md
+++ b/app/_hub/kong-inc/datadog/overview/_index.md
@@ -21,6 +21,10 @@ in the {{site.base_gateway}} documentation.
 
 The queue parameters all reside in a record under the key `queue` in
 the `config` parameter section of the plugin.
+
+Queues are not shared between workers and queueing parameters are
+scoped to one worker.  For whole-system capacity planning, the number
+of workers need to be considered when setting queue parameters.
 {% endif_version %}
 
 ---

--- a/app/_hub/kong-inc/http-log/overview/_index.md
+++ b/app/_hub/kong-inc/http-log/overview/_index.md
@@ -17,6 +17,10 @@ The equivalence of the log server is determined by the parameters
 `http_endpoint`, `method`, `content_type`, `timeout`, and `keepalive`.
 All plugin instances that have the same values for these parameters
 share one queue.
+
+Queues are not shared between workers and queueing parameters are
+scoped to one worker.  For whole-system capacity planning, the number
+of workers need to be considered when setting queue parameters.
 {% endif_plugin_version %}
 
 ## Kong process errors

--- a/app/_hub/kong-inc/opentelemetry/overview/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/overview/_index.md
@@ -20,6 +20,10 @@ in the {{site.base_gateway}} documentation.
 
 The queue parameters all reside in a record under the key `queue` in
 the `config` parameter section of the plugin.
+
+Queues are not shared between workers and queueing parameters are
+scoped to one worker.  For whole-system capacity planning, the number
+of workers need to be considered when setting queue parameters.
 {% endif_version %}
 
 {% if_plugin_version gte:3.5.x %}

--- a/app/_hub/kong-inc/statsd/overview/_index.md
+++ b/app/_hub/kong-inc/statsd/overview/_index.md
@@ -27,6 +27,10 @@ in the {{site.base_gateway}} documentation.
 
 The queue parameters all reside in a record under the key `queue` in
 the `config` parameter section of the plugin.
+
+Queues are not shared between workers and queueing parameters are
+scoped to one worker.  For whole-system capacity planning, the number
+of workers need to be considered when setting queue parameters.
 {% endif_version %}
 
 

--- a/app/_hub/kong-inc/zipkin/overview/_index.md
+++ b/app/_hub/kong-inc/zipkin/overview/_index.md
@@ -20,6 +20,10 @@ in the {{site.base_gateway}} documentation.
 
 The queue parameters all reside in a record under the key `queue` in
 the `config` parameter section of the plugin.
+
+Queues are not shared between workers and queueing parameters are
+scoped to one worker.  For whole-system capacity planning, the number
+of workers need to be considered when setting queue parameters.
 {% endif_version %}
 
 {% if_plugin_version gte:3.5.x %}

--- a/app/_src/gateway/kong-plugins/queue/reference.md
+++ b/app/_src/gateway/kong-plugins/queue/reference.md
@@ -25,6 +25,10 @@ The unified queue parameter set consists of the following parameters:
 |`initial_retry_delay` | fraction | seconds | 0.01 | Initial delay before retrying after processing a failed batch. |
 |`max_retry_delay` | fraction | seconds | 60 | Maximum time to wait between retries. |
 
+Queues are not shared between workers and queueing parameters are
+scoped to one worker.  For whole-system capacity planning, the number
+of workers need to be considered when setting queue parameters.
+
 ## More information
 
 [About Plugin Queuing](/gateway/{{page.release}}/kong-plugins/queue/) - Find out how plugin queuing works.


### PR DESCRIPTION
### Description

Explicitly mention that queue parameters are scoped to one worker in the Queueing section of plugins that use queues.

### Testing instructions

Preview link: https://deploy-preview-7331--kongdocs.netlify.app/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

KAG-4409
