### PR TITLE
Fix Terraform example generation

### DIFF
--- a/app/_includes/plugins/hub-examples/terraform.html
+++ b/app/_includes/plugins/hub-examples/terraform.html
@@ -24,11 +24,7 @@ Add the following to your Terraform configuration to create a Konnect Gateway Pl
 resource "konnect_gateway_plugin_{{ plugin_name }}" "my_{{ plugin_name }}" {
   enabled = true
 
-  config = {
-    {%- for item in include.example.example.config %}
-    {{ item[0] }} = {{ item[1] | quote }}{%- endfor %}
-  }
-
+  {{ include.example.terraform }}
   control_plane_id = konnect_gateway_control_plane.my_konnect_cp.id{% if include.parent %}
   {{ include.parent }} = {
     id = konnect_gateway_{{ include.parent }}.my_{{ include.parent }}.id

--- a/app/_plugins/drops/plugins/examples/terraform.rb
+++ b/app/_plugins/drops/plugins/examples/terraform.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module Plugins
+      module Examples
+        class Terraform < Base
+          def render
+            output(
+              { 'config' => @example.fetch('config') },
+              1,
+              true,
+              "\n"
+            )
+          end
+
+          def output(object, depth, is_root, eol)
+            object.map do |k, v|
+              if v.is_a?(Hash)
+                output_hash(k, v, depth, is_root, eol)
+              elsif v.is_a?(Array)
+                output_list(k, v, depth)
+              else
+                line("#{k} = #{quote(v)}", depth, eol)
+              end
+            end.join
+          end
+
+          def output_hash(key, input, depth, is_root, eol)
+            s = ''
+            s += "\n" unless is_root
+            s += line("#{key} = {", depth, eol)
+            s += output(input, (depth + 1), false, eol)
+            s += line('}', depth, eol)
+            s
+          end
+
+          def output_hash_in_list(input, depth)
+            s = "\n"
+            s += line('{', (depth + 1))
+            s += output(input, (depth + 2), false, "\n")
+            s + line('}, ', (depth + 1))
+          end
+
+          def output_list(key, input, depth)
+            s = line("#{key} = [", depth, '')
+            input.each do |v|
+              s += if v.is_a?(Hash)
+                     output_hash_in_list(v, depth)
+                   else
+                     "#{line(quote(v), (depth + 1), '').strip}, "
+                   end
+            end
+
+            s = s.rstrip.chomp(',')
+            s + end_list(input, depth)
+          end
+
+          def end_list(input, depth)
+            last_line = line(']', depth, "\n")
+            return last_line if input.last.is_a?(Hash)
+
+            last_line.lstrip
+          end
+
+          def line(input, depth, eol = "\n")
+            "#{'  ' * depth}#{input}#{eol}"
+          end
+
+          def quote(input)
+            return '' if input.nil?
+
+            return input if ['true', 'false', true, false].include?(input)
+
+            return input if input.is_a?(Numeric)
+
+            return "<<EOF\n#{input.rstrip}\nEOF" if input.include?("\n")
+
+            "\"#{input.gsub('"', '\\"')}\""
+          end
+
+          def to_s
+            <<~TERRAFORM
+              #{render.strip}
+            TERRAFORM
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/plugins/hub_examples.rb
+++ b/app/_plugins/drops/plugins/hub_examples.rb
@@ -90,6 +90,10 @@ module Jekyll
           @kubernetes ||= Examples::Yaml.new(type:, example:)
         end
 
+        def terraform
+          @terraform ||= Examples::Terraform.new(type:, example:)
+        end
+
         def plugin_name
           @plugin_name ||= @example.fetch('name')
         end


### PR DESCRIPTION
### Description

Fix Terraform examples with nested objects + lists of objects

Old:

```hcl
resource "konnect_gateway_plugin_ai_proxy" "my_ai_proxy" {
 enabled = true

 config = {
   route_type = "llm/v1/chat"
   auth = "{"header_name"=>"Authorization", "header_value"=>"Bearer <OPENAI_API_TOKEN>"}"
   model = "{"provider"=>"openai", "name"=>"gpt-4", "options"=>{"max_tokens"=>512, "temperature"=>1.0}}"
 }

 control_plane_id = konnect_gateway_control_plane.my_konnect_cp.id
 route = {
   id = konnect_gateway_route.my_route.id
 }
}

```

New:

```hcl
resource "konnect_gateway_plugin_ai_proxy" "my_ai_proxy" {
 enabled = true

 config = {
   route_type = "llm/v1/chat"

   auth = {
     header_name = "Authorization"
     header_value = "Bearer <OPENAI_API_TOKEN>"
   }

   model = {
     provider = "openai"
     name = "gpt-4"

     options = {
       max_tokens = 512
       temperature = 1.0
     }
   }
 }

 control_plane_id = konnect_gateway_control_plane.my_konnect_cp.id
 route = {
   id = konnect_gateway_route.my_route.id
 }
}
```

### Testing instructions

Preview link: [/hub/kong-inc/ai-proxy/how-to/basic-example/?tab=konnect-terraform](https://deploy-preview-7457--kongdocs.netlify.app/hub/kong-inc/ai-proxy/how-to/basic-example/?tab=konnect-terraform)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
