### PR TITLE
feat(rate-limiting): add the doc for the added interface in rate-limiting library

### DIFF
--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -55,7 +55,7 @@ Previously, this library used a module level global table `config`, which lacked
 
 The `ratelimiting.new_instance` interface provides the necessary isolation without changing the original interfaces. Every returned instance has its own `ratelimiting.config` which don't interfere with each other. See the following usage example: `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("rate-limiting-foo")`.
 
-If the library is used in the old way, the behavior is as before. In this case, it will return a default instance which may be shared with other plugins. `local ratelimiting = require("kong.tools.public.rate-limiting")`
+If the library is used in the old way, the behavior is as before. In this case, it will return a default instance which may be shared with other plugins: `local ratelimiting = require("kong.tools.public.rate-limiting")`
 
 Other functions below remain unchanged.
 

--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -51,7 +51,7 @@ The following public functions are provided by this library:
 
 _syntax: ratelimiting = ratelimiting.new_instance(instance_name)_
 
-Previously, this library used a module level global table `config`, which lacked the necessary data isolation between plugins. When two or more different plugins used the table at the same time, {{site.base_gateway}} couldn't distinguish which namespaces belong to which plugin. When the `reconfigure` event happened, the plugin deleted all the namespaces it didn't use anymore, but those deleted namespaces could have belonged to other plugins.
+Previously, this library used a module level global table `config`, which lacked the necessary data isolation between plugins. When two or more different plugins used the library at the same time, {{site.base_gateway}} couldn't distinguish which namespaces belong to which plugin. When the `reconfigure` event happened, the plugin deleted all the namespaces it didn't use anymore, but those deleted namespaces could have belonged to other plugins.
 
 The `ratelimiting.new_instance` interface provides the necessary isolation without changing the original interfaces. Every returned instance has its own `ratelimiting.config` which don't interfere with each other. See the following usage example: `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("rate-limiting-foo")`.
 

--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -48,6 +48,8 @@ Module configuration data, such as sync rate, shared dictionary name, storage po
 The following public functions are provided by this library:
 
 {% if_version gte:3.4.x %}
+
+{% if_version gte:3.4.x %}
 `ratelimiting.new_instance`
 
 _syntax: ratelimiting = ratelimiting.new_instance(instance_name)_

--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -47,6 +47,18 @@ Module configuration data, such as sync rate, shared dictionary name, storage po
 ### Public Functions
 The following public functions are provided by this library:
 
+`ratelimiting.new_instance`
+
+_syntax: ratelimiting = ratelimiting.new_instance(instance_name)_
+
+Previously this library used a module level global table `config` and thus lacked of necessary data isolation between different plugins. So when two or more different plugins are using it at the same time, it doesn't work normally because we can't distinguish which namespaces belong to which plugin. When the `reconfigure` event happens, the plugin will delete all the namespaces it does not use anymore, but those deleted namespaces may belong to other plugins.
+
+To provide necessary isolation without changing the original interfaces, we added this new interface. Every returned instance has its own `ratelimiting.config` that won't interfere with each other. As a usage example: `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("rate-limiting-foo")`
+
+If the library is used in the old way, the behavior is as before. In this case, it will return a default instance which may be shared with other plugins. `local ratelimiting = require("kong.tools.public.rate-limiting")`
+
+Other functions below remain unchanged.
+
 `ratelimiting.new`
 
 _syntax: ok = ratelimiting.new(opts)_

--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -47,6 +47,7 @@ Module configuration data, such as sync rate, shared dictionary name, storage po
 ### Public Functions
 The following public functions are provided by this library:
 
+{% if_version gte:3.4.x %}
 `ratelimiting.new_instance`
 
 _syntax: ratelimiting = ratelimiting.new_instance(instance_name)_
@@ -56,7 +57,7 @@ Previously, this library used a module level global table `config`, which lacked
 The `ratelimiting.new_instance` interface provides the necessary isolation without changing the original interfaces. Every returned instance has its own `ratelimiting.config` which don't interfere with each other. See the following usage example: `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("rate-limiting-foo")`.
 
 If the library is used in the old way, the behavior is as before. In this case, it will return a default instance which may be shared with other plugins: `local ratelimiting = require("kong.tools.public.rate-limiting")`
-
+{% endif_version %}
 
 `ratelimiting.new`
 

--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -53,7 +53,7 @@ _syntax: ratelimiting = ratelimiting.new_instance(instance_name)_
 
 Previously, this library used a module level global table `config`, which lacked the necessary data isolation between plugins. When two or more different plugins used the table at the same time, {{site.base_gateway}} couldn't distinguish which namespaces belong to which plugin. When the `reconfigure` event happened, the plugin deleted all the namespaces it didn't use anymore, but those deleted namespaces could have belonged to other plugins.
 
-To provide necessary isolation without changing the original interfaces, we added this new interface. Every returned instance has its own `ratelimiting.config` that won't interfere with each other. As a usage example: `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("rate-limiting-foo")`
+The `ratelimiting.new_instance` interface provides the necessary isolation without changing the original interfaces. Every returned instance has its own `ratelimiting.config` which don't interfere with each other. See the following usage example: `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("rate-limiting-foo")`.
 
 If the library is used in the old way, the behavior is as before. In this case, it will return a default instance which may be shared with other plugins. `local ratelimiting = require("kong.tools.public.rate-limiting")`
 

--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -57,7 +57,6 @@ The `ratelimiting.new_instance` interface provides the necessary isolation witho
 
 If the library is used in the old way, the behavior is as before. In this case, it will return a default instance which may be shared with other plugins: `local ratelimiting = require("kong.tools.public.rate-limiting")`
 
-Other functions below remain unchanged.
 
 `ratelimiting.new`
 

--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -51,7 +51,7 @@ The following public functions are provided by this library:
 
 _syntax: ratelimiting = ratelimiting.new_instance(instance_name)_
 
-Previously this library used a module level global table `config` and thus lacked of necessary data isolation between different plugins. So when two or more different plugins are using it at the same time, it doesn't work normally because we can't distinguish which namespaces belong to which plugin. When the `reconfigure` event happens, the plugin will delete all the namespaces it does not use anymore, but those deleted namespaces may belong to other plugins.
+Previously, this library used a module level global table `config`, which lacked the necessary data isolation between plugins. When two or more different plugins used the table at the same time, {{site.base_gateway}} couldn't distinguish which namespaces belong to which plugin. When the `reconfigure` event happened, the plugin deleted all the namespaces it didn't use anymore, but those deleted namespaces could have belonged to other plugins.
 
 To provide necessary isolation without changing the original interfaces, we added this new interface. Every returned instance has its own `ratelimiting.config` that won't interfere with each other. As a usage example: `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("rate-limiting-foo")`
 

--- a/app/_src/gateway/reference/rate-limiting.md
+++ b/app/_src/gateway/reference/rate-limiting.md
@@ -49,7 +49,6 @@ The following public functions are provided by this library:
 
 {% if_version gte:3.4.x %}
 
-{% if_version gte:3.4.x %}
 `ratelimiting.new_instance`
 
 _syntax: ratelimiting = ratelimiting.new_instance(instance_name)_


### PR DESCRIPTION
### Description

Added the doc for the added interface `ratelimiting.new_instance` in the rate-limiting library.

https://konghq.atlassian.net/browse/FTI-5918


### Testing instructions

Preview link: https://deploy-preview-7455--kongdocs.netlify.app/gateway/latest/reference/rate-limiting/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

