### PR TITLE
chore: Add link to performance info from resource sizing guidelines

### DIFF
--- a/app/_src/gateway/production/sizing-guidelines.md
+++ b/app/_src/gateway/production/sizing-guidelines.md
@@ -7,8 +7,13 @@ This document discusses the performance characteristics of
 resource allocation based on expected {{site.base_gateway}} configuration and
 traffic patterns.
 
-These recommendations are a baseline guide only. Specific tuning or
-benchmarking efforts should be undertaken for performance-critical environments.
+These recommendations are a baseline guide only. 
+{% if_version gte:3.4.x %}
+Specific [tuning or benchmarking efforts](/gateway/{{page.release}}/production/performance/benchmark/) 
+should be undertaken for performance-critical environments.
+{% else %}
+Specific tuning or benchmarking efforts should be undertaken for performance-critical environments.
+{% endif_version %}
 
 ## General resource guidelines
 


### PR DESCRIPTION
### Description

While doing some research for a 3.8 feature, ran into the intro in this doc which refers to guidelines but doesn't tell the user where to find them. Since this page exists since 3.4, we should link to it.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

