### PR TITLE
docs(kic): add konnect integration troubleshooting section

### DIFF
--- a/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
@@ -359,3 +359,19 @@ kong admin` for configuration push failures.
 {{ site.kic_product_name }} provides Kubernetes Events to help understand the state of your system. Events occur when an invalid configuration is rejected by {{ site.base_gateway }} (`KongConfigurationApplyFailed`) or when an invalid configuration such as an upstream service that does not exist is detected (`KongConfigurationTranslationFailed`)..
 
 For more information, see [Events](/kubernetes-ingress-controller/{{ page.release }}/production/observability/events/).
+
+### Debugging Konnect integration
+
+{{ site.kic_product_name }} needs to communicate with the Konnect cloud APIs to provide the [integration](/konnect/gateway-manager/kic). 
+If you encounter an issue with that, you should first inspect logs from {{ site.kic_product_name }} to identify the root cause.
+
+From {{ site.kic_product_name }} v3.3.0, KIC logs every failed request/response's details (method, URL, status code) it
+receives from Konnect. Also, if you set the `LOG_LEVEL` to `trace`, {{ site.kic_product_name }} will log _every_
+request/response details it receives from Konnect.
+
+Here is an example of a failed request/response log entry:
+```text
+Request failed  {"x_b3_traceid": "66c731200000000034ce3297e8e64544", "x_b3_spanid": "4e6955874299011d", "x_datadog_trace_id": "3805034363203503428", "x_datadog_parent_id": "5650141246939267357", "v": 0, "method": "GET", "url": "https://us.kic.api.konghq.tech/kic/api/control-planes/81bc4af5-ed3c-40b4-bb88-b5a05fbe34a1/oauth2?size=1000", "status_code": 404}
+```
+
+If your issue requires further investigation on the Konnect side, please attach logs with tracing information to your support ticket.   

--- a/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
@@ -360,18 +360,21 @@ kong admin` for configuration push failures.
 
 For more information, see [Events](/kubernetes-ingress-controller/{{ page.release }}/production/observability/events/).
 
-### Debugging Konnect integration
 
-{{ site.kic_product_name }} needs to communicate with the Konnect cloud APIs to provide the [integration](/konnect/gateway-manager/kic). 
-If you encounter an issue with that, you should first inspect logs from {{ site.kic_product_name }} to identify the root cause.
+{% if_version gte:3.3.x %}
+### Debugging {{ site.konnect_short_name }} integration
 
-From {{ site.kic_product_name }} v3.3.0, KIC logs every failed request/response's details (method, URL, status code) it
-receives from Konnect. Also, if you set the `LOG_LEVEL` to `trace`, {{ site.kic_product_name }} will log _every_
-request/response details it receives from Konnect.
+{{ site.kic_product_name }} needs to communicate with the {{ site.konnect_short_name }} cloud APIs to provide the [integration](/konnect/gateway-manager/kic). 
+If you encounter issues with KIC in {{ site.konnect_short_name }}, you should first inspect logs from {{ site.kic_product_name }} to identify the root cause.
+
+By default, KIC logs the details for every failed request and response (method, URL, status code) it
+receives from {{ site.konnect_short_name }}. If you set the `LOG_LEVEL` to `trace`, {{ site.kic_product_name }} will log the details for _every_ request and response it receives from {{ site.konnect_short_name }}.
 
 Here is an example of a failed request/response log entry:
 ```text
 Request failed  {"x_b3_traceid": "66c731200000000034ce3297e8e64544", "x_b3_spanid": "4e6955874299011d", "x_datadog_trace_id": "3805034363203503428", "x_datadog_parent_id": "5650141246939267357", "v": 0, "method": "GET", "url": "https://us.kic.api.konghq.tech/kic/api/control-planes/81bc4af5-ed3c-40b4-bb88-b5a05fbe34a1/oauth2?size=1000", "status_code": 404}
 ```
 
-If your issue requires further investigation on the Konnect side, please attach logs with tracing information to your support ticket.   
+If your issue requires further investigation on the {{ site.konnect_short_name }} side, attach logs with tracing information to your support ticket.   
+
+{% endif_version %}


### PR DESCRIPTION
### Description

Adds a Konnect integration section to the troubleshooting guide. 
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: https://deploy-preview-7853--kongdocs.netlify.app/kubernetes-ingress-controller/latest/reference/troubleshooting/#debugging-konnect-integration
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

