### PR TITLE
chore(3.8): Update support matrix

### DIFF
--- a/app/_data/tables/support/gateway/versions/38.yml
+++ b/app/_data/tables/support/gateway/versions/38.yml
@@ -11,8 +11,6 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - <<: *debian10
-    eol: June 2024
   - <<: *debian11
     docker: true
     arm: true
@@ -21,8 +19,6 @@ distributions:
     docker: true
     arm: true
     graviton: true
-  - <<: *rhel7
-    eol: June 2024
   - <<: *rhel8
     docker: false
     fips: true

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -50,7 +50,7 @@ Kong supports the following versions of {{site.ee_product_name}}:
 {% navtabs %}
   {% if_version gte: 3.8.x %}
   {% navtab 3.8 %}
-    {% include_cached gateway-support.html version="3.8" data=site.data.tables.support.gateway.versions.38 eol="TBA" %}
+    {% include_cached gateway-support.html version="3.8" data=site.data.tables.support.gateway.versions.38 eol="Sept 2025" %}
   {% endnavtab %}
   {% endif_version %}
   {% if_version gte: 3.7.x %}


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->

- Added EOL for 3.8
- Removed support for RHEL 7 and Debian 10

 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-4030
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

