### PR TITLE
fix: Pass release variable to links include

### DIFF
--- a/app/_hub/kong-inc/ai-azure-content-safety/overview/_index.md
+++ b/app/_hub/kong-inc/ai-azure-content-safety/overview/_index.md
@@ -28,4 +28,4 @@ compose an Azure Content Safety text check by compiling all chat history, or jus
 
 ### All AI Gateway plugins
 
-{% include_cached /md/ai-plugins-links.md %}
+{% include_cached /md/ai-plugins-links.md release=page.release %}

--- a/app/_hub/kong-inc/ai-prompt-decorator/overview/_index.md
+++ b/app/_hub/kong-inc/ai-prompt-decorator/overview/_index.md
@@ -22,4 +22,4 @@ Check out the [AI Gateway quickstart](/gateway/latest/get-started/ai-gateway/) t
 
 ### All AI Gateway plugins
 
-{% include_cached /md/ai-plugins-links.md %}
+{% include_cached /md/ai-plugins-links.md release=page.release %}

--- a/app/_hub/kong-inc/ai-prompt-guard/overview/_index.md
+++ b/app/_hub/kong-inc/ai-prompt-guard/overview/_index.md
@@ -38,4 +38,4 @@ The matching behavior is as follows:
 
 ### All AI Gateway plugins
 
-{% include_cached /md/ai-plugins-links.md %}
+{% include_cached /md/ai-plugins-links.md release=page.release %}

--- a/app/_hub/kong-inc/ai-prompt-template/overview/_index.md
+++ b/app/_hub/kong-inc/ai-prompt-template/overview/_index.md
@@ -39,4 +39,4 @@ When activated the template restricts an LLM usage to just those pre-defined tem
 
 ### All AI Gateway plugins
 
-{% include_cached /md/ai-plugins-links.md %}
+{% include_cached /md/ai-plugins-links.md release=page.release %}

--- a/app/_hub/kong-inc/ai-proxy/overview/_index.md
+++ b/app/_hub/kong-inc/ai-proxy/overview/_index.md
@@ -201,5 +201,5 @@ See the [sample OpenAPI specification](https://github.com/kong/kong/blob/master/
 
 ### All AI Gateway plugins
 
-{% include_cached /md/ai-plugins-links.md %}
+{% include_cached /md/ai-plugins-links.md release=page.release %}
 

--- a/app/_hub/kong-inc/ai-rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/ai-rate-limiting-advanced/overview/_index.md
@@ -112,4 +112,4 @@ You can decide to use a custom function to count the tokens for a requests. When
 
 ### All AI Gateway plugins
 
-{% include_cached /md/ai-plugins-links.md %}
+{% include_cached /md/ai-plugins-links.md release=page.release %}

--- a/app/_hub/kong-inc/ai-request-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/ai-request-transformer/overview/_index.md
@@ -67,4 +67,4 @@ instructions for the incoming user request body.
 
 ### All AI Gateway plugins
 
-{% include_cached /md/ai-plugins-links.md %}
+{% include_cached /md/ai-plugins-links.md release=page.release %}

--- a/app/_hub/kong-inc/ai-response-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/ai-response-transformer/overview/_index.md
@@ -86,4 +86,4 @@ This lets you change specific headers such as `Content-Type`, or throw errors fr
 
 ### All AI Gateway plugins
 
-{% include_cached /md/ai-plugins-links.md %}
+{% include_cached /md/ai-plugins-links.md release=page.release %}


### PR DESCRIPTION
### Description

Fixing 3.7 links showing up in 3.6.

### Testing instructions

Preview link: https://deploy-preview-7420--kongdocs.netlify.app/hub/kong-inc/ai-proxy/#all-ai-gateway-plugins

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

