### PR TITLE
Fix: Replace list of consumer groups plugins with link

### DIFF
--- a/app/_src/gateway/kong-manager/consumer-groups.md
+++ b/app/_src/gateway/kong-manager/consumer-groups.md
@@ -11,15 +11,8 @@ For example, you could define three consumer groups:
 * A "silver tier" with 10 requests per second
 * A "bronze tier" with 6 requests per 30 seconds
 
-The `consumer_groups` endpoint works together with the following plugins:
-
-* [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced/)
-{% if_version gte:3.4.x -%}
-* [Request Transformer Advanced](/hub/kong-inc/request-transformer-advanced/)
-* [Response transformer Advanced](/hub/kong-inc/request-transformer-advanced/)
-* [Request Transformer](/hub/kong-inc/request-transformer)
-* [Response Transformer](/hub/kong-inc/response-transformer)
-{% endif_version %}
+The `consumer_groups` endpoint works together with a limited set of plugins. 
+See the [scopes compatibility table](/hub/plugins/compatibility/#scopes) for details.
 
 Consumers that are not in a consumer group default to the Rate Limiting advanced
 plugin’s configuration, so you can define tier groups for some users and


### PR DESCRIPTION
### Description

There is a limited number of supported plugins for consumer groups, but that list changes with each release. Instead of manually maintaining a list (that is currently unmaintained), linking to https://docs.konghq.com/hub/plugins/compatibility/#scopes for the most accurate generated info.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

