### PR TITLE
docs(kic): explicitly document SanitizeKonnectConfigDumps

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -474,6 +474,7 @@ runtimes
 SAML
 sandboxed
 sandboxing
+sanitization
 SBOM
 SBOMs
 SCCs

--- a/app/_src/kubernetes-ingress-controller/reference/feature-gates.md
+++ b/app/_src/kubernetes-ingress-controller/reference/feature-gates.md
@@ -16,11 +16,14 @@ The same definitions of `feature gates` and `feature stages` from upstream Kuber
 
 ## Available feature gates
 
-| Feature      | Default | Stage | Since  | Until |
-|--------------|---------|-------|--------|-------|
-| GatewayAlpha | `false` | Alpha | 2.6.0  | TBD   |
-| FillIDs      | `true`  | Beta  | 3.0.0  | TBD   |
-| RewriteURIs  | `false` | Alpha | 2.12.0 | TBD   |
+| Feature                    | Default | Stage | Since  | Until |
+|----------------------------|---------|-------|--------|-------|
+| GatewayAlpha               | `false` | Alpha | 2.6.0  | TBD   |
+| FillIDs                    | `true`  | Beta  | 3.0.0  | TBD   |
+| RewriteURIs                | `false` | Alpha | 2.12.0 | TBD   |
+| KongServiceFacade          | `false` | Alpha | 3.1.0  | TBD   |
+| SanitizeKonnectConfigDumps | `true`  | Beta  | 3.1.0  | TBD   |
+| FallbackConfiguration      | `false` | Alpha | 3.2.0  | TBD   |
 
 ## Using feature gates
 
@@ -61,3 +64,15 @@ kubectl set env -n kong deployment/kong-controller CONTROLLER_FEATURE_GATES="Fil
 [kic-keps]:https://github.com/Kong/kubernetes-ingress-controller/tree/main/keps
 [releases]:https://github.com/Kong/kubernetes-ingress-controller/releases
 
+## Feature gate details 
+
+### SanitizeKonnectConfigDumps
+
+The `SanitizeKonnectConfigDumps` feature enables the sanitization of configuration dumps that are sent to Konnect.
+This means {{site.kic_product_name}} will obfuscate all sensitive information that your Kong config contains, such as 
+private keys in `Certificate` entities and `Consumer` entities' credentials.
+
+{:.important}
+> **Warning:** `KongPlugin`'s and `KongClusterPlugin`'s `config` field is not sanitized. If you have sensitive information 
+> in your `KongPlugin`'s `config` field, it will be sent to Konnect as is. To avoid that, please consider using 
+> [KongVault](/kubernetes-ingress-controller/{{page.release}}/reference/custom-resources/#kongvault).


### PR DESCRIPTION
### Description

We [won't sanitize `KongPlugin` and `KongClusterPlugin`'s `config`](https://github.com/Kong/kubernetes-ingress-controller/pull/6138) - this PR documents that explicitly.

 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-7468--kongdocs.netlify.app/kubernetes-ingress-controller/latest/reference/feature-gates/#sanitizekonnectconfigdumps
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

