### PR TITLE
Chore: Remove beta label from Admin API specs

### DIFF
--- a/app/_data/konnect_oas_data.json
+++ b/app/_data/konnect_oas_data.json
@@ -45,12 +45,12 @@
     "id": "937dcdd7-4485-47dc-af5f-b805d562552f",
     "title": "Gateway Admin - EE",
     "latestVersion": {
-      "name": "3.6.0.0",
-      "id": "95e68025-45a1-4e24-8561-6d7e5f422de5"
+      "name": "3.7.0.0",
+      "id": "7dad8169-6779-49bb-bb78-19f88b186d92"
     },
     "description": "Kong Gateway (EE) comes with an internal RESTful API for administration purposes.",
     "documentCount": 2,
-    "versionCount": 4,
+    "versionCount": 5,
     "versions": [
       {
         "id": "be79b812-46d5-4cc1-b757-b5270bf4fa60",
@@ -98,12 +98,12 @@
     "id": "680541e5-de6e-46e5-b43d-0bd1b2369453",
     "title": "Gateway Admin - OSS",
     "latestVersion": {
-      "name": "3.6.0",
-      "id": "51e64ccc-5c4a-46db-a33d-9b39226abd5e"
+      "name": "3.7",
+      "id": "51f0d174-f8b8-4469-9a93-d0aab9b9296b"
     },
     "description": "Kong Gateway (OSS) comes with an internal RESTful API for administration purposes.",
     "documentCount": 0,
-    "versionCount": 4,
+    "versionCount": 5,
     "versions": [
       {
         "id": "e2a0ef29-573d-4fc4-86df-216c417f4aa9",
@@ -140,7 +140,7 @@
       {
         "id": "51f0d174-f8b8-4469-9a93-d0aab9b9296b",
         "created_at": "2024-05-08T18:40:28.598Z",
-        "updated_at": "2024-05-08T18:40:28.598Z",
+        "updated_at": "2024-05-29T14:32:48.678Z",
         "name": "3.7",
         "deprecated": false,
         "registration_configs": []
@@ -309,6 +309,27 @@
         "id": "b4539157-4ced-4df5-affa-7d790baee356",
         "created_at": "2023-04-29T22:35:19.274Z",
         "updated_at": "2023-06-28T03:09:02.039Z",
+        "name": "v2",
+        "deprecated": false,
+        "registration_configs": []
+      }
+    ]
+  },
+  {
+    "id": "295fef86-02f3-438a-ada1-256680ba6424",
+    "title": "Konnect Developer Portal",
+    "latestVersion": {
+      "name": "v2",
+      "id": "33ab825d-dec0-4d29-8e17-5133655d7ae7"
+    },
+    "description": "The API that powers the Konnect Developer Portal. Access portal data from the perspective of a Portal user, rather than a Portal administrator.",
+    "documentCount": 0,
+    "versionCount": 1,
+    "versions": [
+      {
+        "id": "33ab825d-dec0-4d29-8e17-5133655d7ae7",
+        "created_at": "2024-06-10T13:14:58.432Z",
+        "updated_at": "2024-06-10T13:16:49.437Z",
         "name": "v2",
         "deprecated": false,
         "registration_configs": []

--- a/app/_data/konnect_oas_data.json
+++ b/app/_data/konnect_oas_data.json
@@ -43,12 +43,12 @@
   },
   {
     "id": "937dcdd7-4485-47dc-af5f-b805d562552f",
-    "title": "Gateway Admin - EE (Beta)",
+    "title": "Gateway Admin - EE",
     "latestVersion": {
       "name": "3.6.0.0",
       "id": "95e68025-45a1-4e24-8561-6d7e5f422de5"
     },
-    "description": "Kong Gateway (EE) comes with an internal RESTful API for administration purposes. This spec is a Beta version.",
+    "description": "Kong Gateway (EE) comes with an internal RESTful API for administration purposes.",
     "documentCount": 2,
     "versionCount": 4,
     "versions": [
@@ -96,12 +96,12 @@
   },
   {
     "id": "680541e5-de6e-46e5-b43d-0bd1b2369453",
-    "title": "Gateway Admin - OSS (Beta)",
+    "title": "Gateway Admin - OSS",
     "latestVersion": {
       "name": "3.6.0",
       "id": "51e64ccc-5c4a-46db-a33d-9b39226abd5e"
     },
-    "description": "Kong Gateway (OSS) comes with an internal RESTful API for administration purposes. This spec is a Beta version.",
+    "description": "Kong Gateway (OSS) comes with an internal RESTful API for administration purposes.",
     "documentCount": 0,
     "versionCount": 4,
     "versions": [

--- a/app/_src/gateway/admin-api/index_latest.md
+++ b/app/_src/gateway/admin-api/index_latest.md
@@ -22,8 +22,8 @@ The Kong Admin API is documented in OpenAPI format:
 
 | Spec | Insomnia link |
 |-------|---------------|
-| [Enterprise beta API spec](/gateway/api/admin-ee/latest/){:target="_blank"} |<a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F3.4%2Fkong-ee-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>  |
-|  [Open source beta API spec](/gateway/api/admin-oss/latest/){:target="_blank"} |  <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Open%20Source%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F3.4%2Fkong-oss-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
+| [Enterprise API](/gateway/api/admin-ee/latest/){:target="_blank"} |<a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F3.4%2Fkong-ee-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>  |
+|  [Open source API](/gateway/api/admin-oss/latest/){:target="_blank"} |  <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Open%20Source%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F3.4%2Fkong-oss-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
 
 See the following links for individual entity documentation:
 

--- a/app/konnect/api/index.md
+++ b/app/konnect/api/index.md
@@ -18,7 +18,7 @@ The geo-specific endpoints are used to manage {{site.konnect_short_name}} entiti
 
 | Spec | Insomnia link |
 |------|---------------|
-| [Konnect control plane configuration beta API spec](/konnect/api/control-plane-configuration/latest/) | <a href="https://insomnia.rest/run/?label=Control%20Plane%20Configuration%20API&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FKonnect%2Fcontrol-planes-config%2Fcontrol-planes-config.yaml" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
+| [Konnect control plane configuration API](/konnect/api/control-plane-configuration/latest/) | <a href="https://insomnia.rest/run/?label=Control%20Plane%20Configuration%20API&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FKonnect%2Fcontrol-planes-config%2Fcontrol-planes-config.yaml" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
 
 ## Authentication
 


### PR DESCRIPTION
Removing beta label from admin API specs. 

The changes are staged in Konnect. 