### PR TITLE
fix: adjust table widths

### DIFF
--- a/app/hub/plugins/license-tiers.md
+++ b/app/hub/plugins/license-tiers.md
@@ -28,11 +28,11 @@ If you're looking for plugin deployment topology compatibility, supported networ
   {{ category.name }}
 </h3>
 
-<table style="max-width: 700px">
+<table style="max-width:700px;">
   <thead>
-      <th style="text-align: left; width: 10%">Plugin</th>
-      <th style="text-align: center">Free</th>
-      <th style="text-align: center">Enterprise</th>
+      <th style="text-align: left">Plugin</th>
+      <th style="text-align: center; width:20%">Free</th>
+      <th style="text-align: center; width:20%">Enterprise</th>
   </thead>
   <tbody>
     {% assign plugins_for_category = kong_extns | where_exp: "plugin", "plugin.categories contains category.slug" %}

--- a/app/hub/plugins/license-tiers.md
+++ b/app/hub/plugins/license-tiers.md
@@ -28,7 +28,7 @@ If you're looking for plugin deployment topology compatibility, supported networ
   {{ category.name }}
 </h3>
 
-<table>
+<table style="max-width: 700px">
   <thead>
       <th style="text-align: left; width: 10%">Plugin</th>
       <th style="text-align: center">Free</th>


### PR DESCRIPTION
### Description

Adjust table widths on plugins license tiers page.

Follow-up to https://github.com/Kong/docs.konghq.com/pull/7896#issuecomment-2343466920.

### Testing instructions

Preview link: https://deploy-preview-7912--kongdocs.netlify.app/hub/plugins/license-tiers/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

