### PR TITLE
chore: Move the plugins CTA into sidebar

### DIFF
--- a/app/_assets/stylesheets/sidebar.less
+++ b/app/_assets/stylesheets/sidebar.less
@@ -228,3 +228,31 @@
     }
   }
 }
+
+.sidebar-button {
+  flex-shrink: 0;
+  height: auto;
+  padding: 8px 16px;
+  border: 1px solid #1155cb;
+  background: none;
+  box-sizing: border-box;
+  border-radius: 4px;
+  font-family: Roboto;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 22px;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
+  color: #1155cb;
+  display: block;
+  width: 100%;
+  text-align: center;
+}
+
+.sidebar-button#konnect-cta {
+  margin-top: 20px;
+  &:hover {
+    background-color: #1155cb;
+    border-color: #fff;
+    color: #fff;
+  }
+}

--- a/app/_includes/plugins/sidebar.html
+++ b/app/_includes/plugins/sidebar.html
@@ -13,5 +13,13 @@
     {% for item in include.sidenav.nav_items %}
       {% include_cached sidebar/item.html item=item id=forloop.index %}
     {% endfor %}
+    <li>
+      {% if page.extn_publisher == "kong-inc" %}
+      <a id="konnect-cta" href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=gateway-konnect&utm_content={{ extn_slug }}" class="sidebar-button" target="_blank">
+        Try it in {{site.konnect_short_name}}
+      </a>
+    {% endif %}
+    </li>
   </ul>
+
 </aside>

--- a/app/_includes/plugins/sidebar.html
+++ b/app/_includes/plugins/sidebar.html
@@ -13,13 +13,13 @@
     {% for item in include.sidenav.nav_items %}
       {% include_cached sidebar/item.html item=item id=forloop.index %}
     {% endfor %}
-    <li>
-      {% if page.extn_publisher == "kong-inc" %}
+    {% if page.extn_publisher == "kong-inc" %}
+      <li>
         <a id="konnect-cta" href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=gateway-konnect&utm_content={{ page.extn_slug }}" class="sidebar-button" target="_blank">
           Try it in {{site.konnect_short_name}}
         </a>
-      {% endif %}
-    </li>
+      </li>
+    {% endif %}
   </ul>
 
 </aside>

--- a/app/_includes/plugins/sidebar.html
+++ b/app/_includes/plugins/sidebar.html
@@ -15,10 +15,10 @@
     {% endfor %}
     <li>
       {% if page.extn_publisher == "kong-inc" %}
-      <a id="konnect-cta" href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=gateway-konnect&utm_content={{ extn_slug }}" class="sidebar-button" target="_blank">
-        Try it in {{site.konnect_short_name}}
-      </a>
-    {% endif %}
+        <a id="konnect-cta" href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=gateway-konnect&utm_content={{ page.extn_slug }}" class="sidebar-button" target="_blank">
+          Try it in {{site.konnect_short_name}}
+        </a>
+      {% endif %}
     </li>
   </ul>
 

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -13,19 +13,6 @@ breadcrumbs:
 </blockquote>
 {% endunless %}
 
-{% unless page.free %}
-  {% if page.extn_publisher == "kong-inc" %}
-    {% if page.paid or page.premium %}
-      <blockquote class="note" role="alert">
-        <p>
-          Did you know that you can try this plugin without talking to anyone for just {% if page.paid %}{{ site.pricing.konnect.paid_plugin }}{% else %}{{ site.pricing.konnect.premium_plugin }}{% endif %}/month with Kong Konnect? <a href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=gateway-konnect&utm_content={{ extn_slug }}">Get started in under 5 minutes</a>.
-        </p>
-      </blockquote>
-    {% endif %}
-  {% endif %}
-{% endunless %}
-
-
 {% unless page.extn_publisher == "kong-inc" %}
     {% if page.techpartner %}
       <blockquote class="partner-plugin no-icon">

--- a/spec/templates/plugin_with_versions_spec.rb
+++ b/spec/templates/plugin_with_versions_spec.rb
@@ -54,10 +54,8 @@ RSpec.describe 'Plugin page with multiple versions' do
       expect(nested_how_tos).to have_css('.sidebar-item', text: 'Nested Tutorial Nav title with Min and Max')
     end
 
-    context 'plugins that are `paid` or `premium`' do
-      it 'renders a banner for using the plugins in Konnect' do
-        expect(html).to have_css('blockquote', text: 'Did you know that you can try this plugin without talking to anyone')
-      end
+    it 'renders a Konnect CTA button' do
+      expect(html).to have_css('.sidebar-button', text: 'Try it in Konnect')
     end
   end
 end


### PR DESCRIPTION
### Description

Moving the plugins CTA out of a content banner and into the sidebar, which should help because:
* It now appears on every page in a particular plugin, not just the landing page for it
* Makes it noticeable but not in the way
* We can apply the callout to every plugin that's possible to use in Konnect (currently doesn't appear on Konnect Free plugins)

### Testing instructions

Preview link: Check Kong Enterprise plugins, Kong OSS plugins, and third-party plugins. The button should appear everywhere except the third-party plugins.

https://deploy-preview-7630--kongdocs.netlify.app/hub/kong-inc/ai-proxy/
https://deploy-preview-7630--kongdocs.netlify.app/hub/kong-inc/ai-rate-limiting-advanced/
https://deploy-preview-7630--kongdocs.netlify.app/hub/salt/salt/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

