### PR TITLE
chore: Add terraform tab to plugin_examples blocks

### DIFF
--- a/app/_hub/kong-inc/acl/how-to/_consumer-groups.md.md
+++ b/app/_hub/kong-inc/acl/how-to/_consumer-groups.md.md
@@ -99,6 +99,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->
 
@@ -119,5 +120,6 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->

--- a/app/_hub/kong-inc/ai-azure-content-safety/how-to/_index.md
+++ b/app/_hub/kong-inc/ai-azure-content-safety/how-to/_index.md
@@ -93,6 +93,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -199,6 +200,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/ai-proxy-advanced/how-to/_cloud-provider-authentication.md
+++ b/app/_hub/kong-inc/ai-proxy-advanced/how-to/_cloud-provider-authentication.md
@@ -87,6 +87,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -118,6 +119,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -151,6 +153,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -191,5 +194,6 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->

--- a/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_anthropic.md
+++ b/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_anthropic.md
@@ -53,6 +53,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->
 

--- a/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_azure.md
+++ b/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_azure.md
@@ -64,6 +64,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->
 

--- a/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_cohere.md
+++ b/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_cohere.md
@@ -51,6 +51,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->
 

--- a/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_llama2.md
+++ b/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_llama2.md
@@ -99,6 +99,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->
 

--- a/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_mistral.md
+++ b/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_mistral.md
@@ -90,6 +90,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->
 

--- a/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_openai.md
+++ b/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_openai.md
@@ -51,6 +51,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->
 

--- a/app/_hub/kong-inc/ai-proxy/how-to/_cloud-provider-authentication.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/_cloud-provider-authentication.md
@@ -87,6 +87,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -118,6 +119,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -151,6 +153,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -191,5 +194,6 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->

--- a/app/_hub/kong-inc/http-log/how-to/_splunk.md
+++ b/app/_hub/kong-inc/http-log/how-to/_splunk.md
@@ -42,6 +42,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 {% endif_version %}
 

--- a/app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
@@ -98,6 +98,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!-- vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_authorization-code-flow.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_authorization-code-flow.md
@@ -112,6 +112,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_client-credentials.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_client-credentials.md
@@ -81,6 +81,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
@@ -84,6 +84,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_jwt-access-token.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_jwt-access-token.md
@@ -79,6 +79,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -109,6 +110,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_kong-oauth-token.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_kong-oauth-token.md
@@ -117,6 +117,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_password-grant.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_password-grant.md
@@ -79,6 +79,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_refresh-token.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_refresh-token.md
@@ -87,6 +87,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
@@ -75,6 +75,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_user-info.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_user-info.md
@@ -84,6 +84,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authorization/_acl.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authorization/_acl.md
@@ -42,6 +42,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -85,6 +86,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 
@@ -115,6 +117,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authorization/_claims.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authorization/_claims.md
@@ -58,6 +58,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/authorization/_consumer.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authorization/_consumer.md
@@ -64,6 +64,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on -->
 

--- a/app/_hub/kong-inc/openid-connect/how-to/client-authentication/_mtls.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/client-authentication/_mtls.md
@@ -92,6 +92,7 @@ formats:
   - curl
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!-- vale on -->
 

--- a/app/_hub/kong-inc/opentelemetry/how-to/_dynatrace.md
+++ b/app/_hub/kong-inc/opentelemetry/how-to/_dynatrace.md
@@ -45,6 +45,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 <!--vale on-->
 

--- a/app/_hub/kong-inc/opentelemetry/how-to/_getting-started.md
+++ b/app/_hub/kong-inc/opentelemetry/how-to/_getting-started.md
@@ -155,6 +155,7 @@ formats:
   - konnect
   - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
 {% endif_version %}
 <!--vale on-->

--- a/app/_plugins/blocks/plugin_example.rb
+++ b/app/_plugins/blocks/plugin_example.rb
@@ -19,7 +19,9 @@
 # formats:
 #   - curl
 #   - yaml
+#   - konnect
 #   - kubernetes
+#   - terraform
 # {% endplugin_example %}
 
 module Jekyll


### PR DESCRIPTION
### Description

Adding Terraform as an option for any instance of `plugin_examples`.

@mheap are there any situations where this doesn't apply? All of the plugins with these example blocks are available in Konnect.

### Testing instructions

Preview link: Check any of the updated plugins, eg https://deploy-preview-7926--kongdocs.netlify.app/hub/kong-inc/openid-connect/how-to/authentication/authorization-code-flow/.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

