### PR TITLE
Fix: Exit Transformer plugin handle_unknown description

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/overview/_index.md
@@ -16,7 +16,7 @@ environment.
 ## Transforming 4xx and 5xx Responses
 
 By default, the Exit Transformer is only applied to requests that match its
-criteria (its Route or Service matching configuration) or globally within a Workspace.
+criteria (its route or service matching configuration) or globally within a workspace.
 
 ### Handling Unmatched 400 and 404 Responses
 
@@ -25,14 +25,16 @@ within any specific Workspace, and standard plugin criteria will never match tho
 responses. You can designate Exit Transformer configurations that _do_ handle these
 responses by enabling the `handle_unexpected` (400) and `handle_unknown` (404) settings:
 
-- The `handle_unknown` parameter should only be enabled on a single plugin configuration.
-- The `handle_unexpected` parameter can be enabled on as many plugin configurations
-as you want.
+- The `handle_unknown` parameter must be used on a
+  [globally configured instance of the plugin](/hub/kong-inc/exit-transformer/how-to/basic-example/?tab=enable-globally)
+  running in the default workspace, and only takes effect when a 404 error occurs.
+- The `handle_unexpected` parameter can be enabled for any plugin configuration -
+  on a service, on a route, and so on. It only takes effect when a 400 error occurs.
 
 It's not a prerequisite for `handle_unexpected` to also have `handle_unknown` set,
-if an unexpected error happened within some known Service or Route context. If a
+if an unexpected error happened within some known service or route context. If a
 configuration has both `handle_unknown` and `handle_unexpected` enabled, then an
-unexpected error on an _unknown_ Service or Route will pass through the Exit Transformer plugin.
+unexpected error on an _unknown_ service or route will pass through the Exit Transformer plugin.
 
 ### HTTP Response Status Codes {#http-msgs}
 


### PR DESCRIPTION
### Description

Correcting the description of `handle_unknown`, which is currently misleading and doesn't provide enough context.

Fixes https://konghq.atlassian.net/browse/FTI-6080

### Testing instructions

Preview link: https://deploy-preview-7848--kongdocs.netlify.app/hub/kong-inc/exit-transformer/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

