### PR TITLE
docs: incorrect value for netlify env variable

### DIFF
--- a/app/konnect/dev-portal/customization/netlify.md
+++ b/app/konnect/dev-portal/customization/netlify.md
@@ -60,7 +60,7 @@ You will deploy the self-hosted example Dev Portal using Netlify in this example
 1. Select **prod** from the **Branch to deploy** drop-down menu.
 1. Click **Show advanced**. 
 1. In the **Environment variables** section, click **New variable**.
-1. Enter `VITE_PORTAL_API_URL` in the **Key** field and your custom portal domain API (`api.mycompany.com`) in the **Value** field.
+1. Enter `VITE_PORTAL_API_URL` in the **Key** field and your custom portal domain API (`https://api.mycompany.com`) in the **Value** field.
 1. Click **Deploy site**. 
 
 ### Add your domain to Netlify


### PR DESCRIPTION
Fixed the correct value for netlify deployment of custom dev portal


### Description

<!-- Changed the value for VITE_PORTAL_API_URL -->
 
<!-- Had a discussion with Andrew Wylde, the suggested change works

"VITE_PORTAL_API_URL should be a full url, I think, not just the subdomain. Can you try setting it to https://api-developer.jwconsult.in/  and letting me know if that works for you? " -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

