### PR TITLE
Update: Graphql proxy cache adv plugin API not supported in hybrid mode

### DIFF
--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/_api.md
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/_api.md
@@ -8,7 +8,11 @@ The GraphQL Proxy Cache Advanced plugin exposes several endpoints for cache mana
 They are available through the Kong Admin API.
 
 To configure and enable the plugin itself, [use the `/plugins` API endpoint](/hub/kong-inc/graphql-proxy-cache-advanced/how-to/basic-example/).
-The `/graphql-proxy-cache-advanced` endpoints only appear once the plugin has been enabled. 
+The `/graphql-proxy-cache-advanced` endpoints only appear once the plugin has been enabled.
+
+{:.important}
+> This plugin's API endpoints are not available in hybrid mode. 
+The data that this API targets is located on the data planes, and data planes can't use the Kong Admin API.
 
 ### Retrieve a cache entity
 

--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata/_index.yml
@@ -10,7 +10,9 @@ enterprise: true
 paid: true
 konnect: true
 network_config_opts: All
-notes: --
+notes: | 
+  This plugin's API doesn't work in hybrid mode, as it targets data that only exists on data planes, 
+  and data planes can't use Kong's Admin API. 
 categories:
   - traffic-control
 publisher: Kong Inc.


### PR DESCRIPTION
### Description

Adding a note on API usage in hybrid mode for the graphql proxy cache plugin.

Addresses docs callout in KAG-4357.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

