### PR TITLE
feat: Add kic failure mode page

### DIFF
--- a/app/_data/docs_nav_kic_3.3.x.yml
+++ b/app/_data/docs_nav_kic_3.3.x.yml
@@ -219,3 +219,5 @@ items:
         url: /reference/ingress-to-gateway-migration
       - text: Required Permissions for Installation
         url: /reference/required-permissions
+      - text: Categories of Failures
+        url: /reference/failure-modes

--- a/app/_src/kubernetes-ingress-controller/reference/failure-modes.md
+++ b/app/_src/kubernetes-ingress-controller/reference/failure-modes.md
@@ -1,0 +1,78 @@
+---
+title: Failure Modes and Processing in {{site.kic_product_name}}
+type: reference
+purpose: |
+  What categories of failures would happen in {{site.kic_product_name}} running ? How would them be processed?
+---
+
+Different kinds of failures could happen during the running of {{site.kic_product_name}}, including retriving kubernetes resources, translating kubernetes resources to Kong configuration, applying configuration to {{site.gateway_product_name}}, uploading configuration and status of nodes to {{site.konnect_product_name}}. {{site.kic_product_name}} will use different methods to process the failures, and leave error logs or other evidences like prometheus metrics and kubernetes events for oberserving the failures.
+
+The article will introduce possible categories of failures could happen and how {{site.kic_product_name}} will process them.
+
+## Errors in Reconciling Kubernetes Resources
+
+When the controllers reconciling a specific kind of kubernetes resources run into errors in reconciling a kubernetes resource, a `Reconciler error` line of log will be recorded and the resource will be requeued for another round of reconciliation. Also, prometheus metric `controller_runtime_reconcile_errors_total` stores the total number of reconcile errors per controller from start of {{site.kic_product_name}}. You can find keyword `Reconciler error` in logs of {{site.kic_product_name}} container to see detailed errors of them.
+
+## Failures in Translating Configuration
+
+When {{site.kic_product_name}} found kubernetes resources that can not be correctly translated to Kong configuration (For example, an `Ingress` used a non-exist `Service` as its backend), a translation failure is generated with namespace and name of objects causing the failure. The kubernetes objects causing translation failures will not be translated to Kong configuration in the translation process. Kuberbetes events and prometheus metrics could help to observe the translation failures. If {{site.kic_product_name}} is integrated with {{site.konnect_product_name}}, it will report that translation error happened in uploading node status.
+
+{{site.kic_product_name}} collects all translation failures and generate a kuberenetes `Event` with `Warning` type and `KongConfigurationTranslationFailed` reason per each causing object in a translation failure. Prometheus metrics could also reflect the statics of tranlation failiures: `ingress_controller_translation_broken_resource_count` is the count of translation failures happened in the latest translation, and `ingress_controller_translation_count` with label `success=false` is the total number of translation procedures where translation failures happen.
+
+You can use `kubectl get events -n <namespace> --field-selector reason="KongConfigurationTranslationFailed"` to fetch events generated for translation failures. For example, if an `Ingress` `ing-1` in namespace `test` used a non-exist `Service` as its backend, you can get the event by the following command:
+
+```bash
+$ kubectl get events -n test --field-selector reason="KongConfigurationTranslationFailed"
+
+LAST SEEN   TYPE      REASON                               OBJECT                    MESSAGE
+18m         Warning   KongConfigurationTranslationFailed   ingress/ing-1   failed to resolve Kubernetes Service for backend: failed to fetch Service test/httpbin-deployment-1: Service test/httpbin-deployment-1 not found
+```
+
+## Failures in Applying Configuration to {{site.gateway_product_name}}
+
+When {{site.kic_product_name}} failed to apply translated Kong configuration to {{site.gateway_product_name}} (usually because the translated configuration is rejected by {{site.gateway_product_name}}), {{site.kic_product_name}} will try to recover from the failure, and also record the failure by logs, kubernetes events and prometheus metrics.
+
+{{site.kic_product_name}} would try to apply configuration that was previously successfully applied to {{site.gateway_product_name}} to new instances of {{site.gateway_product_name}} to achieve best effort for making them available. If feature gate `FallbackConfiguration` is enbled, {{site.kic_product_name}} would discover the kubernetes objects that causes the configuration invalid, and try to build a fallback confiugration from valid objects and parts of last valid configuration that are built from the broken objects. See [fallback configuration][fallback_config] for reference.
+
+You can observe failures in applying configuration from kubernetes events and prometheus metrics. {{site.kic_product_name}}  will generate an event with `Warning` type and `KongConfigurationApplyFailed` reason attached to the pod itself when failed to apply configuration. For each object that causes the configuration invalid, {{site.kic_product_name}} will also generate an event `Warning` type and `KongConfigurationApplyFailed` reason attached to the object. The prometheus metric `ingress_controller_configuration_push_count` with label `success=false` shows the total number of configuration applying failures by reason and URL of {{site.gateway_product_name}} admin API, and metruc `ingress_controller_configuration_push_broken_resource_count` could reflect the number of kubernetes resources that caused error in the last configuration push. If the CLI flag `--dump-config` is enabled, The endpoint `/debug/config/raw-error` is enabled on the debug server port of {{site.kic_product_name}} to fetch the raw error returned from {{site.gateway_product_name}} if applying configuration failed.
+
+For example, if we create an `Ingress` with `ImplementationSpecific` path type and an invalid regex in `Path` (This can only be done only when validating webhook is disabled. Otherwise it will be rejected by the webhook.):
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    konghq.com/strip-path: "true"
+  name: ingress-invalid-regex
+  namespace: default
+spec:
+  ingressClassName: kong
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: httpbin-deployment
+            port:
+              number: 80
+        path: /~^^/a$
+        pathType: ImplementationSpecific
+```
+
+You can get the kubernetes events by the following command:
+
+```bash
+$ kubectl get events --all-namespaces --field-selector reason=KongConfigurationApplyFailed
+NAMESPACE   LAST SEEN   TYPE      REASON                         OBJECT                                 MESSAGE
+default     2m9s        Warning   KongConfigurationApplyFailed   ingress/ingress-invalid-regex          invalid paths.1: should start with: / (fixed path) or ~/ (regex path)
+kong        15s         Warning   KongConfigurationApplyFailed   pod/kong-controller-779cb796f4-7q7c2   failed to apply Kong configuration to https://10.244.1.43:8444: HTTP status 400 (message: "failed posting new config to /config")
+```
+
+Both events attached to the invalid ingress and attached to the {{site.kic_product_name}} pod are recorded. 
+
+## Failures in Uploading Configuration to {{site.konnect_product_name}}
+
+When {{site.kic_product_name}} is integrated with {{site.konnect_product_name}} and it failed to send configuration to {{site.konnect_product_name}}, it will generate error logs for failed requests and record the failure to prometheus metrics, and update the node status of itself to {{site.konnect_product_name}}. {{site.kic_product_name}} will parse errors returned from {{site.konnect_product_name}} on failure of uploading configuration and log a line with error level for each Kong entity failed to create/update/delete, with a message `Failed to send request to Konnect`. The prometheus metric `ingress_controller_configuration_push_count` and `ingress_controller_configuration_push_duration_milliseconds_bucket` with the value of label `dataplane` being the URL of {{site.konnect_product_name}} and `success=false` APIs can also reflect failures of uploading configuration to {{site.konnect_product_name}}.
+
+[fallback_config](/kubernetes-ingress-controller/latest/guides/high-availability/fallback-config)


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

Add page for introducing different types of failures and how are they processed in KIC.

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/6193.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->
Review: Which versions should the doc in? Since the `FallbakcConfiguration` is added since KIC 3.2, should we also add the page to KIC 3.2.x docs?
