### PR TITLE
Fix kic's lts versions

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -253,6 +253,7 @@
 - release: "2.5.x"
   version: "2.5.0"
   edition: "kubernetes-ingress-controller"
+  lts: true
 - release: "2.6.x"
   version: "2.6.0"
   edition: "kubernetes-ingress-controller"
@@ -262,7 +263,6 @@
 - release: "2.8.x"
   version: "2.8.2"
   edition: "kubernetes-ingress-controller"
-  lts: true
 - release: "2.9.x"
   version: "2.9.3"
   edition: "kubernetes-ingress-controller"
@@ -275,6 +275,7 @@
 - release: "2.12.x"
   version: "2.12.3"
   edition: "kubernetes-ingress-controller"
+  lts: true
 - release: "3.0.x"
   version: "3.0.2"
   edition: "kubernetes-ingress-controller"


### PR DESCRIPTION
### Description

Set `lts:true` to the right kic versions (2.5.x and 2.12.x)

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

