### PR TITLE
Fix: Errors in mTLS Auth examples

### DIFF
--- a/app/_hub/kong-inc/mtls-auth/how-to/_add-cert-authorities.md
+++ b/app/_hub/kong-inc/mtls-auth/how-to/_add-cert-authorities.md
@@ -11,7 +11,12 @@ and POST it to `/ca_certificates`:
 {% navtabs %}
 {% navtab Kong Admin API %}
 ```bash
-curl -sX POST https://localhost:8001/ca_certificates -F cert=@cert.pem
+curl -X POST https://localhost:8001/ca_certificates \
+  -F cert=@cert.pem
+```
+
+The response will contain an `id` value that can now be used for the mTLS plugin configurations or consumer mappings:
+```
 {
   "tags": null,
   "created_at": 1566597621,
@@ -34,11 +39,11 @@ Go through the Gateway Manager:
 You can view your certificate listed in the **Certificates** tab.
 
 To add a certificate via curl, you need:
-* {{site.konnect_short_name}} ID
+* {{site.konnect_short_name}} control plane ID
 * [A personal access token](/konnect/api/)
 
 ```bash
-curl -X POST https:konnect.konghq.com/api/control_planes/[Konnect-ID]/ca_certificates \
+curl -X POST https://konnect.konghq.com/api/control_planes/{controlPlaneID}/ca_certificates \
   -F cert=@testCACert.pem \
   --header "Authorization: Bearer TOKEN"
 ```


### PR DESCRIPTION
### Description

Fixing mTLS auth examples:
* Incorrect URL in Konnect example
* Split response out from Admin API example to reduce confusion

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

