### PR TITLE
Fix: Fix rendering on version compatibility table

### DIFF
--- a/app/_src/kic-v2/references/version-compatibility.md
+++ b/app/_src/kic-v2/references/version-compatibility.md
@@ -74,6 +74,7 @@ Users should expect all the combinations marked with <i class="fa fa-check"></i>
 | Kubernetes 1.28           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 | Kubernetes 1.29           | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> | <i class="fa fa-check"></i> |
 
+<br>
 {% if_version gte:2.4.0 %}
 
 ### Gateway API


### PR DESCRIPTION
Found an edge case to https://github.com/Kong/jekyll-generator-single-source/pull/16 
where without a line break it wont render the table. 