### PR TITLE
request-termination and forward-proxy incompatibility

### DIFF
--- a/app/_hub/kong-inc/request-termination/overview/_index.md
+++ b/app/_hub/kong-inc/request-termination/overview/_index.md
@@ -13,7 +13,7 @@ Once this plugin is enabled, every request (within the configured plugin scope o
 route, consumer, or global) will be immediately terminated by sending the configured response.
 
 {:.important}
-> **Note:** The Request Termination plugin will not execute if the [Forward Proxy plugin](/hub/kong-inc/forward-proxy/) is enabled. This is because the Forward Proxy plugin has a higher priority and when it executes, the request is forwardered according to the plugin configuration. If you need to change this behaviour, you can configure the Request Termination plugin to execute before the Forward Proxy plugin using [Dynamic Plugin Ordering](/gateway/latest/kong-enterprise/plugin-ordering/).
+> **Note:** The Request Termination plugin will not execute if the [Forward Proxy plugin](/hub/kong-inc/forward-proxy/) is enabled. This is because the Forward Proxy plugin has a higher priority, and when it executes, the request is forwarded according to that plugin's configuration. If you need to change this behavior, you can configure the Request Termination plugin to execute before the Forward Proxy plugin using [Dynamic Plugin Ordering](/gateway/latest/kong-enterprise/plugin-ordering/).
 
 ## Example Use Cases
 

--- a/app/_hub/kong-inc/request-termination/overview/_index.md
+++ b/app/_hub/kong-inc/request-termination/overview/_index.md
@@ -13,7 +13,7 @@ Once this plugin is enabled, every request (within the configured plugin scope o
 route, consumer, or global) will be immediately terminated by sending the configured response.
 
 {:.important}
-> **Note:** The Request Termination plugin will not execute if the [Forward Proxy plugin](/hub/kong-inc/forward-proxy/) is enabled. This is because the Forward Proxy plugin has a higher priority and when it executes, the request is forwardered according to the plugin configuration. If you need to change this behaviour, you can configure the Request Termination plugin to execute before the the Forward Proxy plugin using [Dynamic Plugin Ordering](/gateway/latest/kong-enterprise/plugin-ordering/).
+> **Note:** The Request Termination plugin will not execute if the [Forward Proxy plugin](/hub/kong-inc/forward-proxy/) is enabled. This is because the Forward Proxy plugin has a higher priority and when it executes, the request is forwardered according to the plugin configuration. If you need to change this behaviour, you can configure the Request Termination plugin to execute before the Forward Proxy plugin using [Dynamic Plugin Ordering](/gateway/latest/kong-enterprise/plugin-ordering/).
 
 ## Example Use Cases
 

--- a/app/_hub/kong-inc/request-termination/overview/_index.md
+++ b/app/_hub/kong-inc/request-termination/overview/_index.md
@@ -12,6 +12,9 @@ This plugin can also be used for debugging, as described in the
 Once this plugin is enabled, every request (within the configured plugin scope of a service,
 route, consumer, or global) will be immediately terminated by sending the configured response.
 
+{:.important}
+> **Note:** The Request Termination plugin will not execute if the [Forward Proxy plugin](/hub/kong-inc/forward-proxy/) is enabled. This is because the Forward Proxy plugin has a higher priority and when it executes, the request is forwardered according to the plugin configuration. If you need to change this behaviour, you can configure the Request Termination plugin to execute before the the Forward Proxy plugin using [Dynamic Plugin Ordering](/gateway/{{page.release}}/kong-enterprise/plugin-ordering/).
+
 ## Example Use Cases
 
 - Temporarily disable a service, for example, if the service is under maintenance

--- a/app/_hub/kong-inc/request-termination/overview/_index.md
+++ b/app/_hub/kong-inc/request-termination/overview/_index.md
@@ -13,7 +13,7 @@ Once this plugin is enabled, every request (within the configured plugin scope o
 route, consumer, or global) will be immediately terminated by sending the configured response.
 
 {:.important}
-> **Note:** The Request Termination plugin will not execute if the [Forward Proxy plugin](/hub/kong-inc/forward-proxy/) is enabled. This is because the Forward Proxy plugin has a higher priority and when it executes, the request is forwardered according to the plugin configuration. If you need to change this behaviour, you can configure the Request Termination plugin to execute before the the Forward Proxy plugin using [Dynamic Plugin Ordering](/gateway/{{page.release}}/kong-enterprise/plugin-ordering/).
+> **Note:** The Request Termination plugin will not execute if the [Forward Proxy plugin](/hub/kong-inc/forward-proxy/) is enabled. This is because the Forward Proxy plugin has a higher priority and when it executes, the request is forwardered according to the plugin configuration. If you need to change this behaviour, you can configure the Request Termination plugin to execute before the the Forward Proxy plugin using [Dynamic Plugin Ordering](/gateway/latest/kong-enterprise/plugin-ordering/).
 
 ## Example Use Cases
 


### PR DESCRIPTION
### Description

Clarification: the plugin won't execute if if forward-proxy is enabled (valid for all versions)
Jira: https://konghq.atlassian.net/browse/FTI-5909
Kong idea reported to review the plugin priority: https://kong-internal-portal.ideas.aha.io/ideas/GTWY-I-886

### Testing instructions

Preview link: https://deploy-preview-7358--kongdocs.netlify.app/hub/kong-inc/request-termination/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

