### PR TITLE
Update key-auth request behaviour matrix

### DIFF
--- a/app/_hub/kong-inc/key-auth/overview/_index.md
+++ b/app/_hub/kong-inc/key-auth/overview/_index.md
@@ -300,6 +300,6 @@ Description | Proxied to upstream service? | Response status code
 --------|-----------------------------|---------------------
 The request has a valid API key. | Yes | 200
 No API key is provided. | No | 401
-The API key is known to {{site.base_gateway}} | No | 401
+The API key is not known to {{site.base_gateway}} | No | 401
 A runtime error occurred. | No | 500
 


### PR DESCRIPTION
I've read and re-read this section a few times - and I'm pretty sure there's a typo! But my apologies in advance if I've misunderstood the situation.

Kong will return a 401 when the API key is **not** known.

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

