### PR TITLE
chore: Set source URLs for moved EE plugins

### DIFF
--- a/app/_hub/kong-inc/app-dynamics/_metadata/_index.yml
+++ b/app/_hub/kong-inc/app-dynamics/_metadata/_index.yml
@@ -18,4 +18,4 @@ categories:
   - analytics-monitoring
 bundled: false
 dbless_compatible: 'yes'
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/app-dynamics/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/app-dynamics/schema.lua

--- a/app/_hub/kong-inc/app-dynamics/_metadata/_index.yml
+++ b/app/_hub/kong-inc/app-dynamics/_metadata/_index.yml
@@ -18,3 +18,4 @@ categories:
   - analytics-monitoring
 bundled: false
 dbless_compatible: 'yes'
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/app-dynamics/schema.lua

--- a/app/_hub/kong-inc/canary/_metadata/_index.yml
+++ b/app/_hub/kong-inc/canary/_metadata/_index.yml
@@ -16,4 +16,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Slowly roll out software changes to a subset of users
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/canary/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/canary/schema.lua

--- a/app/_hub/kong-inc/canary/_metadata/_index.yml
+++ b/app/_hub/kong-inc/canary/_metadata/_index.yml
@@ -16,3 +16,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Slowly roll out software changes to a subset of users
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/canary/schema.lua

--- a/app/_hub/kong-inc/degraphql/_metadata/_index.yml
+++ b/app/_hub/kong-inc/degraphql/_metadata/_index.yml
@@ -12,4 +12,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Transform a GraphQL upstream into a REST API
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/degraphql/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/degraphql/schema.lua

--- a/app/_hub/kong-inc/degraphql/_metadata/_index.yml
+++ b/app/_hub/kong-inc/degraphql/_metadata/_index.yml
@@ -12,3 +12,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Transform a GraphQL upstream into a REST API
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/degraphql/schema.lua

--- a/app/_hub/kong-inc/exit-transformer/_metadata/_index.yml
+++ b/app/_hub/kong-inc/exit-transformer/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Customize Kong exit responses sent downstream
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/exit-transformer/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/exit-transformer/schema.lua

--- a/app/_hub/kong-inc/exit-transformer/_metadata/_index.yml
+++ b/app/_hub/kong-inc/exit-transformer/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Customize Kong exit responses sent downstream
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/exit-transformer/schema.lua

--- a/app/_hub/kong-inc/forward-proxy/_metadata/_index.yml
+++ b/app/_hub/kong-inc/forward-proxy/_metadata/_index.yml
@@ -14,4 +14,4 @@ categories:
 publisher: Kong Inc.
 version: 1.2.x
 desc: Allows Kong to connect to intermediary transparent HTTP proxies
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/forward-proxy/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/forward-proxy/schema.lua

--- a/app/_hub/kong-inc/forward-proxy/_metadata/_index.yml
+++ b/app/_hub/kong-inc/forward-proxy/_metadata/_index.yml
@@ -14,3 +14,4 @@ categories:
 publisher: Kong Inc.
 version: 1.2.x
 desc: Allows Kong to connect to intermediary transparent HTTP proxies
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/forward-proxy/schema.lua

--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata/_index.yml
@@ -15,3 +15,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Cache and serve commonly requested responses in Kong
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/graphql-proxy-cache-advanced/schema.lua

--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata/_index.yml
@@ -15,4 +15,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Cache and serve commonly requested responses in Kong
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/graphql-proxy-cache-advanced/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/graphql-proxy-cache-advanced/schema.lua

--- a/app/_hub/kong-inc/jq/_metadata/_index.yml
+++ b/app/_hub/kong-inc/jq/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Transform JSON objects included in API requests or responses using jq programs.
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/jq/schema.lua

--- a/app/_hub/kong-inc/jq/_metadata/_index.yml
+++ b/app/_hub/kong-inc/jq/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Transform JSON objects included in API requests or responses using jq programs.
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/jq/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/jq/schema.lua

--- a/app/_hub/kong-inc/jwe-decrypt/_metadata/_index.yml
+++ b/app/_hub/kong-inc/jwe-decrypt/_metadata/_index.yml
@@ -12,3 +12,4 @@ categories:
   - authentication
 publisher: Kong Inc.
 desc: Decrypt a JWE token in a request
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/jwe-decrypt/schema.lua

