### PR TITLE
Fix: broken table in Konnect SSO doc

### DIFF
--- a/app/konnect/org-management/sso.md
+++ b/app/konnect/org-management/sso.md
@@ -108,11 +108,11 @@ Attribute mapping for Azure configuration:
 | Identifier (Entity ID)                      | `sp_entity_id`           |
 | Reply URL (Assertion Consumer Service URL)  | `callback_url`           |
 | App Federation Metadata Url                 | `idp_metadata_url`       |
-| `user.email`                                        |     `email        |
-| `user.givenname`                                   | `firstname`         |
-| `user.surname`                                    |      `lastname`      |
-| `user.groups`                                      | `groups`            |
-| `user.principalname`                   |   Unique user identifier      |
+| `user.email`                                | `email`                  |
+| `user.givenname`                            | `firstname`              |
+| `user.surname`                              | `lastname`               |
+| `user.groups`                               | `groups`                 |
+| `user.principalname`                        | Unique user identifier   |
 
 
 {% endnavtab %}


### PR DESCRIPTION
### Description

Table currently displays like this because of a missing backtick:

<img width="977" alt="Screenshot 2024-08-29 at 5 19 14 PM" src="https://github.com/user-attachments/assets/c69b10a2-f3de-48d2-ace4-b9e8d992b0cd">


### Testing instructions

Preview link: https://deploy-preview-7819--kongdocs.netlify.app/konnect/org-management/sso/#reference

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

