### PR TITLE
chore: disable summit hackathon banner

### DIFF
--- a/app/_assets/entrypoints/application.js
+++ b/app/_assets/entrypoints/application.js
@@ -17,4 +17,4 @@ import "~/javascripts/sidebar.js"
 
 // uncomment the path to promo-banner.js when adding a new promo banner
 // also uncomment the promo banner sections in app/_assets/stylesheets/header.less and /app/_includes/nav-v2.html -->
-import "~/javascripts/promo-banner.js"
+// import "~/javascripts/promo-banner.js"

--- a/app/_assets/stylesheets/header.less
+++ b/app/_assets/stylesheets/header.less
@@ -119,38 +119,38 @@ body {
       }
       // uncomment this section when adding a new promo banner
       // also uncomment the promo banner sections in /app/_includes/nav-v2.html and /app/_assets/entrypoints/application.js
-      header.navbar-v2 {
-        transition: transform 0.2s ease-in-out;
-        will-change: transform;
-        height: 95px;
-      }
+      // header.navbar-v2 {
+      //   transition: transform 0.2s ease-in-out;
+      //   will-change: transform;
+      //   height: 95px;
+      // }
 
-      header.navbar-v2.closed {
-        transition: 0s ease-in-out;
-      }
+      // header.navbar-v2.closed {
+      //   transition: 0s ease-in-out;
+      // }
 
-      header.closed,
-      header.compress {
-        transform: translateY(-35px);
-      }
+      // header.closed,
+      // header.compress {
+      //   transform: translateY(-35px);
+      // }
 
-      header:not(.closed) ~ .landing-page {
-        margin-top: 35px;
+      // header:not(.closed) ~ .landing-page {
+      //   margin-top: 35px;
 
-        .page--header-background {
-          margin-top: 35px;
-        }
-      }
-      header:not(.closed) ~ div.page.v2 {
-        margin-top: 75px;
+      //   .page--header-background {
+      //     margin-top: 35px;
+      //   }
+      // }
+      // header:not(.closed) ~ div.page.v2 {
+      //   margin-top: 75px;
 
-        .page--header-background {
-          margin-top: 35px;
-        }
-      }
-      header:not(.closed) ~ .page-extension-profile, .page-hub {
-        margin-top: 45px;
-      }
+      //   .page--header-background {
+      //     margin-top: 35px;
+      //   }
+      // }
+      // header:not(.closed) ~ .page-extension-profile, .page-hub {
+      //   margin-top: 45px;
+      // }
     }
   }
 }

--- a/app/_includes/nav-v2.html
+++ b/app/_includes/nav-v2.html
@@ -2,11 +2,11 @@
   <a class="skip-main" href="#main">Skip to content</a>
   <!-- uncomment the promo-banner div when adding a new promo banner-->
   <!--also uncomment the promo banner sections in app/assets/stylesheets/header.less and application.js-->
-  <div id="promo-banner">
+  <!-- <div id="promo-banner">
     <div class="container">
       <div class="closebanner"></div> <strong>2024 API Summit Hackathon: Experiment with API Innovation & AI. Submit by Sept 11 &nbsp;&mdash;<a href="https://konghq.com/conferences/kong-summit/hackathon?utm_medium=website&utm_source=docs-konghq-com&utm_campaign=docs-banner">Enter Now &rarr;</a> </strong>
     </div>
-  </div>
+  </div> -->
   <div class="navbar-content">
     <a href="https://konghq.com" class="navbar-brand col col-xl-auto" target="_blank" rel="noopener noreferrer" data-skip-external-links-hook=true>
       <img src="/assets/images/logos/konglogo-dark-theme.svg" alt="Kong Logo" id="kong-logo">


### PR DESCRIPTION
### Description

Removing the Summit Hackathon banner with the call for submissions, as the deadline was yesterday and the hackthon is now over.

### Testing instructions

Preview link: Check that no banner appears at the top of the screen in the preview.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

