### PR TITLE
docs(rbac): remove a page that is by default not used in kong-mesh

### DIFF
--- a/app/_data/docs_nav_mesh_2.2.x.yml
+++ b/app/_data/docs_nav_mesh_2.2.x.yml
@@ -56,7 +56,7 @@ inherit:
       text: Kong Mesh license
       url: /production/cp-deployment/license
     - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
-      action: modify
+      action: delete
       text: Kong Mesh API access control
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert

--- a/app/_data/docs_nav_mesh_2.2.x.yml
+++ b/app/_data/docs_nav_mesh_2.2.x.yml
@@ -55,9 +55,9 @@ inherit:
       index: 0
       text: Kong Mesh license
       url: /production/cp-deployment/license
-    - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
+    - path: [ Kong Mesh in Production, Secure your deployment ]
       action: delete
-      text: Kong Mesh API access control
+      entries: [ Kuma API access control ]
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert
       index: -1

--- a/app/_data/docs_nav_mesh_2.3.x.yml
+++ b/app/_data/docs_nav_mesh_2.3.x.yml
@@ -56,7 +56,7 @@ inherit:
       text: Kong Mesh license
       url: /production/cp-deployment/license
     - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
-      action: modify
+      action: delete
       text: Kong Mesh API access control
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert

--- a/app/_data/docs_nav_mesh_2.3.x.yml
+++ b/app/_data/docs_nav_mesh_2.3.x.yml
@@ -55,9 +55,9 @@ inherit:
       index: 0
       text: Kong Mesh license
       url: /production/cp-deployment/license
-    - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
+    - path: [ Kong Mesh in Production, Secure your deployment ]
       action: delete
-      text: Kong Mesh API access control
+      entries: [ Kuma API access control ]
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert
       index: -1

--- a/app/_data/docs_nav_mesh_2.4.x.yml
+++ b/app/_data/docs_nav_mesh_2.4.x.yml
@@ -56,7 +56,7 @@ inherit:
       text: Kong Mesh license
       url: /production/cp-deployment/license
     - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
-      action: modify
+      action: delete
       text: Kong Mesh API access control
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert

--- a/app/_data/docs_nav_mesh_2.4.x.yml
+++ b/app/_data/docs_nav_mesh_2.4.x.yml
@@ -55,9 +55,9 @@ inherit:
       index: 0
       text: Kong Mesh license
       url: /production/cp-deployment/license
-    - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
+    - path: [ Kong Mesh in Production, Secure your deployment ]
       action: delete
-      text: Kong Mesh API access control
+      entries: [ Kuma API access control ]
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert
       index: -1

--- a/app/_data/docs_nav_mesh_2.5.x.yml
+++ b/app/_data/docs_nav_mesh_2.5.x.yml
@@ -56,7 +56,7 @@ inherit:
       text: Kong Mesh license
       url: /production/cp-deployment/license
     - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
-      action: modify
+      action: delete
       text: Kong Mesh API access control
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert

--- a/app/_data/docs_nav_mesh_2.5.x.yml
+++ b/app/_data/docs_nav_mesh_2.5.x.yml
@@ -55,9 +55,9 @@ inherit:
       index: 0
       text: Kong Mesh license
       url: /production/cp-deployment/license
-    - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
+    - path: [ Kong Mesh in Production, Secure your deployment ]
       action: delete
-      text: Kong Mesh API access control
+      entries: [ Kuma API access control ]
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert
       index: -1

--- a/app/_data/docs_nav_mesh_2.6.x.yml
+++ b/app/_data/docs_nav_mesh_2.6.x.yml
@@ -52,7 +52,7 @@ inherit:
       text: Kong Mesh license
       url: /production/cp-deployment/license
     - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
-      action: modify
+      action: delete
       text: Kong Mesh API access control
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert

--- a/app/_data/docs_nav_mesh_2.6.x.yml
+++ b/app/_data/docs_nav_mesh_2.6.x.yml
@@ -51,9 +51,9 @@ inherit:
       index: 0
       text: Kong Mesh license
       url: /production/cp-deployment/license
-    - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
+    - path: [ Kong Mesh in Production, Secure your deployment ]
       action: delete
-      text: Kong Mesh API access control
+      entries: [ Kuma API access control ]
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert
       index: -1

--- a/app/_data/docs_nav_mesh_2.7.x.yml
+++ b/app/_data/docs_nav_mesh_2.7.x.yml
@@ -52,7 +52,7 @@ inherit:
       text: Kong Mesh license
       url: /production/cp-deployment/license
     - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
-      action: modify
+      action: delete
       text: Kong Mesh API access control
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert

--- a/app/_data/docs_nav_mesh_2.7.x.yml
+++ b/app/_data/docs_nav_mesh_2.7.x.yml
@@ -51,9 +51,9 @@ inherit:
       index: 0
       text: Kong Mesh license
       url: /production/cp-deployment/license
-    - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
+    - path: [ Kong Mesh in Production, Secure your deployment ]
       action: delete
-      text: Kong Mesh API access control
+      entries: [ Kuma API access control ]
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert
       index: -1

--- a/app/_data/docs_nav_mesh_2.8.x.yml
+++ b/app/_data/docs_nav_mesh_2.8.x.yml
@@ -52,7 +52,7 @@ inherit:
       text: Kong Mesh license
       url: /production/cp-deployment/license
     - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
-      action: modify
+      action: delete
       text: Kong Mesh API access control
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert

--- a/app/_data/docs_nav_mesh_2.8.x.yml
+++ b/app/_data/docs_nav_mesh_2.8.x.yml
@@ -51,9 +51,9 @@ inherit:
       index: 0
       text: Kong Mesh license
       url: /production/cp-deployment/license
-    - path: [ Kong Mesh in Production, Secure your deployment, Kuma API access control ]
+    - path: [ Kong Mesh in Production, Secure your deployment ]
       action: delete
-      text: Kong Mesh API access control
+      entries: [ Kuma API access control ]
     - path: [ Kong Mesh in Production, Secure your deployment ]
       action: insert
       index: -1

--- a/app/_redirects
+++ b/app/_redirects
@@ -728,6 +728,7 @@
 /mesh/:version/introduction/overview-of-kong-mesh /mesh/:version/
 /mesh/:version/overview /mesh/:version/
 /mesh/:version/quickstart/kubernetes/ /mesh/:version/quickstart/kubernetes-demo/
+/mesh/:version/production/secure-deployment/api-access-control/ /mesh/:version/features/rbac/
 
 # Make GUI docs link work
 /mesh/konnect/* /mesh/latest/:splat


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->

I'm removing the https://docs.konghq.com/mesh/latest/production/secure-deployment/api-access-control/ page that in Kong Mesh is handled by https://docs.konghq.com/mesh/latest/features/rbac/. This is an alternative to https://github.com/kumahq/kuma-website/pull/1784.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

