### PR TITLE
chore: set version tags around table

### DIFF
--- a/app/_hub/kong-inc/ai-proxy/overview/_index.md
+++ b/app/_hub/kong-inc/ai-proxy/overview/_index.md
@@ -6,6 +6,7 @@ The AI Proxy plugin lets you transform and proxy requests to a number of AI prov
 
 The plugin accepts requests in one of a few defined and standardised formats, translates them to the configured target format, and then transforms the response back into a standard format.
 
+{% if_version gte:3.7.x %}
 The following table describes which providers and requests the AI Proxy plugin supports:
 
 | Provider | Chat | Completion | Streaming |
@@ -16,6 +17,7 @@ The following table describes which providers and requests the AI Proxy plugin s
 | Anthropic | ✅ | ✅ | Only chat type |
 | Mistral (raw and OLLAMA formats) | ✅ | ✅ | ✅ |
 | Llama2 (raw, OLLAMA, and OpenAI formats) | ✅ | ✅ | ✅ |
+{% endif_version %}
 
 ## How it works
 

--- a/app/_hub/kong-inc/ai-proxy/overview/_index.md
+++ b/app/_hub/kong-inc/ai-proxy/overview/_index.md
@@ -6,6 +6,15 @@ The AI Proxy plugin lets you transform and proxy requests to a number of AI prov
 
 The plugin accepts requests in one of a few defined and standardised formats, translates them to the configured target format, and then transforms the response back into a standard format.
 
+{% if_version lte:3.6.x %}
+The AI Proxy plugin supports `llm/v1/chat` and `llm/v1/completion` style requests for all of the following providers:
+* OpenAI
+* Cohere
+* Azure
+* Anthropic
+* Mistral (raw and OLLAMA formats)
+* Llama2 (raw, OLLAMA, and OpenAI formats)
+{% endif_version %}
 {% if_version gte:3.7.x %}
 The following table describes which providers and requests the AI Proxy plugin supports:
 


### PR DESCRIPTION
### Description

Add version tags to plugin table, since streaming only appears in 3.7.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

