### PR TITLE
Fix: API Docs need update to reflect the current API response format

### DIFF
--- a/api-specs/Gateway-EE/3.5/kong-ee-3.5.yaml
+++ b/api-specs/Gateway-EE/3.5/kong-ee-3.5.yaml
@@ -1717,217 +1717,273 @@ components:
                                 description: Pagination information
                                 example: 'http://localhost:8001/consumers?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
         consumer_group_response:
-            description: The consumer group response body
-            content:
-                application/json:
-                    schema:
-                        type: object
-                        x-examples:
-                            Example 1:
-                                consumer_group:
-                                    created_at: 1638917780
-                                    id: be4bcfca-b1df-4fac-83cc-5cf6774bf48e
-                                    name: JL
-                                    tags: null
-                        properties:
-                            consumer_group:
-                                type: object
-                                properties:
-                                    created_at:
-                                        type: integer
-                                        description: Unix epoch when the resource was created.
-                                        example: 1638918560
-                                    id:
-                                        type: string
-                                        description: The UUID of the consumer group
-                                        example: 42b022c1-eb3c-4512-badc-1aee8c0f50b5
-                                    name:
-                                        type: string
-                                        description: The name of the consumer group
-                                        example: my_group
-                                    tags:
-                                        description: An optional set of strings associated with consumer group for grouping and filtering.
-                    examples:
-                        Consumer group example:
-                            value:
-                                consumer_group:
-                                    created_at: 0
-                                    id: 42b022c1-eb3c-4512-badc-1aee8c0f50b5
-                                    name: my_group
-                                    tags: red
+          description: The consumer group response body
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    description: The data array contains consumer group objects
+                    items:
+                      type: object
+                      properties:
+                        created_at:
+                          type: integer
+                          description: Unix epoch when the resource was created.
+                          example: 1719859003
+                        id:
+                          type: string
+                          description: The UUID of the consumer group
+                          example: 0d8f5353-8dd2-4013-859a-21510b970a64
+                        name:
+                          type: string
+                          description: The name of the consumer group
+                          example: group2
+                        tags:
+                          type: array
+                          description: An optional set of strings associated with the consumer group for grouping and filtering.
+                          items:
+                            type: string
+                            example: example_tag
+                        updated_at:
+                          type: integer
+                          description: Unix epoch when the resource was last updated.
+                          example: 1719859003
+                  next:
+                    type: string
+                    description: Link to the next page of results, if applicable
+                    example: null
+                x-examples:
+                  Example 1:
+                    data:
+                      - created_at: 1719859003
+                        id: 0d8f5353-8dd2-4013-859a-21510b970a64
+                        name: group2
+                        tags: []
+                        updated_at: 1719859003
+                      - created_at: 1719858982
+                        id: 7012a570-e372-4280-92db-7fbbe4af80bb
+                        name: group1
+                        tags: []
+                        updated_at: 1719858982
+                      - created_at: 1719859346
+                        id: 9faf2f1b-2110-4690-8b64-c70dc14aa51a
+                        name: group3
+                        tags: null
+                        updated_at: 1719859346
+                    next: null
+                  Consumer group example:
+                    data:
+                      - created_at: 1719859003
+                        id: 0d8f5353-8dd2-4013-859a-21510b970a64
+                        name: group2
+                        tags: []
+                        updated_at: 1719859003
+                    next: null
         add_consumer_to_group_response:
-            description: The object returns information about the consumer and the group
-            content:
-                application/json:
-                    schema:
+          description: The object returns information about the consumer and the group
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    consumer:
+                      created_at: 1638918560
+                      custom_id: null
+                      id: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+                      tags: null
+                      type: 0
+                      username: BarryAllen
+                      username_lower: barryallen
+                    consumer_groups:
+                      - created_at: 1638918476
+                        id: e2c3f16e-22c7-4ef4-b6e4-ab25c522b339
+                        name: JL
+                        tags: null
+                properties:
+                  consumer:
+                    type: object
+                    properties:
+                      created_at:
+                        type: integer
+                        description: Unix epoch when the resource was created.
+                        example: 1638918560
+                      custom_id:
+                        type: string
+                        description: Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+                        nullable: true
+                      id:
+                        type: string
+                        description: The UUID for the consumer
+                      tags:
                         type: object
