### PR TITLE
Update: 3.8 known issue for JSON threat protection plugin

### DIFF
--- a/app/_hub/kong-inc/json-threat-protection/_changelog.md
+++ b/app/_hub/kong-inc/json-threat-protection/_changelog.md
@@ -3,3 +3,10 @@
 ### {{site.base_gateway}} 3.8.0.0
 
 * Introduced the new **JSON Threat Protection** plugin.
+
+**Known issues**:
+*  In the [JSON Threat Protection plugin](/hub/kong-inc/json-threat-protection/configuration/), the default value of `-1`
+for any of the `max_*` parameters indicates unlimited.
+In some environments (such as ARM64-based environments), the default value is interpreted incorrectly.
+The plugin can erroneously block valid requests if any of the parameters continue with the default values.
+To mitigate this issue, configure the JSON Threat Protection plugin with limits for all of the `max_*` parameters.

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -539,6 +539,14 @@ to be set for the Kafka client.
   * Fixed a memory leak issue where the master nodes cache expanded infinitely upon refresh.
   * Fixed an issue where multiple cluster instances were accidentally flushed.
 
+### Known issues
+
+* In the [JSON Threat Protection plugin](/hub/kong-inc/json-threat-protection/configuration/), the default value of `-1`
+for any of the `max_*` parameters indicates unlimited.
+In some environments (such as ARM64-based environments), the default value is interpreted incorrectly.
+The plugin can erroneously block valid requests if any of the parameters continue with the default values.
+To mitigate this issue, configure the JSON Threat Protection plugin with limits for all of the `max_*` parameters.
+
 ## 3.7.1.2
 **Release Date** 2024/07/09
 


### PR DESCRIPTION
### Description

Document a known issue for the JSON threat protection plugin.

Issue reported in https://konghq.atlassian.net/browse/KAG-5398.

### Testing instructions

Preview link: https://deploy-preview-7924--kongdocs.netlify.app/gateway/changelog/#known-issues

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

