### PR TITLE
Enable Terraform examples for all plugins

### DIFF
--- a/app/_plugins/blocks/inline_plugin_example/config.rb
+++ b/app/_plugins/blocks/inline_plugin_example/config.rb
@@ -4,7 +4,7 @@ module Jekyll
   module InlinePluginExample
     class Config
       TARGETS = %i[service route consumer global consumer_group].freeze
-      FORMATS = %i[curl konnect yaml kubernetes].freeze
+      FORMATS = %i[curl konnect yaml kubernetes terraform].freeze
 
       def initialize(config:, page:)
         @config = config

--- a/app/_plugins/drops/plugins/examples/terraform.rb
+++ b/app/_plugins/drops/plugins/examples/terraform.rb
@@ -7,7 +7,7 @@ module Jekyll
         class Terraform < Base
           def render
             output(
-              { 'config' => @example.fetch('config') },
+              { 'config' => @example.fetch('config', {}) },
               1,
               true,
               "\n"
@@ -30,7 +30,7 @@ module Jekyll
             s = ''
             s += "\n" unless is_root
             s += line("#{key} = {", depth, eol)
-            s += output(input, (depth + 1), false, eol)
+            s += output(input, (depth + 1), true, eol)
             s += line('}', depth, eol)
             s
           end

--- a/app/_plugins/drops/plugins/hub_examples.rb
+++ b/app/_plugins/drops/plugins/hub_examples.rb
@@ -2,37 +2,6 @@
 
 # There are also oauth2, acl and mtls-auth but I don't have examples of how to use them yet
 AUTH_PLUGINS = %w[basic-auth hmac-auth jwt key-auth].freeze
-TERRAFORM_ENABLED_PLUGINS = %w[
-  key-auth
-  cors
-  rate-limiting
-  basic-auth
-  rate-limiting-advanced
-  openid-connect
-  jwt
-  prometheus
-  acl
-  request-termination
-  file-log
-  request-transformer
-  correlation-id
-  proxy-cache
-  request-transformer-advanced
-  response-transformer
-  response-transformer-advanced
-  ip-restriction
-  pre-function
-  oauth2
-  opentelemetry
-  ai-proxy
-  ai-prompt-guard
-  ai-prompt-template
-  ai-prompt-decorator
-  aws-lambda
-  jq
-  jwt-signer
-  saml
-].freeze
 
 module Jekyll
   module Drops
@@ -40,7 +9,8 @@ module Jekyll
       class Example < Liquid::Drop
         attr_reader :example, :type
 
-        def initialize(type:, example:, formats:) # rubocop:disable Lint/MissingSuper
+        def initialize(schema:, type:, example:, formats:) # rubocop:disable Lint/MissingSuper
+          @schema = schema
           @type = type
           @example = example
           @formats = formats
@@ -63,11 +33,15 @@ module Jekyll
         end
 
         def render_terraform?
-          terraform_implemented? && @formats.include?(:terraform)
+          kong_plugin? && plugin_config? && @formats.include?(:terraform)
         end
 
-        def terraform_implemented?
-          TERRAFORM_ENABLED_PLUGINS.include?(plugin_name)
+        def kong_plugin?
+          @schema.is_a?(PluginSingleSource::Plugin::Schemas::Kong)
+        end
+
+        def plugin_config?
+          !!@example.fetch('config', nil)
         end
 
         def auth_plugin?
@@ -112,7 +86,7 @@ module Jekyll
       end
 
       class HubExamples < Liquid::Drop
-        attr_reader :example, :formats
+        attr_reader :schema, :example, :formats
 
         def initialize(schema:, example:, targets:, formats:) # rubocop:disable Lint/MissingSuper
           @schema = schema
@@ -152,29 +126,29 @@ module Jekyll
         def consumer
           return unless enable_on_consumer?
 
-          @consumer ||= Example.new(type: 'consumer', example:, formats:)
+          @consumer ||= Example.new(schema:, type: 'consumer', example:, formats:)
         end
 
         def global
-          @global ||= Example.new(type: 'global', example:, formats:)
+          @global ||= Example.new(schema:, type: 'global', example:, formats:)
         end
 
         def route
           return unless enable_on_route?
 
-          @route ||= Example.new(type: 'route', example:, formats:)
+          @route ||= Example.new(schema:, type: 'route', example:, formats:)
         end
 
         def service
           return unless enable_on_service?
 
-          @service ||= Example.new(type: 'service', example:, formats:)
+          @service ||= Example.new(schema:, type: 'service', example:, formats:)
         end
 
         def consumer_group
           return unless enable_on_consumer_group?
 
-          @consumer_group ||= Example.new(type: 'consumer_group', example:, formats:)
+          @consumer_group ||= Example.new(schema:, type: 'consumer_group', example:, formats:)
         end
       end
     end

--- a/spec/app/_plugins/drops/plugins/example_spec.rb
+++ b/spec/app/_plugins/drops/plugins/example_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe Jekyll::Drops::Plugins::Example do
   let(:type) { 'consumer' }
   let(:schema) do
-    PluginSingleSource::Plugin::Schemas::Kong.new(
-      plugin_name: 'opentelemetry',
+    PluginSingleSource::Plugin::Schemas::Base.make_for(
+      name: 'opentelemetry',
       vendor: 'kong-inc',
       version: '3.2.x'
     )
   end
   let(:example) { schema.example }
-  let(:formats) { [:curl, :konnect, :yaml, :kubernetes] }
+  let(:formats) { [:curl, :konnect, :yaml, :kubernetes, :terraform] }
 
 
-  subject { described_class.new(type:, example:, formats:) }
+  subject { described_class.new(schema:, type:, example:, formats:) }
 
   describe '#type' do
     it { expect(subject.type).to eq(type) }
@@ -62,6 +62,36 @@ RSpec.describe Jekyll::Drops::Plugins::Example do
       let(:formats) { [:curl] }
 
       it { expect(subject.render_kubernetes?).to eq(false) }
+    end
+  end
+
+  describe '#render_terraform?' do
+    context 'when :terraform is included in the targets' do
+      it { expect(subject.render_terraform?).to eq(true) }
+    end
+
+    context 'when :terraform is not included in the targets' do
+      let(:formats) { [:curl] }
+
+      it { expect(subject.render_terraform?).to eq(false) }
+    end
+
+    context 'when the vendor is not kong-inc' do
+      let(:schema) do
+        PluginSingleSource::Plugin::Schemas::Base.make_for(
+          name: 'kong-plugin',
+          vendor: 'acme',
+          version: '3.2.x'
+        )
+      end
+
+      it { expect(subject.render_terraform?).to eq(false) }
+    end
+
+    context 'when the sample config is empty' do
+      let(:example) { return {} }
+
+      it { expect(subject.render_terraform?).to eq(false) }
     end
   end
 


### PR DESCRIPTION
### Description

Enabled TF example generation for all plugins.

### Testing instructions

Preview link: [/hub/kong-inc/ai-semantic-prompt-guard/how-to/basic-example/](https://deploy-preview-7915--kongdocs.netlify.app/hub/kong-inc/ai-semantic-prompt-guard/how-to/basic-example/)

### Checklist 

- [x] Review label added <!-- (see below) -->