-                        x-examples:
-                            Example 1:
-                                consumer:
-                                    created_at: 1638918560
-                                    custom_id: null
-                                    id: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
-                                    tags: null
-                                    type: 0
-                                    username: BarryAllen
-                                    username_lower: barryallen
-                                consumer_groups:
-                                    - created_at: 1638918476
-                                      id: e2c3f16e-22c7-4ef4-b6e4-ab25c522b339
-                                      name: JL
-                                      tags: null
-                        properties:
-                            data:
-                                type: object
-                                properties:
-                                    created_at:
-                                        type: integer
-                                        description: Unix epoch when the resource was created.
-                                        example: 1638918560
-                                    custom_id:
-                                        type: string
-                                        description: Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
-                                        nullable: true
-                                    id:
-                                        type: string
-                                        description: The UUID for the consumer
-                                    tags:
-                                        type: object
-                                        description: An optional set of strings associated with consumer group for grouping and filtering.
-                                        nullable: true
-                                    type:
-                                        type: integer
-                                        default: 0
-                                        example: 0
-                                    username:
-                                        type: string
-                                        description: The unique username of the Consumer. You must send either this field or `custom_id` with the request.
-                                    username_lower:
-                                        type: string
-                                        description: A lowercase representation of the username
-                            consumer_groups:
-                                type: array
-                                items:
-                                    type: object
-                                    properties:
-                                        created_at:
-                                            type: integer
-                                            description: Unix epoch when the resource was created.
-                                        id:
-                                            type: string
-                                            description: The UUID for the consumer group
-                                        name:
-                                            type: string
-                                            description: The name of the consumer group
-                                        tags:
-                                            type: object
-                                            description: An optional set of strings associated with consumer group for grouping and filtering.
-                                            nullable: true
-                    examples:
-                        Example:
-                            value:
-                                consumer:
-                                    created_at: 0
-                                    custom_id: null
-                                    id: string
-                                    tags: null
-                                    type: 0
-                                    username: string
-                                    username_lower: string
-                                consumer_groups:
-                                    - created_at: 0
-                                      id: string
-                                      name: string
-                                      tags:
-                                        red: null
+                        description: An optional set of strings associated with consumer group for grouping and filtering.
+                        nullable: true
+                      type:
+                        type: integer
+                        default: 0
+                        example: 0
+                      username:
+                        type: string
+                        description: The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+                      username_lower:
+                        type: string
+                        description: A lowercase representation of the username
+                  consumer_groups:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        created_at:
+                          type: integer
+                          description: Unix epoch when the resource was created.
+                        id:
+                          type: string
+                          description: The UUID for the consumer group
+                        name:
+                          type: string
+                          description: The name of the consumer group
+                        tags:
+                          type: object
+                          description: An optional set of strings associated with consumer group for grouping and filtering.
+                          nullable: true
+              examples:
+                Example:
+                  value:
+                    consumer:
+                      created_at: 0
+                      custom_id: null
+                      id: string
+                      tags: null
+                      type: 0
+                      username: string
+                      username_lower: string
+                    consumer_groups:
+                      - created_at: 0
+                        id: string
+                        name: string
+                        tags:
+                          red: null
         consumer_response:
             description: A consumer response object
             content:
-                application/json:
-                    schema:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      description: The data array contains consumer objects
+                      items:
                         type: object
-                        x-examples:
-                            Example 1:
-                                data:
-                                    - created_at: 1638918560
-                                      id: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
-                                      type: 0
-                                      username: BarryAllen
-                                      username_lower: barryallen
                         properties:
