### PR TITLE
feat(plugins)(datadog): changelog to add 'route tag name' to configurable options

### DIFF
--- a/app/_hub/kong-inc/datadog/_changelog.md
+++ b/app/_hub/kong-inc/datadog/_changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### {{site.base_gateway}} 3.8.x
+* Added route name to metrics, and allow route-name tag to be customized through the configuration parameter `route_name_tag`.
+ [#13494](https://github.com/Kong/kong/pull/13494)
+
 ### {{site.base_gateway}} 3.6.x
 * Fixed a bug where the plugin wasn't triggered for serviceless routes. 
   The Datadog plugin is now always triggered, and the value of tag `name`(`service_name`) is set as an empty value.


### PR DESCRIPTION
### Description

Updated `datadog` plugin changelog to add 'route tag name' to configurable options, from 3.9.x (predicted).

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

