### PR TITLE
AI Proxy plugin: fix incorrect format in example

### DIFF
--- a/app/_hub/kong-inc/ai-proxy/how-to/llm-provider-integration-guides/_mistral.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/llm-provider-integration-guides/_mistral.md
@@ -68,7 +68,7 @@ curl -X POST http://localhost:8001/services/ai-proxy/routes \
   --data "paths[]=~/mistral-chat$"
 ```
 
-Enable and configure the AI Proxy plugin for Mistral (using `ollama` format in this example):
+Enable and configure the AI Proxy plugin for Mistral (using `openai` format in this example):
 
 ```bash
 curl -X POST http://localhost:8001/routes/mistral-chat/plugins \


### PR DESCRIPTION
### Description

The description of the example and the example itself don't refer to the same format: the description says `ollama` but the example uses `openai`. The correct format is `openai`, as the example also uses an Authorization header, which is required for `openai`.

Fixes https://github.com/Kong/docs.konghq.com/issues/7609. 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

