### PR TITLE
Update default-ports.md

### DIFF
--- a/app/_src/gateway/production/networking/default-ports.md
+++ b/app/_src/gateway/production/networking/default-ports.md
@@ -24,7 +24,7 @@ By default, {{site.base_gateway}} listens on the following ports:
 | [`:8006`](/gateway/{{page.release}}/production/deployment-topologies/hybrid-mode/setup/)         | TCP     | Hybrid mode only. Control Plane listens for Vitals telemetry data from Data Planes. | All tiers and modes |
 
 {% if_version gte:3.6.x %}
-| [`:8007`](/gateway/{{page.release}}/reference/configuration/#status_listen)     | HTTP     | Status listener. Listens for calls from the command line over HTTP. | {{site.ee_product_name}} tier|
+| [`:8007`](/gateway/{{page.release}}/reference/configuration/#status_listen)     | HTTP     | Status listener. Listens for calls from monitoring clients over HTTP. | All tiers and modes |
 {% endif_version %}
 
 {% if_version lte:3.4.x %}


### PR DESCRIPTION
### Description

The status listener section (8007) is incorrect. The Status API is available in OSS, so it should be changed from "Kong Gateway Enterprise tier" to "All Tiers and Modes". Also, the description does not sound right. It does not only listen for calls from the command line. The purpose of this API is to expose metrics to monitoring tools/clients

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

