### PR TITLE
Fix: Validate schemas endpoint 

### DIFF
--- a/api-specs/Gateway-OSS/3.3/kong-oss-33.yaml
+++ b/api-specs/Gateway-OSS/3.3/kong-oss-33.yaml
@@ -6768,7 +6768,7 @@ paths:
 
       tags:
         - Information
-  '/schemas/{entity}/validate':
+  '/schemas/{entity}':
     parameters:
       - schema:
           type: string
@@ -6826,7 +6826,14 @@ paths:
                           timestamp: true
                           type: integer
       operationId: get-schemas-entity
-      description: 'Retrieve the schema of an entity. This is useful to understand what fields an entity accepts, and can be used for building third-party integrations with Kong.'
+      description: Retrieve the schema of an entity. This is useful to understand what fields an entity accepts, and can be used for building third-party integrations with Kong.
+  '/schemas/{entity}/validate':
+    parameters:
+      - schema:
+          type: string
+        name: entity
+        in: path
+        required: true
     post:
       summary: Validate a configuration against a schema
       operationId: post-schemas-entity-validate

--- a/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
+++ b/api-specs/Gateway-OSS/3.4/kong-oss-3.4.yaml
@@ -6230,7 +6230,7 @@ paths:
         List all the supported HTTP methods by an endpoint. This can also be used with a CORS preflight request.
       tags:
         - Information
-  '/schemas/{entity}/validate':
+  '/schemas/{entity}':
     parameters:
       - schema:
           type: string
@@ -6289,6 +6289,13 @@ paths:
                           type: integer
       operationId: get-schemas-entity
       description: Retrieve the schema of an entity. This is useful to understand what fields an entity accepts, and can be used for building third-party integrations with Kong.
+  '/schemas/{entity}/validate':
+    parameters:
+      - schema:
+          type: string
+        name: entity
+        in: path
+        required: true
     post:
       summary: Validate a configuration against a schema
       operationId: post-schemas-entity-validate

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -6672,7 +6672,7 @@ paths:
         List all the supported HTTP methods by an endpoint. This can also be used with a CORS preflight request.
       tags:
         - Information
-  '/schemas/{entity}/validate':
+  '/schemas/{entity}':
     parameters:
       - schema:
           type: string
@@ -6733,7 +6733,13 @@ paths:
           $ref: '#/components/responses/HTTP401Error'
       operationId: get-schemas-entity
       description: Retrieve the schema of an entity. This is useful to understand what fields an entity accepts, and can be used for building third-party integrations with Kong.
-
+  '/schemas/{entity}/validate':
+    parameters:
+      - schema:
+          type: string
+        name: entity
+        in: path
+        required: true
     post:
       summary: Validate a configuration against a schema
       operationId: post-schemas-entity-validate


### PR DESCRIPTION
https://github.com/Kong/docs.konghq.com/issues/7365

The endpoint to retrieve entity schema is GET /schemas/{entity}/validate, but actual endpoint is GET /schemas/{entity}.