### PR TITLE
Fix: Adjust description for consumer scoped plugin limitation

### DIFF
--- a/app/_src/gateway/kong-enterprise/plugin-ordering/index.md
+++ b/app/_src/gateway/kong-enterprise/plugin-ordering/index.md
@@ -59,9 +59,13 @@ PluginA:
 
 ### Consumer scoping
 
-Consumer-scoped plugins don't support dynamic ordering because consumer mapping
-also runs in the access phase. The order of the plugins must be determined
-after consumer mapping has happened. {{site.base_gateway}} can't reliably
+Dynamic plugin ordering cannot coexist with consumer-scoped plugins, 
+even if they are applied to entirely different service and route pairs or are running globally.
+If you have consumer-scoped plugins anywhere in your environment, you can't use
+dynamic plugin ordering.
+
+Consumer mapping and dynamic plugin ordering both run in the access phase, but the order of the 
+plugins must be determined after consumer mapping has happened. {{site.base_gateway}} can't reliably
 change the order of the plugins in relation to consumer mapping.
 
 ### Cascading deletes & updates


### PR DESCRIPTION
### Description

https://konghq.atlassian.net/browse/FTI-6019

### Testing instructions

Preview link: https://deploy-preview-7523--kongdocs.netlify.app/gateway/latest/kong-enterprise/plugin-ordering/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

