### PR TITLE
fix(admin-oss): Plugin ordering is an EE-only feature

### DIFF
--- a/api-specs/Gateway-OSS/3.3/kong-oss-33.json
+++ b/api-specs/Gateway-OSS/3.3/kong-oss-33.json
@@ -529,9 +529,6 @@
             "description": "The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.",
             "type": "string"
           },
-          "ordering": {
-            "type": "object"
-          },
           "protocols": {
             "default": [
               "grpc",
@@ -1646,12 +1643,7 @@
                   "tags": [
                     "user-level",
                     "low-priority"
-                  ],
-                  "ordering": {
-                    "before": [
-                      "plugin-name"
-                    ]
-                  }
+                  ]
                 }
               },
               "properties": {
@@ -1720,18 +1712,6 @@
                   "items": {
                     "type": "string"
                   }
-                },
-                "ordering": {
-                  "type": "object",
-                  "description": "Describes a dependency to another plugin to determine plugin ordering during the access phase.\n–`before`: The plugin will be executed before a specified plugin or list of plugins.\n– `after`: The plugin will be executed after a specified plugin or list of plugins.",
-                  "properties": {
-                    "before": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
                 }
               }
             },
@@ -1753,12 +1733,7 @@
                   "enabled": true,
                   "tags": [
                     "string"
-                  ],
-                  "ordering": {
-                    "before": [
-                      "string"
-                    ]
-                  }
+                  ]
                 }
               }
             }
@@ -3429,18 +3404,6 @@
                   "items": {
                     "type": "string"
                   }
-                },
-                "ordering": {
-                  "type": "object",
-                  "description": "Describes a dependency to another plugin to determine plugin ordering during the access phase.\n–`before`: The plugin will be executed before a specified plugin or list of plugins.\n– `after`: The plugin will be executed after a specified plugin or list of plugins.",
-                  "properties": {
-                    "before": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  }
                 }
               }
             },
@@ -3465,12 +3428,7 @@
                 "tags": [
                   "user-level",
                   "low-priority"
-                ],
-                "ordering": {
-                  "before": [
-                    "plugin-name"
-                  ]
-                }
+                ]
               }
             },
             "examples": {
@@ -3496,12 +3454,7 @@
                       "tags": [
                         "user-level",
                         "low-priority"
-                      ],
-                      "ordering": {
-                        "before": [
-                          "plugin-name"
-                        ]
-                      }
+                      ]
                     },
                     {
                       "id": "66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4",
@@ -3523,12 +3476,7 @@
                         "admin",
                         "high-priority",
                         "critical"
-                      ],
-                      "ordering": {
-                        "after": [
-                          "plugin-name"
-                        ]
-                      }
+                      ]
                     }
                   ],
                   "next": "http://localhost:8001/plugins?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"

--- a/api-specs/Gateway-OSS/3.3/kong-oss-33.yaml
+++ b/api-specs/Gateway-OSS/3.3/kong-oss-33.yaml
@@ -415,8 +415,6 @@ components:
         name:
           description: 'The name of the Plugin that''s going to be added. Currently, the Plugin must be installed in every Kong instance separately.'
           type: string
-        ordering:
-          type: object
         protocols:
           default:
             - grpc
@@ -1261,9 +1259,6 @@ components:
                 tags:
                   - user-level
                   - low-priority
-                ordering:
-                  before:
-                    - plugin-name
             properties:
               name:
                 type: string
@@ -1319,17 +1314,6 @@ components:
                   An optional set of strings associated with the Plugin for grouping and filtering.
                 items:
                   type: string
-              ordering:
-                type: object
-                description: |-
-                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  –`before`: The plugin will be executed before a specified plugin or list of plugins.
-                  – `after`: The plugin will be executed after a specified plugin or list of plugins.
-                properties:
-                  before:
-                    type: array
-                    items:
-                      type: string
           examples:
             request example:
               value:
@@ -1346,9 +1330,6 @@ components:
                 enabled: true
                 tags:
                   - string
-                ordering:
-                  before:
-                    - string
       description: Plugin request body
     key-set-request:
       content:
@@ -2652,17 +2633,6 @@ components:
                   An optional set of strings associated with the Plugin for grouping and filtering.
                 items:
                   type: string
-              ordering:
-                type: object
-                description: |-
-                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  –`before`: The plugin will be executed before a specified plugin or list of plugins.
-                  – `after`: The plugin will be executed after a specified plugin or list of plugins.
-                properties:
-                  before:
-                    type: array
-                    items:
-                      type: string
           x-examples:
             Example 1:
               id: ce44eef5-41ed-47f6-baab-f725cecf98c7
@@ -2682,9 +2652,6 @@ components:
               tags:
                 - user-level
                 - low-priority
-              ordering:
-                before:
-                  - plugin-name
           examples:
             Plugin response:
               value:
@@ -2705,9 +2672,6 @@ components:
                     tags:
                       - user-level
                       - low-priority
