### PR TITLE
chore(rate-limiting): clarify rate-limiting accuracy

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/overview/_index.md
@@ -155,8 +155,12 @@ The plugin supports three strategies.
 | Strategy    | Pros | Cons   |
 | --------- | ---- | ------ |
 | `local`   | Minimal performance impact. | Less accurate. Unless there's a consistent-hashing load balancer in front of Kong, it diverges when scaling the number of nodes.
-| `cluster` | Accurate, no extra components to support. | Each request forces a read and a write on the data store. Therefore, relatively, the biggest performance impact. |
-| `redis`   | Accurate, less performance impact than a `cluster` policy. | Needs a Redis installation. Bigger performance impact than a `local` policy. |
+| `cluster` | Accurate<sup>1</sup>, no extra components to support. | Each request forces a read and a write on the data store. Therefore, relatively, the biggest performance impact. |
+| `redis`   | Accurate<sup>1</sup>, less performance impact than a `cluster` policy. | Needs a Redis installation. Bigger performance impact than a `local` policy. |
+
+{:.note .no-icon}
+> **\[1\]**: Only when `sync_rate` option is set to `0` (synchronous behavior). See the [configuration reference](/hub/kong-inc/rate-limiting-advanced/configuration/#config-sync_rate) for more details.
+
 
 Two common use cases are:
 

--- a/app/_hub/kong-inc/rate-limiting/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/overview/_index.md
@@ -68,7 +68,10 @@ The plugin supports three strategies.
 | --------- | ---- | ------ |
 | `local`   | Minimal performance impact. | Less accurate. Unless there's a consistent-hashing load balancer in front of Kong, it diverges when scaling the number of nodes.
 | `cluster` | Accurate, no extra components to support. | Each request forces a read and a write on the data store. Therefore, relatively, the biggest performance impact. |
-| `redis`   | Accurate, less performance impact than a `cluster` policy. | Needs a Redis installation. Bigger performance impact than a `local` policy. |
+| `redis`   | Accurate<sup>1</sup>, less performance impact than a `cluster` policy. | Needs a Redis installation. Bigger performance impact than a `local` policy. |
+
+{:.note .no-icon}
+> **\[1\]**: Only when `sync_rate` option is set to `-1` (synchronous behavior). When using Redis, it's possible to set the sync rate to a positive value, which can lead to some inaccuracies. See the [configuration reference](/hub/kong-inc/rate-limiting/configuration/#config-sync_rate) for more details.
 
 Two common use cases are:
 


### PR DESCRIPTION
### Description

Both rate-limiting and rate-limiting-advanced plugins documentation specify that various policies are possible and states that `cluster` and `redis` are "Accurate". However it's possible to configure a `sync_rate` option for these plugins and set it to a value that does not offer synchronous behaviour allowing for some slippage in favor of performance.

This commit clarifies that `sync_rate` affects mentioned accuracy.

KAG-2896

https://github.com/Kong/kong/issues/11846

### Testing instructions

Preview link:
- [rate-limiting](https://deploy-preview-7607--kongdocs.netlify.app/hub/kong-inc/rate-limiting/#strategies)
- [rate-limiting-advanced](https://deploy-preview-7607--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/#strategies)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

