### PR TITLE
Update: Clarify that `/debug` doesn't work for DPs

### DIFF
--- a/app/_src/gateway/production/logging/update-log-level-dynamically.md
+++ b/app/_src/gateway/production/logging/update-log-level-dynamically.md
@@ -13,7 +13,8 @@ The log level change is propagated to all NGINX worker nodes in a traditional cl
 > **Notes:**
 > * The `debug` endpoints **do not** work for hybrid mode data planes. They can only be used for [control plane nodes](#manage-new-nodes-in-the-cluster).
 > * Changing the log level to `debug` in a production environment can rapidly fill up the disk.
-> After debug logging, switch back to a higher level like `notice` or use a `timeout` parameter in the request query string. **The default timeout for dynamically set log levels is 60 seconds**.
+> After finishing debug logging, switch back to a higher level like `notice` or use a `timeout` parameter in the request query string.
+> **The default timeout for dynamically set log levels is 60 seconds**.
 
 
 ## View current log level

--- a/app/_src/gateway/production/logging/update-log-level-dynamically.md
+++ b/app/_src/gateway/production/logging/update-log-level-dynamically.md
@@ -4,12 +4,16 @@ content_type: reference
 ---
 
 
-You can change the log level of {{site.base_gateway}} dynamically, without restarting {{site.base_gateway}}, using the Admin API. This set of endpoints can be protected using [RBAC](/gateway/api/admin-ee/latest/#/rbac/post-rbac-roles-name_or_id-endpoints) and changes in log level are reflected in the [audit log](/gateway/{{page.release}}/kong-enterprise/audit-log/).
+You can change the log level of {{site.base_gateway}} dynamically, without restarting {{site.base_gateway}}, using the Admin API's `/debug` endpoints.
+This set of endpoints can be protected using [RBAC](/gateway/api/admin-ee/latest/#/rbac/post-rbac-roles-name_or_id-endpoints) and changes in log level are reflected in the [audit log](/gateway/{{page.release}}/kong-enterprise/audit-log/).
 
-The log level change is propagated to all NGINX worker nodes, including the newly spawned workers.
+The log level change is propagated to all NGINX worker nodes in a traditional cluster, including the newly spawned workers.
 
 {:.note}
-> **Note:** Changing the log level to `debug` in a production environment can rapidly fill up the disk. After debug logging, switch back to a higher level like `notice` or use a `timeout` parameter in the request query string. **The default timeout for dynamically set log levels is 60 seconds**.
+> **Notes:**
+> * The `debug` endpoints **do not** work for hybrid mode data planes. They can only be used for [control plane nodes](#manage-new-nodes-in-the-cluster).
+> * Changing the log level to `debug` in a production environment can rapidly fill up the disk.
+> After debug logging, switch back to a higher level like `notice` or use a `timeout` parameter in the request query string. **The default timeout for dynamically set log levels is 60 seconds**.
 
 
 ## View current log level


### PR DESCRIPTION
### Description

It is not currently possible to change log level of a DP from a CP.

Issue reported on Slack: https://kongstrong.slack.com/archives/C03CTMSHP6C/p1718352130665089

### Testing instructions

Preview link: https://deploy-preview-7524--kongdocs.netlify.app/gateway/latest/production/logging/update-log-level-dynamically/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

