### PR TITLE
feat(ai-proxy): added Azure native auth explanation

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -33,6 +33,7 @@ DPPs
 Datadog
 Dex
 ElastiCache
+Entra
 Equinix
 Equinix
 Fargate
@@ -304,6 +305,7 @@ kafka
 keepalive
 keps
 Keycloak
+keyless
 keyrings
 keyspace
 keystore

--- a/app/_hub/kong-inc/ai-proxy/how-to/_cloud-provider-authentication.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/_cloud-provider-authentication.md
@@ -1,0 +1,136 @@
+---
+nav_title: Cloud Provider Authentication
+title: Authenticate to Cloud-Hosted Models Using its Native Authentication
+---
+
+This guide walks you through setting up the AI Proxy plugin with a cloud-hosted model,
+using the cloud's native authentication mechanism.
+
+## Overview
+
+When running software on a cloud-hosted virtual machine or container instance, the provider will
+offer a key-less role-based access mechanism, allowing you to call services native to that cloud
+provider without having to store any keys inside the running instance (or in the Kong configuration).
+
+This operates like a single-sign-on mechanism for your cloud applications.
+
+Kong's AI Gateway (AI-Proxy) has the capability to take advantage of the authentication mechanisms for
+many different cloud providers and, where available, is also able to use this authentication to call
+LLM-based services using those same methods.
+
+## Supported Providers
+
+Currently supported are:
+
+| AI-Proxy LLM Provider | Cloud Provider | Type                                    |
+|-----------------------|----------------|-----------------------------------------|
+| `azure`               | Azure OpenAI   | [Entra / Managed Identity Authentication](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) |
+
+Sections below outline how you would use each, with examples.
+
+### Azure OpenAI
+
+When hosting your LLMs with [Azure OpenAI Service](https://azure.microsoft.com/en-gb/products/ai-services/openai-service)
+and running them through AI-Proxy, it is possible to use the assigned
+[Azure Managed Identity or User-Assigned Identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview)
+of the VM, Kubernetes service-account, or ACS container, to call the Azure OpenAI models.
+
+You can also use an Entra principal or App Registration (`client_id`, `client_secret`, and `tenant_id` triplet) when
+Kong is hosted outside of Azure.
+
+How you do this, depends on where and how you are running the Kong gateway.
+
+#### Prerequisite
+
+Ensure that the Azure principal that you have assigned to the Compute resource (that is running your Kong gateway) has the necessary
+Entra or IAM permissions to execute commands on the desired OpenAI instances.
+
+Kong requires one of either:
+
+* "Cognitive Services OpenAI User" or
+* "Cognitive Services OpenAI Contributor"
+
+[Use Azure's documention for assistance in setting this up.](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity)
+
+#### Configuring AI Proxy Plugin to use Azure Identity
+
+When running Kong inside of your Azure subscription, AI Proxy is usually able to detect the designated Managed Identity or User-Assigned Identity
+of that Azure Compute resource, and use it accordingly.
+
+**To use an Azure-assigned Managed Identity, set your plugin config like this:**
+
+```yaml
+plugins:
+- name: ai-proxy
+  config:
+  route_type: "llm/v1/chat"
+  auth:
+    azure_use_managed_identity: true
+  model:
+    provider: "azure"
+    name: "gpt-35-turbo"
+    options:
+    azure_instance: "my-openai-instance"
+    azure_deployment_id: "kong-gpt-3-5"
+```
+
+**To use a User-Assigned Identity, specify its client ID like this:**
+
+```yaml
+plugins:
+- name: ai-proxy
+  config:
+  route_type: "llm/v1/chat"
+  auth:
+    azure_use_managed_identity: true
+    azure_client_id: "aabdecea-fc38-40ca-9edd-263878b290fe"
+  model:
+    provider: "azure"
+    name: "gpt-35-turbo"
+    options:
+    azure_instance: "my-openai-instance"
+    azure_deployment_id: "kong-gpt-3-5"
+```
+
+**If running outside of Azure, to use an Entra principal or App Registration, specify all properties like this:**
+
+```yaml
+plugins:
+- name: ai-proxy
+  config:
+  route_type: "llm/v1/chat"
+  auth:
+    azure_use_managed_identity: true
+    azure_client_id: "aabdecea-fc38-40ca-9edd-263878b290fe"
+    azure_client_secret: "be0c34b6-b5f1-4343-99a3-140df73e0c1c"
+    azure_tenant_id: "1e583ecd-9293-4db1-b1c0-2b6126cb5fdd"
+  model:
+    provider: "azure"
+    name: "gpt-35-turbo"
+    options:
+    azure_instance: "my-openai-instance"
+    azure_deployment_id: "kong-gpt-3-5"
+```
+
+**Finally, you can also specify some (or all) of these properties as environment variables, for example this mix:**
+
+```yaml
+# Environment variables:
+AZURE_CLIENT_SECRET="be0c34b6-b5f1-4343-99a3-140df73e0c1c"
+
+# Plugin Config:
+plugins:
+- name: ai-proxy
+  config:
+  route_type: "llm/v1/chat"
+  auth:
+    azure_use_managed_identity: true
+    azure_client_id: "aabdecea-fc38-40ca-9edd-263878b290fe"
+    azure_tenant_id: "1e583ecd-9293-4db1-b1c0-2b6126cb5fdd"
+  model:
+    provider: "azure"
+    name: "gpt-35-turbo"
+    options:
+    azure_instance: "my-openai-instance"
+    azure_deployment_id: "kong-gpt-3-5"
+```

--- a/app/_hub/kong-inc/ai-proxy/how-to/_cloud-provider-authentication.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/_cloud-provider-authentication.md
@@ -1,68 +1,74 @@
 ---
 nav_title: Cloud Provider Authentication
-title: Authenticate to Cloud-Hosted Models Using its Native Authentication
+title: Authenticate to Cloud-Hosted Models Using their Native Authentication
+minimum_version: 3.7.x
 ---
+
+{:.note}
+> This feature requires {{site.ee_product_name}}.
 
 This guide walks you through setting up the AI Proxy plugin with a cloud-hosted model,
 using the cloud's native authentication mechanism.
 
 ## Overview
 
-When running software on a cloud-hosted virtual machine or container instance, the provider will
-offer a key-less role-based access mechanism, allowing you to call services native to that cloud
+When running software on a cloud-hosted virtual machine or container instance, the provider
+offers a keyless role-based access mechanism, allowing you to call services native to that cloud
 provider without having to store any keys inside the running instance (or in the Kong configuration).
 
-This operates like a single-sign-on mechanism for your cloud applications.
+This operates like a single-sign-on (SSO) mechanism for your cloud applications.
 
-Kong's AI Gateway (AI-Proxy) has the capability to take advantage of the authentication mechanisms for
-many different cloud providers and, where available, is also able to use this authentication to call
+Kong's AI Gateway (AI Proxy) can take advantage of the authentication mechanisms for
+many different cloud providers and, where available, can also use this authentication to call
 LLM-based services using those same methods.
 
-## Supported Providers
+## Supported providers
 
-Currently supported are:
+Kong's AI Gateway currently supports the following cloud authentication:
 
 | AI-Proxy LLM Provider | Cloud Provider | Type                                    |
 |-----------------------|----------------|-----------------------------------------|
 | `azure`               | Azure OpenAI   | [Entra / Managed Identity Authentication](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview) |
 
-Sections below outline how you would use each, with examples.
-
-### Azure OpenAI
+## Azure OpenAI
 
 When hosting your LLMs with [Azure OpenAI Service](https://azure.microsoft.com/en-gb/products/ai-services/openai-service)
-and running them through AI-Proxy, it is possible to use the assigned
+and running them through AI Proxy, it is possible to use the assigned
 [Azure Managed Identity or User-Assigned Identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview)
 of the VM, Kubernetes service-account, or ACS container, to call the Azure OpenAI models.
 
 You can also use an Entra principal or App Registration (`client_id`, `client_secret`, and `tenant_id` triplet) when
 Kong is hosted outside of Azure.
 
-How you do this, depends on where and how you are running the Kong gateway.
+How you do this depends on where and how you are running {{site.base_gateway}}.
 
-#### Prerequisite
+### Prerequisites
 
-Ensure that the Azure principal that you have assigned to the Compute resource (that is running your Kong gateway) has the necessary
-Entra or IAM permissions to execute commands on the desired OpenAI instances.
+You must be running a {{site.ee_product_name}} instance.
 
-Kong requires one of either:
+Ensure that the Azure principal that you have assigned to the Compute resource (that is running your {{site.base_gateway}}) has the necessary
+Entra or IAM permissions to execute commands on the desired OpenAI instances. It must have one of the following permissions:
 
-* "Cognitive Services OpenAI User" or
-* "Cognitive Services OpenAI Contributor"
+* Cognitive Services OpenAI User
+* Cognitive Services OpenAI Contributor
 
-[Use Azure's documention for assistance in setting this up.](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity)
+See [Azure's documentation on managed identity](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity)
+to set this up.
 
-#### Configuring AI Proxy Plugin to use Azure Identity
+### Configuring the AI Proxy Plugin to use Azure Identity
 
 When running Kong inside of your Azure subscription, AI Proxy is usually able to detect the designated Managed Identity or User-Assigned Identity
 of that Azure Compute resource, and use it accordingly.
 
-**To use an Azure-assigned Managed Identity, set your plugin config like this:**
+#### Azure-Assigned Managed Identity
 
-```yaml
-plugins:
-- name: ai-proxy
-  config:
+To use an Azure-Assigned Managed Identity, set up your plugin config like this:
+
+<!-- vale off-->
+{% plugin_example %}
+plugin: kong-inc/ai-proxy
+name: ai-proxy
+config:
   route_type: "llm/v1/chat"
   auth:
     azure_use_managed_identity: true
@@ -70,16 +76,29 @@ plugins:
     provider: "azure"
     name: "gpt-35-turbo"
     options:
-    azure_instance: "my-openai-instance"
-    azure_deployment_id: "kong-gpt-3-5"
-```
+      azure_instance: "my-openai-instance"
+      azure_deployment_id: "kong-gpt-3-5"
+targets:
+  - route
+  - consumer_group
+  - global
+formats:
+  - konnect
+  - curl
+  - yaml
+  - kubernetes
+{% endplugin_example %}
+<!--vale on -->
 
-**To use a User-Assigned Identity, specify its client ID like this:**
+#### User-Assigned Identity
 
-```yaml
-plugins:
-- name: ai-proxy
-  config:
+To use a User-Assigned Identity, specify its client ID like this:
+
+<!-- vale off-->
+{% plugin_example %}
+plugin: kong-inc/ai-proxy
+name: ai-proxy
+config:
   route_type: "llm/v1/chat"
   auth:
     azure_use_managed_identity: true
@@ -88,16 +107,29 @@ plugins:
     provider: "azure"
     name: "gpt-35-turbo"
     options:
-    azure_instance: "my-openai-instance"
-    azure_deployment_id: "kong-gpt-3-5"
-```
+      azure_instance: "my-openai-instance"
+      azure_deployment_id: "kong-gpt-3-5"
+targets:
+  - route
+  - consumer_group
+  - global
+formats:
+  - konnect
+  - curl
+  - yaml
+  - kubernetes
+{% endplugin_example %}
+<!--vale on -->
 
-**If running outside of Azure, to use an Entra principal or App Registration, specify all properties like this:**
+#### Using Entra or app registration
 
-```yaml
-plugins:
-- name: ai-proxy
-  config:
+If running outside of Azure, to use an Entra principal or app registration, specify all properties like this:
+
+<!-- vale off-->
+{% plugin_example %}
+plugin: kong-inc/ai-proxy
+name: ai-proxy
+config:
   route_type: "llm/v1/chat"
   auth:
     azure_use_managed_identity: true
@@ -108,20 +140,37 @@ plugins:
     provider: "azure"
     name: "gpt-35-turbo"
     options:
-    azure_instance: "my-openai-instance"
-    azure_deployment_id: "kong-gpt-3-5"
+      azure_instance: "my-openai-instance"
+      azure_deployment_id: "kong-gpt-3-5"
+targets:
+  - route
+  - consumer_group
+  - global
+formats:
+  - konnect
+  - curl
+  - yaml
+  - kubernetes
+{% endplugin_example %}
+<!--vale on -->
+
+#### Environment variables
+
+You can also specify some (or all) of these properties as environment variables. For example:
+
+
+Environment variable:
+```sh
+AZURE_CLIENT_SECRET="be0c34b6-b5f1-4343-99a3-140df73e0c1c"
 ```
 
-**Finally, you can also specify some (or all) of these properties as environment variables, for example this mix:**
+Plugin configuration:
 
-```yaml
-# Environment variables:
-AZURE_CLIENT_SECRET="be0c34b6-b5f1-4343-99a3-140df73e0c1c"
-
-# Plugin Config:
-plugins:
-- name: ai-proxy
-  config:
+<!-- vale off-->
+{% plugin_example %}
+plugin: kong-inc/ai-proxy
+name: ai-proxy
+config:
   route_type: "llm/v1/chat"
   auth:
     azure_use_managed_identity: true
@@ -131,6 +180,16 @@ plugins:
     provider: "azure"
     name: "gpt-35-turbo"
     options:
-    azure_instance: "my-openai-instance"
-    azure_deployment_id: "kong-gpt-3-5"
-```
+      azure_instance: "my-openai-instance"
+      azure_deployment_id: "kong-gpt-3-5"
+targets:
+  - route
+  - consumer_group
+  - global
+formats:
+  - konnect
+  - curl
+  - yaml
+  - kubernetes
+{% endplugin_example %}
+<!--vale on -->


### PR DESCRIPTION
### Description

> ⚠️ I need help here because there are two pre-requisites:
>
> 1. This only works in Kong Enterprise
> 2. This is only available (the whole page / feature) in Kong 3.7

I have added an explanation on how to use [Azure Managed Identity](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity) authentication when using the Kong AI Proxy within the Azure SaaS.

### Testing instructions

Preview link: https://deploy-preview-7390--kongdocs.netlify.app/hub/kong-inc/ai-proxy/unreleased/how-to/cloud-provider-authentication/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable. - **HELP WITH THIS NEEDED**

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version