### PR TITLE
Add docker copy command to move cert and key into container before restarting the gateway

### DIFF
--- a/app/konnect/gateway-manager/data-plane-nodes/renew-certificates.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/renew-certificates.md
@@ -153,6 +153,10 @@ command:
 
 In your Docker container, replace any existing certificates on your data plane nodes
 with the new files and restart the Gateway:
+```sh
+docker cp {PATH_TO_FILE}/tls.cert {CONTAINER_ID}:{PATH_TO_FILE}
+docker cp {PATH_TO_FILE}/tls.key {CONTAINER_ID}:{PATH_TO_FILE}
+```
 
 ```sh
 echo "KONG_CLUSTER_CERT=/{PATH_TO_FILE}/tls.crt \


### PR DESCRIPTION
added docker copy command to move cert and key ointo container before restarting the gateway


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

