### PR TITLE
Chore: Adjust badge spacing on hub landing page

### DIFF
--- a/app/_assets/stylesheets/hub-landing-page.less
+++ b/app/_assets/stylesheets/hub-landing-page.less
@@ -456,7 +456,7 @@
         flex-direction: row;
         align-items: flex-start;
         padding: 0px 24px;
-        gap: 16px;
+        gap: 10px;
         flex: none;
         flex-grow: 0;
         flex-wrap: wrap;


### PR DESCRIPTION
### Description

With so many badges on a card (up to 4 potentially, and often 3), the spacing looks awkward now, and doesn't look like the elements belong with each other. Reducing the spacing between badges (especially when on two lines) to have a better association between elements.

Before:

![Screenshot 2024-09-12 at 9 51 42 AM](https://github.com/user-attachments/assets/7bd660f4-bb32-4860-9b29-164191866d8f)
![Screenshot 2024-09-12 at 9 51 17 AM](https://github.com/user-attachments/assets/25116d4a-941b-4bb1-925b-f367a3a6e776)

After:
![Screenshot 2024-09-12 at 9 51 09 AM](https://github.com/user-attachments/assets/e8572af3-bb94-4141-9936-9d86bea657c1)
![Screenshot 2024-09-12 at 9 50 59 AM](https://github.com/user-attachments/assets/d828dad8-0b78-457d-abe5-197d02329a78)


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

