### PR TITLE
Update distribution.md

### DIFF
--- a/app/_src/gateway/plugin-development/distribution.md
+++ b/app/_src/gateway/plugin-development/distribution.md
@@ -31,10 +31,14 @@ Pack your rock using the following command (from the plugin repo):
     ```
 
 2. Pack the installed rock:
+
+{:.important}
+> **Important:** `luarocks pack` is dependent on the `zip` utility being installed. More recent images of Kong Gateway have been hardened, and utilities such as `zip` are no longer available. If this is being performed as part of a custom Docker image, please ensure `zip` is installed prior to running this command.
+
+
     ```sh
     luarocks pack <plugin-name> <version>
     ```
-
     Assuming your plugin rockspec is called
     `kong-plugin-my-plugin-0.1.0-1.rockspec`, the above would become;
 

--- a/app/_src/gateway/plugin-development/distribution.md
+++ b/app/_src/gateway/plugin-development/distribution.md
@@ -32,8 +32,8 @@ Pack your rock using the following command (from the plugin repo):
 
 2. Pack the installed rock:
 
-{:.important}
-> **Important:** `luarocks pack` is dependent on the `zip` utility being installed. More recent images of Kong Gateway have been hardened, and utilities such as `zip` are no longer available. If this is being performed as part of a custom Docker image, please ensure `zip` is installed prior to running this command.
+   {:.important}
+   > **Important:** `luarocks pack` is dependent on the `zip` utility being installed. More recent images of {{site.base_gateway}} have been hardened, and utilities such as `zip` are no longer available. If this is being performed as part of a custom Docker image, ensure `zip` is installed prior to running this command.
 
 
     ```sh


### PR DESCRIPTION
### Description

Add a note about the luarocks pack dependency on the zip utility. This was removed in our hardened images and if creating a custom docker image will need to be manually added.

see:
https://konghq.atlassian.net/browse/FTI-6036


### Testing instructions

Preview link: https://deploy-preview-7559--kongdocs.netlify.app/gateway/latest/plugin-development/distribution/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

