### PR TITLE
kic: document newly added `konghq.com/headers-separator` annotation

### DIFF
--- a/app/_src/kubernetes-ingress-controller/reference/annotations.md
+++ b/app/_src/kubernetes-ingress-controller/reference/annotations.md
@@ -29,7 +29,10 @@ Following annotations are supported on Ingress resources:
 | [`konghq.com/host-aliases`](#konghqcomhostaliases)                                   | Additional hosts for routes created from this Ingress's rules                                                   |
 | [`konghq.com/override`](#konghqcomoverride)                                          | (Deprecated, replace with per-setting annotations) Control other routing attributes with a KongIngress resource |
 | [`konghq.com/path-handling`](#konghqcompathhandling)                                 | Set the path handling algorithm                                                                                 |
-| [`konghq.com/headers.*`](#konghqcomheaders)                                          | Set header values required to match rules in this Ingress                                                       |
+| [`konghq.com/headers.*`](#konghqcomheaders)                                          | Set header values required to match rules in this Ingress, default separator for multiple values is `,`         |
+{% if_version gte:3.2.x %}
+| [`konghq.com/headers-separator`](#konghqcomheaders-separator)                        | Separator for header values, other than default `,`                                                             |
+{% endif_version %}
 | [`konghq.com/rewrite`](#konghqcomrewrite)                                            | Rewrite the path of a URL                                                                                       |
 | [`konghq.com/tags`](#konghqcomtags)                                                  | Assign custom tags to Kong entities generated out of this Ingress                                               |
 
@@ -570,6 +573,17 @@ annotation name is the header, and the value is a CSV of allowed header values.
 For example, setting `konghq.com/headers.x-routing: alpha,bravo` will only
 match requests that include an `x-routing` header whose value is either `alpha`
 or `bravo`.
+
+{% if_version gte:3.2.x %}
+### konghq.com/headers-separator
+
+> Available since controller 3.2
+
+Sets the separator for the `konghq.com/headers.*` annotation to be something
+other than default `,`. This is useful when the header values themselves contain
+commas. For example, setting `konghq.com/headers-separator: ";"` will allow
+header values to be separated by `;` instead of `,`.
+{% endif_version %}
 
 ### konghq.com/connect-timeout
 


### PR DESCRIPTION
### Description

Document feature introduced in 

- https://github.com/Kong/kubernetes-ingress-controller/pull/5977

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-7351--kongdocs.netlify.app/kubernetes-ingress-controller/3.1.x/reference/annotations/#konghqcomheaders-separator

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

