### PR TITLE
Update: Make license update info easier to find

### DIFF
--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -46,27 +46,19 @@ applies the license to data planes automatically.
 The license data must contain straight quotes to be considered valid JSON
 (`'` and `"`, not `’` or `“`).
 
-`POST` the contents of the provided `license.json` license to your
-{{site.base_gateway}} instance:
-
 {:.note}
-> **Note:** The following license is only an example. You must use the
+> **Note:** The payload of the following license is only an example. You must use the
 following format, but provide your own content.
 
-{% navtabs codeblock %}
-{% navtab cURL %}
+{% navtabs %}
+{% navtab Add new license %}
+To add a new license, `POST` the contents of the provided `license.json` license to your
+{{site.base_gateway}} instance:
+
 ```bash
-$ curl -i -X POST http://localhost:8001/licenses \
+curl -i -X POST http://localhost:8001/licenses \
   -d payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-$ http POST :8001/licenses \
-  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
-```
-{% endnavtab %}
-{% endnavtabs %}
 
 Result:
 ```json
@@ -77,11 +69,40 @@ Result:
   "updated_at": 1500508800
 }
 ```
+{% endnavtab %}
+{% navtab Update existing license %}
+Update the license with a `PATCH` request to the existing license's ID:
+
+1. Find the license you want to update, and copy the ID from the output:
+
+    ```bash
+    curl -i -X GET http://localhost:8001/licenses
+    ```
+
+1. Submit a `PATCH` request to the license ID:
+
+    ```bash
+    curl -i -X PATCH http://localhost:8001/licenses/30b4edb7-0847-4f65-af90-efbed8b0161f \
+      payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-21","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb","version":"1"}}'
+    ```
+
+    Response:
+    ```json
+    {
+      "created_at": 1500595200,
+      "id": "30b4edb7-0847-4f65-af90-efbed8b0161f",
+      "payload": "{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-21\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb\",\"version\":\"1\"}}",
+      "updated_at": 1500595200
+    }
+    ```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Ensure to [restart](/gateway/{{page.release}}/reference/cli/#kong-restart) the {{site.base_gateway}} nodes after adding or updating a license.
 
 For more detail and options, see the
 [Admin API `licenses` endpoint reference](/gateway/latest/licenses/examples).
-
-We recommend [restarting](/gateway/{{page.release}}/reference/cli/#kong-restart) the {{site.base_gateway}} nodes after applying or updating a license.
 
 {% endnavtab %}
 {% navtab Filesystem %}

--- a/app/_includes/md/enterprise/deploy-license.md
+++ b/app/_includes/md/enterprise/deploy-license.md
@@ -99,7 +99,7 @@ Update the license with a `PATCH` request to the existing license's ID:
 {% endnavtab %}
 {% endnavtabs %}
 
-Ensure to [restart](/gateway/{{page.release}}/reference/cli/#kong-restart) the {{site.base_gateway}} nodes after adding or updating a license.
+[Restart](/gateway/{{page.release}}/reference/cli/#kong-restart) the {{site.base_gateway}} nodes after adding or updating a license.
 
 For more detail and options, see the
 [Admin API `licenses` endpoint reference](/gateway/latest/licenses/examples).

--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -140,20 +140,10 @@ quotes to be considered valid JSON (`'` and `"`, not `’` or `“`).
 The following license is only an example. You must use the following format,
 but provide your own content.
 
-{% navtabs codeblock %}
-{% navtab cURL %}
 ```bash
 curl -i -X POST http://localhost:8001/licenses \
   -d payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
 ```
-{% endnavtab %}
-{% navtab HTTPie %}
-```bash
-http POST :8001/licenses \
-  payload='{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-20","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b","version":"1"}}'
-```
-{% endnavtab %}
-{% endnavtabs %}
 
 {% endnavtab %}
 {% navtab Without a database %}


### PR DESCRIPTION
### Description

Add info on updating a license to license deploy doc.

Removed httpie formatted instructions, they shouldn't exist anymore.

Fixes https://konghq.atlassian.net/browse/FTI-5982

### Testing instructions

Preview link: https://deploy-preview-7433--kongdocs.netlify.app/gateway/latest/licenses/deploy/#deploy-the-license

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

