### PR TITLE
Fix: Key Auth Encrypted note and "not applicable" konnect labels

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/_metadata/_index.yml
+++ b/app/_hub/kong-inc/key-auth-enc/_metadata/_index.yml
@@ -16,7 +16,11 @@ enterprise: true
 konnect: false
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 notes: |
-  The time-to-live (ttl) does not work in Konnect or hybrid mode. This setting
+  This plugin is not available in Konnect, and has limitations in hybrid mode:
+  - Konnect automatically encrypts key authentication credentials at rest, so 
+  encryption via this plugin is not necessary. 
+  Use the regular [Key Auth](/hub/kong-inc/key-auth/) plugin instead.
+  - The time-to-live (ttl) does not work in hybrid mode. This setting
   determines the length of time a credential remains valid.
 categories:
   - authentication

--- a/app/hub/plugins/compatibility/index.md
+++ b/app/hub/plugins/compatibility/index.md
@@ -100,7 +100,7 @@ data plane roles. Kong provides and hosts the control plane and a database with
           {% endif %}
         </td>
         <td>
-          {{ plugin.notes }}
+          {{ plugin.notes | markdownify }}
         </td>
       </tr>
     {% endfor %}

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -124,7 +124,7 @@ See the following table for details on each plugin.
         </td>
     
         <td>
-          {{ plugin.notes }}
+          {{ plugin.notes | markdownify }}
         </td>
       </tr>
 

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -91,14 +91,14 @@ See the following table for details on each plugin.
         </td>
         <td style="text-align: center">
         {% if plugin.konnect == false %}
-         <span>Not Applicable</span>
+         <span></span>
         {% elsif plugin.free == true %}
           <i class="fa fa-check"></i>
         {% endif %}
         </td>
         <td style="text-align: center">
           {% unless plugin.konnect %}
-            <span>Not Applicable</span>
+            <span>Not available in {{site.konnect_short_name}}</span>
           {% else %}
             {% unless plugin.free %}
               {% unless plugin.premium %}
@@ -111,7 +111,7 @@ See the following table for details on each plugin.
         </td>
         <td style="text-align: center">
           {% unless plugin.konnect %}
-            <span>Not Applicable</span>
+            <span></span>
           {% else %}
             {% unless plugin.free %}
               {% unless plugin.paid %}


### PR DESCRIPTION
### Description

* Fixing[ misleading/confusing note for Key Auth Enc](https://docs.konghq.com/hub/plugins/compatibility/#authentication:~:text=Key%20Authentication%20%2D%20Encrypted-,The%20time%2Dto%2Dlive%20(ttl)%20does%20not%20work%20in%20Konnect%20or%20hybrid%20mode.%20This%20setting%20determines%20the%20length%20of%20time%20a%20credential%20remains%20valid.,-LDAP%20Authentication), which was not providing enough info about why the plugin doesn't run in Konnect. 
* Rephrasing the "Not applicable" table entries in the konnect compatibility table to say "Not available in Konnect" to make it clearer

Issue reported on Slack.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

