### PR TITLE
Fix: Move Ubuntu install distro note into steps

### DIFF
--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -86,13 +86,6 @@ Once {{ site.base_gateway }} is running, you may want to do the following:
 
 You can install {{site.base_gateway}} by downloading an installation package or using the APT repository.
 
-{% if_version gte:3.4.x %}
-We currently package {{ site.base_gateway }} for Ubuntu Focal and Jammy. If you are using a different release, replace `jammy` with `$(lsb_release -sc)` or the release name in the commands below. To check your release name, run `lsb_release -sc`.
-{% endif_version %}
-{% if_version lte:3.3.x %}
-We currently package {{ site.base_gateway }} for Ubuntu Bionic, Focal, and Jammy. If you are using a different release, replace `jammy` with `$(lsb_release -sc)` or the release name in the commands below. To check your release name, run `lsb_release -sc`.
-{% endif_version %}
-
 The following steps install the package **only**, without a data store. 
 You will need to set one up after installation.
 
@@ -101,7 +94,16 @@ You will need to set one up after installation.
 
 Install {{site.base_gateway}} on Ubuntu from the command line.
 
-1. Download the Kong package:
+1. Download the Kong package.
+
+    {% if_version gte:3.4.x %}
+    We currently package {{ site.base_gateway }} for Ubuntu Focal and Jammy. The following command assumes you're running `jammy`. 
+    If you are using a different release, replace `jammy` with `$(lsb_release -sc)` or the release name in the command below. To check your release name, run `lsb_release -sc`.
+    {% endif_version %}
+    {% if_version lte:3.3.x %}
+    We currently package {{ site.base_gateway }} for Ubuntu Bionic, Focal, and Jammy. The following command assumes you're running `jammy`. 
+    If you are using a different release, replace `jammy` with `$(lsb_release -sc)` or the release name in the command below. To check your release name, run `lsb_release -sc`.
+    {% endif_version %}
 
 {% assign ubuntu_flavor = "jammy" %}
 {% if page.release == "3.0.x" %}
@@ -154,7 +156,17 @@ Install the APT repository from the command line.
 {% assign gpg_key = site.data.installation.gateway.legacy.gpg_key  %}
 {% endunless %}
 
-1. Setup the Kong APT repository:
+1. Set up the Kong APT repository.
+
+    {% if_version gte:3.4.x %}
+    We currently package {{ site.base_gateway }} for Ubuntu Focal and Jammy. The following command assumes you're running `jammy`. 
+    If you are using a different release, replace `jammy` with `$(lsb_release -sc)` or the release name in the command below. To check your release name, run `lsb_release -sc`.
+    {% endif_version %}
+    {% if_version lte:3.3.x %}
+    We currently package {{ site.base_gateway }} for Ubuntu Bionic, Focal, and Jammy. The following command assumes you're running `jammy`. 
+    If you are using a different release, replace `jammy` with `$(lsb_release -sc)` or the release name in the command below. To check your release name, run `lsb_release -sc`.
+    {% endif_version %}
+    
     ```bash
     curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/gpg.{{ gpg_key }}.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-{{ page.major_minor_version }}-archive-keyring.gpg > /dev/null
     curl -1sLf "{{ site.links.direct }}/gateway-{{ page.major_minor_version }}/config.deb.txt?distro=ubuntu&codename={{ ubuntu_flavor }}" | sudo tee /etc/apt/sources.list.d/kong-gateway-{{ page.major_minor_version }}.list > /dev/null


### PR DESCRIPTION
### Description

The release name for Ubuntu is hardcoded in the URL, as most of our users are on Jammy. For those that aren't, they need to replace the distro name with their own. This info exists, but is noted _before_ the steps start, which meant that people weren't seeing the information. Moving the info into the relevant steps to make it clearer.

Fixes https://konghq.atlassian.net/browse/KAG-4608.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

