### PR TITLE
fix(dpop): ambiguity of key validation description

### DIFF
--- a/app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
@@ -140,7 +140,7 @@ If this is configured correctly, it returns a `200` response and something like 
 }
 ```
 
-The token you obtain should include a claim that consists of the hash of the client certificate:
+The token you obtain should include a claim that consists of the hash of the client key:
 ```json
 {
     "exp": 1622556713,
@@ -151,5 +151,5 @@ The token you obtain should include a claim that consists of the hash of the cli
 }
 ```
 
-Access the service using the same client certificate and key used to obtain the token.
-The client should generate proper proof for possession of the key and send it via the `DPoP` header, which will be verified by Kong.
+Using the same client key to both obtain the token and to sign the request to access the resource.
+The client should generate proper proof for possession of the key and send it via the `DPoP` header, which will be verified by Kong together with the token.

--- a/app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
@@ -151,5 +151,5 @@ The token you obtain should include a claim that consists of the hash of the cli
 }
 ```
 
-Using the same client key to both obtain the token and to sign the request to access the resource.
+Use the same client key to obtain both the token and sign the request to access the resource.
 The client should generate proper proof for possession of the key and send it via the `DPoP` header, which will be verified by Kong together with the token.


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

