### PR TITLE
Add gateway-38 repo keys

### DIFF
--- a/app/_data/installation/gateway.yml
+++ b/app/_data/installation/gateway.yml
@@ -1,4 +1,7 @@
 # e.g.: https://cloudsmith.io/~kong/repos/internal-gateway-37/pub-keys/
+"38":
+  rsa_key: E4186B13EAE1A2D5
+  gpg_key: 8F87A07D181DAA6B
 "37":
   rsa_key: A757CBAFE0D65143
   gpg_key: C05D9BEAEB9E8E18


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

Adds the keys from https://cloudsmith.io/~kong/repos/gateway-38/pub-keys
This is a no-op.

### Testing instructions

Preview link: https://deploy-preview-7483--kongdocs.netlify.app/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

Sibling to: https://github.com/Kong/gateway-docker-compose-generator/pull/162