### PR TITLE
chore: add more explanation for hashicorp vault's authentication and secret fetching

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -258,7 +258,7 @@ X-Vault-Namespace: <config.namespace>
 {% endnavtabs %}
 
 {:.important}
-> **Warning:** Make sure you've configured the correct KV engine version in `conig.kv`, otherwise Kong will fail to parse the response.
+> **Warning:** Make sure you've configured the correct KV engine version in `config.kv`, otherwise Kong will fail to parse the response.
 
 Kong will parse the response of the read secret API automatically and return the secret value.
 

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -238,6 +238,7 @@ X-Vault-Token: <client token>
 X-Vault-Namespace: <config.namespace>
 ```
 
+{:.warning}
 > **Warning:** Make sure you've configured the correct KV engine version in `conig.kv`, otherwise Kong will fail to parse the response.
 
 Kong will parse the response of the read secret API automatically and return the secret value.

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
@@ -238,7 +238,7 @@ X-Vault-Token: <client token>
 X-Vault-Namespace: <config.namespace>
 ```
 
-{:.warning}
+{:.important}
 > **Warning:** Make sure you've configured the correct KV engine version in `conig.kv`, otherwise Kong will fail to parse the response.
 
 Kong will parse the response of the read secret API automatically and return the secret value.


### PR DESCRIPTION


### Description

This PR adds a section to the Kong Gateway's HashiCorp Vault backend, describing how Kong does authentication and retrieving secrets by calling HashiCorp Vault's API. This could help users to set a correct `mount`, `namespace`, `auth_path` and secret reference path.

https://konghq.atlassian.net/browse/FTI-6071

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

