### PR TITLE
Update: Add info about Header Cert Auth size limits

### DIFF
--- a/app/_hub/kong-inc/header-cert-auth/overview/_index.md
+++ b/app/_hub/kong-inc/header-cert-auth/overview/_index.md
@@ -38,7 +38,7 @@ Additionally, the plugin has a [static priority](/konnect/reference/plugins/) co
 ### Header size
 
 Sending certificates in headers may exceed header size limits in some environments. 
-You can tune {{site.base_gateway}} to accept larger headers by configuring the [Nginx header buffer parameter in `kong.conf`](/gateway/latest/reference/configuration/#nginx_http_large_client_header_buffers). 
+You can configure {{site.base_gateway}} to accept larger headers by configuring the [Nginx header buffer parameter in `kong.conf`](/gateway/latest/reference/configuration/#nginx_http_large_client_header_buffers). 
 For example:
 
 ```

--- a/app/_hub/kong-inc/header-cert-auth/overview/_index.md
+++ b/app/_hub/kong-inc/header-cert-auth/overview/_index.md
@@ -35,6 +35,21 @@ The plugin can be configured to only accept certificates from trusted IP address
 
 Additionally, the plugin has a [static priority](/konnect/reference/plugins/) configured so that it runs after all authentication plugins, allowing other auth plugins (e.g. basic-auth) to secure the source first. This ensures that the source is secured by multiple layers of authentication by providing L7 level of security.
 
+### Header size
+
+Sending certificates in headers may exceed header size limits in some environments. 
+You can tune {{site.base_gateway}} to accept larger headers by configuring the [Nginx header buffer parameter in `kong.conf`](/gateway/latest/reference/configuration/#nginx_http_large_client_header_buffers). 
+For example:
+
+```
+nginx_proxy_large_client_header_buffers=8 24k
+```
+
+Or via an environment variable:
+```
+KONG_NGINX_PROXY_LARGE_CLIENT_HEADER_BUFFERS=8 24k
+```
+
 ### Client certificate request
 
 The `send_ca_dn` option is not supported in this plugin. This is used in mutual TLS authentication, where the server sends the list of trusted CAs to the client, and the client then uses this list to select the appropriate certificate to present. In this case since the plugin does not do TLS handshakes and only parses the client certificate from the header, it is not applicable.


### PR DESCRIPTION
### Description

Adding a section on how to increase the header size limit so that certs aren't blocked or truncated.

Info provided on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1725983347871329?thread_ts=1725973425.599459&cid=CDSTDSG9J

### Testing instructions

Preview link: https://deploy-preview-7884--kongdocs.netlify.app/hub/kong-inc/header-cert-auth/unreleased/#header-size

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

