### PR TITLE
feat: add documentation about assume role support for rds iam authentication

### DIFF
--- a/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
+++ b/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
@@ -119,6 +119,8 @@ pg_ro_iam_auth_assume_role_arn=<role_arn>
 pg_ro_iam_auth_role_session_name=<role_session_name>
 ```
 
+{% endif_version %}
+
 
 {:.note}
 > **Note:** If you enable AWS IAM authentication in the configuration file, you must specify the configuration file with the feature property on when you run the migrations command. For example, `kong migrations bootstrap -c /path/to/kong.conf`.

--- a/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
+++ b/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
@@ -37,7 +37,7 @@ Before you enable the AWS IAM authentication, you must configure your AWS RDS da
    {:.warning}
    > **Warning:** You **can't** change the value of the environment variables you used to provide the AWS credential after booting {{site.base_gateway}}. Any changes are ignored.
 {% if_version gte:3.8.x %}
-   - {{site.base_gateway}} also supports role assuming which allows you to use a different IAM role to authenticate to the database. If you want to use role assuming, make sure the original IAM role Kong uses has the correct permission to do role assuming to the target IAM role, and the target IAM role has the correct permission to connect to the database using IAM authentication.
+   - If you want to assume a role, make sure the original IAM role that Kong uses has the correct permission to assume the role of the target IAM role, and the target IAM role has the correct permission to connect to the database using IAM authentication.
 {% endif_version %}
 
 - **Assign an IAM policy to the {{site.base_gateway}} IAM role**. For more information, see [Creating and using an IAM policy for IAM database access](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) in the Amazon RDS documentation.
@@ -76,14 +76,14 @@ KONG_PG_RO_IAM_AUTH=on
 ```
 
 {% if_version gte:3.8.x %}
-If you want to use role assuming, set the following environment variables as well:
+If you want to [assume a role](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html), also set the following environment variables:
 
 ```bash
-# For read-write connection
+# For read-write connections
 KONG_PG_IAM_AUTH_ASSUME_ROLE_ARN=<role_arn>
 KONG_PG_IAM_AUTH_ROLE_SESSION_NAME=<role_session_name>
 
-# For read-only connection, if you need a different role for read-only connection
+# For read-only connections, if you need a different role than for read-write
 KONG_PG_RO_IAM_AUTH_ASSUME_ROLE_ARN=<role_arn>
 KONG_PG_RO_IAM_AUTH_ROLE_SESSION_NAME=<role_session_name>
 ```
@@ -107,14 +107,14 @@ pg_ro_iam_auth=on
 ```
 
 {% if_version gte:3.8.x %}
-If you want to use role assuming, set the following environment variables as well:
+If you want to [assume a role](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html), also set the following configuration parameters:
 
 ```bash
-# For read-write connection
+# For read-write connections
 pg_iam_auth_assume_role_arn=<role_arn>
 pg_iam_auth_role_session_name=<role_session_name>
 
-# For read-only connection, if you need a different role for read-only connection
+# For read-only connections, if you need a different role than for read-write
 pg_ro_iam_auth_assume_role_arn=<role_arn>
 pg_ro_iam_auth_role_session_name=<role_session_name>
 ```

--- a/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
+++ b/app/_src/gateway/kong-enterprise/aws-iam-auth-to-rds-database.md
@@ -36,6 +36,9 @@ Before you enable the AWS IAM authentication, you must configure your AWS RDS da
    
    {:.warning}
    > **Warning:** You **can't** change the value of the environment variables you used to provide the AWS credential after booting {{site.base_gateway}}. Any changes are ignored.
+{% if_version gte:3.8.x %}
+   - {{site.base_gateway}} also supports role assuming which allows you to use a different IAM role to authenticate to the database. If you want to use role assuming, make sure the original IAM role Kong uses has the correct permission to do role assuming to the target IAM role, and the target IAM role has the correct permission to connect to the database using IAM authentication.
+{% endif_version %}
 
 - **Assign an IAM policy to the {{site.base_gateway}} IAM role**. For more information, see [Creating and using an IAM policy for IAM database access](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html) in the Amazon RDS documentation.
 
@@ -72,6 +75,21 @@ KONG_PG_IAM_AUTH=off # This line can be omitted because off is the default value
 KONG_PG_RO_IAM_AUTH=on
 ```
 
+{% if_version gte:3.8.x %}
+If you want to use role assuming, set the following environment variables as well:
+
+```bash
+# For read-write connection
+KONG_PG_IAM_AUTH_ASSUME_ROLE_ARN=<role_arn>
+KONG_PG_IAM_AUTH_ROLE_SESSION_NAME=<role_session_name>
+
+# For read-only connection, if you need a different role for read-only connection
+KONG_PG_RO_IAM_AUTH_ASSUME_ROLE_ARN=<role_arn>
+KONG_PG_RO_IAM_AUTH_ROLE_SESSION_NAME=<role_session_name>
+```
+
+{% endif_version %}
+
 ### Enable AWS IAM authentication in the configuration file
 
 The [`kong.conf` file](/gateway/{{page.release}}/production/kong-conf/) contains the `pg_iam_auth` and `pg_ro_iam_auth` properties.
@@ -87,6 +105,20 @@ To enable AWS IAM authentication in read-only mode, set `pg_ro_iam_auth` to `on`
 ```text
 pg_ro_iam_auth=on
 ```
+
+{% if_version gte:3.8.x %}
+If you want to use role assuming, set the following environment variables as well:
+
+```bash
+# For read-write connection
+pg_iam_auth_assume_role_arn=<role_arn>
+pg_iam_auth_role_session_name=<role_session_name>
+
+# For read-only connection, if you need a different role for read-only connection
+pg_ro_iam_auth_assume_role_arn=<role_arn>
+pg_ro_iam_auth_role_session_name=<role_session_name>
+```
+
 
 {:.note}
 > **Note:** If you enable AWS IAM authentication in the configuration file, you must specify the configuration file with the feature property on when you run the migrations command. For example, `kong migrations bootstrap -c /path/to/kong.conf`.


### PR DESCRIPTION



### Description

This is a new feature developed in 3.8.
The PR adds the corresponding descriptions about how to enable the new feature that does role assuming when doing RDS IAM authentication.

https://konghq.atlassian.net/browse/KAG-4561

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

