### PR TITLE
Add missing : to if_version tags in KIC docs

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-host-and-paths.md
+++ b/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-host-and-paths.md
@@ -75,7 +75,7 @@ URL: /?details=true
 ```
 ### Set the Host header explicitly
 
-{% if_version gte 3.2.0 %}
+{% if_version gte:3.2.0 %}
 #### Using Gateway API
 
 You can set the Host header explicitly when using Gateway API's HTTPRoute with [`URLRewrite`](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPURLRewriteFilter) 
@@ -122,7 +122,7 @@ You can set the Host header explicitly if needed by disabling `konghq.com/preser
 
 Users have the following options to rewrite the default path handling behavior:
 
-{% if_version gte 3.2.0 %}* Rewrite using Gateway API's `URLRewrite` filter {% endif_version %}
+{% if_version gte:3.2.0 %}* Rewrite using Gateway API's `URLRewrite` filter {% endif_version %}
 * Rewrite using regular expressions
 * Remove the path prefix using `strip-path`
 * Add a path prefix using the `path` annotation
@@ -131,7 +131,7 @@ Users have the following options to rewrite the default path handling behavior:
 
 {% navtabs rewrite %}
 
-{% if_version gte 3.2.0 %}
+{% if_version gte:3.2.0 %}
 {% navtab Gateway API %}
 You can replace the full path for a request by adding the `URLRewrite` filter with `path.replaceFullPath` to your `HTTPRoute`.
 


### PR DESCRIPTION
### Description

KIC 3.2 content was being rendered in the 3.1 docs.

cc @fabianrbz we should probably error out if `gte:` `lte:` or `:eq` can't be found in the `if_version` tag

### Testing instructions

Preview link: [/kubernetes-ingress-controller/3.1.x/guides/requests/rewrite-host-and-paths/#path-manipulation](https://deploy-preview-7587--kongdocs.netlify.app/kubernetes-ingress-controller/3.1.x/guides/requests/rewrite-host-and-paths/#path-manipulation)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.