### PR TITLE
Fix: Typo in JWT mapping order and clarify behavior

### DIFF
--- a/app/_hub/kong-inc/jwt-signer/overview/_index.md
+++ b/app/_hub/kong-inc/jwt-signer/overview/_index.md
@@ -53,20 +53,21 @@ The following parameters let you provide consumer mapping:
 - `config.channel_token_consumer_claim`
 - `config.channel_token_introspection_consumer_claim`
 
-You can map only once. The plugin applies mappings in the following order:
+The plugin only maps consumers once. 
 
-1. access token introspection results
-2. access token jwt payload
-3. access token introspection results
-4. access token jwt payload
+It applies mappings in the following order, depending on whether the input is opaque or JWT:
 
-The mapping order depends on input (opaque or JWT).
+1. Access token introspection results
+2. Access token JWT payload
+3. Channel token introspection results
+4. Channel token JWT payload
 
-When mapping is done, no other mappings are used. If access token already maps
-to a Kong consumer, the plugin does not try to map a channel token to a consumer
-anymore and does not even error in that case.
+When mapping is done, no other mappings are used.
+The plugin won't try to remap or override consumers once they've been found and mapped. 
+For example, if an access token already maps to a Kong consumer, the plugin doesn't try 
+to map a channel token to that consumer anymore, and won't throw any errors.
 
-A general rule is to map either the access token or the channel token.
+A general rule is to map either the access token or the channel token, not both.
 
 ## Kong Admin API Endpoints
 


### PR DESCRIPTION
### Description

The consumer mapping priority order for the plugin is supposed to include both access token and channel token, but instead just listed access tokens. 

Also clarifying some of the phrasing around mapping so that it doesn't appear to contradict itself

https://konghq.atlassian.net/browse/DOCU-3413

### Testing instructions

Preview link: https://deploy-preview-7484--kongdocs.netlify.app/hub/kong-inc/jwt-signer/#consumer-mapping

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

