### PR TITLE
Fixes check-links.yml

### DIFF
--- a/tools/_utilities/lib/nav-to-urls.js
+++ b/tools/_utilities/lib/nav-to-urls.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 module.exports = function extractNavWithMeta(items, base, srcPrefix) {
   let urls = [];
   for (let u of items) {
@@ -29,16 +31,22 @@ module.exports = function extractNavWithMeta(items, base, srcPrefix) {
         }
       } else {
         const url = `${base}${u.url}`;
-        urls.push({
-          src:
-            srcPrefix +
-            (u.src || url)
-              .replace(/\/?#.*$/, "") // Remove anchor links
-              .replace(/\/$/, "") + // Remove trailing slashes
-            ".md",
-          url,
-          is_absolute: false,
-        });
+
+        let src = srcPrefix
+          .concat(u.src || url)
+          .replace(/\/?#.*$/, "") // Remove anchor links
+          .replace(/\/$/, ""); // Remove trailing slashes
+
+        // check if src.md exists, otherwise check if src/index.md exists
+        if (fs.existsSync(`${src}.md`)) {
+          src += '.md';
+        } else if (`${src}/index.md`) {
+          src += '/index.md';
+        } else {
+          console.log(`Could not find the src file of: ${url}.`)
+        }
+
+        urls.push({ src, url, is_absolute: false });
       }
     }
   }


### PR DESCRIPTION
### Description

The broken link checker didn't catch a broken link when it was run in "PR" mode, but the full scan did.

Related PR: https://github.com/Kong/docs.konghq.com/pull/7381

In "PR" mode, the check pull the modified files, gets the corresponding urls, and checks those urls for broken links.

The problem was with the filenames-to-URLs transformation. The way it works is by checking the `docs_nav` files for an entry that has a file as `src` or `url`. If an entry in a nav file didn't have a `src` we used the `url` as `src`. See
https://github.com/Kong/docs.konghq.com/blob/main/tools/_utilities/lib/nav-to-urls.js#L34-L38.

However, this didn't consider the case where the `url` corresponds to a file that ends with `index.md`

Example:
In a PR `app/_src/gateway/ai-gateway/index.md` was modified and a broken link is introduced.

The corresponding entry in gateway's `doc_nav` file is:
```
- text: Overview
  url: /ai-gateway/
```

It has no `src`, so the `url` is used to find the corresponding source file during single source generation. Single Source Generation checks for `app/_src/gateway/ai-gateway.md` and `app/_src/gateway/ai-gateway/index.md`.

However, the broken link checker in "PR" mode only checked for `app/_src/gateway/ai-gateway.md`. Hence, it couldn't find the file and didn't generate a url to check.

This commit fixes the issue by checking for the existence of both files.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

