### PR TITLE
Update _local-testing-development.md

### DIFF
--- a/app/_hub/kong-inc/acme/how-to/_local-testing-development.md
+++ b/app/_hub/kong-inc/acme/how-to/_local-testing-development.md
@@ -40,8 +40,7 @@ Leave the process running.
     ```
     curl http://localhost:8001/routes \
     -d service.name=acme-test \
-    -d hosts=$NGROK_HOST \
-    -d paths=/mock
+    -d hosts=$NGROK_HOST
     ```
 
 1. Enable the plugin:


### PR DESCRIPTION
### Description

Removed the "path" value from route created in step 2, as this would cause request in step 4 "Trigger certificate creation" to fail, and will not work with the "/.well-known/acme-challenge/x" path which would also need to be associated to this test route for the purpose of this walkthrough.
 
Noted in Support case: 00047179

