### PR TITLE
Update install tests for deprecated packages and site [skip ci]

### DIFF
--- a/.github/workflows/install-instructions-test.yml
+++ b/.github/workflows/install-instructions-test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [ubuntu, rhel, amazon-linux, debian, centos]
+        distro: [ubuntu, rhel, amazon-linux, debian]
         arch: ["linux/amd64", "linux/arm64"]
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/tools/install-tester/config/jobs.yaml
+++ b/tools/install-tester/config/jobs.yaml
@@ -29,7 +29,7 @@
   distros:
     - amazon-linux
     - ubuntu
-    - rhel:7
+    - rhel:9
     - debian
   arch:
     - linux/amd64
@@ -43,15 +43,11 @@
       - enterprise
   distros:
     - ubuntu
-    - rhel:7
+    - rhel:8
     - amazon-linux
     - debian
-    - centos
   arch:
     - linux/amd64
-  skip:
-    - 2.8.x/centos/oss/package # No OSS package for 2.8
-    - 2.8.x/centos/oss/repository # No OSS package for 2.8
   outputs:
     enterprise: "Kong Enterprise {{ version }}"
     oss: "{{ version }}"

--- a/tools/install-tester/config/setup.yaml
+++ b/tools/install-tester/config/setup.yaml
@@ -14,8 +14,8 @@ debian:
     - useradd tester -m -p password
     - usermod -aG sudo tester
     - "echo 'ALL            ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/tester"
-"rhel:7":
-  image: "registry.access.redhat.com/ubi7/ubi-init:latest"
+"rhel:8":
+  image: "registry.access.redhat.com/ubi8/ubi-init:latest"
   setup:
     - yum install -y curl gpg sudo
     - useradd tester -m -p password
@@ -30,11 +30,5 @@ amazon-linux:
   image: "amazonlinux:2"
   setup:
     - yum install -y curl gpg sudo shadow-utils util-linux
-    - useradd tester -m -p password
-    - "echo 'ALL            ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/tester"
-centos:
-  image: "centos:centos7"
-  setup:
-    - yum install -y curl gpg sudo
     - useradd tester -m -p password
     - "echo 'ALL            ALL = (ALL) NOPASSWD: ALL' > /etc/sudoers.d/tester"

--- a/tools/install-tester/index.js
+++ b/tools/install-tester/index.js
@@ -134,34 +134,8 @@ async function runSingleJob(distro, job, arch, installOption, conditions) {
     );
 
     if (expected !== version) {
-      // Check if the package exists on download.konghq.com
-      // Only supports RHEL at the moment
-      let existsOnOldSite = "❓";
-      const expectedParts = expected.split(" ");
-      const expectedVersion = expectedParts[expectedParts.length - 1];
-      let packageArch = arch.replace("linux/", "");
-
-      let packageName = "kong";
-      if (installOption.package == "enterprise") {
-        packageName = "kong-enterprise-edition";
-      }
-
-      if (distro === "rhel") {
-        // 2.x packages are noarch for enterprise on RHEL
-        if (
-          installOption.package == "enterprise" &&
-          expectedVersion[0] == "2"
-        ) {
-          packageArch = "noarch";
-        }
-        url = `https://download.konghq.com/gateway-${expectedVersion[0]}.x-rhel-7/Packages/k/${packageName}-${expectedVersion}.rhel7.${packageArch}.rpm`;
-
-        const response = await fetch(url, { method: "HEAD" });
-        existsOnOldSite = response.status != 404 ? "✅" : "❌";
-      }
-
       console.log(
-        `❌ ${summary} Expected: ${expected}, Got: ${version}, Exists on download.konghq.com: ${existsOnOldSite}`,
+        `❌ ${summary} Expected: ${expected}, Got: ${version}`,
       );
       process.exitCode = 1;
 


### PR DESCRIPTION
### Description

Updating install tests to remove RHEL 7 and CentOS, as both are now deprecated and not supported.

### Testing instructions

Preview link: install test should pass: https://github.com/Kong/docs.konghq.com/actions/runs/10818418685

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

