### PR TITLE
fix: Remove AI RLA plugin from traffic control category on plugin hub

### DIFF
--- a/app/_hub/kong-inc/ai-rate-limiting-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-rate-limiting-advanced/_metadata/_index.yml
@@ -16,7 +16,6 @@ notes: |
   In DB-less, hybrid mode, and Konnect, the <code>cluster</code> config strategy
   is not supported. Use <code>redis</code> instead.
 categories:
-  - traffic-control
   - ai
 publisher: Kong Inc.
 desc: Provide rate limiting for AI providers defined in the AI plugins


### PR DESCRIPTION
### Description

The plugin currently appears twice because it's listed under two categories, and it should only be under AI: 

<img src="https://github.com/user-attachments/assets/d7b0fca6-16a6-40a0-b637-58bc75caf7a1" width="300px"/>

Issue reported by on Slack by Marco.

### Testing instructions

Preview link: search the plugin hub in the preview for "AI Rate Limiting Advanced" and make sure it only appears once.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

