### PR TITLE
Lock spec-renderer and kongponents to the version without the toggle bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "proprietary",
       "dependencies": {
-        "@kong-ui-public/spec-renderer": "2.2.20",
-        "@kong/kongponents": "9.4.1",
+        "@kong-ui-public/spec-renderer": "2.1.21",
+        "@kong/kongponents": "9.0.0-alpha.146",
         "@kong/sdk-portal-js": "^2.14.0",
         "@segment/analytics-next": "1.72.1",
         "algoliasearch": "^5.0.0",
@@ -1294,68 +1294,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
-      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.7"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
-      "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.7"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
-      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
-      "license": "MIT"
-    },
-    "node_modules/@floating-ui/vue": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.1.4.tgz",
-      "integrity": "sha512-ammH7T3vyCx7pmm9OF19Wc42zrGnUw0QvLoidgypWsCLJMtGXEwY7paYIHO+K+oLC3mbWpzIHzeTVienYenlNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0",
-        "@floating-ui/utils": "^0.2.7",
-        "vue-demi": ">=0.13.0"
-      }
-    },
-    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.0.0.tgz",
@@ -1857,19 +1795,18 @@
       }
     },
     "node_modules/@kong-ui-public/spec-renderer": {
-      "version": "2.2.20",
-      "resolved": "https://registry.npmjs.org/@kong-ui-public/spec-renderer/-/spec-renderer-2.2.20.tgz",
-      "integrity": "sha512-kkwgxzZ3ym5WMSYPtlQIHaCS8R6w2yO3PUp2lMA9HKUgV/fvq9ofsjLnviZxN+Q9wKYgZO9HNQDxhc7CS5kwxg==",
-      "license": "Apache-2.0",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/@kong-ui-public/spec-renderer/-/spec-renderer-2.1.21.tgz",
+      "integrity": "sha512-WeGpTqNi3lSssj0I0/L7EvC4o+KV9BFCV5zJ2OXKp1fJcaqg2fEzYKWH+7LBtVjoX4mA1zE9zvj2bPMwTxvmyQ==",
       "dependencies": {
-        "@kong-ui-public/i18n": "^2.2.2",
-        "@kong-ui-public/swagger-ui-web-component": "^0.12.0",
-        "@kong/icons": "^1.15.1",
+        "@kong-ui-public/i18n": "^2.1.5",
+        "@kong-ui-public/swagger-ui-web-component": "^0.11.9",
+        "@kong/icons": "^1.9.1",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.1"
       },
       "peerDependencies": {
-        "@kong/kongponents": "^9.3.0",
+        "@kong/kongponents": "^9.0.0-alpha.146",
         "vue": ">= 3.3.13 < 4"
       }
     },
@@ -1887,16 +1824,15 @@
       }
     },
     "node_modules/@kong-ui-public/swagger-ui-web-component": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@kong-ui-public/swagger-ui-web-component/-/swagger-ui-web-component-0.12.0.tgz",
-      "integrity": "sha512-RO+xr0LHG8YHnm1iec1Yxra0haENzM4PD2fG0zkdipTM7pesE9wInSpV92YkkYHUd5jxtDJhABzArXGGmxEn2Q==",
-      "license": "Apache-2.0",
+      "version": "0.11.9",
+      "resolved": "https://registry.npmjs.org/@kong-ui-public/swagger-ui-web-component/-/swagger-ui-web-component-0.11.9.tgz",
+      "integrity": "sha512-5yFa6qbhOQ4WdCeR5o1ACKZgUPOih7GgfTwiEYGbEj51T9drmt/7n9eM4Es69mONMSPuJMrRCOf46b5pXOWb1A==",
       "dependencies": {
         "@kong/swagger-ui-kong-theme-universal": "^4.3.3",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "swagger-client": "^3.26.8",
-        "swagger-ui": "^5.7.2"
+        "swagger-ui": "^5.1.3"
       }
     },
     "node_modules/@kong/icons": {
@@ -1912,50 +1848,42 @@
       }
     },
     "node_modules/@kong/kongponents": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.4.1.tgz",
