### PR TITLE
fix description about the execution order of the ai-request-transformer plugin

### DIFF
--- a/app/_hub/kong-inc/ai-request-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/ai-request-transformer/overview/_index.md
@@ -9,7 +9,7 @@ This plugin supports `llm/v1/chat` style requests for all of the same providers 
 
 It also uses all of the same configuration and tuning parameters as the AI Proxy plugin, under the [`config.llm`](/hub/kong-inc/ai-request-transformer/configuration/#config-llm) block.
 
-The AI Request Transformer plugin runs **after** all of the [AI Prompt](/hub/?search=ai%2520prompt) plugins, but **before** the
+The AI Request Transformer plugin runs **before** all of the [AI Prompt](/hub/?search=ai%2520prompt) plugins and the
 AI Proxy plugin, allowing it to also introspect LLM requests against the same, or a different, LLM.
 
 ## How it works


### PR DESCRIPTION
### Description

This PR is to fix the description about the execution order of the ai-request-transformer plugin

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

