### PR TITLE
kgo: make Gateway API APIVersion, depend on KGO version

### DIFF
--- a/app/_plugins/blocks/kgo_podtemplatespec_example.rb
+++ b/app/_plugins/blocks/kgo_podtemplatespec_example.rb
@@ -32,7 +32,21 @@ module Jekyll
       options.split("\n").map { |line| "      #{line}" }.join("\n").strip
     end
 
-    def gateway_config_example(gateway_config_api_version, dataplane, controlplane, release)
+    def release_to_version(release)
+      # Extract the major and minor version numbers from the release string
+      major, minor = release.split('.').map(&:to_i)[0, 2]
+      # Determine the return value based on the extracted version numbers
+      if major == 1 && minor == 1
+        'v1beta1'
+      else
+        # Use v1 as both the default fallback and the return value for 1.1.x and up.
+        'v1'
+      end
+    end
+
+    def gateway_config_example(gateway_config_api_version, dataplane, controlplane, release) # rubocop:disable Metrics/MethodLength
+      gateway_api_version = release_to_version(release)
+
       <<~TEXT
 
         ### Using GatewayConfiguration
@@ -61,7 +75,7 @@ module Jekyll
 
             ```yaml
             kind: GatewayClass
-            apiVersion: gateway.networking.k8s.io/v1beta1
+            apiVersion: gateway.networking.k8s.io/#{gateway_api_version}
             metadata:
               name: kong
             spec:
@@ -77,7 +91,7 @@ module Jekyll
 
             ```yaml
             kind: Gateway
-            apiVersion: gateway.networking.k8s.io/v1
+            apiVersion: gateway.networking.k8s.io/#{gateway_api_version}
             metadata:
               name: kong
               namespace: default

--- a/app/_src/gateway-operator/customization/data-plane-image.md
+++ b/app/_src/gateway-operator/customization/data-plane-image.md
@@ -7,7 +7,7 @@ title: Customizing the Data Plane image
 {% assign gatewayConfigApiVersion = "v1alpha1" %}
 {% endif_version %}
 
-You can customize the image of your `DataPlane` using  the `DataPlane` resource or the `GatewayConfiguration` CRD .
+You can customize the image of your `DataPlane` using the `DataPlane` resource or the `GatewayConfiguration` CRD .
 
 {% kgo_podtemplatespec_example %}
 release: {{ page.release }}

--- a/app/_src/gateway-operator/get-started/kic/create-gateway.md
+++ b/app/_src/gateway-operator/get-started/kic/create-gateway.md
@@ -5,6 +5,11 @@ book: kgo-kic-get-started
 chapter: 2
 ---
 
+{% assign gatewayApiVersion = "v1beta1" %}
+{% if_version gte:1.1.x %}
+{% assign gatewayApiVersion = "v1" %}
+{% endif_version %}
+
 {% assign gatewayConfigApiVersion = "v1beta1" %}
 {% if_version lte:1.1.x %}
 {% assign gatewayConfigApiVersion = "v1alpha1" %}
@@ -49,7 +54,7 @@ spec:
               value: debug
 ---
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 metadata:
   name: kong
 spec:
@@ -61,7 +66,7 @@ spec:
     namespace: default
 ---
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 metadata:
   name: kong
   namespace: default

--- a/app/_src/gateway-operator/get-started/kic/create-route.md
+++ b/app/_src/gateway-operator/get-started/kic/create-route.md
@@ -5,6 +5,11 @@ book: kgo-kic-get-started
 chapter: 3
 ---
 
+{% assign gatewayApiVersion = "v1beta1" %}
+{% if_version gte:1.1.x %}
+{% assign gatewayApiVersion = "v1" %}
+{% endif_version %}
+
 {% if_version lte: 1.1.x %}
 {:.note}
 > **Note:** `Gateway` and `ControlPlane` controllers are still `alpha` so be sure
@@ -27,7 +32,7 @@ After you've installed all of the required components and configured a `GatewayC
     ```yaml
     echo '
     kind: HTTPRoute
-    apiVersion: gateway.networking.k8s.io/v1beta1
+    apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
     metadata:
       name: echo
     spec:

--- a/app/_src/gateway-operator/guides/ai-gateway.md
+++ b/app/_src/gateway-operator/guides/ai-gateway.md
@@ -2,6 +2,11 @@
 title: AI Gateway
 ---
 
+{% assign gatewayApiVersion = "v1beta1" %}
+{% if_version gte:1.1.x %}
+{% assign gatewayApiVersion = "v1" %}
+{% endif_version %}
+
 The `AIGateway` CRD is an opinionated CRD to simplify getting started with [Kong's AI capabilities](https://konghq.com/products/kong-ai-gateway).
 
 `AIGateway` allows you to configure `largeLanguageModels` and will translate the configuration in to `Gateway`, `HTTPRoute` and `KongPlugin` resources automatically. 
@@ -36,7 +41,7 @@ After providing authentication credentials, create a `GatewayClass` and `AIGatew
 echo '
 ---
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 metadata:
   name: kong-ai-gateways
 spec:

