### PR TITLE
Fix Ubuntu install script versions

### DIFF
--- a/app/_src/gateway/install/linux/ubuntu.md
+++ b/app/_src/gateway/install/linux/ubuntu.md
@@ -37,12 +37,12 @@ The quickest way to get started with {{ site.base_gateway }} is using the instal
 {% navtabs_ee codeblock %}
 {% navtab Kong Gateway %}
 ```bash
-bash <(curl -sS https://get.konghq.com/install) -v {{ page.versions_ee }}
+bash <(curl -sS https://get.konghq.com/install) -v {{ page.versions.ee }}
 ```
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-bash <(curl -sS https://get.konghq.com/install) -p kong -v {{ page.versions_ce }}
+bash <(curl -sS https://get.konghq.com/install) -p kong -v {{ page.versions.ce }}
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}


### PR DESCRIPTION
### Description

There's an unexpected `-v` without a version currently. This adds the version back in

### Testing instructions

Preview link: [/gateway/3.7.x/install/linux/ubuntu/?install=oss](https://deploy-preview-7622--kongdocs.netlify.app/gateway/3.7.x/install/linux/ubuntu/?install=oss)


### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
