### PR TITLE
Fix DockerHub links in Docker custom image instructions

### DIFF
--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -5,7 +5,7 @@ content_type: how-to
 
 Kong is distributed as prebuilt {% if_version lte:3.3.x %}`apk`, {% endif_version %}`deb` and `rpm` packages, in addition to official Docker images hosted on [DockerHub](https://hub.docker.com/r/kong)
 
-Kong builds and verifies [Debian](#dockerhub-debian-link-here) and [RHEL](#dockerhub-rhel-link-here) images for use in production. {% if_version lte:3.3.x %}[Alpine](#dockerhub-alpine-link-here) images are provided for **development purposes only** as they contain development tooling such as `git` for plugin development purposes.{%- endif_version %}
+Kong builds and verifies [Debian](https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name={{ page.release.tag }}-debian) and [RHEL](https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name={{ page.release.tag }}-rhel) images for use in production. {% if_version lte:3.3.x %}[Alpine](https://hub.docker.com/r/kong/kong-gateway/tags?page=&page_size=&ordering=&name={{ page.release.tag }}-alpine) images are provided for **development purposes only** as they contain development tooling such as `git` for plugin development purposes.{%- endif_version %}
 
 The Debian and RHEL images are built with minimal dependencies (as of {{ site.base_gateway }} 3.0) and run through automated security scanners before being published. Any vulnerabilities detected in supported images will be addressed in the next available patch release.
 


### PR DESCRIPTION
### Description

Replaced some placeholder links with links to Dockerhub

### Testing instructions

Preview link: /gateway/3.7.x/install/docker/build-custom-images/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