--- a/app/_src/gateway-operator/guides/autoscaling-workloads/overview.md
+++ b/app/_src/gateway-operator/guides/autoscaling-workloads/overview.md
@@ -3,6 +3,11 @@ title: Horizontally autoscale workloads
 badge: enterprise
 ---
 
+{% assign gatewayApiVersion = "v1beta1" %}
+{% if_version gte:1.1.x %}
+{% assign gatewayApiVersion = "v1" %}
+{% endif_version %}
+
 {{ site.kgo_product_name }} can scrape {{ site.base_gateway }} and enrich it with Kubernetes metadata so that it can be used by users to autoscale their workloads.
 
 {% include md/kgo/prerequisites.md version=page.version release=page.release enterprise=true %}
@@ -139,7 +144,7 @@ spec:
       name: kong
 ---
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 metadata:
   name: kong
 spec:
@@ -151,7 +156,7 @@ spec:
     namespace: default
 ---
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 metadata:
   name: kong
   namespace: default
@@ -162,7 +167,7 @@ spec:
     protocol: HTTP
     port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 kind: HTTPRoute
 metadata:
   name: httproute-echo
@@ -204,7 +209,7 @@ Nevertheless you can follow our guides to integrate {{ site.kgo_product_name }} 
 {{ site.kgo_product_name }} is not able to provide accurate measurements for multi backend Kong services e.g. `HTTPRoute`s that have more than 1 `backendRef`:
 
 ```yaml
-apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 kind: HTTPRoute
 metadata:
   name: httproute-testing

--- a/app/_src/gateway-operator/topologies/dbless.md
+++ b/app/_src/gateway-operator/topologies/dbless.md
@@ -2,6 +2,16 @@
 title: DB-less Deployments
 ---
 
+{% assign gatewayApiVersion = "v1beta1" %}
+{% if_version gte:1.1.x %}
+{% assign gatewayApiVersion = "v1" %}
+{% endif_version %}
+
+{% assign gatewayConfigApiVersion = "v1beta1" %}
+{% if_version lte:1.1.x %}
+{% assign gatewayConfigApiVersion = "v1alpha1" %}
+{% endif_version %}
+
 {{ site.kgo_product_name }} can deploy both a {{ site.kic_product_name }} Control Plane and Data Plane resources automatically.
 
 DB-less deployments are powered using the [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api).
@@ -12,7 +22,7 @@ You configure your `GatewayClass`, `Gateway` and `GatewayConfiguration` objects 
 ```yaml
 echo '
 kind: GatewayConfiguration
-apiVersion: gateway-operator.konghq.com/v1alpha1
+apiVersion: gateway-operator.konghq.com/{{ gatewayConfigApiVersion }}
 metadata:
   name: kong
   namespace: default
@@ -39,7 +49,7 @@ spec:
               value: debug
 ---
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 metadata:
   name: kong
 spec:
@@ -51,7 +61,7 @@ spec:
     namespace: default
 ---
 kind: Gateway
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 metadata:
   name: kong
   namespace: default
@@ -81,7 +91,7 @@ For example:
 
 ```yaml
 kind: GatewayConfiguration
-apiVersion: gateway-operator.konghq.com/v1alpha1
+apiVersion: gateway-operator.konghq.com/{{ gatewayConfigApiVersion }}
 metadata:
   name: kong
   namespace: default
@@ -112,7 +122,7 @@ Configurations like the above can be created on the API, but won't be active unt
 
 ```yaml
 kind: GatewayClass
-apiVersion: gateway.networking.k8s.io/v1beta1
+apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
 metadata:
   name: kong
 spec:
@@ -145,7 +155,7 @@ You can use {{site.ee_product_name}} as the data plane using the following steps
 
     ```yaml
     kind: GatewayConfiguration
-    apiVersion: gateway-operator.konghq.com/v1alpha1
+    apiVersion: gateway-operator.konghq.com/{{ gatewayConfigApiVersion }}
     metadata:
       name: kong
       namespace: <your-namespace>
@@ -169,7 +179,7 @@ You can use {{site.ee_product_name}} as the data plane using the following steps
 
     ```yaml
     kind: GatewayClass
-    apiVersion: gateway.networking.k8s.io/v1beta1
+    apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
     metadata:
       name: kong
     spec:
@@ -185,7 +195,7 @@ You can use {{site.ee_product_name}} as the data plane using the following steps
 
     ```yaml
     kind: Gateway
-    apiVersion: gateway.networking.k8s.io/v1beta1
+    apiVersion: gateway.networking.k8s.io/{{ gatewayApiVersion }}
     metadata:
       name: kong
       namespace: <your-namespace>


### PR DESCRIPTION
### Description

Make version of Gateway API APIVersion depend on KGO version.

### Testing instructions

Preview links

- https://deploy-preview-7686--kongdocs.netlify.app/gateway-operator/latest/get-started/kic/create-gateway/
- https://deploy-preview-7686--kongdocs.netlify.app/gateway-operator/latest/get-started/kic/create-route/
- https://deploy-preview-7686--kongdocs.netlify.app/gateway-operator/latest/guides/ai-gateway/
- https://deploy-preview-7686--kongdocs.netlify.app/gateway-operator/1.3.x/customization/data-plane-image/#using-gatewayconfiguration

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

