### PR TITLE
Fix installation docs for 3.7

### DIFF
--- a/app/_data/installation/gateway.yml
+++ b/app/_data/installation/gateway.yml
@@ -1,7 +1,7 @@
 # e.g.: https://cloudsmith.io/~kong/repos/internal-gateway-37/pub-keys/
 "37":
-  rsa_key: 4C3E847EC336BAB7
-  gpg_key: 6973875013D1931E
+  rsa_key: A757CBAFE0D65143
+  gpg_key: C05D9BEAEB9E8E18
 "36":
   rsa_key: 6D312E174BE30B5A
   gpg_key: 1D935A6039ECFC53


### PR DESCRIPTION
### Description

* Updating 3.7 gpg and rsa keys public keys, the old ones were wrong.

This test should pass: https://github.com/Kong/docs.konghq.com/actions/runs/9306681536

Check https://deploy-preview-7442--kongdocs.netlify.app/gateway/3.7.x/install/linux/debian/?install=oss to see the correct gpg key.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

