### PR TITLE
Fix: broken command examples for running decK with Docker

### DIFF
--- a/app/_src/deck/guides/run-with-docker-1.28.md
+++ b/app/_src/deck/guides/run-with-docker-1.28.md
@@ -5,6 +5,8 @@ content_type: how-to
 
 If you used the `kong/deck` Docker image to install decK, you can use the Docker image to manage decK. 
 
+Adjust `localhost` and the port `8001` in the following examples to the host and port of your own {{site.base_gateway}} instance.
+
 ## Prerequisites
 decK must be installed using a [Docker image](/deck/latest/installation/#docker-image).
 
@@ -14,7 +16,7 @@ Run this command to export the `kong.yaml` file:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://KONG_ADMIN_HOST:KONG_ADMIN_PORT --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml gateway dump
+kong/deck --kong-addr http://localhost:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml gateway dump
 ```
 Where `$(pwd)/kong.yaml` is the path to a `kong.yaml` file.
 
@@ -25,7 +27,7 @@ Run this command to export objects from all the workspaces:
 docker run -i \
 -v $(pwd):/deck \
 --workdir /deck \
-kong/deck --kong-addr http://KONG_ADMIN_HOST:KONG_ADMIN_PORT:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml gateway dump --all-workspaces
+kong/deck --kong-addr http://localhost:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml gateway dump --all-workspaces
 ```
 
 ## Reset the configuration
@@ -34,7 +36,7 @@ Run this command to initialize Kong objects:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://KONG_ADMIN_HOST:KONG_ADMIN_PORT:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN gateway reset
+kong/deck --kong-addr http://localhost:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN gateway reset
 ```
 
 ## Import the configuration
@@ -43,7 +45,7 @@ Run this command to import `kong.yaml`:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://KONG_ADMIN_HOST:KONG_ADMIN_PORT:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN /deck/kong.yaml gateway sync
+kong/deck --kong-addr http://localhost:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN /deck/kong.yaml gateway sync
 ```
 In this example, `kong.yaml` is in `$(pwd)/kong.yaml`.
 

--- a/app/_src/deck/guides/run-with-docker-1.28.md
+++ b/app/_src/deck/guides/run-with-docker-1.28.md
@@ -5,7 +5,7 @@ content_type: how-to
 
 If you used the `kong/deck` Docker image to install decK, you can use the Docker image to manage decK. 
 
-Adjust `localhost` and the port `8001` in the following examples to the host and port of your own {{site.base_gateway}} instance.
+Adjust `KONG_ADMIN_HOST` and the port `8001` in the following examples to the host and port of your own {{site.base_gateway}} instance.
 
 ## Prerequisites
 decK must be installed using a [Docker image](/deck/latest/installation/#docker-image).
@@ -16,7 +16,7 @@ Run this command to export the `kong.yaml` file:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://localhost:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml gateway dump
+kong/deck --kong-addr http://KONG_ADMIN_HOST:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml gateway dump
 ```
 Where `$(pwd)/kong.yaml` is the path to a `kong.yaml` file.
 
@@ -27,7 +27,7 @@ Run this command to export objects from all the workspaces:
 docker run -i \
 -v $(pwd):/deck \
 --workdir /deck \
-kong/deck --kong-addr http://localhost:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml gateway dump --all-workspaces
+kong/deck --kong-addr http://KONG_ADMIN_HOST:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml gateway dump --all-workspaces
 ```
 
 ## Reset the configuration
@@ -36,7 +36,7 @@ Run this command to initialize Kong objects:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://localhost:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN gateway reset
+kong/deck --kong-addr http://KONG_ADMIN_HOST:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN gateway reset
 ```
 
 ## Import the configuration
@@ -45,7 +45,7 @@ Run this command to import `kong.yaml`:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://localhost:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN /deck/kong.yaml gateway sync
+kong/deck --kong-addr http://KONG_ADMIN_HOST:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN gateway sync /deck/kong.yaml
 ```
 In this example, `kong.yaml` is in `$(pwd)/kong.yaml`.
 

--- a/app/_src/deck/guides/run-with-docker.md
+++ b/app/_src/deck/guides/run-with-docker.md
@@ -5,6 +5,8 @@ content_type: how-to
 
 If you used the `kong/deck` Docker image to install decK, you can use the Docker image to manage decK. 
 
+Adjust `KONG_ADMIN_HOST` and the port `8001` in the following examples to the host and port of your own {{site.base_gateway}} instance.
+
 ## Prerequisites
 decK must be installed using a [Docker image](/deck/latest/installation/#docker-image).
 
@@ -14,7 +16,7 @@ Run this command to export the `kong.yaml` file:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://KONG_ADMIN_HOST:KONG_ADMIN_PORT --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml dump
+kong/deck --kong-addr http://KONG_ADMIN_HOST:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -o /deck/kong.yaml dump
 ```
 Where `$(pwd)/kong.yaml` is the path to a `kong.yaml` file.
 
@@ -25,7 +27,7 @@ Run this command to export objects from all the workspaces:
 docker run -i \
 -v $(pwd):/deck \
 --workdir /deck \
-kong/deck --kong-addr http://KONG_ADMIN_HOST:KONG_ADMIN_PORT:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN dump --all-workspaces
+kong/deck --kong-addr http://KONG_ADMIN_HOST:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN dump --all-workspaces
 ```
 
 ## Reset the configuration
@@ -34,7 +36,7 @@ Run this command to initialize Kong objects:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://KONG_ADMIN_HOST:KONG_ADMIN_PORT:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN reset
+kong/deck --kong-addr http://KONG_ADMIN_HOST:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN reset
 ```
 
 ## Import the configuration
@@ -43,7 +45,7 @@ Run this command to import `kong.yaml`:
 ```bash
 docker run -i \
 -v $(pwd):/deck \
-kong/deck --kong-addr http://KONG_ADMIN_HOST:KONG_ADMIN_PORT:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -s /deck/kong.yaml sync
+kong/deck --kong-addr http://KONG_ADMIN_HOST:8001 --headers kong-admin-token:KONG_ADMIN_TOKEN -s /deck/kong.yaml sync
 ```
 In this example, `kong.yaml` is in `$(pwd)/kong.yaml`.
 


### PR DESCRIPTION
### Description

While working on decK docs, ran into this page and found that it had incorrect commands that set the port twice (`KONG_ADMIN_HOST:KONG_ADMIN_PORT:8001`), likely because of a copy/paste error. Tested all of them to make sure this wasn't some strange convention - it does not need the port twice.

Didn't convert to localhost, since this is connecting to Gateway from within the Docker container. If you're running on `localhost`, you need to use `host.docker.internal`, which will cause even more confusion. 

There was also one command that had the filename in the wrong position, fixed that as well.

### Testing instructions

Preview link: https://deploy-preview-7923--kongdocs.netlify.app/deck/latest/guides/run-with-docker/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

