### PR TITLE
chore: Convert remaining OIDC topic that uses httpie to curl

### DIFF
--- a/app/_hub/kong-inc/openid-connect/how-to/_cert-bound-access-tokens.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_cert-bound-access-tokens.md
@@ -48,11 +48,12 @@ Follow these prerequisites to set up a demo Keycloak app and a Kong service and 
 1. Configure {{site.base_gateway}} to use mTLS client certificate authentication. You can do this by configuring the [TLS Handshake Modifier plugin](/hub/kong-inc/tls-handshake-modifier/) or the [Mutual TLS Authentication plugin](/hub/kong-inc/mtls-auth/):
 
     ```bash
-    http -f post :8001/plugins    \
-    name=tls-handshake-modifier \
-    service.name=openid-connect
+    curl -X POST http://localhost:8001/plugins \
+      --data "name=tls-handshake-modifier" \
+      --data "service.name=openid-connect"
     ```
-    If this is configured correctly, it returns a `200` response and something like the following:
+    
+    If this is configured correctly, it returns a `200` response with the following data:
     ```json
     {
         "id": "a7f676e6-580d-4841-80de-de46e1f79eb2",
@@ -66,16 +67,16 @@ Follow these prerequisites to set up a demo Keycloak app and a Kong service and 
 1. To enable certificate-bound access tokens, use the [`proof_of_possession_mtls`](/hub/kong-inc/openid-connect/configuration/#config-proof_of_possession_mtls) configuration option:
 
     ```bash
-    http -f put :8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f4f9 \
-    name=openid-connect                                          \
-    service.name=openid-connect                                  \
-    config.issuer=https://keycloak.test:8440/auth/realms/master  \
-    config.client_id=cert-bound                                  \
-    config.client_secret=cf4c655a-0622-4ce6-a0de-d3353ef0b714    \
-    config.auth_methods=bearer                                   \
-    config.proof_of_possession_mtls=strict
+    curl -X PUT http://localhost:8001/plugins/5f35b796-ced6-4c00-9b2a-90eef745f4f9 \
+      --data "name=openid-connect" \
+      --data "service.name=openid-connect" \
+      --data "config.issuer=https://keycloak.test:8440/auth/realms/master" \
+      --data "config.client_id=cert-bound" \
+      --data "config.client_secret=cf4c655a-0622-4ce6-a0de-d3353ef0b714" \
+      --data "config.auth_methods=bearer" \
+      --data "config.proof_of_possession_mtls=strict" 
     ```
-    If this is configured correctly, it returns a `200` response and something like the following:
+    If this is configured correctly, it returns a `200` response with the following data:
     ```json
     {
         "id": "5f35b796-ced6-4c00-9b2a-90eef745f4f9",
@@ -95,13 +96,14 @@ Follow these prerequisites to set up a demo Keycloak app and a Kong service and 
 
 1. Obtain the token from the IdP, making sure to modify the following command for your environment:
     ```bash
-    http --cert client-cert.pem --cert-key client-key.pem                                 \
-    -f post https://keycloak.test:8440/auth/realms/master/protocol/openid-connect/token \
-    client_id=cert-bound                                                                \
-    client_secret=cf4c655a-0622-4ce6-a0de-d3353ef0b714                                  \
-    grant_type=client_credentials
+     curl -f -X POST https://keycloak.test:8440/auth/realms/master/protocol/openid-connect/token \
+       --cert client-cert.pem \
+       --cert-key client-key.pem \
+       --data "client_id=cert-bound" \
+       --data "client_secret=cf4c655a-0622-4ce6-a0de-d3353ef0b714" \
+       --data "grant_type=client_credentials" \
     ```
-    If this is configured correctly, it returns a `200` response and something like the following:
+    If this is configured correctly, it returns a `200` response with the following data:
     ```json
     {
         "access_token": "eyJhbG...",
@@ -121,9 +123,10 @@ Follow these prerequisites to set up a demo Keycloak app and a Kong service and 
 
 1. Access the service using the same client certificate and key used to obtain the token:
     ```bash
-    http --cert client-cert.pem --cert-key client-key.pem \
-    -f post https://kong.test:8443                      \
-    Authorization:"Bearer eyJhbGc..."
+    curl -f -X POST https://kong.test:8443 \
+      -H "Authorization: Bearer eyJhbGc..." \
+      --cert client-cert.pem \
+      --cert-key client-key.pem \
     ```
     If this is configured correctly, it returns a `200` response:
     ```http


### PR DESCRIPTION
### Description

Converting HTTPie to curl. This topic was added in 3.6 and I ran out of time to convert it, so we just merged it.

### Testing instructions

Preview link: https://deploy-preview-7422--kongdocs.netlify.app/hub/kong-inc/openid-connect/how-to/cert-bound-access-tokens/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

