### PR TITLE
chore: Update label for install workflow [skip ci]

### DIFF
--- a/.github/workflows/install-instructions-test.yml
+++ b/.github/workflows/install-instructions-test.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       base_url:
         type: string
-        description: URL to test against. Defaults to http://localhost:8888
+        description: URL to test against. Defaults to https://docs.konghq.com. Use the netlify preview URL when testing against a branch.
 
 jobs:
   install-instructions:


### PR DESCRIPTION
### Description

The localhost instruction is only accurate when testing locally. In the GH action, it tests against the prod site by default.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

