### PR TITLE
Add clarifying statement about private dev portals

### DIFF
--- a/app/konnect/dev-portal/create-dev-portal.md
+++ b/app/konnect/dev-portal/create-dev-portal.md
@@ -4,7 +4,7 @@ title: Create a Dev Portal
 
 The {{site.konnect_short_name}} Dev Portal is a customizable website for developers to locate, access, and consume API services.
 
-You can create both public and private Dev Portals, depending on your use case. Public Dev Portals don't require users to login to see published APIs, and are discoverable on the internet. Private Dev Portals require users to create an account and log in to see published APIs. <!-- commenting out for now: Coming soon, Konnect will support Dev Portals that contain pages that are public _and_ private, allowing the public to browse the publicly available catalog, but requiring users to login to see a full catalog, and begin consuming those APIs.-->
+You can create both public and private Dev Portals, depending on your use case. Public Dev Portals don't require users to login to see published APIs, and are discoverable on the internet. Private Dev Portals require users to create an account and log in to see published APIs, and are not discoverable on the internet. <!-- commenting out for now: Coming soon, Konnect will support Dev Portals that contain pages that are public _and_ private, allowing the public to browse the publicly available catalog, but requiring users to login to see a full catalog, and begin consuming those APIs.-->
 
 When Dev Portal admins require developers to create an account and log in to use the Dev Portal, developers can "self serve" their API consumption. Developers can create applications, register them to their target APIs, and generate credentials to start consuming those APIs.
 


### PR DESCRIPTION
### Description

The prior sentence states that `and are discoverable on the internet` for Public Dev Portals. It seems like it would be good to  explicit that private are not (which is just an assumption I made)

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

