### PR TITLE
Fix: Correct the URL for Nginx proxy_next_upstream property

### DIFF
--- a/app/_src/gateway/how-kong-works/routing-traffic.md
+++ b/app/_src/gateway/how-kong-works/routing-traffic.md
@@ -979,8 +979,8 @@ There are two configurable elements here:
    means an error or timeout occurring while establishing a connection with the
    server, passing a request to it, or reading the response headers.
 
-The second option is based on Nginx's
-[proxy_next_upstream][proxy_next_upstream] directive. This option is not
+The second option is based on Nginx's 
+[proxy_next_upstream](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream) directive. This option is not
 directly configurable through {{site.base_gateway}}, but can be added using a custom Nginx
 configuration. See the [configuration reference][configuration-reference] for
 more details.

--- a/app/_src/gateway/how-kong-works/routing-traffic.md
+++ b/app/_src/gateway/how-kong-works/routing-traffic.md
@@ -980,7 +980,7 @@ There are two configurable elements here:
    server, passing a request to it, or reading the response headers.
 
 The second option is based on Nginx's 
-[proxy_next_upstream](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream) directive. This option is not
+[`proxy_next_upstream`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream) directive. This option is not
 directly configurable through {{site.base_gateway}}, but can be added using a custom Nginx
 configuration. See the [configuration reference][configuration-reference] for
 more details.


### PR DESCRIPTION
### Description

Fixed the URL for proxy_next_upstream to direct to Nginx documentation for that property. 

Fixes issue noted here: https://kongstrong.slack.com/archives/CDSTDSG9J/p1725897019405109

### Testing instructions

N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.