-                    ordering:
-                      before:
-                        - plugin-name
                   - id: 66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4
                     name: rate-limiting
                     created_at: 1422386534
@@ -2725,9 +2689,6 @@ components:
                       - admin
                       - high-priority
                       - critical
-                    ordering:
-                      after:
-                        - plugin-name
                 next: 'http://localhost:8001/plugins?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
     key-set-response:
       description: Key set object response body

--- a/api-specs/Gateway-OSS/3.4/kong-oss-3.4.json
+++ b/api-specs/Gateway-OSS/3.4/kong-oss-3.4.json
@@ -538,9 +538,6 @@
               "description": "The name of the Plugin that's going to be added. Currently, the Plugin must be installed in every Kong instance separately.",
               "type": "string"
             },
-            "ordering": {
-              "type": "object"
-            },
             "protocols": {
               "default": [
                 "grpc",
@@ -1672,12 +1669,7 @@
                     "tags": [
                       "user-level",
                       "low-priority"
-                    ],
-                    "ordering": {
-                      "before": [
-                        "plugin-name"
-                      ]
-                    }
+                    ]
                   }
                 },
                 "properties": {
@@ -1746,18 +1738,6 @@
                     "items": {
                       "type": "string"
                     }
-                  },
-                  "ordering": {
-                    "type": "object",
-                    "description": "Describes a dependency to another plugin to determine plugin ordering during the access phase.\n–`before`: The plugin will be executed before a specified plugin or list of plugins.\n– `after`: The plugin will be executed after a specified plugin or list of plugins.",
-                    "properties": {
-                      "before": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
                   }
                 }
               },
@@ -1779,12 +1759,7 @@
                     "enabled": true,
                     "tags": [
                       "string"
-                    ],
-                    "ordering": {
-                      "before": [
-                        "string"
-                      ]
-                    }
+                    ]
                   }
                 }
               }
@@ -3455,18 +3430,6 @@
                     "items": {
                       "type": "string"
                     }
-                  },
-                  "ordering": {
-                    "type": "object",
-                    "description": "Describes a dependency to another plugin to determine plugin ordering during the access phase.\n–`before`: The plugin will be executed before a specified plugin or list of plugins.\n– `after`: The plugin will be executed after a specified plugin or list of plugins.",
-                    "properties": {
-                      "before": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      }
-                    }
                   }
                 }
               },
@@ -3491,12 +3454,7 @@
                   "tags": [
                     "user-level",
                     "low-priority"
-                  ],
-                  "ordering": {
-                    "before": [
-                      "plugin-name"
-                    ]
-                  }
+                  ]
                 }
               },
               "examples": {
@@ -3522,12 +3480,7 @@
                         "tags": [
                           "user-level",
                           "low-priority"
-                        ],
-                        "ordering": {
-                          "before": [
-                            "plugin-name"
-                          ]
-                        }
+                        ]
                       },
                       {
                         "id": "66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4",
@@ -3549,12 +3502,7 @@
                           "admin",
                           "high-priority",
                           "critical"
-                        ],
-                        "ordering": {
-                          "after": [
-                            "plugin-name"
-                          ]
-                        }
+                        ]
                       }
                     ],
                     "next": "http://localhost:8001/plugins?offset=6378122c-a0a1-438d-a5c6-efabae9fb969"

--- a/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
+++ b/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
@@ -493,8 +493,6 @@ components:
         name:
           description: The name of the Plugin thats going to be added. Currently, the Plugin must be installed in every Kong instance separately.
           type: string
-        ordering:
-          type: object
         protocols:
           default:
             - grpc
@@ -1433,9 +1431,6 @@ components:
                 tags:
                   - user-level
                   - low-priority
-                ordering:
-                  before:
-                    - plugin-name
             properties:
               name:
                 type: string
@@ -1495,17 +1490,6 @@ components:
                   An optional set of strings associated with the Plugin for grouping and filtering.
                 items:
                   type: string
-              ordering:
-                type: object
-                description: |
-                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
-                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
-                properties:
-                  before:
-                    type: array
-                    items:
-                      type: string
           examples:
             request example:
               value:
@@ -1522,9 +1506,6 @@ components:
                 enabled: true
                 tags:
                   - string
-                ordering:
-                  before:
-                    - string
       description: Plugin request body
     key-set-request:
       content:
@@ -3349,17 +3330,6 @@ components:
                   An optional set of strings associated with the Plugin for grouping and filtering.
                 items:
                   type: string
-              ordering:
-                type: object
-                description: |
-                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
-                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
-                properties:
-                  before:
-                    type: array
-                    items:
-                      type: string
           x-examples:
             Example 1:
               id: ce44eef5-41ed-47f6-baab-f725cecf98c7
@@ -3379,9 +3349,6 @@ components:
               tags:
                 - user-level
                 - low-priority
-              ordering:
-                before:
-                  - plugin-name
           examples:
             Plugin response:
               value:
@@ -3402,9 +3369,6 @@ components:
                     tags:
                       - user-level
                       - low-priority
