### PR TITLE
fix: enable config dumps in fallback guide

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/high-availability/fallback-config.md
+++ b/app/_src/kubernetes-ingress-controller/guides/high-availability/fallback-config.md
@@ -507,7 +507,8 @@ valid version. To demonstrate this, we'll use the same setup as in the default m
 ```bash
 helm upgrade --install kong kong/ingress -n kong \
 --set controller.ingressController.env.feature_gates=FallbackConfiguration=true \
---set controller.ingressController.env.use_last_valid_config_for_fallback=true
+--set controller.ingressController.env.use_last_valid_config_for_fallback=true \
+--set controller.ingressController.env.dump_config=true
 ```
 
 #### Attaching the plugin back


### PR DESCRIPTION
### Description

Enables KIC config dumps in the fallback configuration guide as we rely on it in instructions.

### Testing instructions

Preview link: 
https://deploy-preview-7516--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/high-availability/fallback-config/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