--- a/app/_hub/kong-inc/jwe-decrypt/_metadata/_index.yml
+++ b/app/_hub/kong-inc/jwe-decrypt/_metadata/_index.yml
@@ -12,4 +12,4 @@ categories:
   - authentication
 publisher: Kong Inc.
 desc: Decrypt a JWE token in a request
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/jwe-decrypt/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/jwe-decrypt/schema.lua

--- a/app/_hub/kong-inc/key-auth-enc/_metadata/_index.yml
+++ b/app/_hub/kong-inc/key-auth-enc/_metadata/_index.yml
@@ -22,3 +22,4 @@ categories:
   - authentication
 publisher: Kong Inc.
 desc: Add key authentication to your services
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/key-auth-enc/schema.lua

--- a/app/_hub/kong-inc/key-auth-enc/_metadata/_index.yml
+++ b/app/_hub/kong-inc/key-auth-enc/_metadata/_index.yml
@@ -22,4 +22,4 @@ categories:
   - authentication
 publisher: Kong Inc.
 desc: Add key authentication to your services
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/key-auth-enc/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/key-auth-enc/schema.lua

--- a/app/_hub/kong-inc/mocking/_metadata/_index.yml
+++ b/app/_hub/kong-inc/mocking/_metadata/_index.yml
@@ -15,4 +15,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Provide mock endpoints to test your APIs against your services
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/mocking/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/mocking/schema.lua

--- a/app/_hub/kong-inc/mocking/_metadata/_index.yml
+++ b/app/_hub/kong-inc/mocking/_metadata/_index.yml
@@ -15,3 +15,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Provide mock endpoints to test your APIs against your services
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/mocking/schema.lua

--- a/app/_hub/kong-inc/oauth2-introspection/_metadata/_index.yml
+++ b/app/_hub/kong-inc/oauth2-introspection/_metadata/_index.yml
@@ -11,4 +11,4 @@ notes: --
 categories:
   - authentication
 desc: Integrate Kong with a third-party OAuth 2.0 Authorization Server
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/oauth2-introspection/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/oauth2-introspection/schema.lua

--- a/app/_hub/kong-inc/oauth2-introspection/_metadata/_index.yml
+++ b/app/_hub/kong-inc/oauth2-introspection/_metadata/_index.yml
@@ -11,3 +11,4 @@ notes: --
 categories:
   - authentication
 desc: Integrate Kong with a third-party OAuth 2.0 Authorization Server
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/oauth2-introspection/schema.lua

--- a/app/_hub/kong-inc/request-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/request-transformer-advanced/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Use powerful regular expressions, variables, and templates to transform API requests
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/request-transformer-advanced/schema.lua

--- a/app/_hub/kong-inc/request-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/request-transformer-advanced/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Use powerful regular expressions, variables, and templates to transform API requests
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/request-transformer-advanced/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/request-transformer-advanced/schema.lua

--- a/app/_hub/kong-inc/response-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/response-transformer-advanced/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Modify the upstream response before returning it to the client, with greater customization capabilities
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/response-transformer-advanced/schema.lua

--- a/app/_hub/kong-inc/response-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/response-transformer-advanced/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Modify the upstream response before returning it to the client, with greater customization capabilities
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/response-transformer-advanced/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/response-transformer-advanced/schema.lua

--- a/app/_hub/kong-inc/route-by-header/_metadata/_index.yml
+++ b/app/_hub/kong-inc/route-by-header/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Route request based on request headers
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/route-by-header/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/route-by-header/schema.lua

--- a/app/_hub/kong-inc/route-by-header/_metadata/_index.yml
+++ b/app/_hub/kong-inc/route-by-header/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Route request based on request headers
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/route-by-header/schema.lua

--- a/app/_hub/kong-inc/route-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/route-transformer-advanced/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Transform routing by changing the upstream server, port, or path
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/route-transformer-advanced/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/route-transformer-advanced/schema.lua

