### PR TITLE
(fix) Remove "enterprise" category from Datadome

### DIFF
--- a/app/_hub/datadome/kong-plugin-datadome/_metadata/_index.yml
+++ b/app/_hub/datadome/kong-plugin-datadome/_metadata/_index.yml
@@ -13,7 +13,7 @@ support_url: https://docs.datadome.co/docs/support
 
 dbless_compatible: yes
 
-enterprise: true
+enterprise: false
 techpartner: false
 konnect: true
 


### PR DESCRIPTION
### Description

Based on review w/ @DaniellaFreese and Eric, this plugin doesn't qualify as Enterprise based on the revised categorization set at end of last year. 
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-7350--kongdocs.netlify.app/hub/datadome/kong-plugin-datadome/  (Enterprise badge removed from under title)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

