### PR TITLE
Update: Plugin Hub cards show both EE and OSS when both are supported

### DIFF
--- a/app/_plugins/drops/plugins/badges.rb
+++ b/app/_plugins/drops/plugins/badges.rb
@@ -20,7 +20,7 @@ module Jekyll
         end
 
         def enterprise?
-          !!@metadata['enterprise'] && !!!@metadata['free']
+          !!@metadata['enterprise']
         end
 
         def techpartner?

--- a/spec/app/_plugins/drops/plugins/badges_spec.rb
+++ b/spec/app/_plugins/drops/plugins/badges_spec.rb
@@ -49,13 +49,6 @@ RSpec.describe Jekyll::Drops::Plugins::Badges do
       it { expect(subject.enterprise?).to eq(false) }
     end
 
-    context 'when `free` is set to true' do
-      let(:enterprise) { true }
-      let(:free) { true }
-
-      it { expect(subject.enterprise?).to eq(false) }
-    end
-
     context 'when `enterprise` is true and `free` is false' do
       let(:enterprise) { true }
       let(:free) { false }


### PR DESCRIPTION
### Description

Plugin Hub feature request: show both oss and enterprise badges when a plugin is supported in both.

### Testing instructions

Preview link: https://deploy-preview-7914--kongdocs.netlify.app/hub/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

