### PR TITLE
Fix: GraphQL RLA example needs a warning to not run in prod

### DIFF
--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_metadata/_index.yml
@@ -19,3 +19,7 @@ categories:
   - traffic-control
 publisher: Kong Inc.
 desc: Provide rate limiting for GraphQL queries
+examples_description: |
+  {:.important}
+  > **Important**: A cluster strategy with a sync rate of -1 **should not** be used in production with hybrid mode, 
+  DB-less mode, or Konnect, as it creates security risks.

--- a/app/_layouts/plugins/configuration_examples.html
+++ b/app/_layouts/plugins/configuration_examples.html
@@ -5,10 +5,10 @@ type: plugin
 
 <h2 id="configuration">Basic configuration examples</h2>
 
+{% if page.examples_description %}
 The following configuration examples are for illustrative purposes only, and shouldn't be used as-is in production.
 Adjust the configuration for your own purposes.
 
-{% if page.examples_description %}
   {{ page.examples_description | markdownify }}
 {% endif %}
 

--- a/app/_layouts/plugins/configuration_examples.html
+++ b/app/_layouts/plugins/configuration_examples.html
@@ -5,6 +5,13 @@ type: plugin
 
 <h2 id="configuration">Basic configuration examples</h2>
 
+The following configuration examples are for illustrative purposes only, and shouldn't be used as-is in production.
+Adjust the configuration for your own purposes.
+
+{% if page.examples_description %}
+  {{ page.examples_description | markdownify }}
+{% endif %}
+
 {% if page.hub_examples.render? %}
   {% include hub-examples.html hub_examples=page.hub_examples render_intro_text=true %}
 {% endif %}

--- a/docs/templates/kong-plugin-template/_metadata/_index.yml
+++ b/docs/templates/kong-plugin-template/_metadata/_index.yml
@@ -10,6 +10,7 @@ publisher: Kong Inc.
 type: plugin
 
 categories: # (Required) Uncomment ONE that applies.
+  #- ai
   #- authentication
   #- security
   #- traffic-control
@@ -58,3 +59,7 @@ dbless_compatible:
 # dbless_explanation: 
   # (Optional) Free-text explanation containing details about the degree of
   # compatibility with DB-less mode.
+
+# examples_description: |
+  # (Optional) Any extra description (notes, warnings, etc.) necessary to preface the basic 
+  # examples (for example, https://docs.konghq.com/hub/kong-inc/acl/how-to/basic-example/).


### PR DESCRIPTION
### Description

Adding a disclaimer to plugin basic examples about not using the examples in prod, and adding some extra language for the GraphQL RLA examples to caution against `sync_rate = -1` with the `cluster` strategy.

We can use this same templating to add extra example descriptions to any of the plugins in the future.

https://konghq.atlassian.net/browse/DOCU-3489

### Testing instructions

Additional note for GraphQL RLA:  https://deploy-preview-7590--kongdocs.netlify.app/hub/kong-inc/graphql-rate-limiting-advanced/how-to/basic-example/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

