### PR TITLE
update gateway part in splitting traffic page

### DIFF
--- a/app/_includes/md/kic/http-test-routing-resource.md
+++ b/app/_includes/md/kic/http-test-routing-resource.md
@@ -1,8 +1,10 @@
 {%- assign path = include.path | default: '/echo' %}
 {%- assign hostname = include.hostname | default: 'kong.example' %}
 {%- assign name = include.name | default: 'echo' %}
+{%- assign namespace = include.namespace | default: '' %}
 {%- assign service = include.service | default: 'echo' %}
 {%- assign port = include.port | default: '1027' %}
+{%- assign ingress_class = include.ingress_class | default: 'kong' %}
 
 {% capture the_code %}
 {% navtabs api %}
@@ -17,12 +19,14 @@ apiVersion: gateway.networking.k8s.io/{{ gwapi_version }}
 kind: HTTPRoute
 metadata:
   name: {{ name }}
+  {% unless .namespace == '' %}namespace: {{ namespace }}   {% endunless %}
   annotations:{% if include.annotation_rewrite %}
     konghq.com/rewrite: '{{ include.annotation_rewrite }}'{% endif %}
     konghq.com/strip-path: 'true'
 spec:
   parentRefs:
   - name: kong
+    {% unless .namespace == '' %}namespace: {{ namespace }}{% endunless %}
 {% unless include.skip_host %}  hostnames:
   - '{{ hostname }}'
 {% endunless %}  rules:
@@ -48,7 +52,7 @@ metadata:
     konghq.com/rewrite: '{{ include.annotation_rewrite }}'{% endif %}
     konghq.com/strip-path: 'true'
 spec:
-  ingressClassName: kong
+  ingressClassName: {{ ingress_class }}
   rules:
   - {% unless include.skip_host %}host: {{ hostname }}
     {% endunless %}http:

--- a/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
@@ -28,7 +28,6 @@ metadata:
   name: external
 spec:
   controller: ingress-controllers.konghq.com/kong' | kubectl apply -f -
-
 ```
 
 ## Creating Gateways

--- a/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
@@ -12,17 +12,23 @@ Users can also split traffic into different gateways when they are using Gateway
 
 The `IngressClass` resource binds an `Ingress` definition to an ingress controller. The value in the `spec.controller` field defines which ingress controller will process those ingress definitions. {{ site.kic_product_name }} processes any `IngressClass` where `spec.controller` is set to `ingress-controllers.konghq.com/kong`.
 
-## Installing Kong
-
-{{ site.kic_product_name }} processes one `IngressClass` per installation. {{ site.kic_product_name }} requires two deployments to split internal and external traffic.
-
-Each deployment lives in its namespace, and the `controller.ingressController.ingressClass` value is set depending on whether that deployment should handle internal or external traffic.
-
-To split traffics to different `Gateway`s in Kubernetes gateway APIs, we could configure the environment variable `CONTROLLER_GATEWAY_TO_RECONCILE` to configure {{ site.kic_product_name }} to reconcile specific `Gatweway` and routes attached to the gateway.
+You can use the following command to create `internal` and `external` ingress classes:
 
 ```bash
-helm upgrade --install kong-internal kong/ingress -n internal --create-namespace --set controller.ingressController.ingressClass=internal --set controller.ingressController.env.gateway_to_reconcile=internal/kong
-helm upgrade --install kong-external kong/ingress -n external --create-namespace --set controller.ingressController.ingressClass=external --set controller.ingressController.env.gateway_to_reconcile=external/kong
+echo 'apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: internal
+spec:
+  controller: ingress-controllers.konghq.com/kong
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: external
+spec:
+  controller: ingress-controllers.konghq.com/kong' | kubectl apply -f -
+
 ```
 
 ## Creating Gateways
@@ -64,33 +70,25 @@ spec:
     port: 80' | kubectl apply -f -
 ```
 
