### PR TITLE
docs(mesh): document caCert for cert-manager

### DIFF
--- a/app/_src/mesh/features/cert-manager.md
+++ b/app/_src/mesh/features/cert-manager.md
@@ -88,10 +88,19 @@ spec:
           name: my-ca-issuer
           kind: Issuer
           group: cert-manager.io
+        caCert: # can be used to specify the root CA
+          inlineString: | # or secret
+            -----BEGIN CERTIFICATE-----
+            ...
 ```
 
 In `issuerRef`, only `name` is strictly required.
 `group` and `kind` will default to cert-manager default values. See `issuerRef` in [cert-manager API](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateRequestSpec) for details.
+
+If `caCert` is not provided, {{ site.mesh_product_name }} assumes that the
+issuer sets `status.CA` on `CertificateRequests`.
+Note that if `secret` is used,
+it must be [a {{ site.mesh_product_name }} Secret](/mesh/{{page.release}}/production/secure-deployment/secrets/).
 
 Apply the configuration with `kubectl apply -f [..]`.
 


### PR DESCRIPTION
### Description

Missing docs for existing feature

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

