### PR TITLE
Update: Konnect plugin pricing tiers

### DIFF
--- a/app/_assets/javascripts/app.js
+++ b/app/_assets/javascripts/app.js
@@ -561,12 +561,6 @@ jQuery(function () {
     $(".badge.techpartner").append(
       '<div class="tooltip"><span class="tooltiptext">Verified Kong technical partner</span></div>'
     );
-    $(".badge.paid").append(
-      '<div class="tooltip"><span class="tooltiptext">Available with Konnect Paid subscription </span></div>'
-    );
-    $(".badge.premium").append(
-      '<div class="tooltip"><span class="tooltiptext">Available with Konnect Premium subscription - <a target="_blank" href="https://konghq.com/contact-sales">Contact Sales</a></span></div>'
-    );
   }
 });
 

--- a/app/_assets/stylesheets/badges.less
+++ b/app/_assets/stylesheets/badges.less
@@ -16,20 +16,11 @@
     border-radius: 2px;
   }
 
-  &.paid {
-    background: #F2F6FE;
-
-    &::after {
-      content: "KONNECT PAID";
-      color: #0364AC;
-    }
-  }
-
-  &.premium {
+  &.konnect {
     background: @blue-100;
 
     &::after {
-      content: "KONNECT PREMIUM";
+      content: "KONNECT COMPATIBLE";
       background: linear-gradient(90deg, #5052FD 0%, #033796 100%);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;

--- a/app/_hub/kong-inc/acl/_metadata/_index.yml
+++ b/app/_hub/kong-inc/acl/_metadata/_index.yml
@@ -6,7 +6,6 @@ dbless_explanation: |
   Admin API endpoints that POST, PUT, PATCH, or DELETE ACLs do not work in DB-less mode.
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/acme/_metadata/_index.yml
+++ b/app/_hub/kong-inc/acme/_metadata/_index.yml
@@ -5,7 +5,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-azure-content-safety/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-azure-content-safety/_metadata/_index.yml
@@ -11,7 +11,6 @@ search_aliases:
 dbless_compatible: yes
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-prompt-decorator/_metadata/_3.6.x.yml
+++ b/app/_hub/kong-inc/ai-prompt-decorator/_metadata/_3.6.x.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-prompt-decorator/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-prompt-decorator/_metadata/_index.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-prompt-guard/_metadata/_3.6.x.yml
+++ b/app/_hub/kong-inc/ai-prompt-guard/_metadata/_3.6.x.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-prompt-guard/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-prompt-guard/_metadata/_index.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-prompt-template/_metadata/_3.6.x.yml
+++ b/app/_hub/kong-inc/ai-prompt-template/_metadata/_3.6.x.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-prompt-template/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-prompt-template/_metadata/_index.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-proxy/_metadata/_3.6.x.yml
+++ b/app/_hub/kong-inc/ai-proxy/_metadata/_3.6.x.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-proxy/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-proxy/_metadata/_index.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-rate-limiting-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-rate-limiting-advanced/_metadata/_index.yml
@@ -9,7 +9,6 @@ dbless_explanation: |
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 notes: |

--- a/app/_hub/kong-inc/ai-request-transformer/_metadata/_3.6.x.yml
+++ b/app/_hub/kong-inc/ai-request-transformer/_metadata/_3.6.x.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-request-transformer/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-request-transformer/_metadata/_index.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-response-transformer/_metadata/_3.6.x.yml
+++ b/app/_hub/kong-inc/ai-response-transformer/_metadata/_3.6.x.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-response-transformer/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-response-transformer/_metadata/_index.yml
@@ -9,7 +9,6 @@ search_aliases:
 dbless_compatible: yes
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/ai-semantic-cache/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ai-semantic-cache/_metadata/_index.yml
@@ -12,7 +12,6 @@ dbless_compatible: yes
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 categories:

--- a/app/_hub/kong-inc/app-dynamics/_metadata/_index.yml
+++ b/app/_hub/kong-inc/app-dynamics/_metadata/_index.yml
@@ -6,7 +6,6 @@ publisher: Kong Inc.
 desc: Integrate Kong with the AppDynamics APM Platform
 free: false
 enterprise: true
-paid: true
 konnect: true
 cloud_gateways: false
 network_config_opts: traditional, hybrid, konnect hybrid, and db-less

--- a/app/_hub/kong-inc/aws-lambda/_metadata/_index.yml
+++ b/app/_hub/kong-inc/aws-lambda/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: |

--- a/app/_hub/kong-inc/azure-functions/_metadata/_index.yml
+++ b/app/_hub/kong-inc/azure-functions/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/basic-auth/_metadata/_index.yml
+++ b/app/_hub/kong-inc/basic-auth/_metadata/_index.yml
@@ -10,8 +10,6 @@ dbless_explanation: |
 free: true
 enterprise: true
 konnect: true
-paid: true
-premium: true
 network_config_opts: All
 notes: --
 categories:

--- a/app/_hub/kong-inc/bot-detection/_metadata/_index.yml
+++ b/app/_hub/kong-inc/bot-detection/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/canary/_metadata/_index.yml
+++ b/app/_hub/kong-inc/canary/_metadata/_index.yml
@@ -4,7 +4,6 @@ free: false
 plus: false
 enterprise: true
 k8s_examples: false
-premium: true
 konnect: true
 network_config_opts: All
 notes: |

--- a/app/_hub/kong-inc/confluent/_metadata/_index.yml
+++ b/app/_hub/kong-inc/confluent/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/degraphql/_metadata/_index.yml
+++ b/app/_hub/kong-inc/degraphql/_metadata/_index.yml
@@ -4,7 +4,6 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 notes: --

--- a/app/_hub/kong-inc/exit-transformer/_metadata/_index.yml
+++ b/app/_hub/kong-inc/exit-transformer/_metadata/_index.yml
@@ -5,7 +5,6 @@ yaml_examples: false
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/forward-proxy/_metadata/_index.yml
+++ b/app/_hub/kong-inc/forward-proxy/_metadata/_index.yml
@@ -5,7 +5,6 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/_metadata/_index.yml
@@ -7,7 +7,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: | 

--- a/app/_hub/kong-inc/graphql-rate-limiting-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/graphql-rate-limiting-advanced/_metadata/_index.yml
@@ -9,7 +9,6 @@ dbless_explanation: |
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 notes: |

--- a/app/_hub/kong-inc/jq/_metadata/_index.yml
+++ b/app/_hub/kong-inc/jq/_metadata/_index.yml
@@ -5,7 +5,6 @@ examples: false
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/jwe-decrypt/_metadata/_index.yml
+++ b/app/_hub/kong-inc/jwe-decrypt/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/kafka-log/_metadata/_index.yml
+++ b/app/_hub/kong-inc/kafka-log/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/kafka-upstream/_metadata/_index.yml
+++ b/app/_hub/kong-inc/kafka-upstream/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/key-auth/_metadata/_index.yml
+++ b/app/_hub/kong-inc/key-auth/_metadata/_index.yml
@@ -9,7 +9,6 @@ dbless_explanation: |
   Admin API endpoints that do POST, PUT, PATCH, or DELETE on Credentials are not available on DB-less mode.
 free: true
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: |

--- a/app/_hub/kong-inc/ldap-auth-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/ldap-auth-advanced/_metadata/_index.yml
@@ -5,7 +5,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/mocking/_metadata/_index.yml
+++ b/app/_hub/kong-inc/mocking/_metadata/_index.yml
@@ -7,7 +7,6 @@ dbless_explanation: |
 examples: true
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/mtls-auth/_metadata/_index.yml
+++ b/app/_hub/kong-inc/mtls-auth/_metadata/_index.yml
@@ -7,7 +7,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/oas-validation/_metadata/_index.yml
+++ b/app/_hub/kong-inc/oas-validation/_metadata/_index.yml
@@ -8,7 +8,6 @@ dbless_compatible: 'yes'
 konnect_examples: true
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: Self-managed traditional, DB-less, and hybrid
 categories:

--- a/app/_hub/kong-inc/oauth2-introspection/_metadata/_index.yml
+++ b/app/_hub/kong-inc/oauth2-introspection/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/opa/_metadata/_index.yml
+++ b/app/_hub/kong-inc/opa/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/openid-connect/_metadata/_index.yml
+++ b/app/_hub/kong-inc/openid-connect/_metadata/_index.yml
@@ -8,7 +8,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/prometheus/_metadata/_index.yml
+++ b/app/_hub/kong-inc/prometheus/_metadata/_index.yml
@@ -6,7 +6,6 @@ dbless_explanation: |
   emitted in DB-less mode.
 free: true
 enterprise: true
-paid: true
 konnect: true
 cloud_gateways: false
 network_config_opts: traditional, hybrid, konnect hybrid, and db-less

--- a/app/_hub/kong-inc/proxy-cache-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/proxy-cache-advanced/_metadata/_index.yml
@@ -6,7 +6,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/rate-limiting-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/rate-limiting-advanced/_metadata/_index.yml
@@ -12,7 +12,6 @@ dbless_explanation: |
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: |

--- a/app/_hub/kong-inc/request-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/request-transformer-advanced/_metadata/_index.yml
@@ -5,7 +5,6 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/request-validator/_metadata/_index.yml
+++ b/app/_hub/kong-inc/request-validator/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/response-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/response-transformer-advanced/_metadata/_index.yml
@@ -5,7 +5,6 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/route-by-header/_metadata/_index.yml
+++ b/app/_hub/kong-inc/route-by-header/_metadata/_index.yml
@@ -5,7 +5,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/route-transformer-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/route-transformer-advanced/_metadata/_index.yml
@@ -5,7 +5,6 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/saml/_metadata/_index.yml
+++ b/app/_hub/kong-inc/saml/_metadata/_index.yml
@@ -5,7 +5,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/statsd-advanced/_metadata/_index.yml
+++ b/app/_hub/kong-inc/statsd-advanced/_metadata/_index.yml
@@ -2,7 +2,6 @@ name: StatsD Advanced
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/upstream-timeout/_metadata/_index.yml
+++ b/app/_hub/kong-inc/upstream-timeout/_metadata/_index.yml
@@ -5,7 +5,6 @@ dbless_compatible: yes
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/websocket-size-limit/_metadata/_index.yml
+++ b/app/_hub/kong-inc/websocket-size-limit/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/websocket-validator/_metadata/_index.yml
+++ b/app/_hub/kong-inc/websocket-validator/_metadata/_index.yml
@@ -4,7 +4,6 @@ search_aliases:
 dbless_compatible: 'yes'
 free: false
 enterprise: true
-paid: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_hub/kong-inc/xml-threat-protection/_metadata/_index.yml
+++ b/app/_hub/kong-inc/xml-threat-protection/_metadata/_index.yml
@@ -5,7 +5,6 @@ dbless_compatible: 'yes'
 free: false
 plus: false
 enterprise: true
-premium: true
 konnect: true
 network_config_opts: All
 notes: --

--- a/app/_includes/hub_cards.html
+++ b/app/_includes/hub_cards.html
@@ -5,12 +5,6 @@
 {%- if badges.konnect? -%}
   {%- assign css_classes =  css_classes | append: " konnect" -%}
 {%- endif -%}
-{%- if badges.paid? == true -%}
-  {%- assign css_classes = css_classes | append: " paid" -%}
-{%- endif -%}
-{%- if badges.premium? == true -%}
-  {%- assign css_classes = css_classes | append: " premium" -%}
-{%- endif -%}
 {%- if badges.enterprise? -%}
   {%- assign css_classes =  css_classes | append: " enterprise" -%}
 {%- endif -%}
@@ -44,11 +38,8 @@
           <p>{{ extn.name }}</p>
         </div>
         <div class="plugin-card--meta__badges">
-          {% if badges.paid? %}
-              <span class="badge paid"></span>
-          {% endif %}
-          {% if badges.premium? %}
-              <span class="badge premium"></span>
+          {% if badges.konnect? %}
+            <span class="badge konnect"></span>
           {% endif %}
           {% if badges.enterprise? %}
             <span class="badge enterprise"></span>

--- a/app/_includes/plugins/badges.html
+++ b/app/_includes/plugins/badges.html
@@ -1,8 +1,5 @@
-{% if include.badges.paid? %}
-  <a href="https://konghq.com/pricing" target="_blank" class="badge paid" aria-label="available with Konnect Paid subscription"> </a>
-{% endif %}
-{% if include.badges.premium? %}
-  <a href="https://konghq.com/pricing" target="_blank" class="badge premium" aria-label="available with Konnect Premium subscription"> </a>
+{% if include.badges.konnect? %}
+  <a href="https://konghq.com/pricing" target="_blank" class="badge konnect" aria-label="available in Konnect"> </a>
 {% endif %}
 {% if include.badges.enterprise? %}
   <a href="https://konghq.com/pricing" target="_blank" class="badge enterprise" aria-label="available with Kong Gateway Enterprise subscription"> </a>

--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -119,8 +119,7 @@ id: documentation
 
             {% if page.badge %}
               <a href="https://konghq.com/pricing" {%
-                if page.badge == 'paid' %}class="badge paid" aria-label="available with Konnect Paid subscription"{% endif %}{%
-                if page.badge == 'premium' %}class="badge premium" aria-label="available with Konnect Premium subscription"{% endif %}{%
+                if page.badge == 'konnect' %}class="badge konnect" aria-label="available in Konnect"{% endif %}{%
                 if page.badge == 'enterprise' %}class="badge enterprise" aria-label="available with Kong Gateway Enterprise subscription"{% endif %}{%
                 if page.badge == 'free' %}class="badge free" aria-label="available in Kong Gateway free mode"{% endif %}{%
                 if page.badge == 'oss' %}class="badge oss" aria-label="open-source only"{% endif %}>

--- a/app/_layouts/plugins/show.html
+++ b/app/_layouts/plugins/show.html
@@ -17,8 +17,6 @@ type: plugin
                       breadcrumbs=page.breadcrumbs
                       name=page.title
                       img=page.extn_icon
-                      paid=page.paid
-                      premium=page.premium
                       enterprise=page.enterprise
                       free=page.free
                       oss=page.oss

--- a/app/_plugins/drops/plugins/badges.rb
+++ b/app/_plugins/drops/plugins/badges.rb
@@ -19,14 +19,6 @@ module Jekyll
           !!@metadata['free'] && @publisher == KONG_INC
         end
 
-        def paid?
-          !@metadata['free'] && !!@metadata['paid'] && @publisher == KONG_INC
-        end
-
-        def premium?
-          !@metadata['free'] && !@metadata['paid'] && !!@metadata['premium'] && @publisher == KONG_INC
-        end
-
         def enterprise?
           !!@metadata['enterprise'] && !!!@metadata['free']
         end
@@ -38,8 +30,6 @@ module Jekyll
         def hash
           "publisher:#{@publisher}-" \
             "konnect:#{konnect?}-" \
-            "paid:#{paid?}-" \
-            "premium:#{premium?}-" \
             "enterprise:#{enterprise?}-" \
             "techpartner:#{techpartner?}-" \
             "oss:#{oss?}"

--- a/app/contributing/markdown-rules.md
+++ b/app/contributing/markdown-rules.md
@@ -501,8 +501,7 @@ Badge | HTML tag | Markdown tag | Purpose
 ------|----------|--------------|---------
 <span class="badge free"></span> | `<span class="badge free"></span>` | `{:.badge .free}` | {{site.ee_product_name}} - free mode
 <span class="badge enterprise"></span> | `<span class="badge enterprise"></span>` | `{:.badge .enterprise}` | {{site.ee_product_name}} features
-<span class="badge paid"></span> | `<span class="badge paid"></span>` | `{:.badge .paid}` | {{site.konnect_short_name}} paid plugins
-<span class="badge premium"></span> | `<span class="badge premium"></span>` | `{:.badge .premium}` |  {{site.konnect_short_name}} premium plugins
+<span class="badge konnect"></span> | `<span class="badge konnect"></span>` | `{:.badge .konnect}` |  {{site.konnect_short_name}} compatible plugins
 <span class="badge dbless"></span> | `<span class="badge dbless"></span>` | `{:.badge .dbless}` | Used to label API endpoints as DB-less compatible
 <span class="badge beta"></span> | `<span class="badge beta"></span>` | `{:.badge .beta}` | Beta features
 <span class="badge alpha"></span> | `<span class="badge alpha"></span>` | `{:.badge .alpha}` | Alpha/tech preview features

--- a/app/hub/plugins/license-tiers.md
+++ b/app/hub/plugins/license-tiers.md
@@ -1,22 +1,22 @@
 ---
-title: Plugin License Tiers
-header_title: Plugin License Tiers
-type: concept
+title: Kong Gateway Plugin License Tiers
+header_title: Kong Gateway Plugin License Tiers
+type: reference
 layout: plugins/introduction
 ---
 
-Each [subscription tier](https://konghq.com/pricing) gives you
+Each {{site.base_gateway}} [subscription tier](https://konghq.com/pricing) gives you
 access to a subset of plugins.
 
 * **Free tier:** Open-source {{site.base_gateway}} plugins. Available in:
     * {{site.base_gateway}} Free tier (Enterprise package, self-managed)
     * {{site.ce_product_name}} (open-source package, self-managed)
-    * {{site.konnect_short_name}}
 * **Enterprise tier:** All Kong plugins. Available in:
     * {{site.ee_product_name}} (self-managed)
-
 If you're looking for plugin deployment topology compatibility, supported network protocols, and supported entity scopes, see [Plugin Compatibility](/hub/plugins/compatibility/).
 
+{:.note}
+> In {{site.konnect_short_name}}, you have access to all plugins, regardless of your subscription tier &mdash; as long as the plugins are [compatible with {{site.konnect_short_name}}](/hub/?compatibility=konnect).
 
 {% assign hub = site.data.ssg_hub %}
 {% assign kong_extns = hub | where: "extn_publisher", "kong-inc" %}

--- a/app/hub/plugins/license-tiers.md
+++ b/app/hub/plugins/license-tiers.md
@@ -6,84 +6,12 @@ layout: plugins/introduction
 ---
 
 Each [subscription tier](https://konghq.com/pricing) gives you
-access to a subset of plugins:
-
-## {{site.konnect_short_name}}
-
-{{site.konnect_short_name}} allows you to pay only for what you use with flexible pay-as-you-go billing. There are three plugin tiers categorized by pricing models:
-* **Free tier:** A selection of our world-class open-source plugins available in {{site.konnect_short_name}} for free. 
-* **Paid tier:** Plugins developed by Kong that are available for a monthly fee.
-* **Premium tier:** Advanced plugins that are available for a monthly fee.
-
-For more information, review the [billing page](https://konghq.com/pricing). 
-
-If you're looking for plugin deployment topology compatibility, supported network protocols, and supported entity scopes, see [Plugin Compatibility](/hub/plugins/compatibility/).
-
-{% assign hub = site.data.ssg_hub %}
-{% assign kong_extns = hub | where: "extn_publisher", "kong-inc" %}
-{% assign categories = site.extensions.categories %}
-{% assign plugins = site.data.ssg_hub | where: "extn_publisher", "kong-inc" %}
-
-{% for category in categories %}
-<h3 id="{{ category.slug }}">
-  {{ category.name }}
-</h3>
-
-<table>
-  <thead>
-      <th style="text-align: left; width: 10%">Plugin</th>
-      <th style="text-align: center">Free</th>
-      <th style="text-align: center">Paid</th>
-      <th style="text-align: center">Premium</th>
-  </thead>
-  <tbody>
-    {% assign plugins_for_category = kong_extns | where_exp: "plugin", "plugin.categories contains category.slug" %}
-    {% for plugin in plugins_for_category %}
-     {% if plugin.konnect == true %}
-      <tr>
-        <td>
-          <a href="{{plugin.url}}">{{ plugin.name }}</a>
-        </td>
-        <td style="text-align: center">
-          {% if plugin.free == true %}
-            <i class="fa fa-check"></i>
-
-          {% endif %}
-        </td>
-        <td style="text-align: center">
-          {% unless plugin.free %}
-            {% unless plugin.premium %}
-              {% if plugin.paid == true %}
-                <i class="fa fa-check"></i>
-              {% endif %}
-            {% endunless %}
-          {% endunless %}
-        </td>
-        <td style="text-align: center">
-          {% unless plugin.free == true or plugin.paid == true %}
-            {% if plugin.premium == true %}
-              <i class="fa fa-check"></i>
-            {% else %}
-              <i class="fa fa-times"></i>
-            {% endif %}
-          {% endunless %}
-        </td>
-      </tr>
-      {% endif %}
-    {% endfor %}
-  </tbody>
-</table>
-
-{% endfor %}
-
-
-
-## {{site.base_gateway}}
-
+access to a subset of plugins.
 
 * **Free tier:** Open-source {{site.base_gateway}} plugins. Available in:
     * {{site.base_gateway}} Free tier (Enterprise package, self-managed)
     * {{site.ce_product_name}} (open-source package, self-managed)
+    * {{site.konnect_short_name}}
 * **Enterprise tier:** All Kong plugins. Available in:
     * {{site.ee_product_name}} (self-managed)
 

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -37,18 +37,12 @@ To use [Mesh Manager](/konnect/mesh-manager/), you must also use a compatible ve
 | {{site.mesh_product_name}} 2.4.x | <i class="fa fa-check"></i> | 2.4.1
 | {{site.mesh_product_name}} 2.3.x or earlier | <i class="fa fa-times"></i> | -
 
-
 ## Plugin compatibility
 
-There are three tiers of plugins available in {{site.konnect_saas}}:
+Most {{site.base_gateway}} plugins are compatible with {{site.konnect_short_name}}.
+You can find details on specific plugin support at:
+* [Plugin Compatibility](/hub/plugins/compatibility/): supported network protocols and entity scopes
 
-* [**Free tier**](/hub/?tier=free&compatibility=konnect)
-* [**Paid tier**](/hub/?tier=paid&compatibility=konnect)
-* [**Premium tier**](/hub/?tier=premium&compatibility=konnect)
-
-The tiers denote plugin pricing. See the [{{site.konnect_short_name}} pricing page](https://konghq.com/pricing) for more detail. 
-
-If you're looking for supported network protocols and entity scopes, see [Plugin Compatibility](/hub/plugins/compatibility/) on the Plugin Hub.
 
 ### Considerations for Dedicated Cloud Gateways
 
@@ -59,78 +53,4 @@ There are some limitations for plugins with Dedicated Cloud Gateways:
 * Any plugins or functionality that depend on AWS IAM `AssumeRole` need to be configured differently. 
 This includes [Data Plane Resilience](/gateway/latest/kong-enterprise/cp-outage-handling/).
 
-See the following table for details on each plugin.
-
-### Plugin tiers
-
-{% assign hub = site.data.ssg_hub %}
-{% assign kong_extns = hub | where: "extn_publisher", "kong-inc" %}
-{% assign categories = site.extensions.categories %}
-{% assign plugins = site.data.ssg_hub | where: "extn_publisher", "kong-inc" %}
-
-{% for category in categories %}
-<h3 id="{{ category.slug }}">
-  {{ category.name }}
-</h3>
-
-<table>
-  <thead>
-      <th style="text-align: left; width: 10%">Plugin</th>
-      <th style="text-align: center">Free</th>
-      <th style="text-align: center">Paid</th>
-      <th style="text-align: center">Premium</th>
-
-      <th style="text-align: left; width: 35%">Notes</th>
-  </thead>
-  <tbody>
-    {% assign plugins_for_category = kong_extns | where_exp: "plugin", "plugin.categories contains category.slug" %}
-    {% for plugin in plugins_for_category %}
-      <tr>
-        <td>
-          <a href="{{plugin.url}}">{{ plugin.name }}</a>
-        </td>
-        <td style="text-align: center">
-        {% if plugin.konnect == false %}
-         <span></span>
-        {% elsif plugin.free == true %}
-          <i class="fa fa-check"></i>
-        {% endif %}
-        </td>
-        <td style="text-align: center">
-          {% unless plugin.konnect %}
-            <span>Not available in {{site.konnect_short_name}}</span>
-          {% else %}
-            {% unless plugin.free %}
-              {% unless plugin.premium %}
-                {% if plugin.paid == true %}
-                  <i class="fa fa-check"></i>
-                {% endif %}
-              {% endunless %}
-            {% endunless %}
-          {% endunless %}
-        </td>
-        <td style="text-align: center">
-          {% unless plugin.konnect %}
-            <span></span>
-          {% else %}
-            {% unless plugin.free %}
-              {% unless plugin.paid %}
-                {% if plugin.premium == true %}
-                  <i class="fa fa-check"></i>
-                {% endif %}
-              {% endunless %}
-            {% endunless %}
-          {% endunless %}
-        </td>
-    
-        <td>
-          {{ plugin.notes | markdownify }}
-        </td>
-      </tr>
-
-    {% endfor %}
-  </tbody>
-</table>
-
-{% endfor %}
 

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -40,9 +40,7 @@ To use [Mesh Manager](/konnect/mesh-manager/), you must also use a compatible ve
 ## Plugin compatibility
 
 Most {{site.base_gateway}} plugins are compatible with {{site.konnect_short_name}}.
-You can find details on specific plugin support at:
-* [Plugin Compatibility](/hub/plugins/compatibility/): supported network protocols and entity scopes
-
+See the [Kong Plugin Hub](/hub/?compatibility=konnect) for all compatible plugins.
 
 ### Considerations for Dedicated Cloud Gateways
 

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways.md
@@ -46,6 +46,14 @@ Dedicated Cloud Gateways support public and private networking on AWS.
  
 You can set up private networking for Dedicated Cloud Gateways with [AWS Transit Gateways](/konnect/gateway-manager/data-plane-nodes/transit-gateways/).
 
+## Plugin considerations for Dedicated Cloud Gateways
+There are some limitations for plugins with Dedicated Cloud Gateways:
+
+* Any plugins that depend on a local agent will not work with Dedicated Cloud Gateways.
+* Any plugins that depend on the Status API or on Admin API endpoints will not work.
+* Any plugins or functionality that depend on AWS IAM `AssumeRole` need to be configured differently. 
+This includes [Data Plane Resilience](/gateway/latest/kong-enterprise/cp-outage-handling/).
+
 ## More information
 
 * [Networking and Peering information](/konnect/network-resiliency/#how-does-network-peering-work-with-dedicated-cloud-gateway-nodes)

--- a/app/konnect/updates.md
+++ b/app/konnect/updates.md
@@ -12,6 +12,12 @@ services. [Try it today!](https://cloud.konghq.com/quick-start)
 
 ## September 2024
 
+**Plugin pricing updated**
+: Plugins are no longer priced are Free, Plus, and Premium tiers separate from the {{site.konnect_short_name}} subscription.
+There is no more extra fee to use any particular plugin. 
+
+: Plugins now follow the same tier scheme as in self-managed {{site.kong_gateway}}, where you have access to free or Enterprise plugins, depending on your subscription level.
+
 **Cloud Launchers deprecated**
 : Cloud Launchers will be deprecated on November 30th, 2024. From this date onward, you will no longer be able to use pre-populated templates to launch data planes in AWS, Azure, or GCP using Cloud Launchers.
 

--- a/docs/templates/kong-plugin-template/_metadata/_index.yml
+++ b/docs/templates/kong-plugin-template/_metadata/_index.yml
@@ -28,14 +28,6 @@ free: # true OR false
   # (Required) Set true if your plugin is open-source and available in the 
   # free version of Kong Gateway. Set false if not.
 
-paid: # true OR false
-  # (Required) Set true if your plugin is available in the Konnect Paid tier, 
-  # and not available for free.
-
-premium: # true OR false
-# (Required) Set true if your plugin is available in the Konnect Premium tier *only*, 
-# and not available for free or in the Paid tier.
-
 enterprise: # true OR false
   # (Required) Set true if the plugin is *only* available with a 
   # Kong Gateway Enterprise subscription.

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -192,8 +192,6 @@ hub-filters:
       slug: free
     - name: Kong Gateway Enterprise
       slug: enterprise
-    - name: Konnect Enterprise
-      slug: konnect-enterprise
   support:
     - name: Kong
       slug: kong-inc

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -78,13 +78,6 @@ extensions:
     # - name: dev portal extension
     #   slug: dev-mod
 
-
-# Pricing
-pricing:
-  konnect:
-    paid_plugin: $5
-    premium_plugin: $10
-
 exclude:
   - node_modules
   - jekyll-cache
@@ -197,12 +190,10 @@ hub-filters:
   tiers:
     - name: Free
       slug: free
-    - name: Konnect Paid
-      slug: paid
-    - name: Konnect Premium
-      slug: premium
     - name: Kong Gateway Enterprise
       slug: enterprise
+    - name: Konnect Enterprise
+      slug: konnect-enterprise
   support:
     - name: Kong
       slug: kong-inc

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -178,8 +178,6 @@ hub-filters:
       slug: free
     - name: Kong Gateway Enterprise
       slug: enterprise
-    - name: Konnect Enterprise
-      slug: konnect-enterprise
   support:
     - name: Kong
       slug: kong-inc

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -78,12 +78,6 @@ extensions:
     # - name: dev portal extension
     #   slug: dev-mod
 
-# Pricing
-pricing:
-  konnect:
-    paid_plugin: $5
-    premium_plugin: $10
-
 exclude:
   - app/assets
 
@@ -182,12 +176,10 @@ hub-filters:
   tiers:
     - name: Free
       slug: free
-    - name: Konnect Paid
-      slug: paid
-    - name: Konnect Premium
-      slug: premium
     - name: Kong Gateway Enterprise
       slug: enterprise
+    - name: Konnect Enterprise
+      slug: konnect-enterprise
   support:
     - name: Kong
       slug: kong-inc

--- a/spec/app/_plugins/drops/plugins/badges_spec.rb
+++ b/spec/app/_plugins/drops/plugins/badges_spec.rb
@@ -2,12 +2,10 @@ RSpec.describe Jekyll::Drops::Plugins::Badges do
   let(:publisher) { 'kong-inc' }
   let(:free) { false }
   let(:konnect) { true }
-  let(:paid) { true }
   let(:enterprise) { true }
 
   let(:metadata) do
     {
-      'paid' => paid,
       'free' => free,
       'konnect' => konnect,
       'enterprise' => enterprise
@@ -15,37 +13,6 @@ RSpec.describe Jekyll::Drops::Plugins::Badges do
   end
 
   subject { described_class.new(metadata:, publisher:) }
-
-  describe '#paid?' do
-    context 'when the plugin is free' do
-      let(:free) { true }
-
-      it { expect(subject.paid?).to eq(false) }
-    end
-
-    context 'when the plugin is not paid' do
-      let(:free) { false }
-      let(:paid) { false }
-
-      it { expect(subject.paid?).to eq(false) }
-    end
-
-    context 'when the publisher is not `kong-inc`' do
-      let(:free) { false }
-      let(:paid) { true }
-      let(:publisher) { 'third-party' }
-
-      it { expect(subject.paid?).to eq(false) }
-    end
-
-    context 'when the plugin is not free, is paid, and the publisher is `kong-inc`' do
-      let(:free) { false }
-      let(:paid) { true }
-      let(:publisher) { 'kong-inc' }
-
-      it { expect(subject.paid?).to eq(true) }
-    end
-  end
 
   describe '#konnect?' do
     context 'when `konnect` is set to false' do

--- a/spec/app/_plugins/generators/plugin_single_source/plugin/page_data_spec.rb
+++ b/spec/app/_plugins/generators/plugin_single_source/plugin/page_data_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe PluginSingleSource::Plugin::PageData do
           'publisher' => 'Kong Inc.',
           'desc' => 'Verify and sign one or two tokens in a request',
           'enterprise' => true,
-          'paid' => true,
           'kong_version_compatibility' => { 'community_edition' => { 'compatible' => nil }, 'enterprise_edition' => { 'compatible' => true } }
         )
       end
@@ -73,7 +72,6 @@ RSpec.describe PluginSingleSource::Plugin::PageData do
           'publisher' => 'Kong Inc.',
           'desc' => 'Verify and (re-)sign one or two tokens in a request',
           'enterprise' => true,
-          'paid' => true,
           'kong_version_compatibility' => { 'community_edition' => { 'compatible' => nil }, 'enterprise_edition' => { 'compatible' => true } }
         )
       end

--- a/spec/fixtures/app/_hub/_init/my-extension/_index.md
+++ b/spec/fixtures/app/_hub/_init/my-extension/_index.md
@@ -105,19 +105,11 @@ cloud: # (Kong Inc plugins only) Boolean
 
 # SUBSCRIPTION TIERS (KONG INC PLUGINS ONLY)
 # Set the subscription tiers that your plugin is restricted to.
-# If your plugin is free/open-source, set `false` for the enterprise, paid, and premium tiers.
+# If your plugin is free/open-source, set `false` for the enterprise tier.
 
 enterprise: # (Kong Gateway; Kong Inc plugins only) Boolean
   # Specifies if your plugin is an Enterprise-tier plugin in Kong Gateway (on-prem).
   # Set true if only available in Enterprise, or false if available for free.
-
-paid: # (Konnect tier; Kong Inc plugins only) Boolean
-  # Specifies if your plugin is a paid-tier plugin in Konnect.
-  # Set true if the plugin is available in the paid Konnect tier.
-
-premium: # (Konnect tier; Kong Inc plugins only) Boolean
-  # Specifies if your plugin is a premium-tier plugin in Konnect.
-  # Set true if the plugin is available _only_ in the premium Konnect tier.
 
 
 #########################

--- a/spec/fixtures/app/_hub/kong-inc/jwt-signer/_metadata/_2.6.x.yml
+++ b/spec/fixtures/app/_hub/kong-inc/jwt-signer/_metadata/_2.6.x.yml
@@ -11,7 +11,6 @@ description: |
   From \_2.6.x.md: The Kong JWT Signer plugin makes it possible to verify and (re-)sign one or two tokens in a request.
 
 enterprise: true
-paid: true
 kong_version_compatibility:
     community_edition:
       compatible: null

--- a/spec/fixtures/app/_hub/kong-inc/jwt-signer/_metadata/_index.yml
+++ b/spec/fixtures/app/_hub/kong-inc/jwt-signer/_metadata/_index.yml
@@ -5,7 +5,6 @@ categories:
 publisher: Kong Inc.
 desc: Verify and sign one or two tokens in a request
 enterprise: true
-paid: true
 kong_version_compatibility:
   community_edition:
     compatible: null

--- a/spec/templates/plugin_spec.rb
+++ b/spec/templates/plugin_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe 'Plugin page' do
     expect(html).to have_css('.page-header--info-icon')
     expect(html).to have_css('h1#main', text: 'Unbundled Plugin')
     expect(html).not_to have_css('.badge.konnect')
-    expect(html).not_to have_css('.badge.paid')
-    expect(html).not_to have_css('.badge.premium')
     expect(html).to have_css('.badge.enterprise')
     expect(html).not_to have_css('.badge.oss')
   end

--- a/spec/templates/plugin_with_versions_spec.rb
+++ b/spec/templates/plugin_with_versions_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'Plugin page with multiple versions' do
     it 'renders metadata in the header' do
       expect(html).to have_css('.page-header--info-icon')
       expect(html).to have_css('h1#main', text: 'Kong JWT Signer')
-      expect(html).to have_css('.badge.paid')
       expect(html).to have_css('.badge.enterprise')
     end
   end
@@ -34,7 +33,6 @@ RSpec.describe 'Plugin page with multiple versions' do
     it 'renders metadata in the header' do
       expect(html).to have_css('.page-header--info-icon')
       expect(html).to have_css('h1#main', text: 'Kong JWT Signer')
-      expect(html).to have_css('.badge.paid')
       expect(html).to have_css('.badge.enterprise')
     end
 


### PR DESCRIPTION
### Description

Removing all instances of `paid` and `premium` plugin badges and categorization.
Adding a "konnect compatible" badge instead.

https://konghq.atlassian.net/browse/DOCU-4018

### Testing instructions
https://deploy-preview-7896--kongdocs.netlify.app/hub/

To review, check:
* [Plugin hub filters](https://deploy-preview-7896--kongdocs.netlify.app/hub/?compatibility=konnect)
* Badges on plugins - click into plugins as well
* [Konnect compatibility reference page](https://deploy-preview-7896--kongdocs.netlify.app/konnect/compatibility/#plugin-compatibility)
* [Plugin license tiers page](https://deploy-preview-7896--kongdocs.netlify.app/hub/plugins/license-tiers/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

