### PR TITLE
Fix: Consumer groups versioned links

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -160,7 +160,7 @@
 
 /gateway/latest/production/security-update-process /gateway/latest/support/vulnerability-patching-process
 /gateway/latest/kong-enterprise/consumer-groups /gateway/latest/key-concepts/consumer-groups
-/gateway/latest/admin-api/consumer-groups/reference  /gateway/api/admin-ee/3.3.0.x/#/consumer_groups/get-consumer_groups
+/gateway/latest/admin-api/consumer-groups/reference  /gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups
 /konnect/runtime-manager/configuration/consumer-groups /hub/kong-inc/rate-limiting-advanced/how-to/
 
 # 3.3

--- a/app/_src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/app/_src/gateway/kong-enterprise/consumer-groups/index.md
@@ -591,5 +591,5 @@ if you need to cycle the group for a new batch of users.
 ## More information
 
 * [Consumer group precedence information](/gateway/latest/key-concepts/plugins/#precedence).
-* [API documentation](/gateway/api/admin-ee/3.3.0.x/#/consumer_groups/get-consumer_groups)
+* [API documentation](/gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups)
 * [Enforcing rate limiting tiers with the Rate Limiting Advanced plugin](/hub/kong-inc/rate-limiting-advanced/how-to/)

--- a/app/_src/gateway/kong-manager/consumer-groups.md
+++ b/app/_src/gateway/kong-manager/consumer-groups.md
@@ -29,7 +29,7 @@ the plugin accepts
 plugin's global configuration
 
 For all possible requests, see the
-[Consumer Groups reference](/gateway/api/admin-ee/3.3.0.x/#/consumer_groups/get-consumer_groups).
+[Consumer Groups reference](/gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups).
 
 ## Set up a consumer group with consumers
 


### PR DESCRIPTION
### Description

There are a few links to the consumer groups API point that point to 3.3.0.0 instead of `latest`. Updating to remove the hardcoded version.

Fixes https://github.com/Kong/docs.konghq.com/issues/7824. 

### Testing instructions

Preview link: 
https://deploy-preview-7843--kongdocs.netlify.app/gateway/latest/kong-enterprise/consumer-groups/
https://deploy-preview-7843--kongdocs.netlify.app/gateway/latest/kong-manager/consumer-groups/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

