### PR TITLE
Fix links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here are some things you should know before getting started:
 
 ### Running locally
 
-For minor changes, use the GitHub UI via the "Edit this page" button on any docs page, or use [GitHub Codespaces]. 
+For minor changes, use the GitHub UI via the "Edit this page" button on any docs page, or use [GitHub Codespaces](https://docs.github.com/en/codespaces). 
 
 For anything other than minor changes, [clone the repository onto your local machine and build locally](docs/platform-install.md). Once you've installed all of the tools required, you can use our `Makefile` to build the docs:
 
@@ -84,7 +84,7 @@ At least one of these labels must be applied to a PR or the build will fail.
 
 ### Troubleshooting
 
-For troubleshooting instructions, see the [troubleshooting documentation](docs/troubleshoot.md).
+For troubleshooting instructions, see the [troubleshooting documentation](docs/troubleshooting/troubleshoot.md).
 
 
 ## Plugin contributors


### PR DESCRIPTION
### Description

Ran into a broken link and a nonexistent link in the README.md.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