-                    ordering:
-                      before:
-                        - plugin-name
                   - id: 66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4
                     name: rate-limiting
                     created_at: 1422386534
@@ -3422,9 +3386,6 @@ components:
                       - admin
                       - high-priority
                       - critical
-                    ordering:
-                      after:
-                        - plugin-name
                 next: 'http://localhost:8001/plugins?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
     key-set-response:
       description: Key set object response body

--- a/api-specs/Gateway-OSS/3.5/kong-oss-3.5.yaml
+++ b/api-specs/Gateway-OSS/3.5/kong-oss-3.5.yaml
@@ -494,8 +494,6 @@ components:
         name:
           description: The name of the Plugin thats going to be added. Currently, the Plugin must be installed in every Kong instance separately.
           type: string
-        ordering:
-          type: object
         protocols:
           default:
             - grpc
@@ -1434,9 +1432,6 @@ components:
                 tags:
                   - user-level
                   - low-priority
-                ordering:
-                  before:
-                    - plugin-name
             properties:
               name:
                 type: string
@@ -1496,17 +1491,6 @@ components:
                   An optional set of strings associated with the Plugin for grouping and filtering.
                 items:
                   type: string
-              ordering:
-                type: object
-                description: |
-                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
-                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
-                properties:
-                  before:
-                    type: array
-                    items:
-                      type: string
           examples:
             request example:
               value:
@@ -1523,9 +1507,6 @@ components:
                 enabled: true
                 tags:
                   - string
-                ordering:
-                  before:
-                    - string
       description: Plugin request body
     key-set-request:
       content:
@@ -3331,17 +3312,6 @@ components:
                   An optional set of strings associated with the Plugin for grouping and filtering.
                 items:
                   type: string
-              ordering:
-                type: object
-                description: |
-                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
-                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
-                properties:
-                  before:
-                    type: array
-                    items:
-                      type: string
           x-examples:
             Example 1:
               id: ce44eef5-41ed-47f6-baab-f725cecf98c7
@@ -3361,9 +3331,6 @@ components:
               tags:
                 - user-level
                 - low-priority
-              ordering:
-                before:
-                  - plugin-name
           examples:
             Plugin response:
               value:
@@ -3384,9 +3351,6 @@ components:
                     tags:
                       - user-level
                       - low-priority
-                    ordering:
-                      before:
-                        - plugin-name
                   - id: 66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4
                     name: rate-limiting
                     created_at: 1422386534
@@ -3404,9 +3368,6 @@ components:
                       - admin
                       - high-priority
                       - critical
-                    ordering:
-                      after:
-                        - plugin-name
                 next: 'http://localhost:8001/plugins?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
     key-set-response:
       description: Key set object response body

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -504,8 +504,6 @@ components:
         name:
           description: The name of the Plugin thats going to be added. Currently, the Plugin must be installed in every Kong instance separately.
           type: string
-        ordering:
-          type: object
         protocols:
           default:
             - grpc
@@ -1444,9 +1442,6 @@ components:
                 tags:
                   - user-level
                   - low-priority
-                ordering:
-                  before:
-                    - plugin-name
             properties:
               name:
                 type: string
@@ -1512,17 +1507,6 @@ components:
                   An optional set of strings associated with the Plugin for grouping and filtering.
                 items:
                   type: string
-              ordering:
-                type: object
-                description: |
-                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
-                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
-                properties:
-                  before:
-                    type: array
-                    items:
-                      type: string
           examples:
             request example:
               value:
@@ -1539,9 +1523,6 @@ components:
                 enabled: true
                 tags:
                   - string
-                ordering:
-                  before:
-                    - string
       description: Plugin request body
     key-set-request:
       content:
@@ -3375,17 +3356,6 @@ components:
                   An optional set of strings associated with the Plugin for grouping and filtering.
                 items:
                   type: string
-              ordering:
-                type: object
-                description: |
-                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
-                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
-                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
-                properties:
-                  before:
-                    type: array
-                    items:
-                      type: string
           x-examples:
             Example 1:
               id: ce44eef5-41ed-47f6-baab-f725cecf98c7
@@ -3405,9 +3375,6 @@ components:
               tags:
                 - user-level
                 - low-priority
-              ordering:
-                before:
-                  - plugin-name
           examples:
             Plugin response:
               value:
@@ -3428,9 +3395,6 @@ components:
                     tags:
                       - user-level
                       - low-priority
-                    ordering:
-                      before:
-                        - plugin-name
                   - id: 66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4
                     name: rate-limiting
                     created_at: 1422386534
@@ -3448,9 +3412,6 @@ components:
                       - admin
                       - high-priority
                       - critical
-                    ordering:
-                      after:
-                        - plugin-name
                 next: 'http://localhost:8001/plugins?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
     key-set-response:
       description: Key set object response body


### PR DESCRIPTION
### Description

Remove references to the `plugin.ordering` field from OSS OpenAPI docs.

### Testing instructions

### Checklist 

- [x] Review label added <!-- (see below) -->
