### PR TITLE
GRPCRoute is no longer experimental

### DIFF
--- a/app/_includes/md/kic/prerequisites.md
+++ b/app/_includes/md/kic/prerequisites.md
@@ -10,12 +10,18 @@
 {% endunless %}
 
 {% unless include.disable_gateway_api %}
+
+{% assign gw_api_crd_version = "v1.1.0" %}
+{% if_version lte:3.1.x %}
+{% assign gw_api_crd_version = "v1.0.0" %}
+{% endif_version %}
+
 ### Install the Gateway APIs
 
 1. Install the Gateway API CRDs before installing {{ site.kic_product_name }}.
 
     ```bash
-    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{ gw_api_crd_version}}/standard-install.yaml
     ```
 
     {% if include.gateway_api_experimental %}
@@ -23,7 +29,7 @@
 1. Install the experimental Gateway API CRDs to test this feature.
 
     ```bash
-    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/experimental-install.yaml
+    kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{ gw_api_crd_version}}/experimental-install.yaml
     ```
     {% endif %}
 

--- a/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
@@ -16,7 +16,12 @@ For this example, you need to:
 
 To make `gRPC` requests, you need a client that can invoke gRPC requests. You can use [`grpcurl`](https://github.com/fullstorydev/grpcurl#installation) as the client. Ensure that you have it installed on your local system.
 
-{% include_cached /md/kic/prerequisites.md release=page.release disable_gateway_api=false %}
+{% assign grpcroute_is_experimental = false %}
+{% if_version lte:3.1.x %}
+{% assign grpcroute_is_experimental = true %}
+{% endif_version %}
+
+{% include_cached /md/kic/prerequisites.md release=page.release disable_gateway_api=false gateway_api_experimental=grpcroute_is_experimental %}
 
 ## Deploy a gRPC test application
 

--- a/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/grpc.md
@@ -16,7 +16,7 @@ For this example, you need to:
 
 To make `gRPC` requests, you need a client that can invoke gRPC requests. You can use [`grpcurl`](https://github.com/fullstorydev/grpcurl#installation) as the client. Ensure that you have it installed on your local system.
 
-{% include_cached /md/kic/prerequisites.md release=page.release disable_gateway_api=false gateway_api_experimental=true %}
+{% include_cached /md/kic/prerequisites.md release=page.release disable_gateway_api=false %}
 
 ## Deploy a gRPC test application
 


### PR DESCRIPTION
### Description

`GRPCRoute` is now GA and does not require the experimental CRDs or `GatewayAlpha` flag.

### Testing instructions

Preview link: /kubernetes-ingress-controller/latest/guides/services/grpc/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
