### PR TITLE
Fix: HMAC signing string in plugin example

### DIFF
--- a/app/_hub/kong-inc/hmac-auth/overview/_index.md
+++ b/app/_hub/kong-inc/hmac-auth/overview/_index.md
@@ -248,13 +248,12 @@ The HMAC plugin can be enabled on a service or a route. This example uses a serv
     hash the digest:
 
     ```
-    signing_string="date: Thu, 22 Jun 2017 17:15:21 GMT\nGET /requests HTTP/1.1"
+    signing_string="date: Thu, 22 Jun 2017 17:15:21 GMT\nget /requests"
     digest=HMAC-SHA256(<signing_string>, "secret")
     base64_digest=base64(<digest>)
     ```
 
     So the final value of the `Authorization` header would look like:
-
 
     ```
     Authorization: hmac username="alice123", algorithm="hmac-sha256", headers="date @request-target", signature=<base64_digest>"


### PR DESCRIPTION
### Description

Fixes https://konghq.atlassian.net/browse/FTI-6211.

### Testing instructions

Preview link: https://deploy-preview-7841--kongdocs.netlify.app/hub/kong-inc/hmac-auth/#hmac-example

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

