### PR TITLE
chore: Replace Kuma with AI Gateway in top nav

### DIFF
--- a/app/_data/docs_top_nav.yml
+++ b/app/_data/docs_top_nav.yml
@@ -4,6 +4,9 @@
 - name: Kong Konnect
   desc: Single platform for SaaS end-to-end connectivity
   url: /konnect/
+- name: Kong AI Gateway
+  desc: Multi-LLM AI Gateway for GenAI infrastructure
+  url: /gateway/latest/ai-gateway/
 - name: Kong Mesh
   desc: Enterprise service mesh based on Kuma and Envoy
   url: /mesh/latest/
@@ -19,6 +22,3 @@
 - name: Insomnia
   desc: Collaborative API development platform
   url: https://docs.insomnia.rest/
-- name: Kuma
-  desc: Open-source distributed control plane with a bundled Envoy Proxy integration
-  url: https://kuma.io/docs/


### PR DESCRIPTION
### Description

Adding AI Gateway to top nav.
Removing Kuma to keep our nav formatting. Kuma docs are now fully contained within Mesh docs, so the link is essentially a duplicate.

### Testing instructions

Preview link: https://deploy-preview-7513--kongdocs.netlify.app/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