+## Installing Kong
+
+{{ site.kic_product_name }} processes one `IngressClass` per installation. {{ site.kic_product_name }} requires two deployments to split internal and external traffic.
+
+Each deployment lives in its namespace, and the `controller.ingressController.ingressClass` value is set depending on whether that deployment should handle internal or external traffic.
+
+To split traffics to different `Gateway`s in Kubernetes gateway APIs, we could configure the environment variable `CONTROLLER_GATEWAY_TO_RECONCILE` to configure {{ site.kic_product_name }} to reconcile specific `Gatweway` and routes attached to the gateway.
+
+```bash
+helm upgrade --install kong-internal kong/ingress -n internal --create-namespace --set controller.ingressController.ingressClass=internal --set controller.ingressController.env.gateway_to_reconcile=internal/kong
+helm upgrade --install kong-external kong/ingress -n external --create-namespace --set controller.ingressController.ingressClass=external --set controller.ingressController.env.gateway_to_reconcile=external/kong
+```
+
 ## Creating Routes
 
 Rather than setting `spec.ingressClassName: kong` in your `Ingress` definitions, you should now use either `internal` or `external`. Ingress definitions that target `internal` will only be available via {{ site.base_gateway }} running in the `internal` namespace. Definitions that target `external` will only be available via the `external` gateway.
 
 For routes in Kubernetes gateway APIs (like `HTTPRoute`), you should refer to the corresponding `Gateway` in its `spec.parentRef`.
 
+This is an example to create a `Ingress` or `HTTPRoute` for routing internal traffic.
+
 {% include /md/kic/http-test-routing-resource.md release=page.release path='/echo' name='echo-internal' service='echo' namespace='internal' ingress_class='internal' skip_host=true no_results=true %}
-
-
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: echo-internal
-  annotations:
-    konghq.com/strip-path: "true"
-spec:
-  # This line controls if it's available internally or externally
-  ingressClassName: internal 
-  rules:
-    - http:
-        paths:
-          - path: /echo
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: echo
-                port:
-                  number: 1027
-```

--- a/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
@@ -4,7 +4,9 @@ title: Using Custom Classes to split Internal/External traffic
 
 {{ site.kic_product_name }} automatically creates a `kong` `IngressClass` when installed. All of the example ingress definitions in the documentation set `spec.ingressClassName: kong`, which allows things to work by default.
 
-Advanced users of {{ site.kic_product_name }} may wish to split traffic in to internal and external ingress definitions. This requires multiple {{ site.kic_product_name }} instances, each pointing to a different `IngressClass`
+Advanced users of {{ site.kic_product_name }} may wish to split traffic into internal and external ingress definitions. This requires multiple {{ site.kic_product_name }} instances, each pointing to a different `IngressClass`.
+
+Users can also split traffic into different gateways when they are using Gateway APIs with multiple {{ site.kic_product_name }} instances and multiple `Gateway`s.
 
 ## Understanding IngressClass
 
@@ -16,14 +18,60 @@ The `IngressClass` resource binds an `Ingress` definition to an ingress controll
 
 Each deployment lives in its namespace, and the `controller.ingressController.ingressClass` value is set depending on whether that deployment should handle internal or external traffic.
 
+To split traffics to different `Gateway`s in Kubernetes gateway APIs, we could configure the environment variable `CONTROLLER_GATEWAY_TO_RECONCILE` to configure {{ site.kic_product_name }} to reconcile specific `Gatweway` and routes attached to the gateway.
+
 ```bash