--- a/app/_hub/kong-inc/route-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/route-transformer-advanced/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
   - transformations
 publisher: Kong Inc.
 desc: Transform routing by changing the upstream server, port, or path
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/route-transformer-advanced/schema.lua

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_2.6.x.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_2.6.x.yml
@@ -21,3 +21,4 @@ kong_version_compatibility:
     - 1.5.x
     - 1.3-x
     - 0.36-x
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_2.6.x.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_2.6.x.yml
@@ -21,4 +21,4 @@ kong_version_compatibility:
     - 1.5.x
     - 1.3-x
     - 0.36-x
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_2.7.x.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_2.7.x.yml
@@ -21,3 +21,4 @@ kong_version_compatibility:
     - 1.5.x
     - 1.3-x
     - 0.36-x
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_2.7.x.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_2.7.x.yml
@@ -21,4 +21,4 @@ kong_version_compatibility:
     - 1.5.x
     - 1.3-x
     - 0.36-x
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_2.8.x.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_2.8.x.yml
@@ -21,3 +21,4 @@ kong_version_compatibility:
     - 1.5.x
     - 1.3-x
     - 0.36-x
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_2.8.x.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_2.8.x.yml
@@ -21,4 +21,4 @@ kong_version_compatibility:
     - 1.5.x
     - 1.3-x
     - 0.36-x
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_index.yml
@@ -10,4 +10,4 @@ categories:
   - analytics-monitoring
 publisher: Kong Inc.
 desc: (Deprecated) Send metrics to StatsD with more flexible options
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_index.yml
@@ -10,3 +10,4 @@ categories:
   - analytics-monitoring
 publisher: Kong Inc.
 desc: (Deprecated) Send metrics to StatsD with more flexible options
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/statsd-advanced/schema.lua

--- a/app/_hub/kong-inc/tls-handshake-modifier/_metadata/_index.yml
+++ b/app/_hub/kong-inc/tls-handshake-modifier/_metadata/_index.yml
@@ -15,3 +15,4 @@ categories:
 publisher: Kong Inc.
 
 desc: Requests a client to present its client certificate
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/tls-handshake-modifier/schema.lua

--- a/app/_hub/kong-inc/tls-handshake-modifier/_metadata/_index.yml
+++ b/app/_hub/kong-inc/tls-handshake-modifier/_metadata/_index.yml
@@ -15,4 +15,4 @@ categories:
 publisher: Kong Inc.
 
 desc: Requests a client to present its client certificate
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/tls-handshake-modifier/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/tls-handshake-modifier/schema.lua

--- a/app/_hub/kong-inc/tls-metadata-headers/_metadata/_index.yml
+++ b/app/_hub/kong-inc/tls-metadata-headers/_metadata/_index.yml
@@ -15,4 +15,4 @@ categories:
 publisher: Kong Inc.
 
 desc: Proxies TLS client certificate metadata to upstream services via HTTP headers
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/tls-metadata-headers/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/tls-metadata-headers/schema.lua

--- a/app/_hub/kong-inc/tls-metadata-headers/_metadata/_index.yml
+++ b/app/_hub/kong-inc/tls-metadata-headers/_metadata/_index.yml
@@ -15,3 +15,4 @@ categories:
 publisher: Kong Inc.
 
 desc: Proxies TLS client certificate metadata to upstream services via HTTP headers
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/tls-metadata-headers/schema.lua

--- a/app/_hub/kong-inc/upstream-timeout/_metadata/_index.yml
+++ b/app/_hub/kong-inc/upstream-timeout/_metadata/_index.yml
@@ -14,3 +14,4 @@ categories:
 
 publisher: Kong Inc.
 desc: Set timeouts on routes and override service-level timeouts
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/upstream-timeout/schema.lua

--- a/app/_hub/kong-inc/upstream-timeout/_metadata/_index.yml
+++ b/app/_hub/kong-inc/upstream-timeout/_metadata/_index.yml
@@ -14,4 +14,4 @@ categories:
 
 publisher: Kong Inc.
 desc: Set timeouts on routes and override service-level timeouts
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/upstream-timeout/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/upstream-timeout/schema.lua

--- a/app/_hub/kong-inc/websocket-size-limit/_metadata/_index.yml
+++ b/app/_hub/kong-inc/websocket-size-limit/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
 
 publisher: Kong Inc.
 desc: Block incoming WebSocket messages greater than a specified size
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/websocket-size-limit/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/websocket-size-limit/schema.lua

--- a/app/_hub/kong-inc/websocket-size-limit/_metadata/_index.yml
+++ b/app/_hub/kong-inc/websocket-size-limit/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
 
 publisher: Kong Inc.
 desc: Block incoming WebSocket messages greater than a specified size
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/websocket-size-limit/schema.lua

--- a/app/_hub/kong-inc/websocket-validator/_metadata/_index.yml
+++ b/app/_hub/kong-inc/websocket-validator/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
 
 publisher: Kong Inc.
 desc: Validate WebSocket messages before they are proxied
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/websocket-validator/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/websocket-validator/schema.lua

--- a/app/_hub/kong-inc/websocket-validator/_metadata/_index.yml
+++ b/app/_hub/kong-inc/websocket-validator/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
 
 publisher: Kong Inc.
 desc: Validate WebSocket messages before they are proxied
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/websocket-validator/schema.lua

