### PR TITLE
chore: add more explanations about aws secret with slash in kong gateway

### DIFF
--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -89,7 +89,10 @@ In the following example, `AWSCURRENT` refers to the latest secret version and `
 ```
 
 {:.note}
-> **Note:** The slash symbol `/` is a valid character for the secret name in AWS SecretsManager. If you want to reference a secret name that starts with slash or have two consecutive slashes, make sure those slashes inside the name are transformed into URL-encoded format. For example a secret named `/secret/key` should be referenced as `{vault://aws/%2F/secret/key}`, and a secret named `secret/path//aaa/key` should be referenced as `{vault://aws/secret/path/%2F/aaa/key}`. Since {{site.base_gateway}} tries to resolve the secret reference as a valid URL, using slash instead of URL-encoded slash will result in unexpected secret name fetching.
+> **Note:** The slash symbol (`/`) is a valid character for the secret name in AWS SecretsManager. If you want to reference a secret name that starts with a slash or has two consecutive slashes, transform one of the slashes in the name into URL-encoded format. For example:
+ *  A secret named `/secret/key` should be referenced as `{vault://aws/%2Fsecret/key}`
+ *  A secret named `secret/path//aaa/key` should be referenced as `{vault://aws/secret/path/%2Faaa/key}`
+ Since {{site.base_gateway}} tries to resolve the secret reference as a valid URL, using a slash instead of a URL-encoded slash will result in unexpected secret name fetching.
 
 
 ## Configuration via vaults entity

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -92,7 +92,8 @@ In the following example, `AWSCURRENT` refers to the latest secret version and `
 > **Note:** The slash symbol (`/`) is a valid character for the secret name in AWS SecretsManager. If you want to reference a secret name that starts with a slash or has two consecutive slashes, transform one of the slashes in the name into URL-encoded format. For example:
  *  A secret named `/secret/key` should be referenced as `{vault://aws/%2Fsecret/key}`
  *  A secret named `secret/path//aaa/key` should be referenced as `{vault://aws/secret/path/%2Faaa/key}`
- Since {{site.base_gateway}} tries to resolve the secret reference as a valid URL, using a slash instead of a URL-encoded slash will result in unexpected secret name fetching.
+>
+> Since {{site.base_gateway}} tries to resolve the secret reference as a valid URL, using a slash instead of a URL-encoded slash will result in unexpected secret name fetching.
 
 
 ## Configuration via vaults entity

--- a/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
+++ b/app/_src/gateway/kong-enterprise/secrets-management/backends/aws-sm.md
@@ -88,6 +88,10 @@ In the following example, `AWSCURRENT` refers to the latest secret version and `
 {vault://aws/secret-name/foo#2}
 ```
 
+{:.note}
+> **Note:** The slash symbol `/` is a valid character for the secret name in AWS SecretsManager. If you want to reference a secret name that starts with slash or have two consecutive slashes, make sure those slashes inside the name are transformed into URL-encoded format. For example a secret named `/secret/key` should be referenced as `{vault://aws/%2F/secret/key}`, and a secret named `secret/path//aaa/key` should be referenced as `{vault://aws/secret/path/%2F/aaa/key}`. Since {{site.base_gateway}} tries to resolve the secret reference as a valid URL, using slash instead of URL-encoded slash will result in unexpected secret name fetching.
+
+
 ## Configuration via vaults entity
 
 The vault entity can only be used once the database is initialized. Secrets for values that are used _before_ the database is initialized can't make use of the vaults entity.


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

This PR adds a note to show a correct way of referencing secrets that has special slash symbols.

https://konghq.atlassian.net/browse/KAG-5054

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->



