### PR TITLE
chore: upgrade paths for 3.8

### DIFF
--- a/app/_includes/md/gateway/upgrade-paths.md
+++ b/app/_includes/md/gateway/upgrade-paths.md
@@ -177,3 +177,40 @@
 | 3.6.x | DB-less | Yes | Upgrade to 3.7.x. |
 
 {% endif_version %}
+
+{% if_version eq: 3.8.x %}
+| **Current version** | **Topology** | **Direct upgrade possible?** | **Upgrade path** |
+| ------------------- | ------------ | ---------------------------- | ---------------- |
+| 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x,  upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, upgrade to 3.1.x, upgrade to 3.2.x, upgrade to 3.3.x upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x.|
+| 2.8.x | Traditional | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 2.8.x | Hybrid | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 2.8.x | DB-less | No | Upgrade to 3.4.x via [LTS upgrade](/gateway/{{page.release}}/upgrade/lts-upgrade/), upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.0.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x,  upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.0.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.0.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.1.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.1.0.x-3.1.1.2 | Hybrid | No | Upgrade to 3.1.1.3, upgrade to 3.2.x, upgrade to 3.3.x, upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.1.1.3 | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.1.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.2.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.2.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.2.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.3.x | Traditional | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.3.x | Hybrid | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.3.x | DB-less | No | Upgrade to 3.4.x, upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.4.x | Traditional | No | Upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.4.x | Hybrid | No | Upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.4.x | DB-less | No | Upgrade to 3.5.x, upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.5.x | Traditional | No | Upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.5.x | Hybrid | No | Upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.5.x | DB-less | No | Upgrade to 3.6.x, upgrade to 3.7.x, and then upgrade to 3.8.x. |
+| 3.6.x | Traditional | Yes | Upgrade to 3.7.x, then upgrade to 3.8.x. |
+| 3.6.x | Hybrid | Yes | Upgrade to 3.7.x, then upgrade to 3.8.x.|
+| 3.6.x | DB-less | Yes | Upgrade to 3.7.x, then upgrade to 3.8.x. |
+| 3.7.x | Traditional | Yes | Upgrade to 3.8.x. |
+| 3.7.x | Hybrid | Yes | Upgrade to 3.8.x. |
+| 3.7.x | DB-less | Yes | Upgrade to 3.8.x. |
+
+{% endif_version %}


### PR DESCRIPTION
### Description

https://konghq.atlassian.net/browse/DOCU-4031

Will be revisiting these paths following the release to see if this is still needed, for now just updating them regularly.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

