### PR TITLE
docs(consumer_groups): add prefix `/{workspace}` for consumer_groups's endpoint in 3.3 and 3.4

### DIFF
--- a/api-specs/Gateway-EE/3.3/kong-ee-3.3.json
+++ b/api-specs/Gateway-EE/3.3/kong-ee-3.3.json
@@ -12400,6 +12400,459 @@
         "description": "Delete custom rate limiting settings for a consumer group.\n"
       }
     },
+    "/{workspace}/consumer_groups": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        }
+      ],
+      "get": {
+        "summary": "List consumer groups",
+        "tags": [
+          "consumer_groups"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "operationId": "get-consumer_groups_with_workspace",
+        "description": "List all consumer groups\n\nUse consumer groups to manage custom rate limiting configuration for subsets of consumers. For more information read the [consumer group examples documentation](https://docs.konghq.com/gateway/3.2.x/kong-enterprise/consumer-groups/).\n"
+      },
+      "post": {
+        "summary": "Create a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "post-consumer_groups_with_workspace",
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "description": "Create a new consumer group.",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/consumer_group_request"
+        }
+      }
+    },
+    "/{workspace}/consumer_groups/{group_name_or_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        }
+      ],
+      "get": {
+        "summary": "List a specific consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "operationId": "get-consumer_groups-group_name_with_workspace",
+        "description": "Returns a consumer group by passing either the `group_name` or `group_id` as a path parameter. "
+      },
+      "put": {
+        "summary": "Create consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "put-consumer_groups-group_name_or_id_with_workspace",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "description": "Create a consumer group by passing a new group name as the path parameter",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/consumer_group_request"
+        }
+      },
+      "delete": {
+        "summary": "Delete a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "delete-consumer_groups-group_name_or_id_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Delete a consumer group. Deleting a consumer group removes all consumers from that group. This operation does not delete existing consuemrs.\n"
+      }
+    },
+    "/{workspace}/consumers/{consumer_username_or_id}/consumer_groups": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/Gatewayapi_Consumer_username_or_id"
+        }
+      ],
+      "get": {
+        "summary": "List consumer groups for a consumer",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "operationId": "get-consumers-consumer_name_or_id-consumer_groups_with_workspace",
+        "description": "View all consumer groups that a consumer is assigned to.\n",
+        "tags": [
+          "consumer_groups"
+        ]
+      },
+      "post": {
+        "summary": "Add a consumer to a specific consumer group.",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "post-consumers-consumer_username_or_id-consumer_groups_with_workspace",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/add_consumer_to_group_response"
+          }
+        },
+        "description": "Add a consumer to a specific consumer group.\n\nIf you add a consumer to multiple groups:\n\nIf all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.\nOtherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "group": {
+                    "type": "string",
+                    "description": "The name or ID of the group to add the consumer to.\n",
+                    "example": "288f2bfc-04e2-4ec3-b6f3-40408dff5417"
+                  }
+                },
+                "required": [
+                  "group"
+                ]
+              },
+              "examples": {
+                "Example request body": {
+                  "value": {
+                    "group": "288f2bfc-04e2-4ec3-b6f3-40408dff5417"
+                  }
+                }
+              }
+            }
+          },
+          "description": "The request body contains the group ID for the group that you are adding a consumer into."
+        }
+      },
+      "delete": {
+        "summary": "Remove a consumer from all groups",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "delete-consumers-consumer_username_or_id-consumer_groups_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Remove a consumer from all groups."
+      }
+    },
+    "/{workspace}/consumer_groups/{group_name_or_id}/consumers": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        }
+      ],
+      "get": {
+        "summary": "List all consumers in a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "get-consumer_groups-group_name_or_id-consumers_with_workspace",
+        "description": "List all consumers in a consumer group",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Gatewayapi_Pagination-tags-filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_response"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a consumer to a group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "post-consumer_groups-group_name_or_id-consumers_with_workspace",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/add_consumer_to_group_response"
+          }
+        },
+        "description": "Add a consumer to a specific consumer group.\n\nIf you add a consumer to multiple groups:\n\nIf all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.\nOtherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "consumer": {
+                    "type": "string",
+                    "description": "The name or ID of the consumer to add to this group.\n",
+                    "example": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove all consumers from a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "delete-consumer_groups-group_name_or_id-consumers_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Removes all consumers from a specified consumer group."
+      }
+    },
+    "/{workspace}/consumers/{consumer_name_or_id}/consumer_groups/{group_name_or_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/consumer_name_or_id"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        }
+      ],
+      "delete": {
+        "summary": "Remove a consumer from a consumer group",
+        "operationId": "delete-consumers-consumer_name_or_id-consumer_groups-group_name_or_id_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Removes a consumer from a consumer group. This operation does not delete the consumer group.",
+        "tags": [
+          "consumer_groups"
+        ]
+      }
+    },
+    "/{workspace}/consumer_groups/{group_name_or_id}/consumers/{consumer_username_or_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        },
+        {
+          "$ref": "#/components/parameters/consumer_username_or_id"
+        }
+      ],
+      "delete": {
+        "summary": "Remove a consumer from a consumer group",
+        "operationId": "delete-consumer_groups-group_name_or_id-consumers-consumer_name_or_id_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "The consumer groups endpoint for removing a consumer from a specified consumer group.",
+        "tags": [
+          "consumer_groups"
+        ]
+      }
+    },
+    "/{workspace}/consumer_groups/{group_name_or_id}/overrides/plugins/rate-limiting-advanced": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        }
+      ],
+      "put": {
+        "summary": "Configure rate limiting for a consumer group",
+        "operationId": "put-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "x-examples": {
+                    "Example 1": {
+                      "config": {
+                        "limit": [
+                          10
+                        ],
+                        "retry_after_jitter_max": 0,
+                        "window_size": [
+                          10
+                        ],
+                        "window_type": "sliding"
+                      },
+                      "group": "test-group",
+                      "plugin": "rate-limiting-advanced"
+                    }
+                  },
+                  "properties": {
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "limit": {
+                          "type": "array",
+                          "description": "An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.\n",
+                          "items": {
+                            "type": "integer",
+                            "example": 10
+                          }
+                        },
+                        "retry_after_jitter_max": {
+                          "type": "integer",
+                          "description": "The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.\n"
+                        },
+                        "window_size": {
+                          "type": "array",
+                          "description": "An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.\n",
+                          "items": {
+                            "type": "integer",
+                            "example": 10
+                          }
+                        },
+                        "window_type": {
+                          "type": "string",
+                          "description": "Set the time window type to either sliding (default) or fixed.\n",
+                          "example": "sliding"
+                        }
+                      }
+                    },
+                    "group": {
+                      "type": "string",
+                      "description": "The consumer group",
+                      "example": "test-group"
+                    },
+                    "plugin": {
+                      "type": "string",
+                      "description": "The name of the plugin",
+                      "example": "rate-limiting-advanced"
+                    }
+                  }
+                },
+                "examples": {
+                  "Example ": {
+                    "value": {
+                      "config": {
+                        "limit": [
+                          10
+                        ],
+                        "retry_after_jitter_max": 0,
+                        "window_size": [
+                          10
+                        ],
+                        "window_type": "sliding"
+                      },
+                      "group": "test-group",
+                      "plugin": "rate-limiting-advanced"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Define custom rate limiting settings for a consumer group. This endpoint overrides the settings of the Rate Limiting Advanced plugin.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "config.limit": {
+                    "type": "string",
+                    "description": "An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.\n"
+                  },
+                  "config.window_size": {
+                    "type": "string",
+                    "description": "An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.\n",
+                    "example": " 10"
+                  },
+                  "config.window_type": {
+                    "type": "string",
+                    "description": "Set the time window type to either sliding (default) or fixed.\n",
+                    "default": "sliding",
+                    "enum": [
+                      "sliding",
+                      "fixed"
+                    ]
+                  },
+                  "config.retry_after_jitter_max": {
+                    "type": "string",
+                    "description": "The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header."
+                  }
+                },
+                "required": [
+                  "config.limit",
+                  "config.window_size"
+                ]
+              },
+              "examples": {
+                "Request body": {
+                  "value": {
+                    "config.limit": "string",
+                    "config.window_size": " 10",
+                    "config.window_type": "sliding",
+                    "config.retry_after_jitter_max": "string"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Request Body\n"
+        },
+        "tags": [
+          "consumer_groups"
+        ]
+      },
+      "delete": {
+        "summary": "Delete the configurations for a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "delete-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Delete custom rate limiting settings for a consumer group.\n"
+      }
+    },
     "/licenses": {
       "get": {
         "summary": "List licenses",

--- a/api-specs/Gateway-EE/3.3/kong-ee-3.3.yaml
+++ b/api-specs/Gateway-EE/3.3/kong-ee-3.3.yaml
@@ -1167,12 +1167,7 @@ components:
             portal_auto_approve: true
             portal_cors_origins:
               - string
-            portal_developer_meta_fields:
-              - label: Full Name
-                title: full_name
-                validator:
-                  required: true
-                  type: string
+            portal_developer_meta_fields: '[{"label":"Full Name","title":"full_name","validator":{"required":true,"type":"string"}}]'
             portal_emails_from: string
             portal_emails_reply_to: string
             portal_invite_email: true
@@ -8533,6 +8528,330 @@ paths:
       tags:
         - consumer_groups
       operationId: delete-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: |
+        Delete custom rate limiting settings for a consumer group.
+  /{workspace}/consumer_groups:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+    get:
+      summary: List consumer groups
+      tags:
+        - consumer_groups
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+      operationId: get-consumer_groups_with_workspace
+      description: |
+        List all consumer groups
+
+        Use consumer groups to manage custom rate limiting configuration for subsets of consumers. For more information read the [consumer group examples documentation](https://docs.konghq.com/gateway/3.2.x/kong-enterprise/consumer-groups/).
+    post:
+      summary: Create a consumer group
+      tags:
+        - consumer_groups
+      operationId: post-consumer_groups_with_workspace
+      responses:
+        '201':
+          $ref: '#/components/responses/consumer_group_response'
+      description: Create a new consumer group.
+      requestBody:
+        $ref: '#/components/requestBodies/consumer_group_request'
+  /{workspace}/consumer_groups/{group_name_or_id}:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    get:
+      summary: List a specific consumer group
+      tags:
+        - consumer_groups
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+      operationId: get-consumer_groups-group_name_with_workspace
+      description: 'Returns a consumer group by passing either the `group_name` or `group_id` as a path parameter. '
+    put:
+      summary: Create consumer group
+      tags:
+        - consumer_groups
+      operationId: put-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+      description: Create a consumer group by passing a new group name as the path parameter
+      requestBody:
+        $ref: '#/components/requestBodies/consumer_group_request'
+    delete:
+      summary: Delete a consumer group
+      tags:
+        - consumer_groups
+      operationId: delete-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: |
+        Delete a consumer group. Deleting a consumer group removes all consumers from that group. This operation does not delete existing consuemrs.
+  /{workspace}/consumers/{consumer_username_or_id}/consumer_groups:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/Gatewayapi_Consumer_username_or_id'
+    get:
+      summary: List consumer groups for a consumer
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+      operationId: get-consumers-consumer_name_or_id-consumer_groups_with_workspace
+      description: |
+        View all consumer groups that a consumer is assigned to.
+      tags:
+        - consumer_groups
+    post:
+      summary: Add a consumer to a specific consumer group.
+      tags:
+        - consumer_groups
+      operationId: post-consumers-consumer_username_or_id-consumer_groups_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/add_consumer_to_group_response'
+      description: |
+        Add a consumer to a specific consumer group.
+
+        If you add a consumer to multiple groups:
+
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.
+        Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                group:
+                  type: string
+                  description: |
+                    The name or ID of the group to add the consumer to.
+                  example: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+              required:
+                - group
+            examples:
+              Example request body:
+                value:
+                  group: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+        description: The request body contains the group ID for the group that you are adding a consumer into.
+    delete:
+      summary: Remove a consumer from all groups
+      tags:
+        - consumer_groups
+      operationId: delete-consumers-consumer_username_or_id-consumer_groups_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: Remove a consumer from all groups.
+  /{workspace}/consumer_groups/{group_name_or_id}/consumers:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    get:
+      summary: List all consumers in a consumer group
+      tags:
+        - consumer_groups
+      operationId: get-consumer_groups-group_name_or_id-consumers_with_workspace
+      description: List all consumers in a consumer group
+      parameters:
+        - $ref: '#/components/parameters/Gatewayapi_Pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+    post:
+      summary: Add a consumer to a group
+      tags:
+        - consumer_groups
+      operationId: post-consumer_groups-group_name_or_id-consumers_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/add_consumer_to_group_response'
+      description: |-
+        Add a consumer to a specific consumer group.
+
+        If you add a consumer to multiple groups:
+
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.
+        Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                consumer:
+                  type: string
+                  description: |
+                    The name or ID of the consumer to add to this group.
+                  example: 8a4bba3c-7f82-45f0-8121-ed4d2847c4a4
+    delete:
+      summary: Remove all consumers from a consumer group
+      tags:
+        - consumer_groups
+      operationId: delete-consumer_groups-group_name_or_id-consumers_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: Removes all consumers from a specified consumer group.
+  /{workspace}/consumers/{consumer_name_or_id}/consumer_groups/{group_name_or_id}:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_name_or_id'
+      - $ref: '#/components/parameters/group_name_or_id'
+    delete:
+      summary: Remove a consumer from a consumer group
+      operationId: delete-consumers-consumer_name_or_id-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: Removes a consumer from a consumer group. This operation does not delete the consumer group.
+      tags:
+        - consumer_groups
+  /{workspace}/consumer_groups/{group_name_or_id}/consumers/{consumer_username_or_id}:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+    delete:
+      summary: Remove a consumer from a consumer group
+      operationId: delete-consumer_groups-group_name_or_id-consumers-consumer_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: The consumer groups endpoint for removing a consumer from a specified consumer group.
+      tags:
+        - consumer_groups
+  /{workspace}/consumer_groups/{group_name_or_id}/overrides/plugins/rate-limiting-advanced:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    put:
+      summary: Configure rate limiting for a consumer group
+      operationId: put-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    config:
+                      limit:
+                        - 10
+                      retry_after_jitter_max: 0
+                      window_size:
+                        - 10
+                      window_type: sliding
+                    group: test-group
+                    plugin: rate-limiting-advanced
+                properties:
+                  config:
+                    type: object
+                    properties:
+                      limit:
+                        type: array
+                        description: |
+                          An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
+                        items:
+                          type: integer
+                          example: 10
+                      retry_after_jitter_max:
+                        type: integer
+                        description: |
+                          The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.
+                      window_size:
+                        type: array
+                        description: |
+                          An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+                        items:
+                          type: integer
+                          example: 10
+                      window_type:
+                        type: string
+                        description: |
+                          Set the time window type to either sliding (default) or fixed.
+                        example: sliding
+                  group:
+                    type: string
+                    description: The consumer group
+                    example: test-group
+                  plugin:
+                    type: string
+                    description: The name of the plugin
+                    example: rate-limiting-advanced
+              examples:
+                'Example ':
+                  value:
+                    config:
+                      limit:
+                        - 10
+                      retry_after_jitter_max: 0
+                      window_size:
+                        - 10
+                      window_type: sliding
+                    group: test-group
+                    plugin: rate-limiting-advanced
+      description: |
+        Define custom rate limiting settings for a consumer group. This endpoint overrides the settings of the Rate Limiting Advanced plugin.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                config.limit:
+                  type: string
+                  description: |
+                    An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
+                config.window_size:
+                  type: string
+                  description: |
+                    An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+                  example: ' 10'
+                config.window_type:
+                  type: string
+                  description: |
+                    Set the time window type to either sliding (default) or fixed.
+                  default: sliding
+                  enum:
+                    - sliding
+                    - fixed
+                config.retry_after_jitter_max:
+                  type: string
+                  description: The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.
+              required:
+                - config.limit
+                - config.window_size
+            examples:
+              Request body:
+                value:
+                  config.limit: string
+                  config.window_size: ' 10'
+                  config.window_type: sliding
+                  config.retry_after_jitter_max: string
+        description: |
+          Request Body
+      tags:
+        - consumer_groups
+    delete:
+      summary: Delete the configurations for a consumer group
+      tags:
+        - consumer_groups
+      operationId: delete-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace
       responses:
         '204':
           description: |

--- a/api-specs/Gateway-EE/3.4/kong-ee-3.4.json
+++ b/api-specs/Gateway-EE/3.4/kong-ee-3.4.json
@@ -12742,6 +12742,666 @@
         }
       ]
     },
+    "/{workspace}/consumer_groups": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        }
+      ],
+      "get": {
+        "summary": "List consumer groups",
+        "tags": [
+          "consumer_groups"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "operationId": "get-consumer_groups_with_workspace",
+        "description": "List all consumer groups\n\nUse consumer groups to manage consumer affiliation.\n"
+      },
+      "post": {
+        "summary": "Create a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "post-consumer_groups_with_workspace",
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "description": "Create a new consumer group.",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/consumer_group_request"
+        }
+      }
+    },
+    "/{workspace}/consumer_groups/{group_name_or_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        }
+      ],
+      "get": {
+        "summary": "List a specific consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "operationId": "get-consumer_groups-group_name_with_workspace",
+        "description": "Returns a consumer group by passing either the `group_name` or `group_id` as a path parameter."
+      },
+      "put": {
+        "summary": "Create consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "put-consumer_groups-group_name_or_id_with_workspace",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "description": "Create a consumer group by passing a new group name as the path parameter",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/consumer_group_request"
+        }
+      },
+      "delete": {
+        "summary": "Delete a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "delete-consumer_groups-group_name_or_id_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Delete a consumer group. Deleting a consumer group removes all consumers from that group. This operation does not delete existing consuemrs.\n"
+      }
+    },
+    "/{workspace}/consumers/{consumer_username_or_id}/consumer_groups": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/Gatewayapi_Consumer_username_or_id"
+        }
+      ],
+      "get": {
+        "summary": "List consumer groups for a consumer",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_group_response"
+          }
+        },
+        "operationId": "get-consumers-consumer_name_or_id-consumer_groups_with_workspace",
+        "description": "View all consumer groups that a consumer is assigned to.\n",
+        "tags": [
+          "consumer_groups"
+        ]
+      },
+      "post": {
+        "summary": "Add a consumer to a specific consumer group.",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "post-consumers-consumer_username_or_id-consumer_groups_with_workspace",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/add_consumer_to_group_response"
+          }
+        },
+        "description": "Add a consumer to a specific consumer group.\n\nIf you add a consumer to multiple groups:\n\nIf all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.\nOtherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "group": {
+                    "type": "string",
+                    "description": "The name or ID of the group to add the consumer to.\n",
+                    "example": "288f2bfc-04e2-4ec3-b6f3-40408dff5417"
+                  }
+                },
+                "required": [
+                  "group"
+                ]
+              },
+              "examples": {
+                "Example request body": {
+                  "value": {
+                    "group": "288f2bfc-04e2-4ec3-b6f3-40408dff5417"
+                  }
+                }
+              }
+            }
+          },
+          "description": "The request body contains the group ID for the group that you are adding a consumer into."
+        }
+      },
+      "delete": {
+        "summary": "Remove a consumer from all groups",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "delete-consumers-consumer_username_or_id-consumer_groups_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Remove a consumer from all groups."
+      }
+    },
+    "/{workspace}/consumer_groups/{group_name_or_id}/consumers": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        }
+      ],
+      "get": {
+        "summary": "List all consumers in a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "get-consumer_groups-group_name_or_id-consumers_with_workspace",
+        "description": "List all consumers in a consumer group",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Gatewayapi_Pagination-tags-filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/consumer_response"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a consumer to a group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "post-consumer_groups-group_name_or_id-consumers_with_workspace",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/add_consumer_to_group_response"
+          }
+        },
+        "description": "Add a consumer to a specific consumer group.\n\nIf you add a consumer to multiple groups:\n\nIf all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.\nOtherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "consumer": {
+                    "type": "string",
+                    "description": "The name or ID of the consumer to add to this group.\n",
+                    "example": "8a4bba3c-7f82-45f0-8121-ed4d2847c4a4"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove all consumers from a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "delete-consumer_groups-group_name_or_id-consumers_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Removes all consumers from a specified consumer group."
+      }
+    },
+    "/{workspace}/consumers/{consumer_name_or_id}/consumer_groups/{group_name_or_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/consumer_name_or_id"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        }
+      ],
+      "delete": {
+        "summary": "Remove a consumer from a consumer group",
+        "operationId": "delete-consumers-consumer_name_or_id-consumer_groups-group_name_or_id_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Removes a consumer from a consumer group. This operation does not delete the consumer group.",
+        "tags": [
+          "consumer_groups"
+        ]
+      }
+    },
+    "/{workspace}/consumer_groups/{group_name_or_id}/consumers/{consumer_username_or_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        },
+        {
+          "$ref": "#/components/parameters/consumer_username_or_id"
+        }
+      ],
+      "delete": {
+        "summary": "Remove a consumer from a consumer group",
+        "operationId": "delete-consumer_groups-group_name_or_id-consumers-consumer_name_or_id_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "The consumer groups endpoint for removing a consumer from a specified consumer group.",
+        "tags": [
+          "consumer_groups"
+        ]
+      }
+    },
+    "/{workspace}/consumer_groups/{group_name_or_id}/overrides/plugins/rate-limiting-advanced": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/group_name_or_id"
+        }
+      ],
+      "put": {
+        "summary": "Configure rate limiting for a consumer group.",
+        "operationId": "put-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace",
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "x-examples": {
+                    "Example 1": {
+                      "config": {
+                        "limit": [
+                          10
+                        ],
+                        "retry_after_jitter_max": 0,
+                        "window_size": [
+                          10
+                        ],
+                        "window_type": "sliding"
+                      },
+                      "group": "test-group",
+                      "plugin": "rate-limiting-advanced"
+                    }
+                  },
+                  "properties": {
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "limit": {
+                          "type": "array",
+                          "description": "An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified. \n",
+                          "items": {
+                            "type": "integer",
+                            "example": 10
+                          }
+                        },
+                        "retry_after_jitter_max": {
+                          "type": "integer",
+                          "description": "The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.\n"
+                        },
+                        "window_size": {
+                          "type": "array",
+                          "description": "An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.\n",
+                          "items": {
+                            "type": "integer",
+                            "example": 10
+                          }
+                        },
+                        "window_type": {
+                          "type": "string",
+                          "description": "Set the time window type to either sliding (default) or fixed.\n",
+                          "example": "sliding"
+                        }
+                      }
+                    },
+                    "group": {
+                      "type": "string",
+                      "description": "The consumer group",
+                      "example": "test-group"
+                    },
+                    "plugin": {
+                      "type": "string",
+                      "description": "The name of the plugin",
+                      "example": "rate-limiting-advanced"
+                    }
+                  }
+                },
+                "examples": {
+                  "Example ": {
+                    "value": {
+                      "config": {
+                        "limit": [
+                          10
+                        ],
+                        "retry_after_jitter_max": 0,
+                        "window_size": [
+                          10
+                        ],
+                        "window_type": "sliding"
+                      },
+                      "group": "test-group",
+                      "plugin": "rate-limiting-advanced"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Define custom rate limiting settings for a consumer group. This endpoint overrides the settings of the Rate Limiting Advanced plugin. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "config.limit": {
+                    "type": "string",
+                    "description": "An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.\n"
+                  },
+                  "config.window_size": {
+                    "type": "string",
+                    "description": "An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.\n",
+                    "example": " 10"
+                  },
+                  "config.window_type": {
+                    "type": "string",
+                    "description": "Set the time window type to either sliding (default) or fixed.\n",
+                    "default": "sliding",
+                    "enum": [
+                      "sliding",
+                      "fixed"
+                    ]
+                  },
+                  "config.retry_after_jitter_max": {
+                    "type": "string",
+                    "description": "The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header."
+                  }
+                },
+                "required": [
+                  "config.limit",
+                  "config.window_size"
+                ]
+              },
+              "examples": {
+                "Request body": {
+                  "value": {
+                    "config.limit": "string",
+                    "config.window_size": " 10",
+                    "config.window_type": "sliding",
+                    "config.retry_after_jitter_max": "string"
+                  }
+                }
+              }
+            }
+          },
+          "description": "Request Body\n"
+        },
+        "tags": [
+          "consumer_groups"
+        ]
+      },
+      "delete": {
+        "summary": "Delete the configurations for a consumer group",
+        "tags": [
+          "consumer_groups"
+        ],
+        "operationId": "delete-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace",
+        "responses": {
+          "204": {
+            "description": "HTTP/1.1 204 No Content\n"
+          }
+        },
+        "description": "Delete custom rate limiting settings for a consumer group. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.\n"
+      }
+    },
+    "/{workspace}/consumer_groups/{consumer_username_or_id}/plugins": {
+      "get": {
+        "description": "Retrieve a list of all plugins associated with a consumer group.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/pagination-size"
+          },
+          {
+            "$ref": "#/components/parameters/pagination-offset"
+          },
+          {
+            "$ref": "#/components/parameters/pagination-tags-filter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "$ref": "#/components/schemas/Plugin"
+                      },
+                      "type": "array"
+                    },
+                    "offset": {
+                      "$ref": "#/components/schemas/pagination-offset-response"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "A successful response listing plugins"
+          }
+        },
+        "summary": "List all plugins associated with a consumer group",
+        "operationId": "get-plugin-for-consumer-group__with_workspace",
+        "tags": [
+          "Plugins"
+        ]
+      },
+      "post": {
+        "description": "Create a new plugin associated with a Consumer Group",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Plugin"
+                }
+              }
+            },
+            "description": "Successfully created plugin"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Invalid plugin"
+          }
+        },
+        "summary": "Create a new plugin associated with a consumer group",
+        "tags": [
+          "Plugins"
+        ],
+        "operationId": "create-plugin-for-consumer-group_with_workspace",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/plugin-request"
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/consumer_username_or_id"
+        }
+      ]
+    },
+    "/{workspace}/consumer_groups/{consumer_group_name_or_id}/plugins/{plugin_id}": {
+      "delete": {
+        "description": "Delete a plugin associated with a a consumer group using ID.",
+        "responses": {
+          "204": {
+            "description": "Successfully deleted plugin or the resource didn't exist"
+          }
+        },
+        "summary": "Delete a plugin associated with a consumer group",
+        "tags": [
+          "Plugins"
+        ],
+        "operationId": "delete-plugin-for-consumer-group_with_workspace"
+      },
+      "get": {
+        "description": "Get a plugin associated with a Consumer Group using ID.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/plugin-response"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "x-examples": {
+                    "Example 1": {
+                      "message": "Not found"
+                    }
+                  },
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Not Found",
+                      "description": "404 Not Found"
+                    }
+                  }
+                },
+                "examples": {
+                  "Not Found": {
+                    "value": {
+                      "message": "Not Found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Fetch a plugin associated with a Consumer Group",
+        "tags": [
+          "Plugins"
+        ],
+        "operationId": "fetch-plugin-with-consumer-group_with_workspace"
+      },
+      "patch": {
+        "description": "Update a plugin associated with a consumer group using the consumergroup name or ID.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/plugin-response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Invalid plugin"
+          },
+          "404": {
+            "description": "Resource does not exist"
+          }
+        },
+        "summary": "Update a plugin associated with a consumer group",
+        "tags": [
+          "Plugins"
+        ],
+        "operationId": "update-plugin-with-consumer-group_with_workspace",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/plugin-request"
+        }
+      },
+      "put": {
+        "description": "Create or Update a plugin associated with a Consumer Group using ID.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/plugin-response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Invalid plugin"
+          }
+        },
+        "summary": "Upsert a plugin associated with a Consumer Group",
+        "tags": [
+          "Plugins"
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/plugin-request"
+        },
+        "operationId": "upsert-plugin-for-customer-group_with_workspace"
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/workspace"
+        },
+        {
+          "$ref": "#/components/parameters/consumer_group_name_or_id"
+        },
+        {
+          "$ref": "#/components/parameters/plugin_id"
+        }
+      ]
+    },
     "/licenses": {
       "get": {
         "summary": "List licenses",

--- a/api-specs/Gateway-EE/3.4/kong-ee-3.4.yaml
+++ b/api-specs/Gateway-EE/3.4/kong-ee-3.4.yaml
@@ -8755,6 +8755,455 @@ paths:
     parameters:
       - $ref: '#/components/parameters/consumer_group_name_or_id'
       - $ref: '#/components/parameters/plugin_id'
+  /{workspace}/consumer_groups:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+    get:
+      summary: List consumer groups
+      tags:
+        - consumer_groups
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+      operationId: get-consumer_groups_with_workspace
+      description: |
+        List all consumer groups
+
+        Use consumer groups to manage consumer affiliation.
+    post:
+      summary: Create a consumer group
+      tags:
+        - consumer_groups
+      operationId: post-consumer_groups_with_workspace
+      responses:
+        '201':
+          $ref: '#/components/responses/consumer_group_response'
+      description: Create a new consumer group.
+      requestBody:
+        $ref: '#/components/requestBodies/consumer_group_request'
+  /{workspace}/consumer_groups/{group_name_or_id}:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    get:
+      summary: List a specific consumer group
+      tags:
+        - consumer_groups
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+      operationId: get-consumer_groups-group_name_with_workspace
+      description: Returns a consumer group by passing either the `group_name` or `group_id` as a path parameter.
+    put:
+      summary: Create consumer group
+      tags:
+        - consumer_groups
+      operationId: put-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+      description: Create a consumer group by passing a new group name as the path parameter
+      requestBody:
+        $ref: '#/components/requestBodies/consumer_group_request'
+    delete:
+      summary: Delete a consumer group
+      tags:
+        - consumer_groups
+      operationId: delete-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: |
+        Delete a consumer group. Deleting a consumer group removes all consumers from that group. This operation does not delete existing consuemrs.
+  /{workspace}/consumers/{consumer_username_or_id}/consumer_groups:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/Gatewayapi_Consumer_username_or_id'
+    get:
+      summary: List consumer groups for a consumer
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+      operationId: get-consumers-consumer_name_or_id-consumer_groups_with_workspace
+      description: |
+        View all consumer groups that a consumer is assigned to.
+      tags:
+        - consumer_groups
+    post:
+      summary: Add a consumer to a specific consumer group.
+      tags:
+        - consumer_groups
+      operationId: post-consumers-consumer_username_or_id-consumer_groups_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/add_consumer_to_group_response'
+      description: |
+        Add a consumer to a specific consumer group.
+
+        If you add a consumer to multiple groups:
+
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.
+        Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                group:
+                  type: string
+                  description: |
+                    The name or ID of the group to add the consumer to.
+                  example: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+              required:
+                - group
+            examples:
+              Example request body:
+                value:
+                  group: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+        description: The request body contains the group ID for the group that you are adding a consumer into.
+    delete:
+      summary: Remove a consumer from all groups
+      tags:
+        - consumer_groups
+      operationId: delete-consumers-consumer_username_or_id-consumer_groups_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: Remove a consumer from all groups.
+  /{workspace}/consumer_groups/{group_name_or_id}/consumers:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    get:
+      summary: List all consumers in a consumer group
+      tags:
+        - consumer_groups
+      operationId: get-consumer_groups-group_name_or_id-consumers_with_workspace
+      description: List all consumers in a consumer group
+      parameters:
+        - $ref: '#/components/parameters/Gatewayapi_Pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+    post:
+      summary: Add a consumer to a group
+      tags:
+        - consumer_groups
+      operationId: post-consumer_groups-group_name_or_id-consumers_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/add_consumer_to_group_response'
+      description: |-
+        Add a consumer to a specific consumer group.
+
+        If you add a consumer to multiple groups:
+
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group’s settings will apply.
+        Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                consumer:
+                  type: string
+                  description: |
+                    The name or ID of the consumer to add to this group.
+                  example: 8a4bba3c-7f82-45f0-8121-ed4d2847c4a4
+    delete:
+      summary: Remove all consumers from a consumer group
+      tags:
+        - consumer_groups
+      operationId: delete-consumer_groups-group_name_or_id-consumers_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: Removes all consumers from a specified consumer group.
+  /{workspace}/consumers/{consumer_name_or_id}/consumer_groups/{group_name_or_id}:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_name_or_id'
+      - $ref: '#/components/parameters/group_name_or_id'
+    delete:
+      summary: Remove a consumer from a consumer group
+      operationId: delete-consumers-consumer_name_or_id-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: Removes a consumer from a consumer group. This operation does not delete the consumer group.
+      tags:
+        - consumer_groups
+  /{workspace}/consumer_groups/{group_name_or_id}/consumers/{consumer_username_or_id}:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+    delete:
+      summary: Remove a consumer from a consumer group
+      operationId: delete-consumer_groups-group_name_or_id-consumers-consumer_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: The consumer groups endpoint for removing a consumer from a specified consumer group.
+      tags:
+        - consumer_groups
+  /{workspace}/consumer_groups/{group_name_or_id}/overrides/plugins/rate-limiting-advanced:
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    put:
+      summary: Configure rate limiting for a consumer group.
+      operationId: put-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    config:
+                      limit:
+                        - 10
+                      retry_after_jitter_max: 0
+                      window_size:
+                        - 10
+                      window_type: sliding
+                    group: test-group
+                    plugin: rate-limiting-advanced
+                properties:
+                  config:
+                    type: object
+                    properties:
+                      limit:
+                        type: array
+                        description: |
+                          An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified. 
+                        items:
+                          type: integer
+                          example: 10
+                      retry_after_jitter_max:
+                        type: integer
+                        description: |
+                          The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.
+                      window_size:
+                        type: array
+                        description: |
+                          An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+                        items:
+                          type: integer
+                          example: 10
+                      window_type:
+                        type: string
+                        description: |
+                          Set the time window type to either sliding (default) or fixed.
+                        example: sliding
+                  group:
+                    type: string
+                    description: The consumer group
+                    example: test-group
+                  plugin:
+                    type: string
+                    description: The name of the plugin
+                    example: rate-limiting-advanced
+              examples:
+                'Example ':
+                  value:
+                    config:
+                      limit:
+                        - 10
+                      retry_after_jitter_max: 0
+                      window_size:
+                        - 10
+                      window_type: sliding
+                    group: test-group
+                    plugin: rate-limiting-advanced
+      description: |
+        Define custom rate limiting settings for a consumer group. This endpoint overrides the settings of the Rate Limiting Advanced plugin. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                config.limit:
+                  type: string
+                  description: |
+                    An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
+                config.window_size:
+                  type: string
+                  description: |
+                    An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+                  example: ' 10'
+                config.window_type:
+                  type: string
+                  description: |
+                    Set the time window type to either sliding (default) or fixed.
+                  default: sliding
+                  enum:
+                    - sliding
+                    - fixed
+                config.retry_after_jitter_max:
+                  type: string
+                  description: The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.
+              required:
+                - config.limit
+                - config.window_size
+            examples:
+              Request body:
+                value:
+                  config.limit: string
+                  config.window_size: ' 10'
+                  config.window_type: sliding
+                  config.retry_after_jitter_max: string
+        description: |
+          Request Body
+      tags:
+        - consumer_groups
+    delete:
+      summary: Delete the configurations for a consumer group
+      tags:
+        - consumer_groups
+      operationId: delete-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: |
+        Delete custom rate limiting settings for a consumer group. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.
+  /{workspace}/consumer_groups/{consumer_username_or_id}/plugins:
+    get:
+      description: Retrieve a list of all plugins associated with a consumer group.
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Plugin'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing plugins
+      summary: List all plugins associated with a consumer group
+      operationId: get-plugin-for-consumer-group__with_workspace
+      tags:
+        - Plugins
+    post:
+      description: Create a new plugin associated with a Consumer Group
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plugin'
+          description: Successfully created plugin
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+      summary: Create a new plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: create-plugin-for-consumer-group_with_workspace
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+  /{workspace}/consumer_groups/{consumer_group_name_or_id}/plugins/{plugin_id}:
+    delete:
+      description: Delete a plugin associated with a a consumer group using ID.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+      summary: Delete a plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: delete-plugin-for-consumer-group_with_workspace
+    get:
+      description: Get a plugin associated with a Consumer Group using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    message: Not found
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                    description: 404 Not Found
+              examples:
+                Not Found:
+                  value:
+                    message: Not Found
+      summary: Fetch a plugin associated with a Consumer Group
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-consumer-group_with_workspace
+    patch:
+      description: Update a plugin associated with a consumer group using the consumergroup name or ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: update-plugin-with-consumer-group_with_workspace
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    put:
+      description: Create or Update a plugin associated with a Consumer Group using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+      summary: Upsert a plugin associated with a Consumer Group
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-for-customer-group_with_workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_group_name_or_id'
+      - $ref: '#/components/parameters/plugin_id'
   /licenses:
     get:
       summary: List licenses


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->
KM-468
DOCU-4054
