### PR TITLE
Fix: AWS Lambda plugin changelog entry for base64_encode_body

### DIFF
--- a/app/_hub/kong-inc/aws-lambda/_changelog.md
+++ b/app/_hub/kong-inc/aws-lambda/_changelog.md
@@ -48,6 +48,7 @@ removed in 3.x.x.
 
 **{{site.base_gateway}} 2.6.x**
 * The AWS region can now be set with the environment variables: `AWS_REGION` or `AWS_DEFAULT_REGION`.
+* Added support for configurable body base64 encoding via the `base64_encode_body` parameter, which is `true` by default. 
 
 **{{site.base_gateway}} 2.2.x**
 * Added support for `isBase64Encoded` flag in Lambda function responses.


### PR DESCRIPTION
### Description

Adding a missing changelog entry for `base64_encode_body` (tracked down via blame in https://github.com/Kong/kong/commit/5853f9d0c0bb6afce4b6d3165cacbd86bb46b8d2). 
Since we no longer have specific docs for version 2.5.x, we don't need to update the config reference.

Fixes https://github.com/Kong/docs.konghq.com/issues/5544.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

