### PR TITLE
Fix: Updated kong-oss.yaml

### DIFF
--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -2602,15 +2602,10 @@ components:
                   - user-level
                   - low-priority
             properties:
-              upstream:
-                type: object
-                description: |
-                  The unique identifier or the name of the upstream for which to update the target.
-                properties:
-                  id:
-                    type: string
-                    example: 173a6cee-90d1-40a7-89cf-0329eca780a6
-                    description: The unique identifier or the name of the upstream for which to update the target.
+              target:
+                default: example.com:8000
+                description: The target for the upstream
+                type: string
               weight:
                 default: 100
                 description: The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.
@@ -2625,8 +2620,7 @@ components:
           examples:
             Example:
               value:
-                upstream:
-                  id: 173a6cee-90d1-40a7-89cf-0329eca780a6
+                target: example.com:8000
                 weight: 100
                 tags:
                   - string
@@ -3620,7 +3614,7 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   title: Kong Admin API
-  version: 3.7.0
+  version: 3.7.1
 openapi: 3.0.0
 paths:
   /:


### PR DESCRIPTION
### Description

Patched the schema definition for `target-request` in the OpenAPI Specification (OAS) to update the request body structure. The change emphasizes the `target` property as a direct attribute with a default value and descriptive documentation, enhancing clarity and usability.

The current request body now ensures better alignment with actual payload expectations, streamlining API interactions and improving developer experience.

<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

To test this change:
1. Import the updated OpenAPI Specification into Postman.
2. Attempt to create an upstream target using the old payload structure.
3. Compare the behavior with the updated payload structure to observe the refined handling of `target` property.

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist

- [ ] Review label added