-      "integrity": "sha512-P24QKv7Y+y+lly9wGswNhvtVVEUburbOUCrQJgqaUs2hV6jMeU7viL4VdVbSOZxcbO7OGMYbv9y+fnTNjq92Rg==",
-      "license": "Apache-2.0",
+      "version": "9.0.0-alpha.146",
+      "resolved": "https://registry.npmjs.org/@kong/kongponents/-/kongponents-9.0.0-alpha.146.tgz",
+      "integrity": "sha512-ATnmEAyHog8ApChPUsIJvomrQvR7V07AQoKhXt/IEr7mpw8vmd24CFxZI6BIQUjjTubaN/PAuBp05nNXSr1TTg==",
       "dependencies": {
-        "@floating-ui/vue": "^1.1.4",
-        "@kong/icons": "^1.15.1",
+        "@kong/icons": "^1.9.0",
         "@popperjs/core": "^2.11.8",
         "date-fns": "^2.30.0",
         "date-fns-tz": "^2.0.1",
         "focus-trap": "^7.5.4",
         "focus-trap-vue": "^4.0.3",
-        "nanoid": "^5.0.7",
+        "popper.js": "^1.16.1",
         "sortablejs": "^1.15.2",
         "swrv": "^1.0.4",
+        "uuid": "^9.0.1",
         "v-calendar": "^3.1.2",
-        "vue-bind-once": "^0.2.1",
         "vue-draggable-next": "^2.2.1"
       },
       "engines": {
-        "node": ">=v16.20.2 || >=18.12.1 || >=20.14.0"
+        "node": ">=v16.20.2"
       },
       "peerDependencies": {
-        "axios": "^1.7.4",
+        "axios": "^1.6.8",
         "vue": ">= 3.3.4 < 4",
-        "vue-router": "^4.4.3"
+        "vue-router": "^4.3.0"
       }
     },
-    "node_modules/@kong/kongponents/node_modules/nanoid": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
-      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
+    "node_modules/@kong/kongponents/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@kong/sdk-portal-js": {
@@ -3144,9 +3072,9 @@
       "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
     },
     "node_modules/@types/ramda": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.1.tgz",
-      "integrity": "sha512-aoyF/ADPL6N+/NXXfhPWF+Qj6w1Cql59m9wX0Gi15uyF+bpzXeLd63HPdiTDE2bmLXfNcVufsDPKmbfOrOzTBA==",
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
+      "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
       "dependencies": {
         "types-ramda": "^0.30.1"
       }
@@ -4675,9 +4603,9 @@
       "hasInstallScript": true
     },
     "node_modules/core-js-pure": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.0.tgz",
-      "integrity": "sha512-8balb/HAXo06aHP58mZMtXgD8vcnXz9tUDePgqBgJgKdmTlMt+jw3ujqniuBDQXMvTzxnMpxHFeuSM3g1jWQuQ==",
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.38.1.tgz",
+      "integrity": "sha512-BY8Etc1FZqdw1glX0XNOq2FDwfrg/VGqoZOZCdaL+UmdaqDwQwYXkMJT4t6In+zfEfOJDcM9T0KdbBeJg8KKCQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -12251,6 +12179,8 @@
     },
     "node_modules/netlify-cli/node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/napi-wasm/-/napi-wasm-1.1.0.tgz",
+      "integrity": "sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -24150,9 +24080,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/node-abi": {
-      "version": "3.65.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
-      "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
+      "version": "3.67.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
+      "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
       "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
@@ -25732,12 +25662,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "node_modules/scule": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
-      "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
-      "license": "MIT"
-    },
     "node_modules/search-insights": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.15.0.tgz",
@@ -27264,18 +27188,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vue-bind-once": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/vue-bind-once/-/vue-bind-once-0.2.1.tgz",
-      "integrity": "sha512-17toDsxK7hc8folglp6TYtybi/Q0FVJal6plFeMeofWd2nOl4axHg9ckR/5ORNCj+GyjMAWh/OD10MvT6AXbHA==",
-      "license": "MIT",
-      "dependencies": {
-        "scule": "^1.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^3"
       }
     },
     "node_modules/vue-draggable-next": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     ]
   },
   "dependencies": {
-    "@kong-ui-public/spec-renderer": "2.2.20",
-    "@kong/kongponents": "9.4.1",
+    "@kong-ui-public/spec-renderer": "2.1.21",
+    "@kong/kongponents": "9.0.0-alpha.146",
     "@kong/sdk-portal-js": "^2.14.0",
     "@segment/analytics-next": "1.72.1",
     "algoliasearch": "^5.0.0",


### PR DESCRIPTION
### Description

Lock spec-renderer and kongponents to the version without the toggle bug.
Looks like dependabot force-pushed the branch with my change on it. Setting the version back to the ones that work

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

