### PR TITLE
Fix: Hardcode gateway version in centos doc

### DIFF
--- a/app/gateway/2.8.x/install-and-run/centos.md
+++ b/app/gateway/2.8.x/install-and-run/centos.md
@@ -35,13 +35,13 @@ Install {{site.base_gateway}} on CentOS from the command line.
 1. Download the Kong package:
 
     ```bash
-    curl -Lo kong-enterprise-edition-{{page.versions.ee}}.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{centos_ver}/x86_64/kong-enterprise-edition-{{page.versions.ee}}.el%{centos_ver}.noarch.rpm)
+    curl -Lo kong-enterprise-edition-2.8.4.11.rpm $(rpm --eval {{ site.links.direct }}/gateway-{{ page.major_minor_version }}/rpm/el/%{centos_ver}/x86_64/kong-enterprise-edition-2.8.4.11.el%{centos_ver}.noarch.rpm)
     ```
 
 2. Install the package:
 
     ```bash
-    sudo yum install -y kong-enterprise-edition-{{page.versions.ee}}.rpm
+    sudo yum install -y kong-enterprise-edition-2.8.4.11.rpm
     ```
 
 {% endnavtab %}
@@ -58,7 +58,7 @@ Install the YUM repository from the command line.
 2. Install Kong:
 
     ```bash
-    sudo yum install -y kong-enterprise-edition-{{page.versions.ee}}
+    sudo yum install -y kong-enterprise-edition-2.8.4.11
     ```
 
 {% endnavtab %}


### PR DESCRIPTION
### Description

As of 2.8.4.12, we are no longer building Centos packages for Gateway 2.8. Changing the variables on the 2.8 page to hardcoded so that they don't pick up a version of a package that doesn't exist. The version no longer needs to change dynamically with releases.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

