### PR TITLE
fix log format indentation

### DIFF
--- a/app/_includes/md/plugins-hub/log-format.md
+++ b/app/_includes/md/plugins-hub/log-format.md
@@ -88,16 +88,16 @@ Every request is logged separately in a JSON object, separated by a new line `\n
   "client_ip": "192.168.144.1",
   "workspace": "54baa5a9-23d6-41e0-9c9a-02434b010b25",
   "upstream_uri": "/anything",
-	"authenticated_entity": {
+  "authenticated_entity": {
 		"id": "c62c1455-9b1d-4f2d-8797-509ba83b8ae8"
-	},
-	"consumer": {
-		"id": "ae974d6c-0f8a-4dc5-b701-fa0aa38592bd",
-		"created_at": 1674035962,
-		"username_lower": "foo",
-		"username": "foo",
-		"type": 0
-	},
+  },
+  "consumer": {
+    "id": "ae974d6c-0f8a-4dc5-b701-fa0aa38592bd",
+    "created_at": 1674035962,
+    "username_lower": "foo",
+    "username": "foo",
+    "type": 0
+  },
   "started_at": 1614232668342
 }
 ```

--- a/app/_includes/md/plugins-hub/log-format.md
+++ b/app/_includes/md/plugins-hub/log-format.md
@@ -89,7 +89,7 @@ Every request is logged separately in a JSON object, separated by a new line `\n
   "workspace": "54baa5a9-23d6-41e0-9c9a-02434b010b25",
   "upstream_uri": "/anything",
   "authenticated_entity": {
-		"id": "c62c1455-9b1d-4f2d-8797-509ba83b8ae8"
+    "id": "c62c1455-9b1d-4f2d-8797-509ba83b8ae8"
   },
   "consumer": {
     "id": "ae974d6c-0f8a-4dc5-b701-fa0aa38592bd",
@@ -190,16 +190,16 @@ Every request is logged separately in a JSON object, separated by a new line `\n
   "workspace": "54baa5a9-23d6-41e0-9c9a-02434b010b25",
   "workspace_name": "default",
   "upstream_uri": "/anything",
-	"authenticated_entity": {
-		"id": "c62c1455-9b1d-4f2d-8797-509ba83b8ae8"
-	},
-	"consumer": {
-		"id": "ae974d6c-0f8a-4dc5-b701-fa0aa38592bd",
-		"created_at": 1674035962,
-		"username_lower": "foo",
-		"username": "foo",
-		"type": 0
-	},
+  "authenticated_entity": {
+    "id": "c62c1455-9b1d-4f2d-8797-509ba83b8ae8"
+  },
+  "consumer": {
+    "id": "ae974d6c-0f8a-4dc5-b701-fa0aa38592bd",
+    "created_at": 1674035962,
+    "username_lower": "foo",
+    "username": "foo",
+    "type": 0
+  },
   "started_at": 1614232668342
 }
 ```


### PR DESCRIPTION
### Description

Fixed Log Format Indentation 
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: [link](https://app.netlify.com/sites/kongdocs/deploys/664f896b0caadc0009df3a0f) 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

