### PR TITLE
Fix: instead of Update Cluster Config should be Edit or Resize Cluster

### DIFF
--- a/app/konnect/gateway-manager/data-plane-nodes/upgrade.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/upgrade.md
@@ -25,7 +25,7 @@ To upgrade a data plane node to a new version, follow these steps:
 {% navtabs %}
 {% navtab Konnect UI %}
 1. In [**Gateway Manager**](https://cloud.konghq.com/us/gateway-manager/), select the Dedicated Cloud Gateways powered control plane you want to upgrade the data plane nodes for.
-1. From the **Actions** menu, select **Update Cluster Config**.
+1. From the **Actions** menu, select **Edit or Resize Cluster**.
 1. Select the desired {{site.base_gateway}} version, and click **Update Cluster**.
 
 {{site.konnect_short_name}} will upgrade the version of all the data plane nodes to the version you selected automatically. 


### PR DESCRIPTION
Documentation does not line up with the product: instead of Update Cluster Config should be Edit or Resize Cluster


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

