### PR TITLE
Added fix information for HTTP/2 content length breaking change

### DIFF
--- a/app/_src/gateway/breaking-changes/36x.md
+++ b/app/_src/gateway/breaking-changes/36x.md
@@ -111,4 +111,5 @@ Currently known affected plugins:
 * [Request Transformer](/hub/kong-inc/request-transformer/)
 * [Request Transformer Advanced](/hub/kong-inc/request-transformer-advanced/)
 
-Kong is currently investigating potential remediations.
+**Issue fixed in 3.6.1.1**:
+Reverted the hard-coded limitation of the `ngx.read_body()` API in OpenResty upstreams’ new versions when downstream connections are in HTTP/2 or HTTP/3 stream modes.


### PR DESCRIPTION
In 3.6.x their was a breaking change for HTTP/2 requests involving content-length of request body.  This was fixed in 3.7.0.0 and backported to 3.6.1.1.

This PR reflects that information in the 3.6.x changelog.


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

