### PR TITLE
Fix: AppD plugin missing info + broken collapsible note

### DIFF
--- a/app/_hub/kong-inc/app-dynamics/overview/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/overview/_index.md
@@ -16,7 +16,12 @@ Before using the plugin, download and install the [AppDynamics C/C++ Application
 
 ### Platform support
 
-The AppDynamics C SDK supports Linux distributions based on glibc 2.5+. MUSL-based distributions like the Alpine distribution, which is popular for container usage, are not supported. {{site.base_gateway}} must be running on a glibc-based distribution like RHEL, CentOS, Debian, or Ubuntu to support this plugin. 
+The AppDynamics C SDK supports Linux distributions based on glibc 2.5+. 
+{{site.base_gateway}} must be running on a glibc-based distribution like RHEL, CentOS, Debian, or Ubuntu to support this plugin.
+
+The AppDynamics C/C++ SDK **does not** support the following:
+* MUSL-based distributions like the Alpine distribution, which is popular for container usage
+* ARM64 architecture
 
 See the [AppDynamics C/C++ SDK Supported Environments](https://docs.appdynamics.com/appd/21.x/21.12/en/application-monitoring/install-app-server-agents/c-c++-sdk/c-c++-sdk-supported-environments) document for more information.
 

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -30,7 +30,7 @@ breadcrumbs:
 
 {% if page.bundled == false or page.bundled == false %}
   <blockquote class="important">
-    <details class="collapsible-note">
+    <details class="custom collapsible-note">
     <summary style="cursor:pointer;"><strong>This plugin is not enabled by default</strong>. Click here for instructions to enable it</summary>
 
     <ul>


### PR DESCRIPTION
### Description

* Documenting the ARM64 limitation for the C/C++ AppD SDK
* Fixing the collapsible note

https://konghq.atlassian.net/browse/DOCU-4061

Collapsible note with broken styling: https://docs.konghq.com/hub/kong-inc/app-dynamics/

![Screenshot 2024-09-12 at 1 35 15 PM](https://github.com/user-attachments/assets/7bb1e367-76eb-4ae8-ba36-fcc54b4954a4)


### Testing instructions

Preview link: https://deploy-preview-7921--kongdocs.netlify.app/hub/kong-inc/app-dynamics/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

