### PR TITLE
Fix: Traceable overview title

### DIFF
--- a/app/_hub/traceableai/traceableai/overview/_index.md
+++ b/app/_hub/traceableai/traceableai/overview/_index.md
@@ -1,6 +1,5 @@
 ---
 nav_title: Overview
-title: Overview
 ---
 
 Traceable's Kong plugin lets Traceable capture a copy of the API traffic that is flowing through {{site.base_gateway}}.


### PR DESCRIPTION
### Description

Traceable overview page had "Overview" as title instead of "Traceable.io" because of the title element in the frontmatter.