### PR TITLE
chore(kic): list all CRDs that supports konghq.com/plugins annotation

### DIFF
--- a/app/_includes/md/kic/crd-ref/kong_plugin_description.md
+++ b/app/_includes/md/kic/crd-ref/kong_plugin_description.md
@@ -1,1 +1,1 @@
-Plugins can be associated with the Ingress or Service object in Kubernetes using `konghq.com/plugins` annotation.
+Plugins can be associated with the `Ingress`, `Service`, `HTTPRoute`, `KongConsumer` or `KongConsumerGroup` object in Kubernetes using `konghq.com/plugins` annotation.

--- a/app/_src/kubernetes-ingress-controller/concepts/annotations.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/annotations.md
@@ -11,7 +11,7 @@ Annotations can be added to a route `Ingress` or Gateway API resource such as `H
 
 The most commonly used annotations are:
 
-* [`konghq.com/plugins`](/kubernetes-ingress-controller/{{ page.release }}/reference/annotations/#konghqcomplugins) - Add plugins to a route, service or consumer
+* [`konghq.com/plugins`](/kubernetes-ingress-controller/{{ page.release }}/reference/annotations/#konghqcomplugins) - Add plugins to `Ingress`, `Service`, `HTTPRoute`, `KongConsumer` or `KongConsumerGroup`
 * [`konghq.com/strip-path`](/kubernetes-ingress-controller/{{ page.release }}/reference/annotations/#konghqcomstrip-path) - Strip the path defined in the route and then forward the request to the upstream service
 * [`konghq.com/methods`](/kubernetes-ingress-controller/{{ page.release }}/reference/annotations/#konghqcommethods) - Match specific HTTP methods in the route
 * [`konghq.com/headers.*`](/kubernetes-ingress-controller/{{ page.release }}/reference/annotations/#konghqcomheaders) - Require specific headers in the incoming request to match the defined route

--- a/app/_src/kubernetes-ingress-controller/concepts/custom-resources.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/custom-resources.md
@@ -77,7 +77,7 @@ These plugins can be used to modify the request or impose restrictions
 on the traffic.
 
 Once this resource is created, the resource needs to be associated with an
-Ingress, Service, or KongConsumer resource in Kubernetes.
+Ingress, Service, HTTPRoute, KongConsumer or KongConsumerGroup resource in Kubernetes.
 
 This diagram shows how you can link a KongPlugin resource to an
 Ingress, Service, or KongConsumer.

--- a/app/_src/kubernetes-ingress-controller/reference/annotations.md
+++ b/app/_src/kubernetes-ingress-controller/reference/annotations.md
@@ -187,7 +187,7 @@ are proxied to your service.
 
 With the {{site.kic_product_name}}, plugins can be configured by creating
 KongPlugin Custom Resources and then associating them with an Ingress, Service,
-KongConsumer or a combination of those.
+HTTPRoute, KongConsumer, KongConsumerGroup or a combination of those.
 
 This is an example of how to use the annotation:
 


### PR DESCRIPTION
### Description

During work on

- https://github.com/Kong/kubernetes-ingress-controller/issues/5749
- https://github.com/Kong/kubernetes-ingress-controller/issues/5602

it's been spotted that docs do not mention all CRDs that support `konghq.com/plugins` annotation, this PR improves it. 

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
- https://deploy-preview-7352--kongdocs.netlify.app/kubernetes-ingress-controller/latest/reference/custom-resources/#kongplugin
- https://deploy-preview-7352--kongdocs.netlify.app/kubernetes-ingress-controller/latest/concepts/annotations/#main
- https://deploy-preview-7352--kongdocs.netlify.app/kubernetes-ingress-controller/latest/concepts/custom-resources/#kongplugin (the diagrams should be updated too)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

