### PR TITLE
fix: Table that expresses all HTTP responses returned by the admin API

### DIFF
--- a/app/_src/gateway/admin-api/index_latest.md
+++ b/app/_src/gateway/admin-api/index_latest.md
@@ -146,6 +146,45 @@ curl -i -X POST http://localhost:8001/services/test-service/routes \
      -F "paths[2]=/path/two"
 ```
 
+## HTTP status response codes
+
+The following status codes can be returned in HTTP responses:
+
+| HTTP Code | HTTP Description | Notes |
+| --------- | ---------------- | ----- |
+| a | a | a |
+
+GET
+200
+401
+404
+
+POST
+200
+201
+400
+401
+409
+
+DELETE
+204
+401
+
+PATCH
+200
+400
+401
+404
+
+PUT
+200
+400
+401
+404
+405
+
+
+
 ## Using the API in workspaces 
 {:.badge .enterprise}
 

--- a/app/_src/gateway/admin-api/index_latest.md
+++ b/app/_src/gateway/admin-api/index_latest.md
@@ -152,7 +152,7 @@ The following status codes are returned in HTTP responses:
 
 | HTTP Code | HTTP Description | Notes | Request method |
 | --------- | ---------------- | ----- | ------------- |
-| 200 | OK | The request succeeded. The result of a `200` request depends on the request type: `GET`: The resource was fetched and sent in the message body. `PUT` or `POST`:  The resource that describes the result of the action is sent in the message body. `PATCH`: ? | `GET`, `POST`, `PATCH`, `PUT` |
+| 200 | OK | The request succeeded. The result of a `200` request depends on the request type: <br>- `GET`: The resource was fetched and sent in the message body. <br>- `PUT` or `POST`:  The resource that describes the result of the action is sent in the message body. <br>- `PATCH`: ? | `GET`, `POST`, `PATCH`, `PUT` |
 | 201 | Created | The request succeeded and a new resource was created. | `POST` |
 | 204 | No Content | There is no content in the request to send. | `DELETE` |
 | 400 | Bad Request | The server can't or won't send the request because of an error by the client. | `POST`, `PATCH`, `PUT` |

--- a/app/_src/gateway/admin-api/index_latest.md
+++ b/app/_src/gateway/admin-api/index_latest.md
@@ -148,42 +148,18 @@ curl -i -X POST http://localhost:8001/services/test-service/routes \
 
 ## HTTP status response codes
 
-The following status codes can be returned in HTTP responses:
+The following status codes are returned in HTTP responses:
 
-| HTTP Code | HTTP Description | Notes |
-| --------- | ---------------- | ----- |
-| a | a | a |
-
-GET
-200
-401
-404
-
-POST
-200
-201
-400
-401
-409
-
-DELETE
-204
-401
-
-PATCH
-200
-400
-401
-404
-
-PUT
-200
-400
-401
-404
-405
-
-
+| HTTP Code | HTTP Description | Notes | Request method |
+| --------- | ---------------- | ----- | ------------- |
+| 200 | OK | The request succeeded. The result of a `200` request depends on the request type: `GET`: The resource was fetched and sent in the message body. `PUT` or `POST`:  The resource that describes the result of the action is sent in the message body. `PATCH`: ? | `GET`, `POST`, `PATCH`, `PUT` |
+| 201 | Created | The request succeeded and a new resource was created. | `POST` |
+| 204 | No Content | There is no content in the request to send. | `DELETE` |
+| 400 | Bad Request | The server can't or won't send the request because of an error by the client. | `POST`, `PATCH`, `PUT` |
+| 401 | Unauthorized | The client is unauthenticated. | `GET`, `POST`, `DELETE`, `PATCH`, `PUT` |
+| 404 | Not Found | The server can't find the resource you requested. With an API, this can mean that the endpoint is valid but the resource doesn't exist. | `GET`, `PATCH`, `PUT` |
+| 405 | Method Not Allowed | The server knows the request method, but it isn't supported by the resource. | `PUT` |
+| 409 | Conflict | A request conflicts with the current state of the server.  | `POST` |
 
 ## Using the API in workspaces 
 {:.badge .enterprise}


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Customers were requesting a table that explains which status codes the admin API returns and what those codes mean.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-2952
### Testing instructions

Preview link: 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

