### PR TITLE
Fix: key-auth-enc plugin request must use key_id

### DIFF
--- a/app/_hub/kong-inc/key-auth-enc/overview/_index.md
+++ b/app/_hub/kong-inc/key-auth-enc/overview/_index.md
@@ -305,10 +305,10 @@ Retrieve a [consumer][consumer-object] associated with an API
 key by making the following request:
 
 ```bash
-curl -X GET http://localhost:8001/key-auths-enc/{key or id}/consumer
+curl -X GET http://localhost:8001/key-auths-enc/{key_id}/consumer
 ```
 
-`key or id`: The `id` or `key` property of the API key for which to get the
+`key_id`: The `id` property of the API key for the
 associated consumer.
 
 ```json


### PR DESCRIPTION
https://kongstrong.slack.com/archives/CDSTDSG9J/p1722881243530569


We can only issue a request using key Id and not with the key itself. 