### PR TITLE
Provide link to limitations of dynamic plugin ordering

### DIFF
--- a/app/konnect/reference/plugins.md
+++ b/app/konnect/reference/plugins.md
@@ -13,6 +13,8 @@ and lets you create _dynamic_ dependencies between plugins.
 
 To configure this setting in {{site.konnect_short_name}}, go to **Gateway Manager > Plugins**, and then select **Configure Dynamic Ordering** from the context menu next to the plugin you want to configure. From the plugin ordering settings, you can configure whether a plugin runs before or after another plugin.
 
+There are certain limitations to Dynamic plugin ordering, particularly dynamic plugin ordering cannot coexist with consumer-scoped plugins, even if they are applied to entirely different service and route pairs or are running globally. For more information see [known limitations in Dynamic Plugin Ordering](/gateway/{{page.release}}/kong-enterprise/plugin-ordering/#known-limitations)
+
 ## Plugin execution order
 
 The order in which plugins are executed in {{site.konnect_short_name}} is determined by their

--- a/app/konnect/reference/plugins.md
+++ b/app/konnect/reference/plugins.md
@@ -13,7 +13,8 @@ and lets you create _dynamic_ dependencies between plugins.
 
 To configure this setting in {{site.konnect_short_name}}, go to **Gateway Manager > Plugins**, and then select **Configure Dynamic Ordering** from the context menu next to the plugin you want to configure. From the plugin ordering settings, you can configure whether a plugin runs before or after another plugin.
 
-There are certain limitations to Dynamic plugin ordering, particularly dynamic plugin ordering cannot coexist with consumer-scoped plugins, even if they are applied to entirely different service and route pairs or are running globally. For more information see [known limitations in Dynamic Plugin Ordering](/gateway/{{page.release}}/kong-enterprise/plugin-ordering/#known-limitations)
+{:.note}
+> **Note**: There are limitations to dynamic plugin ordering. Particularly, dynamic plugin ordering can't coexist with consumer-scoped plugins, even if they are applied to entirely different service and route pairs, or are running globally. For more information, see [Known Limitations in Dynamic Plugin Ordering](/gateway/{{page.release}}/kong-enterprise/plugin-ordering/#known-limitations).
 
 ## Plugin execution order
 

--- a/app/konnect/reference/plugins.md
+++ b/app/konnect/reference/plugins.md
@@ -14,7 +14,7 @@ and lets you create _dynamic_ dependencies between plugins.
 To configure this setting in {{site.konnect_short_name}}, go to **Gateway Manager > Plugins**, and then select **Configure Dynamic Ordering** from the context menu next to the plugin you want to configure. From the plugin ordering settings, you can configure whether a plugin runs before or after another plugin.
 
 {:.note}
-> **Note**: There are limitations to dynamic plugin ordering. Particularly, dynamic plugin ordering can't coexist with consumer-scoped plugins, even if they are applied to entirely different service and route pairs, or are running globally. For more information, see [Known Limitations in Dynamic Plugin Ordering](/gateway/{{page.release}}/kong-enterprise/plugin-ordering/#known-limitations).
+> **Note**: There are limitations to dynamic plugin ordering. Particularly, dynamic plugin ordering can't coexist with consumer-scoped plugins, even if they are applied to entirely different service and route pairs, or are running globally. For more information, see [Known Limitations in Dynamic Plugin Ordering](/gateway/latest/kong-enterprise/plugin-ordering/#known-limitations).
 
 ## Plugin execution order
 


### PR DESCRIPTION
Users are not warned about the limitations of Dynamic plugin ordering, particularly in relation to consumer scoped plugins.  This change informs of the limitation and provides a link to the details.


### Description

 Users are not warned about the limitations of Dynamic plugin ordering in this page, particularly in relation to consumer scoped plugins. This change informs of the limitation and provides a link to the details. There have been cases of customers implementing dynamic ordering and then realise it is incompatible with consumer scoped plugins.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

