### PR TITLE
Fix: Add changelog entry for deprecated OTEL parameters in 3.7

### DIFF
--- a/app/_hub/kong-inc/opentelemetry/_changelog.md
+++ b/app/_hub/kong-inc/opentelemetry/_changelog.md
@@ -2,7 +2,13 @@
 ### {{site.base_gateway}} 3.7.x
 * The propagation module has been reworked. The new
 options allow better control over the configuration of tracing header propagation.
- [#12670](https://github.com/Kong/kong/issues/12670)
+ [#12670](https://github.com/Kong/kong/issues/12670).
+
+  As part of the rework, the following parameters have been deprecated and will be removed in a future major version: 
+  * `config.header_type`  is deprecated, use `config.propagation` instead.
+  * `config.batch_span_count` is deprecated, use `config.queue.max_batch_size` instead.
+  * `config.batch_flush_deplay` is deprecated, use `config.queue.max_coalescing_delay` instead.
+    
 * Fixed an OTEL sampling mode Lua panic bug, which happened 
 when the `http_response_header_for_traceid` option was enabled.
  [#12544](https://github.com/Kong/kong/issues/12544)


### PR DESCRIPTION
### Description

Issue reported on slack: certain parameters in the OTEL plugin are marked deprecated, but there is no changelog entry noting when the deprecation happened.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

