### PR TITLE
Feat: AppD analytics_enable

### DIFF
--- a/app/_hub/kong-inc/app-dynamics/overview/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/overview/_index.md
@@ -86,7 +86,7 @@ for more information about the configuration parameters.
 | `KONG_CONTROLLER_CERTIFICATE_DIR` | Path to a certificate directory. For example, `/etc/kong/certs/`. | String | | 
 {% endif_version %}
 {% if_version gte:3.8.x %}
-| `KONG_ANALYTICS_ENABLE` | Whether to enable sending analytics to AppDynamics. | Boolean | `false` | 
+| `KONG_ANALYTICS_ENABLE` | Enable or disable Analytics Agent reporting. When disabled (default), Analytics-related logging messages are suppressed. | Boolean | `false` | 
 {% endif_version %}
 
 #### Possible values for the `KONG_APPD_LOGGING_LEVEL` parameter

--- a/app/_hub/kong-inc/app-dynamics/overview/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/overview/_index.md
@@ -85,6 +85,9 @@ for more information about the configuration parameters.
 | `KONG_CONTROLLER_CERTIFICATE_FILE` | Path to a self-signed certificate file. For example, `/etc/kong/certs/ca-certs.pem`. | String | | 
 | `KONG_CONTROLLER_CERTIFICATE_DIR` | Path to a certificate directory. For example, `/etc/kong/certs/`. | String | | 
 {% endif_version %}
+{% if_version gte:3.8.x %}
+| `KONG_ANALYTICS_ENABLE` | Whether to enable sending analytics to AppDynamics. | Boolean | `false` | 
+{% endif_version %}
 
 #### Possible values for the `KONG_APPD_LOGGING_LEVEL` parameter
 


### PR DESCRIPTION
### Description

Adding ANALYTICS_ENABLE env variable to the AppDynamics env variables table.

Discovered via changelog entry.

@oowl what kind of analytics get logged via this variable, and _is_ it sending the data to AppD?

### Testing instructions

Preview link: https://deploy-preview-7861--kongdocs.netlify.app/hub/kong-inc/app-dynamics/unreleased/#environment-variables

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