--- a/app/_hub/kong-inc/xml-threat-protection/_metadata/_index.yml
+++ b/app/_hub/kong-inc/xml-threat-protection/_metadata/_index.yml
@@ -13,4 +13,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Apply structural and size checks on XML payloads
-source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/xml-threat-protection/schema.lua
+schema_source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/xml-threat-protection/schema.lua

--- a/app/_hub/kong-inc/xml-threat-protection/_metadata/_index.yml
+++ b/app/_hub/kong-inc/xml-threat-protection/_metadata/_index.yml
@@ -13,3 +13,4 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Apply structural and size checks on XML payloads
+source_url: https://github.com/Kong/kong-ee/edit/master/kong/plugins/xml-threat-protection/schema.lua

--- a/app/_plugins/generators/plugin_single_source/pages/configuration.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/configuration.rb
@@ -52,6 +52,8 @@ module PluginSingleSource
       end
 
       def kong_edit_link
+        return @release.metadata['source_url'] if @release.metadata.key?('source_url')
+
         if @release.enterprise_plugin?
           "https://github.com/Kong/kong-ee/edit/master/plugins-ee/#{@release.name}/kong/plugins/#{@release.name}/schema.lua"
         elsif @release.name == 'pre-function' || @release.name == 'post-function'

--- a/app/_plugins/generators/plugin_single_source/pages/configuration.rb
+++ b/app/_plugins/generators/plugin_single_source/pages/configuration.rb
@@ -52,7 +52,7 @@ module PluginSingleSource
       end
 
       def kong_edit_link
-        return @release.metadata['source_url'] if @release.metadata.key?('source_url')
+        return @release.metadata['schema_source_url'] if @release.metadata.key?('schema_source_url')
 
         if @release.enterprise_plugin?
           "https://github.com/Kong/kong-ee/edit/master/plugins-ee/#{@release.name}/kong/plugins/#{@release.name}/schema.lua"

--- a/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
@@ -63,13 +63,13 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
   end
 
   describe '#edit_link' do
-    context 'plugins having a `source_url`' do
+    context 'plugins having a `schema_source_url`' do
       let(:plugin_name) { 'kong-inc/app-dynamics' }
       let(:source_path) { File.expand_path('_hub/kong-inc/app-dynamics/', site.source) }
       let(:file) { "app/_src/.repos/kong-plugins/schemas/app-dynamics/#{version}.json" }
 
       before do
-        allow(release).to receive(:metadata).and_return({ 'source_url' => 'https://github.com/Kong/kong-ee/edit/master/kong/plugins/app-dynamics/schema.lua' })
+        allow(release).to receive(:metadata).and_return({ 'schema_source_url' => 'https://github.com/Kong/kong-ee/edit/master/kong/plugins/app-dynamics/schema.lua' })
       end
 
       it { expect(subject.edit_link).to eq('https://github.com/Kong/kong-ee/edit/master/kong/plugins/app-dynamics/schema.lua') }

--- a/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/pages/configuration_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe PluginSingleSource::Pages::Configuration do
   end
 
   describe '#edit_link' do
+    context 'plugins having a `source_url`' do
+      let(:plugin_name) { 'kong-inc/app-dynamics' }
+      let(:source_path) { File.expand_path('_hub/kong-inc/app-dynamics/', site.source) }
+      let(:file) { "app/_src/.repos/kong-plugins/schemas/app-dynamics/#{version}.json" }
+
+      before do
+        allow(release).to receive(:metadata).and_return({ 'source_url' => 'https://github.com/Kong/kong-ee/edit/master/kong/plugins/app-dynamics/schema.lua' })
+      end
+
+      it { expect(subject.edit_link).to eq('https://github.com/Kong/kong-ee/edit/master/kong/plugins/app-dynamics/schema.lua') }
+    end
+
     context 'kong-inc plugins' do
       context 'enterprise plugins' do
         let(:plugin_name) { 'kong-inc/jwt-signer' }


### PR DESCRIPTION
### Description

A bunch of EE plugins were moved to a new directory, breaking the "Edit this page" links on their schema config reference pages. This PR adds a source_url to each moved plugin to use as the link for editing.

https://konghq.atlassian.net/browse/DOCU-3841

### Testing instructions
For example, see https://deploy-preview-7386--kongdocs.netlify.app/hub/kong-inc/response-transformer-advanced/configuration/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

