### PR TITLE
fix: Use inline if_version blocks

### DIFF
--- a/app/_includes/md/admin-listen.md
+++ b/app/_includes/md/admin-listen.md
@@ -4,17 +4,13 @@
    >
    > <br>
    > If you need to expose the `admin_listen` port to the internet in a production environment,
-   > {% if_version lte:2.8.x
-   %}[secure it with authentication](/gateway/{{include.release}}/admin-api/secure-admin-api/).{% endif_version %}{% if_version gte:3.0.x
-   %}[secure it with authentication](/gateway/{{include.release}}/production/running-kong/secure-admin-api/).{% endif_version %}
+   > {% if_version lte:2.8.x %}[secure it with authentication](/gateway/{{include.release}}/admin-api/secure-admin-api/).{% endif_version %}{% if_version gte:3.0.x %}[secure it with authentication](/gateway/{{include.release}}/production/running-kong/secure-admin-api/).{% endif_version %}
 
 
 {% endif %}
 {% if include.desc == "short" %}
    {:.important}
    > **Important**: If you need to expose the `admin_listen` port to the internet in a production environment,
-  > {% if_version lte:2.8.x
-    %}[secure it with authentication](/gateway/{{include.release}}/admin-api/secure-admin-api/).{% endif_version %}{% if_version gte:3.0.x
-    %}[secure it with authentication](/gateway/{{include.release}}/production/running-kong/secure-admin-api/).{% endif_version %}
+  > {% if_version lte:2.8.x %}[secure it with authentication](/gateway/{{include.release}}/admin-api/secure-admin-api/).{% endif_version %}{% if_version gte:3.0.x %}[secure it with authentication](/gateway/{{include.release}}/production/running-kong/secure-admin-api/).{% endif_version %}
 
 {% endif %}

--- a/app/_includes/md/gateway/setup.md
+++ b/app/_includes/md/gateway/setup.md
@@ -228,8 +228,7 @@ See the [Kong Manager setup guide](/gateway/{{page.release}}/kong-manager/enable
 {:.badge .enterprise}
 
 If you're running {{site.base_gateway}} with a database (either in traditional
-or hybrid mode), you can enable the {% if_version lte:2.8.x %}[Dev Portal](/gateway/{{page.release}}/developer-portal/).{% endif_version %}{% if_version gte:3.0.x lte:3.4.x
-   %}[Dev Portal](/gateway/{{page.release}}/kong-enterprise/dev-portal/){% endif_version %}
+or hybrid mode), you can enable the {% if_version lte:2.8.x %}[Dev Portal](/gateway/{{page.release}}/developer-portal/).{% endif_version %}{% if_version gte:3.0.x lte:3.4.x %}[Dev Portal](/gateway/{{page.release}}/kong-enterprise/dev-portal/){% endif_version %}
 
 1. Enable the Dev Portal in the `kong.conf` file by setting the `portal` property to `on` and the
    `portal_gui_host` property to the DNS or IP address of the system.


### PR DESCRIPTION
### Description

Now that if_version uses the same whitespace handling we no longer need to do weird hacks to make conditionals work right, like closing an if_version block in the line below.

This type of hack cause issues when sending the files to Smartling and downloading them.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

