### PR TITLE
Fix: Clarify workspace instead of environment for Dynamic Plugin Ordering feature

### DIFF
--- a/app/_src/gateway/kong-enterprise/plugin-ordering/index.md
+++ b/app/_src/gateway/kong-enterprise/plugin-ordering/index.md
@@ -61,7 +61,7 @@ PluginA:
 
 Dynamic plugin ordering cannot coexist with consumer-scoped plugins, 
 even if they are applied to entirely different service and route pairs or are running globally.
-If you have consumer-scoped plugins anywhere in your environment, you can't use
+If you have consumer-scoped plugins anywhere in your workspace, you can't use
 dynamic plugin ordering.
 
 Consumer mapping and dynamic plugin ordering both run in the access phase, but the order of the 


### PR DESCRIPTION
### Description

According to tests, this seems to be unique to each workspace. In other words, one workspace can still use dynamic ordering if consumer-scoped plugins are in use as long as the consumer-scoped plugins are in a different workspace than the one using dynamic ordering for example. This created confusion with a customer and required manual testing.

Case #[00047793](https://kong.lightning.force.com/lightning/r/Case/500PJ00000E12XaYAJ/view?ws=%2Flightning%2Fr%2FAccount%2F0014100001jcxrkAAA%2Fview).

### Testing instructions

N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

