### PR TITLE
feat: Add Mermaid export instructions to contributing guide

### DIFF
--- a/.github/styles/kong/auto-ignore.txt
+++ b/.github/styles/kong/auto-ignore.txt
@@ -64,6 +64,7 @@ start_cmd
 stream_listen
 stringified
 subcomponent
+subgraphs
 trusted_ips
 DECK_
 Gateway

--- a/app/contributing/diagrams.md
+++ b/app/contributing/diagrams.md
@@ -226,8 +226,10 @@ flowchart TD
 
 ## Export a Mermaid diagram from the docs
 
-You can export a Mermaid diagram from the Kong docs using the Mermaid live editor. 
+You can export a Mermaid diagram from the Kong docs using the Mermaid live editor. This method will only work with diagrams that don't contain icons or images.
 
 1. Copy the Mermaid diagram from the Kong doc file. You can find the doc source file by clicking **Edit this page** at the top right corner of the doc.
-1. Paste the Mermaid diagram into the [Mermaid live editor](https://mermaid.live/edit).
+1. Paste the Mermaid diagram into the [Mermaid live editor](https://mermaid.live/edit#pako:eNpl0D1vwjAQBuC_El3XDFQCRDK2VdWhXaDqUHm52Gew5I_o4lBSlP9eh4Dkiu107_PecGeQQRHUoG34kQfkWLxvoQRH7NCoFJyFLwoB8UCOBNRpbLBLU5ntv5ANNpa6CVwKU6SDj6_ojB3m3hvZI0Uj8Vq-mZ35vV5-XLWnLGzZOOThOdjAM3jQWt-Dp8CKOGdL3Kxpcy8_6RT_uWol18vMWeMpB1XVLORCwJSPwo_pNdjHsBu8hDpyTyX0rcJILwb3jA5qjbZLW1ImBv6Yn3v5cQkt-u8Qbmb8A-8_eHU).
+1. If the diagram contains images, remove all `<img>` tags.
+1. Replace any [Liquid variables](/contributing/variables/) (for example, {% raw %}`{{site.base_gateway}}`{% endraw %}) with their output. Liquid variables won't render correctly in the Mermaid live editor.
 1. Click **Actions** on the bottom left corner and select the file type you want to export the diagram to.

--- a/app/contributing/diagrams.md
+++ b/app/contributing/diagrams.md
@@ -223,3 +223,11 @@ flowchart TD
 ```
 {% endnavtab %}
 {% endnavtabs %}
+
+## Export a Mermaid diagram from the docs
+
+You can export a Mermaid diagram from the Kong docs using the Mermaid live editor. 
+
+1. Copy the Mermaid diagram from the Kong doc file. You can find the doc source file by clicking **Edit this page** at the top right corner of the doc.
+1. Paste the Mermaid diagram into the [Mermaid live editor](https://mermaid.live/edit).
+1. Click **Actions** on the bottom left corner and select the file type you want to export the diagram to.


### PR DESCRIPTION
### Description

I added instructions to the contributing docs about how to export Mermaid diagrams from the docs using the Mermaid live editor. This way, people can easily get the images for our diagrams and reuse them.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3828
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