-helm upgrade --install kong-internal kong/ingress -n internal --create-namespace --set controller.ingressController.ingressClass=internal
-helm upgrade --install kong-external kong/ingress -n external --create-namespace --set controller.ingressController.ingressClass=external
+helm upgrade --install kong-internal kong/ingress -n internal --create-namespace --set controller.ingressController.ingressClass=internal --set controller.ingressController.env.gateway_to_reconcile=internal/kong
+helm upgrade --install kong-external kong/ingress -n external --create-namespace --set controller.ingressController.ingressClass=external --set controller.ingressController.env.gateway_to_reconcile=external/kong
+```
+
+## Creating Gateways
+
+For splitting traffics into different gateways using Kubernetes gateway API, you should create 2 `Gateway`s in the kubernetes cluster, where each reconciled by one {{ site.kic_product_name }} instance.
+
+```bash
+echo 'apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: kong
+  annotations:
+    konghq.com/gatewayclass-unmanaged: "true"
+spec:
+  controllerName: konghq.com/kic-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong
+  namespace: internal
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong
+  namespace: external
+spec:
+  gatewayClassName: kong
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80' | kubectl apply -f -
 ```
 
 ## Creating Routes
 
 Rather than setting `spec.ingressClassName: kong` in your `Ingress` definitions, you should now use either `internal` or `external`. Ingress definitions that target `internal` will only be available via {{ site.base_gateway }} running in the `internal` namespace. Definitions that target `external` will only be available via the `external` gateway.
+
+For routes in Kubernetes gateway APIs (like `HTTPRoute`), you should refer to the corresponding `Gateway` in its `spec.parentRef`.
+
+{% include /md/kic/http-test-routing-resource.md release=page.release path='/echo' name='echo-internal' service='echo' namespace='internal' ingress_class='internal' skip_host=true no_results=true %}
+
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
@@ -87,7 +87,7 @@ helm upgrade --install kong-external kong/ingress -n external --create-namespace
 
 Rather than setting `spec.ingressClassName: kong` in your `Ingress` definitions, you should now use either `internal` or `external`. Ingress definitions that target `internal` will only be available via {{ site.base_gateway }} running in the `internal` namespace. Definitions that target `external` will only be available via the `external` gateway.
 
-For routes in Kubernetes gateway APIs (like `HTTPRoute`), you should refer to the corresponding `Gateway` in its `spec.parentRef`.
+For routes in Kubernetes Gateway APIs (like `HTTPRoute`), refer to the corresponding `Gateway` in its `spec.parentRef`.
 
 For example, this is how you can create a `Ingress` or `HTTPRoute` for routing internal traffic:
 

--- a/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
+++ b/app/_src/kubernetes-ingress-controller/guides/custom-class/internal-external.md
@@ -4,9 +4,9 @@ title: Using Custom Classes to split Internal/External traffic
 
 {{ site.kic_product_name }} automatically creates a `kong` `IngressClass` when installed. All of the example ingress definitions in the documentation set `spec.ingressClassName: kong`, which allows things to work by default.
 
-Advanced users of {{ site.kic_product_name }} may wish to split traffic into internal and external ingress definitions. This requires multiple {{ site.kic_product_name }} instances, each pointing to a different `IngressClass`.
+Advanced users of {{ site.kic_product_name }} may want to split traffic into internal and external ingress definitions. This requires multiple {{ site.kic_product_name }} instances, each pointing to a different `IngressClass`.
 
-Users can also split traffic into different gateways when they are using Gateway APIs with multiple {{ site.kic_product_name }} instances and multiple `Gateway`s.
+You can also split traffic into different gateways when you are using Gateway APIs with multiple {{ site.kic_product_name }} instances and multiple `Gateway`s.
 
 ## Understanding IngressClass
 
@@ -33,7 +33,7 @@ spec:
 
 ## Creating Gateways
 
-For splitting traffics into different gateways using Kubernetes gateway API, you should create 2 `Gateway`s in the kubernetes cluster, where each reconciled by one {{ site.kic_product_name }} instance.
+For splitting traffic into different gateways using the Kubernetes Gateway API, create two `Gateway`s in the Kubernetes cluster, where each is reconciled by one {{ site.kic_product_name }} instance:
 
 ```bash
 echo 'apiVersion: gateway.networking.k8s.io/v1
@@ -76,7 +76,7 @@ spec:
 
 Each deployment lives in its namespace, and the `controller.ingressController.ingressClass` value is set depending on whether that deployment should handle internal or external traffic.
 
-To split traffics to different `Gateway`s in Kubernetes gateway APIs, we could configure the environment variable `CONTROLLER_GATEWAY_TO_RECONCILE` to configure {{ site.kic_product_name }} to reconcile specific `Gatweway` and routes attached to the gateway.
+You can split traffic into different `Gateway`s in the Kubernetes Gateway APIs by using the environment variable `CONTROLLER_GATEWAY_TO_RECONCILE`. Configure the variable to instruct {{ site.kic_product_name }} to reconcile specific `Gateway` instances and routes attached to the gateway:
 
 ```bash
 helm upgrade --install kong-internal kong/ingress -n internal --create-namespace --set controller.ingressController.ingressClass=internal --set controller.ingressController.env.gateway_to_reconcile=internal/kong
@@ -89,6 +89,6 @@ Rather than setting `spec.ingressClassName: kong` in your `Ingress` definitions,
 
 For routes in Kubernetes gateway APIs (like `HTTPRoute`), you should refer to the corresponding `Gateway` in its `spec.parentRef`.
 
-This is an example to create a `Ingress` or `HTTPRoute` for routing internal traffic.
+For example, this is how you can create a `Ingress` or `HTTPRoute` for routing internal traffic:
 
 {% include /md/kic/http-test-routing-resource.md release=page.release path='/echo' name='echo-internal' service='echo' namespace='internal' ingress_class='internal' skip_host=true no_results=true %}


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
Add introduction of how to split internal and external traffic using gateway APIs. 
Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5237.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

https://deploy-preview-7551--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/custom-class/internal-external/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