-                            data:
-                                type: array
-                                description: The consumers array contains consumer objects
-                                items:
-                                    type: object
-                                    properties:
-                                        created_at:
-                                            type: integer
-                                            description: Unix epoch when the resource was created.
-                                            example: 1638918560
-                                        id:
-                                            type: string
-                                            example: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
-                                            description: The consumer ID
-                                        type:
-                                            type: integer
-                                            default: 0
-                                            example: 0
-                                        username:
-                                            type: string
-                                            example: BarryAllen
-                                            description: The username of the consumer
-                                        username_lower:
-                                            type: string
-                                            example: barryallen
-                                            description: Lowercase representation of the consumer username.
-                                        tags:
-                                            type: array
-                                            description: tags
-                                            items:
-                                                type: string
-                                                example: test
-                            id:
-                                type: string
-                                default: 496a3eae-5f7f-4e70-b254-95d5c9b8b764
-                                description: Consumer ID
-                    examples:
-                        One consumer:
-                            value:
-                                consumers:
-                                    - created_at: 1638918560
-                                      id: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
-                                      type: 0
-                                      username: BarryAllen
-                                      username_lower: barryallen
-                        Multiple consumers:
-                            value:
-                                next: null
-                                data:
-                                    - type: 0
-                                      username_lower: angel
-                                      created_at: 1683054731
-                                      custom_id: '123412312312312312312312'
-                                      username: angel
-                                      tags: null
-                                      id: 1ec7a260-b005-46b4-89e2-c62a417aa45c
-                                    - type: 0
-                                      username_lower: repr
-                                      created_at: 1682006579
-                                      custom_id: nisi in id ad
-                                      username: repr
-                                      tags:
-                                        - Duis aliqua in
-                                        - velit deserunt non dolor
-                                      id: 4e8032e7-02b9-460c-8b2c-a6fee42aea51
-                                    - type: 0
-                                      username_lower: bob-the-builder
-                                      created_at: 1682006428
-                                      custom_id: '4200'
-                                      username: bob-the-builder
-                                      tags:
-                                        - silver-tier
-                                      id: 8a388226-80e8-4027-a486-25e4f7db5d21
+                          created_at:
+                            type: integer
+                            description: Unix epoch when the resource was created.
+                            example: 1719859293
+                          custom_id:
+                            type: string
+                            description: Custom ID of the consumer
+                            example: consumer_id3
+                          id:
+                            type: string
+                            example: 1cf590ba-4b23-46fa-9e8d-4296213e2ac6
+                            description: The consumer ID
+                          tags:
+                            type: array
+                            description: Tags associated with the consumer
+                            items:
+                              type: string
+                              example: test
+                          type:
+                            type: integer
+                            default: 0
+                            example: 0
+                          updated_at:
+                            type: integer
+                            description: Unix epoch when the resource was last updated.
+                            example: 1719859293
+                          username:
+                            type: string
+                            example: consumer3
+                            description: The username of the consumer
+                          username_lower:
+                            type: string
+                            example: consumer3
+                            description: Lowercase representation of the consumer username.
+                    next:
+                      type: string
+                      description: Link to the next page of results, if applicable
+                      example: null
+                  x-examples:
+                    Example 1:
+                      data:
+                        - created_at: 1719859293
+                          custom_id: consumer_id3
+                          id: 1cf590ba-4b23-46fa-9e8d-4296213e2ac6
+                          tags: null
+                          type: 0
+                          updated_at: 1719859293
+                          username: consumer3
+                          username_lower: consumer3
+                        - created_at: 1719858943
+                          custom_id: consumer_id
+                          id: 73b74f15-5185-4b16-a2fc-3c2fd834ba6c
+                          tags: null
+                          type: 0
+                          updated_at: 1719858943
+                          username: consumer
+                          username_lower: consumer
+                        - created_at: 1719858965
+                          custom_id: consumer_id2
+                          id: f9383372-7bf4-4275-8bbc-4f89d7a38a23
+                          tags: null
+                          type: 0
+                          updated_at: 1719858965
+                          username: consumer2
+                          username_lower: consumer2
+                      next: null
+                    One consumer:
+                      data:
+                        - created_at: 1719859293
+                          custom_id: consumer_id3
+                          id: 1cf590ba-4b23-46fa-9e8d-4296213e2ac6
+                          tags: null
+                          type: 0
+                          updated_at: 1719859293
+                          username: consumer3
+                          username_lower: consumer3
+                      next: null
+                    Multiple consumers:
+                      data:
+                        - created_at: 1719859293
+                          custom_id: consumer_id3
+                          id: 1cf590ba-4b23-46fa-9e8d-4296213e2ac6
+                          tags: null
+                          type: 0
+                          updated_at: 1719859293
+                          username: consumer3
+                          username_lower: consumer3
+                        - created_at: 1719858943
+                          custom_id: consumer_id
+                          id: 73b74f15-5185-4b16-a2fc-3c2fd834ba6c
+                          tags: null
+                          type: 0
+                          updated_at: 1719858943
+                          username: consumer
+                          username_lower: consumer
+                        - created_at: 1719858965
+                          custom_id: consumer_id2
+                          id: f9383372-7bf4-4275-8bbc-4f89d7a38a23
+                          tags: null
+                          type: 0
+                          updated_at: 1719858965
+                          username: consumer2
+                          username_lower: consumer2
+                      next: null
         license-response:
             description: The license response object.
             content:

--- a/api-specs/Gateway-EE/3.5/kong-ee-3.5.yaml
+++ b/api-specs/Gateway-EE/3.5/kong-ee-3.5.yaml
@@ -1813,7 +1813,7 @@ components:
                         example: 1638918560
                       custom_id:
                         type: string
-                        description: Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+                        description: Field for storing an existing unique ID for the consumer. Useful for mapping Kong Gateway with users in your existing database. You must send either this field or `username` with the request.
                         nullable: true
                       id:
                         type: string
@@ -1828,7 +1828,7 @@ components:
                         example: 0
                       username:
                         type: string
-                        description: The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+                        description: The unique username of the consumer. You must send either this field or `custom_id` with the request.
                       username_lower:
                         type: string
                         description: A lowercase representation of the username
@@ -1848,7 +1848,7 @@ components:
                           description: The name of the consumer group
                         tags:
                           type: object
-                          description: An optional set of strings associated with consumer group for grouping and filtering.
+                          description: An optional set of strings associated with the consumer group for grouping and filtering.
                           nullable: true
               examples:
                 Example:


### PR DESCRIPTION


Direct entities: /consumers and /consumer_groups (they have pagination support as of 3.5.0.2, which means they have data keys)
https://konghq.atlassian.net/browse/DOCU-3883