### PR TITLE
fix(404): update link to plugin development guide

### DIFF
--- a/app/_data/docs_nav_gateway_3.7.x.yml
+++ b/app/_data/docs_nav_gateway_3.7.x.yml
@@ -470,7 +470,7 @@ items:
       - text: Getting Started
         items:
           - text: Introduction
-            url: /plugin-development/get-started/index
+            url: /plugin-development/get-started/
           - text: Set up the Plugin Project
             url: /plugin-development/get-started/setup
           - text: Add Plugin Testing

--- a/app/_data/docs_nav_gateway_3.8.x.yml
+++ b/app/_data/docs_nav_gateway_3.8.x.yml
@@ -477,7 +477,7 @@ items:
       - text: Getting Started
         items:
           - text: Introduction
-            url: /plugin-development/get-started/index
+            url: /plugin-development/get-started/
           - text: Set up the Plugin Project
             url: /plugin-development/get-started/setup
           - text: Add Plugin Testing

--- a/app/_includes/md/about-plugins.md
+++ b/app/_includes/md/about-plugins.md
@@ -93,7 +93,7 @@ Kong provides PDKs in the following languages:
 These PDKs are sets of functions that a plugin can use to facilitate interactions between plugins
 and the core (or other components) of Kong.
 
-To start creating your own plugins, review the [Getting Started documentation](/gateway/latest/plugin-development/get-started/index/),
+To start creating your own plugins, review the [Getting Started documentation](/gateway/latest/plugin-development/get-started/),
 or see the following references:
 * [Plugin Development Kit reference](/gateway/latest/plugin-development/pdk/)
 * [Other Language Support](/gateway/latest/plugin-development/pluginserver/go/)

--- a/app/_includes/md/about-plugins.md
+++ b/app/_includes/md/about-plugins.md
@@ -93,7 +93,7 @@ Kong provides PDKs in the following languages:
 These PDKs are sets of functions that a plugin can use to facilitate interactions between plugins
 and the core (or other components) of Kong.
 
-To start creating your own plugins, review the [Getting Started documentation](/gateway/latest/plugin-development/get-started/),
+To start creating your own plugins, review the [Getting Started documentation](/gateway/latest/plugin-development/get-started/index/),
 or see the following references:
 * [Plugin Development Kit reference](/gateway/latest/plugin-development/pdk/)
 * [Other Language Support](/gateway/latest/plugin-development/pluginserver/go/)


### PR DESCRIPTION
This link was leading to 404


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-7637--kongdocs.netlify.app/hub/plugins/overview/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

