### PR TITLE
Fix: Set accurate EOL for RHEL8

### DIFF
--- a/app/_data/tables/support/gateway/versions/28.yml
+++ b/app/_data/tables/support/gateway/versions/28.yml
@@ -10,6 +10,7 @@ distributions:
     eol: June 2024
   - <<: *rhel8
     docker: true
+    eol: May 2024
   - <<: *amazonlinux2
     docker: true
   - <<: *centos7

--- a/app/_data/tables/support/gateway/versions/34.yml
+++ b/app/_data/tables/support/gateway/versions/34.yml
@@ -28,6 +28,7 @@ distributions:
   - <<: *rhel8
     docker: false
     fips: true
+    eol: May 2024
   - <<: *rhel9
     docker: true
     arm: true

--- a/app/_data/tables/support/gateway/versions/35.yml
+++ b/app/_data/tables/support/gateway/versions/35.yml
@@ -26,6 +26,7 @@ distributions:
   - <<: *rhel8
     docker: false
     fips: true
+    eol: May 2024
   - <<: *rhel9
     docker: true
     arm: true

--- a/app/_data/tables/support/gateway/versions/36.yml
+++ b/app/_data/tables/support/gateway/versions/36.yml
@@ -26,6 +26,7 @@ distributions:
   - <<: *rhel8
     docker: false
     fips: true
+    eol: May 2024
   - <<: *rhel9
     docker: true
     arm: true

--- a/app/_data/tables/support/gateway/versions/37.yml
+++ b/app/_data/tables/support/gateway/versions/37.yml
@@ -26,6 +26,7 @@ distributions:
   - <<: *rhel8
     docker: false
     fips: true
+    eol: May 2024
   - <<: *rhel9
     docker: true
     arm: true


### PR DESCRIPTION
### Description

Full support for RHEL 8 ends this month: https://access.redhat.com/product-life-cycles?product=Red%20Hat%20Enterprise%20Linux,OpenShift%20Container%20Platform%204

Full support for RHEL 7 also ended a while ago but we still list it, and have been building packages for a while. Will address that issue (if it is an issue) separately.

### Testing instructions

Preview link: https://deploy-preview-7400--kongdocs.netlify.app/gateway/latest/support-policy/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags (or `if_plugin_version` tags for plugins). 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

