### PR TITLE
fix(sandbox): add more explanation about kong.cache instance inside serverless function sandbox

### DIFF
--- a/app/_includes/md/plugins-hub/sandbox.md
+++ b/app/_includes/md/plugins-hub/sandbox.md
@@ -25,5 +25,5 @@ In addition to the above restrictions:
 * All the provided modules (like `string` or `table`) are read-only and can't be modified.
 * Bytecode execution is disabled.
 {% if_version gte:3.3.x %}
-* The `kong.cache` points to a cache instance that is dedicated to the Serverless Functions plugins. It does not provide access to the global Kong Gateway cache. It only exposes `get` method. Explicit write operations like `set` or `invalidate` are not available.
+* The `kong.cache` points to a cache instance that is dedicated to the Serverless Functions plugins. It does not provide access to the global {{site.base_gateway}} cache. It only exposes `get` method. Explicit write operations like `set` or `invalidate` are not available.
 {% endif_version %}

--- a/app/_includes/md/plugins-hub/sandbox.md
+++ b/app/_includes/md/plugins-hub/sandbox.md
@@ -24,4 +24,6 @@ In addition to the above restrictions:
 
 * All the provided modules (like `string` or `table`) are read-only and can't be modified.
 * Bytecode execution is disabled.
+{% if_version gte:3.3.x %}
 * The `kong.cache` points to a cache instance that is dedicated to the Serverless Functions plugins. It does not provide access to the global Kong Gateway cache. It only exposes `get` method. Explicit write operations like `set` or `invalidate` are not available.
+{% endif_version %}

--- a/app/_includes/md/plugins-hub/sandbox.md
+++ b/app/_includes/md/plugins-hub/sandbox.md
@@ -25,5 +25,5 @@ In addition to the above restrictions:
 * All the provided modules (like `string` or `table`) are read-only and can't be modified.
 * Bytecode execution is disabled.
 {% if_version gte:3.3.x %}
-* The `kong.cache` points to a cache instance that is dedicated to the Serverless Functions plugins. It does not provide access to the global {{site.base_gateway}} cache. It only exposes `get` method. Explicit write operations like `set` or `invalidate` are not available.
+* The `kong.cache` points to a cache instance that is dedicated to the Serverless Functions plugins. It does not provide access to the global {{site.base_gateway}} cache. It only exposes the `get` method. Explicit write operations like `set` or `invalidate` are not available.
 {% endif_version %}

--- a/app/_includes/md/plugins-hub/sandbox.md
+++ b/app/_includes/md/plugins-hub/sandbox.md
@@ -24,3 +24,4 @@ In addition to the above restrictions:
 
 * All the provided modules (like `string` or `table`) are read-only and can't be modified.
 * Bytecode execution is disabled.
+* The `kong.cache` points to a cache instance that is dedicated to the Serverless Functions plugins. It does not provide access to the global Kong Gateway cache. It only exposes `get` method. Explicit write operations like `set` or `invalidate` are not available.


### PR DESCRIPTION



### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

This PR adds more explanation about `kong.cache` cache instance inside serverless functions' sandbox environment.

Solves FTI-5898

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

