### PR TITLE
add content-type and body-validation explanation in _index.md

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -159,6 +159,7 @@ booleans
 burstable
 CAs
 certificate_admin
+charset
 chatbot
 cleartext
 client_payload

--- a/app/_hub/kong-inc/request-validator/overview/_index.md
+++ b/app/_hub/kong-inc/request-validator/overview/_index.md
@@ -6,6 +6,25 @@ Validate requests before they reach their upstream service. Supports validating
 the schema of the body and the parameters of the request using either Kong's own
 schema validator (body only) or a JSON Schema Draft 4 compliant validator.
 
+## Content-Type Validation
+
+Request Content-Type Header is validated against the plugin's [`allowed_content_types`](/hub/kong-inc/request-validator/configuration/#config-allowed_content_types). If the request Content-Type is not listed, the request will be rejected with an HTTP/400 error: `{"message":"specified Content-Type is not allowed"}`
+
+The parameter is strictly validated, which means a request with a parameter (e.g. `application/json; charset=UTF-8`) is NOT considered valid for one without the same parameter (e.g. `application/json`). The type, subtype, parameter names, and the value of the charset parameter are not case sensitive based on the RFC explanation.
+
+Only one parameter is supported. If a request sends more than one parameter with the Content-Type header, only the first parameter is evaluated and the rest are truncated.
+
+## Body Validation
+
+{% if_plugin_version lte:3.5.x %}
+Request body validation is only performed for requests with `application/json` Content-Type.
+{% endif_plugin_version %}
+{% if_plugin_version gte:3.6.x %}
+Request body validation is only performed for requests with `application/json` Content-Type or when `+json` is suffixed in the request Content-Type’s subtype (for example, `application/merge-patch+json`).
+{% endif_plugin_version %}
+
+For requests with any other allowed Content-Type, body validation will be skipped. So the requuest will be proxied to upstream without validating the body.
+
 ## Examples
 
 ### Overview

--- a/app/_hub/kong-inc/request-validator/overview/_index.md
+++ b/app/_hub/kong-inc/request-validator/overview/_index.md
@@ -23,7 +23,7 @@ Request body validation is only performed for requests with `application/json` C
 Request body validation is only performed for requests with `application/json` Content-Type or when `+json` is suffixed in the request Content-Type’s subtype (for example, `application/merge-patch+json`).
 {% endif_plugin_version %}
 
-For requests with any other allowed Content-Type, body validation will be skipped. So the requuest will be proxied to upstream without validating the body.
+For requests with any other allowed Content-Type, body validation will be skipped. So the request will be proxied to upstream without validating the body.
 
 ## Examples
 

--- a/app/_hub/kong-inc/request-validator/overview/_index.md
+++ b/app/_hub/kong-inc/request-validator/overview/_index.md
@@ -8,22 +8,22 @@ schema validator (body only) or a JSON Schema Draft 4 compliant validator.
 
 ## Content-Type Validation
 
-Request Content-Type Header is validated against the plugin's [`allowed_content_types`](/hub/kong-inc/request-validator/configuration/#config-allowed_content_types). If the request Content-Type is not listed, the request will be rejected with an HTTP/400 error: `{"message":"specified Content-Type is not allowed"}`
+The request Content-Type header is validated against the plugin's [`allowed_content_types`](/hub/kong-inc/request-validator/configuration/#config-allowed_content_types) setting. If the request Content-Type is not listed, the request will be rejected with an HTTP/400 error: `{"message":"specified Content-Type is not allowed"}`
 
-The parameter is strictly validated, which means a request with a parameter (e.g. `application/json; charset=UTF-8`) is NOT considered valid for one without the same parameter (e.g. `application/json`). The type, subtype, parameter names, and the value of the charset parameter are not case sensitive based on the RFC explanation.
+The parameter is strictly validated, which means a request with a parameter (for example, `application/json; charset=UTF-8`) is NOT considered valid for one without the same parameter (for example, `application/json`). The type, subtype, parameter names, and the value of the charset parameter are not case sensitive based on the RFC explanation.
 
 Only one parameter is supported. If a request sends more than one parameter with the Content-Type header, only the first parameter is evaluated and the rest are truncated.
 
 ## Body Validation
 
-{% if_plugin_version lte:3.5.x %}
+{% if_version lte:3.5.x %}
 Request body validation is only performed for requests with `application/json` Content-Type.
-{% endif_plugin_version %}
-{% if_plugin_version gte:3.6.x %}
+{% endif_version %}
+{% if_version gte:3.6.x %}
 Request body validation is only performed for requests with `application/json` Content-Type or when `+json` is suffixed in the request Content-Type’s subtype (for example, `application/merge-patch+json`).
-{% endif_plugin_version %}
+{% endif_version %}
 
-For requests with any other allowed Content-Type, body validation will be skipped. So the request will be proxied to upstream without validating the body.
+For requests with any other allowed Content-Type, body validation is skipped. In that case, the request is proxied to  the upstream without validating the body.
 
 ## Examples
 


### PR DESCRIPTION
### Description

request-validation limitations are not listed anymore since 3.4 version. Adding them in the main page

https://github.com/Kong/docs.konghq.com/commit/b492d3ecb31e2335f37dfe361295c8bc545f2e85#diff-f88716a1e934cd881cb07ecb1cc41ebdcd62fd950aa0e821603755e1a8caa2d4

New feature in 3.6 to perform body validation on +json content-types.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ x ] Review label added <!-- (see below) -->
- [ x ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

