### PR TITLE
Add `shared` to list of available substitution sources in _templates.md

### DIFF
--- a/app/_hub/kong-inc/request-transformer/how-to/_templates.md
+++ b/app/_hub/kong-inc/request-transformer/how-to/_templates.md
@@ -9,10 +9,11 @@ You can use any of the current request headers, query parameters, and captured U
 groups as templates to populate supported configuration fields.
 
 | Request Parameter | Template
-| ------------- | -----------
-| header        | `$(headers.<header_name>)`, `$(headers["<Header-Name>"])` or `$(headers["<header-name>"])`)
-| querystring   | `$(query_params.<query-param-name>)` or `$(query_params["<query-param-name>"])`)
-| captured URIs | `$(uri_captures.<group-name>)` or `$(uri_captures["<group-name>"])`)
+| -------------- | -----------
+| header         | `$(headers.<header_name>)`, `$(headers["<Header-Name>"])` or `$(headers["<header-name>"])`
+| querystring    | `$(query_params.<query-param-name>)` or `$(query_params["<query-param-name>"])`
+| captured URIs  | `$(uri_captures.<group-name>)` or `$(uri_captures["<group-name>"])`
+| shared context | `$(shared.<context-key>)` or  `$(shared["<context-key>"])`
 
 To escape a template, wrap it inside quotes and pass inside another template.
 For example:

--- a/app/_hub/kong-inc/request-transformer/how-to/_templates.md
+++ b/app/_hub/kong-inc/request-transformer/how-to/_templates.md
@@ -13,7 +13,7 @@ groups as templates to populate supported configuration fields.
 | header         | `$(headers.<header_name>)`, `$(headers["<Header-Name>"])` or `$(headers["<header-name>"])`
 | querystring    | `$(query_params.<query-param-name>)` or `$(query_params["<query-param-name>"])`
 | captured URIs  | `$(uri_captures.<group-name>)` or `$(uri_captures["<group-name>"])`
-| shared context | `$(shared.<context-key>)` or  `$(shared["<context-key>"])`
+| shared variables | `$(shared.<variable-name>)` or `$(shared["<variable-name>"])`)
 
 To escape a template, wrap it inside quotes and pass inside another template.
 For example:


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
- Added undocumented "shared" substitution variable to documentation based on the specification defined in the plugin sources.
 - Removed extraneous trailing character from code samples in the same section
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

- request-transformer sources: https://github.com/Kong/kong-plugin-request-transformer/blob/master/kong/plugins/request-transformer/access.lua#L87-L89


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

