### PR TITLE
chore(docs): add instructions on how to upgrade custom plugins to redis v2 config

### DIFF
--- a/app/_src/gateway/breaking-changes/38x.md
+++ b/app/_src/gateway/breaking-changes/38x.md
@@ -8,11 +8,32 @@ chapter: 10
 Before upgrading, review any configuration or breaking changes in this version and prior versions that
 affect your current installation.
 
-You may need to adopt different [upgrade paths](/gateway/{{page.release}}/upgrade/#guaranteed-upgrade-paths) depending on your 
+You may need to adopt different [upgrade paths](/gateway/{{page.release}}/upgrade/#guaranteed-upgrade-paths) depending on your
 deployment methods, set of features in use, or custom plugins, for example.
 
 Review the [changelog](/gateway/changelog/#3800) for all the changes in this release.
 
 ## Breaking changes and deprecations
 
-TBA
+### Custom plugins that used shared Redis config
+
+In 3.8.0.0 version we have changed and refactored the shared Redis configuration that previously was imported by `require "kong.enterprise_edition.redis"`. If you have created a custom plugin that is using this shared configuration or if you have a forked version
+of a plugin (ex. `rate-limiting-advanced`) then there might be additional steps that would require you to upgrade to version 2 of this Redis config.
+
+Out of the box the custom plugins should still be working since the old shared configuration was left in place. The new config adds `cluster_max_redirections` option for Redis Cluster and the format of `cluster_nodes` and
+`sentinel_nodes` has been changed. Apart from that - the initialization step is not required anymore.
+
+#### Shared Redis Config: How to upgrade custom plugins
+
+If your plugin is using shared Redis config - i.e. you import: `require "kong.enterprise_edition.redis"` you should do the following steps:
+
+1. Remove library initialization call: `redis.init_conf(conf)` - where `redis` is `local redis = require "kong.enterprise_edition.redis"`
+2. Switch the imports of redis from `local redis = require "kong.enterprise_edition.redis"` to `local redis = require "kong.enterprise_edition.tools.redis.v2"`
+
+#### Rate-Limiting library: How to upgrade custom plugins
+
+If your plugin is using Rate-Limiting library - i.e. you import `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("your-plugin-name")` you should do the following steps:
+
+1. Switch the imports of:
+    1. Shared Redis config: `local redis = require "kong.enterprise_edition.redis"` to `local redis = require "kong.enterprise_edition.tools.redis.v2"`
+    2. Rate-Limiting library: `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("your-plugin-name")` to `local ratelimiting = require("kong.tools.public.rate-limiting").new_instance("your-plugin-name", { redis_config_version = "v2" })`


### PR DESCRIPTION
### Description

The upcoming changes for 3.8.0.0 might affect users that have forked or created custom plugins. Their config should work out of the box but if they wanted to fully upgrade to 3.8 they'd need to follow additional steps. This PR adds these instructions.

KAG-5009

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

