### PR TITLE
Fix: wrong postgres key in plugin migrations examples

### DIFF
--- a/app/_src/gateway/plugin-development/custom-entities.md
+++ b/app/_src/gateway/plugin-development/custom-entities.md
@@ -91,7 +91,7 @@ A migration file is a Lua file which returns a table with the following structur
 ``` lua
 -- `<plugin_name>/migrations/000_base_my_plugin.lua`
 return {
-  postgresql = {
+  postgres = {
     up = [[
       CREATE TABLE IF NOT EXISTS "my_plugin_table" (
         "id"           UUID                         PRIMARY KEY,
@@ -112,7 +112,7 @@ return {
 
 -- `<plugin_name>/migrations/001_100_to_110.lua`
 return {
-  postgresql = {
+  postgres = {
     up = [[
       DO $$
       BEGIN
@@ -180,7 +180,7 @@ A migration file is a Lua file which returns a table with the following structur
 ``` lua
 -- `<plugin_name>/migrations/000_base_my_plugin.lua`
 return {
-  postgresql = {
+  postgres = {
     up = [[
       CREATE TABLE IF NOT EXISTS "my_plugin_table" (
         "id"           UUID                         PRIMARY KEY,
@@ -213,7 +213,7 @@ return {
 
 -- `<plugin_name>/migrations/001_100_to_110.lua`
 return {
-  postgresql = {
+  postgres = {
     up = [[
       DO $$
       BEGIN


### PR DESCRIPTION
### Description

The `postgresql` key is wrong and should be `postgres`. 

Can check this in any plugin migrations file for our existing plugins, eg: https://github.com/Kong/kong/blob/master/kong/plugins/acl/migrations/000_base_acl.lua

Fixes https://github.com/Kong/docs.konghq.com/issues/5584.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

