### PR TITLE
docs(kgo): add PodDisruptionBudget guide

### DIFF
--- a/app/_data/docs_nav_kgo_1.4.x.yml
+++ b/app/_data/docs_nav_kgo_1.4.x.yml
@@ -87,6 +87,8 @@ items:
             url: /customization/sidecars/
           - text: Customizing PodTemplateSpec
             url: /customization/pod-template-spec/
+          - text: Defining PodDisruptionBudget for DataPlane
+            url: /customization/pod-disruption-budget/
       - text: Autoscaling Kong Gateway
         url: /guides/autoscaling-kong/
       - text: Autoscaling Workloads

--- a/app/_src/gateway-operator/customization/pod-disruption-budget.md
+++ b/app/_src/gateway-operator/customization/pod-disruption-budget.md
@@ -9,12 +9,12 @@ title: Defining PodDisruptionBudget for DataPlane
 This is useful to ensure that a certain number or percentage of pods are always available.
 
 See the [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) guide
-for more details on `PodDisruptionBudget` API itself.
+for more details on the `PodDisruptionBudget` API itself.
 
-## Creating DataPlane with PodDisruptionBudget
+## Creating a DataPlane with PodDisruptionBudget
 
 For `DataPlane` resources, you can define a `PodDisruptionBudget` in the `spec.resources.podDisruptionBudget` field.
-`DataPlane`'s `spec.resources.podDisruptionBudget.spec` matches the `PodDisruptionBudget` API, excluding
+The `DataPlane`'s `spec.resources.podDisruptionBudget.spec` matches the `PodDisruptionBudget` API, excluding
 the `selector` field, which is automatically set by {{ site.kgo_product_name }} to match the `DataPlane` pods.
 
 Here is an example of a `DataPlane` resource with a `PodDisruptionBudget`:

--- a/app/_src/gateway-operator/customization/pod-disruption-budget.md
+++ b/app/_src/gateway-operator/customization/pod-disruption-budget.md
@@ -1,0 +1,38 @@
+---
+title: Defining PodDisruptionBudget for DataPlane
+---
+
+`DataPlane` resources can be configured with a `PodDisruptionBudget` to control the number of pods that can be unavailable
+during maintenance. This is useful when you want to ensure that a certain number of pods are always available. See the
+[Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) guide
+for more details on `PodDisruptionBudget` API itself.
+
+## Creating DataPlane with PodDisruptionBudget
+
+For `DataPlane` resources, you can define a `PodDisruptionBudget` in the `spec.resources.podDisruptionBudget` field.
+`DataPlane`'s `spec.resources.podDisruptionBudget.spec` matches the `PodDisruptionBudget` API, excluding
+the `selector` field, which is automatically set by {{ site.kgo_product_name }} to match the `DataPlane` pods.
+
+Here is an example of a `DataPlane` resource with a `PodDisruptionBudget`:
+
+```yaml
+apiVersion: gateway-operator.konghq.com/v1beta1
+kind: DataPlane
+metadata:
+  name: dataplane-with-pdb
+spec:
+  resources:
+    podDisruptionBudget:
+      spec:
+        maxUnavailable: 1
+  deployment:
+    replicas: 3
+    podTemplateSpec:
+      spec:
+        containers:
+        - name: proxy
+          image: kong/kong-gateway:3.7
+```
+
+If you leave the `resources.podDisruptionBudget` field empty, {{ site.kgo_product_name }} will not create a
+`PodDisruptionBudget` for the `DataPlane`.

--- a/app/_src/gateway-operator/customization/pod-disruption-budget.md
+++ b/app/_src/gateway-operator/customization/pod-disruption-budget.md
@@ -2,9 +2,13 @@
 title: Defining PodDisruptionBudget for DataPlane
 ---
 
-`DataPlane` resources can be configured with a `PodDisruptionBudget` to control the number of pods that can be unavailable
-during maintenance. This is useful when you want to ensure that a certain number of pods are always available. See the
-[Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) guide
+`DataPlane` resources can be configured with a `PodDisruptionBudget` to control:
+- The number or percentage of pods that can be unavailable during maintenance (e.g. rollout).
+- The number or percentage of pods that has to be available during maintenance (e.g. rollout).
+
+This is useful when you want to ensure that a certain number or percentage of pods are always available.
+
+See the [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) guide
 for more details on `PodDisruptionBudget` API itself.
 
 ## Creating DataPlane with PodDisruptionBudget

--- a/app/_src/gateway-operator/customization/pod-disruption-budget.md
+++ b/app/_src/gateway-operator/customization/pod-disruption-budget.md
@@ -31,7 +31,7 @@ spec:
       spec:
         containers:
         - name: proxy
-          image: kong/kong-gateway:3.7
+          image: kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
 ```
 
 If you leave the `resources.podDisruptionBudget` field empty, {{ site.kgo_product_name }} will not create a

--- a/app/_src/gateway-operator/customization/pod-disruption-budget.md
+++ b/app/_src/gateway-operator/customization/pod-disruption-budget.md
@@ -4,9 +4,9 @@ title: Defining PodDisruptionBudget for DataPlane
 
 `DataPlane` resources can be configured with a `PodDisruptionBudget` to control:
 - The number or percentage of pods that can be unavailable during maintenance (e.g. rollout).
-- The number or percentage of pods that has to be available during maintenance (e.g. rollout).
+- The number or percentage of pods that must be available during maintenance (e.g. rollout).
 
-This is useful when you want to ensure that a certain number or percentage of pods are always available.
+This is useful to ensure that a certain number or percentage of pods are always available.
 
 See the [Specifying a Disruption Budget for your Application](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) guide
 for more details on `PodDisruptionBudget` API itself.


### PR DESCRIPTION
### Description

Adds a guide explaining how to define PodDisruptionBudget for DataPlane deployments.
<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

Part of https://github.com/Kong/gateway-operator/issues/142.

### Testing instructions

Preview link: https://deploy-preview-7729--kongdocs.netlify.app/gateway-operator/unreleased/customization/pod-disruption-budget/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

