### PR TITLE
Update: Add API instructions for finding Konnect hostnames

### DIFF
--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -99,6 +99,9 @@ Control Planes API:
     --header 'Authorization: Bearer <token>'
     ```
 
+    {:.note}
+    > **Tip**: You can find your control plane's API URL on its overview page in the Gateway Manager.
+
 2. In the response, find your `control_plane_endpoint` and the `telemetry_endpoint`:
     ```json
     {
@@ -192,6 +195,9 @@ You can find the control plane and telemetry hostnames through the Control Plane
     curl -X GET https://us.api.konghq.com/v2/control-planes/{controlPlaneId}  \
     --header 'Authorization: Bearer <token>'
     ```
+
+    {:.note}
+    > **Tip**: You can find your control plane's API URL on its overview page in the Gateway Manager.
 
 2. In the response, find your `control_plane_endpoint` and the `telemetry_endpoint`:
     ```json

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -30,13 +30,8 @@ By default, {{site.base_gateway}} listens on the following ports:
 For Kubernetes or Docker deployments, map ports as needed. For example, if you
 want to use port `3001` for the proxy, map `3001:8000`.
 
-## Hostnames
-### Control planes
+## {{site.base_gateway}} hostnames
 
-Depending on your control plane type, you may need to add hostnames to your firewall allowlist.
-
-{% navtabs %}
-{% navtab Kong Gateway %}
 Data plane nodes initiate the connection to the {{site.konnect_short_name}} control plane.
 They require access through firewalls to communicate with the control plane.
 
@@ -78,7 +73,11 @@ add the following hostnames to the firewall allowlist (depending on the [geograp
 
 ### Find configuration and telemetry hostnames
 
-You can find the configuration and telemetry hostnames through the Gateway Manager:
+You can find the configuration and telemetry hostnames through the Gateway Manager or the {{site.konnect_short_name}}
+Control Planes API:
+
+{% navtabs %}
+{% navtab Gateway Manager %}
 
 1. Open a control plane.
 2. Select **Data Plane Nodes** from the side menu, then click the **New Data Plane Node** button.
@@ -92,8 +91,37 @@ You can find the configuration and telemetry hostnames through the Gateway Manag
     cluster_telemetry_server_name = example.us.tp0.konghq.com
     ```
 {% endnavtab %}
+{% navtab Control Planes API %}
+1. Send a GET request to the `control-planes` API and inspect the response:
 
-{% navtab Kong Ingress Controller %}
+    ```sh
+    curl -X GET https://us.api.konghq.com/v2/control-planes/{controlPlaneId}  \
+    --header 'Authorization: Bearer <token>'
+    ```
+
+2. In the response, find your `control_plane_endpoint` and the `telemetry_endpoint`:
+    ```json
+    {
+        "config": {
+            "auth_type": "pinned_client_certs",
+            "cloud_gateway": false,
+            "cluster_type": "CLUSTER_TYPE_CONTROL_PLANE",
+            "control_plane_endpoint": "https://example.us.cp0.konghq.com",
+            "proxy_urls": [],
+            "telemetry_endpoint": "https://example.us.tp0.konghq.com"
+        },
+        "created_at": "2024-07-24T22:43:31.705Z",
+        "description": "",
+        "id": "8f0daba0-2246-48fb-8d56-a47ab94saf78",
+        "labels": {},
+        "name": "Example CP",
+        "updated_at": "2024-07-24T22:43:31.705Z"
+    }
+    ```
+{% endnavtab %}
+{% endnavtabs %}
+
+## {{site.kic_product_name}} hostnames
 
 {{site.kic_product_name}} initiates the connection to the {{site.konnect_short_name}} [Control Planes Configuration API](/konnect/api/control-plane-configuration/latest/) to:
 
@@ -140,7 +168,10 @@ Add the following hostnames to the firewall allowlist (depending on the [geograp
 
 ### Find configuration and telemetry hostnames
 
-You can find the Telemetry hostname through the Gateway Manager:
+{% navtabs %}
+{% navtab Gateway Manager %}
+
+You can find the telemetry hostname through the Gateway Manager:
 
 1. Open a control plane.
 2. Click {% konnect_icon cogwheel %} **Control Plane Actions** > **View Connection Instructions**.
@@ -149,12 +180,43 @@ You can find the Telemetry hostname through the Gateway Manager:
     ```
     cluster_telemetry_endpoint: "example.us.tp0.konghq.com:443"
     ```
+
+{% endnavtab %}
+{% navtab Control Planes API %}
+
+You can find the control plane and telemetry hostnames through the Control Planes API.
+
+1. Send a GET request to the `control-planes` API and inspect the response:
+
+    ```sh
+    curl -X GET https://us.api.konghq.com/v2/control-planes/{controlPlaneId}  \
+    --header 'Authorization: Bearer <token>'
+    ```
+
+2. In the response, find your `control_plane_endpoint` and the `telemetry_endpoint`:
+    ```json
+    {
+        "config": {
+            "auth_type": "pinned_client_certs",
+            "cloud_gateway": false,
+            "cluster_type": "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
+            "control_plane_endpoint": "https://example.us.cp0.konghq.com",
+            "telemetry_endpoint": "https://example.us.tp0.konghq.com"
+        },
+        "created_at": "2023-03-17T16:54:48.905Z",
+        "description": "",
+        "id": "32bf6188-906c-483c-b9e3-d7838a089364",
+        "labels": {},
+        "name": "KIC CP",
+        "updated_at": "2024-07-09T07:47:34.514Z"
+    }
+    ```
 {% endnavtab %}
 {% endnavtabs %}
 
 {:.note}
 > **Note**: Visit [https://ip-addresses.origin.konghq.com/ip-addresses.json](https://ip-addresses.origin.konghq.com/ip-addresses.json) for the list of IPs associated to regional hostnames. You can also subscribe to [https://ip-addresses.origin.konghq.com/rss](https://ip-addresses.origin.konghq.com/rss) for updates. 
 
-### Mesh Manager
+## Mesh Manager hostnames
 
 If you plan to use [Mesh Manager](/konnect/mesh-manager/) to manage your Kong service mesh, you must add the `{geo}.mesh.sync.konghq.com:443` hostname to your firewall allowlist. The geo can be `au`, `eu`, `us`, or `global`.


### PR DESCRIPTION
### Description

Adding API instructions to find control plane and telemetry hostnames for Konnect control planes. Tested both regular and KIC control planes.

The headings on this page were also broken and didn't work as anchor links, as they were nested inside navtabs. This doesn't work, so I turned them into regular headings.

Fixes https://github.com/Kong/docs.konghq.com/issues/6869.

### Testing instructions

Preview link: https://deploy-preview-7681--kongdocs.netlify.app/konnect/network/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

