### PR TITLE
Revert "Fix: Set accurate EOL for RHEL8"

### DIFF
--- a/app/_data/tables/support/gateway/versions/28.yml
+++ b/app/_data/tables/support/gateway/versions/28.yml
@@ -10,7 +10,6 @@ distributions:
     eol: June 2024
   - <<: *rhel8
     docker: true
-    eol: May 2024
   - <<: *amazonlinux2
     docker: true
   - <<: *centos7

--- a/app/_data/tables/support/gateway/versions/34.yml
+++ b/app/_data/tables/support/gateway/versions/34.yml
@@ -28,7 +28,6 @@ distributions:
   - <<: *rhel8
     docker: false
     fips: true
-    eol: May 2024
   - <<: *rhel9
     docker: true
     arm: true

--- a/app/_data/tables/support/gateway/versions/35.yml
+++ b/app/_data/tables/support/gateway/versions/35.yml
@@ -26,7 +26,6 @@ distributions:
   - <<: *rhel8
     docker: false
     fips: true
-    eol: May 2024
   - <<: *rhel9
     docker: true
     arm: true

--- a/app/_data/tables/support/gateway/versions/36.yml
+++ b/app/_data/tables/support/gateway/versions/36.yml
@@ -26,7 +26,6 @@ distributions:
   - <<: *rhel8
     docker: false
     fips: true
-    eol: May 2024
   - <<: *rhel9
     docker: true
     arm: true

--- a/app/_data/tables/support/gateway/versions/37.yml
+++ b/app/_data/tables/support/gateway/versions/37.yml
@@ -26,7 +26,6 @@ distributions:
   - <<: *rhel8
     docker: false
     fips: true
-    eol: May 2024
   - <<: *rhel9
     docker: true
     arm: true


### PR DESCRIPTION
Reverts Kong/docs.konghq.com#7400

Was changed in error due to confusion in terminology. We will continue supporting RHEL 8 until either full EOL, or the EOL of the Kong version - whichever comes first.