### PR TITLE
Update to improve accuracy regarding scoping of roles

### DIFF
--- a/app/konnect/org-management/teams-and-roles/index.md
+++ b/app/konnect/org-management/teams-and-roles/index.md
@@ -25,8 +25,8 @@ roles.
 for assigning access by functionality, they can provide granular access to
 any group of {{site.konnect_short_name}} resources based on roles.
 
-* **Role:** Predefined access to a particular resource, or an
-instances of a particular resource type (for example, a particular service or all services).
+* **Role:** Predefined access to a particular resource, or
+instances of a particular resource type (for example, API product roles can be scoped to a particular API product or all API products whilst control plane roles can be scoped to a particular control plane or all control planes).
 
 When you create a {{site.konnect_short_name}} account, you are automatically added to the Organization
 Admin team, which is one of the [predefined teams](/konnect/org-management/teams-and-roles/teams-reference/)


### PR DESCRIPTION
Old wording implied you can scope access to an individual service which is not true


### Description

<!-- What did you change and why? -->
 
Old wording implied you can scope access to an individual service which is not true

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

