### PR TITLE
Remove version from Terraform plugin examples

### DIFF
--- a/app/_includes/plugins/hub-examples/terraform.html
+++ b/app/_includes/plugins/hub-examples/terraform.html
@@ -12,7 +12,7 @@ terraform {
 
 provider "konnect" {
   personal_access_token = "kpat_YOUR_TOKEN"
-  server_url            = "https://us.api.konghq.com/v2"
+  server_url            = "https://us.api.konghq.com/"
 }
 ```
 </details>


### PR DESCRIPTION
### Description

Version is no longer part of `server_url` in Terraform

### Testing instructions

Preview link: 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
