### PR TITLE
fix: Convert to AI Semantic Cache LLM examples to `plugin_example`

### DIFF
--- a/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_mistral.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_mistral.md
@@ -25,10 +25,12 @@ curl -X POST http://localhost:8001/services/ai-semantic-cache/routes \
 ```
 
 1. Set the AI Semantic Cache plugin. This uses Mistral's API Key explicitly, but you can use an environment variable instead if you want.
+
+<!--vale off-->
 {% plugin_example %}
 title: Mistral Example
-plugin: kong-inc/ai_semantic-cache
-name: ai_semantic-cache
+plugin: kong-inc/ai-semantic-cache
+name: ai-semantic-cache
 config:
   embeddings:
     auth:
@@ -51,8 +53,12 @@ targets:
   - route
 formats:
   - curl
+  - konnect
+  - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
+<!--vale on-->
 
 This configures the following:
 * `embeddings.model.name`: The AI model to use for generating embeddings. This example is configured with `mistral-embed` because it's the only option available for Mistral AI.

--- a/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_mistral.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_mistral.md
@@ -25,40 +25,35 @@ curl -X POST http://localhost:8001/services/ai-semantic-cache/routes \
 ```
 
 1. Set the AI Semantic Cache plugin. This uses Mistral's API Key explicitly, but you can use an environment variable instead if you want.
-```sh
-curl -s -X POST http://localhost:8001/routes/mistral-semantic-cache/plugins \
-  --header 'Content-Type: application/json' \
-  --header 'accept: application/json' \
-  --data '{
-    "name": "ai-semantic-cache",
-    "instance_name": "ai-semantic-cache",
-    "config": {
-      "embeddings": {
-        "auth": {
-          "header_name": "Authorization",
-          "header_value": "Bearer MISTRAL_API_KEY"
-        },
-        "model": {
-          "provider": "mistral",
-          "name": "mistral-embed",
-          "options": {
-            "upstream_url": "https://api.mistral.ai/v1/embeddings"
-          }
-        }
-      },
-      "vectordb": {
-        "dimensions": 1024,
-        "distance_metric": "cosine",
-        "strategy": "redis",
-        "threshold": 0.1,
-        "redis": {
-          "host": "redis-stack.redis.svc.cluster.local",
-          "port": 6379
-        }
-      }
-    }
-  }'
-```
+{% plugin_example %}
+title: Mistral Example
+plugin: kong-inc/ai_semantic-cache
+name: ai_semantic-cache
+config:
+  embeddings:
+    auth:
+      header_name: Authorization
+      header_value: Bearer MISTRAL_API_KEY
+  model:
+    provider: mistral
+    name: mistral-embed
+    options:
+      upstream_url: https://api.mistral.ai/v1/embeddings
+  vectordb:
+    dimensions: 1024
+    distance_metric: cosine
+    strategy: redis
+    threshold: 0.1
+    redis:
+      host: redis-stack.redis.svc.cluster.local
+      port: 6379
+targets:
+  - route
+formats:
+  - curl
+  - kubernetes
+{% endplugin_example %}
+
 This configures the following:
 * `embeddings.model.name`: The AI model to use for generating embeddings. This example is configured with `mistral-embed` because it's the only option available for Mistral AI.
 * `vectordb.dimensions`: The dimensionality for the vectors. This configuration uses `1024` since it's the [example Mistral uses in their documentation](https://docs.mistral.ai/capabilities/embeddings/#mistral-embed-api).

--- a/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_mistral.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_mistral.md
@@ -15,16 +15,14 @@ title: Set up AI Semantic Cache with Mistral
   --data "url=http://localhost:32000"
   ```
   Remember that the upstream URL can point anywhere empty, as it won’t be used by the plugin.
+  
+  Then, create a route:
+  ```sh
+  curl -X POST http://localhost:8001/services/ai-semantic-cache/routes \
+    --data "name=mistral-semantic-cache" \
+    --data "paths[]=~/mistral-semantic-cache$"
+  ```
 
-## Steps
-1. Create a route:
-```sh
-curl -X POST http://localhost:8001/services/ai-semantic-cache/routes \
-  --data "name=mistral-semantic-cache" \
-  --data "paths[]=~/mistral-semantic-cache$"
-```
-
-1. Set the AI Semantic Cache plugin. This uses Mistral's API Key explicitly, but you can use an environment variable instead if you want.
 
 <!--vale off-->
 {% plugin_example %}
@@ -61,7 +59,10 @@ formats:
 <!--vale on-->
 
 This configures the following:
-* `embeddings.model.name`: The AI model to use for generating embeddings. This example is configured with `mistral-embed` because it's the only option available for Mistral AI.
+* `embeddings.auth.header_value`: The API key for Mistral. This uses Mistral's API Key explicitly, but you can use an environment variable instead if you want.
+* `model.provider`: The model provider you want to use. In this example, Mistral.
+* `model.name`: The AI model to use for generating embeddings. This example is configured with `mistral-embed` because it's the only option available for Mistral AI.
+* `model.options.upstream_url`: The upstream URL for the LLM provider.
 * `vectordb.dimensions`: The dimensionality for the vectors. This configuration uses `1024` since it's the [example Mistral uses in their documentation](https://docs.mistral.ai/capabilities/embeddings/#mistral-embed-api).
 * `vectordb.distance_metric`: The distance metric to use for vectors. This example uses `cosine`.
 * `vectordb.strategy`: Defines the vector database, in this case, Redis.

--- a/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_mistral.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_mistral.md
@@ -8,7 +8,7 @@ title: Set up AI Semantic Cache with Mistral
 * Mistral's API key
 * [Redis configured as a vector database](https://redis.io/docs/latest/develop/get-started/vector-database/)
 * [Redis configured as a cache](https://redis.io/docs/latest/operate/oss_and_stack/management/config/#configuring-redis-as-a-cache)
-* You need a service to contain the route for the LLM provider. Create a service **first**:
+* A service and a route for the LLM provider. You need a service to contain the route for the LLM provider. Create a service **first**:
   ```sh
   curl -X POST http://localhost:8001/services \
   --data "name=ai-semantic-cache" \
@@ -34,11 +34,11 @@ config:
     auth:
       header_name: Authorization
       header_value: Bearer MISTRAL_API_KEY
-  model:
-    provider: mistral
-    name: mistral-embed
-    options:
-      upstream_url: https://api.mistral.ai/v1/embeddings
+    model:
+      provider: mistral
+      name: mistral-embed
+      options:
+        upstream_url: https://api.mistral.ai/v1/embeddings
   vectordb:
     dimensions: 1024
     distance_metric: cosine

--- a/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_openai.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_openai.md
@@ -25,10 +25,12 @@ curl -X POST http://localhost:8001/services/ai-semantic-cache/routes \
 ```
 
 1. Set the AI Semantic Cache plugin. This uses Mistral's API Key explicitly, but you can use an environment variable instead if you want.
+
+<!--vale off-->
 {% plugin_example %}
 title: OpenAI Example
-plugin: kong-inc/ai_semantic-cache
-name: ai_semantic-cache
+plugin: kong-inc/ai-semantic-cache
+name: ai-semantic-cache
 config:
   embeddings:
     auth:
@@ -51,8 +53,13 @@ targets:
   - route
 formats:
   - curl
+  - konnect
+  - yaml
   - kubernetes
+  - terraform
 {% endplugin_example %}
+<!--vale on-->
+
 This configures the following:
 * `embeddings.model.name`: The AI model to use for generating embeddings. This example is configured with `text-embedding-3-large`, but you can also choose `text-embedding-3-small` for OpenAI.
 * `vectordb.dimensions`: The dimensionality for the vectors. Since this example uses `text-embedding-3-large`, OpenAI uses `3072` as the [default embedding dimension](https://platform.openai.com/docs/guides/embeddings/how-to-get-embeddings).

--- a/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_openai.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_openai.md
@@ -25,40 +25,34 @@ curl -X POST http://localhost:8001/services/ai-semantic-cache/routes \
 ```
 
 1. Set the AI Semantic Cache plugin. This uses Mistral's API Key explicitly, but you can use an environment variable instead if you want.
-```sh
-curl -s -X POST http://localhost:8001/routes/openai-semantic-cache/plugins \
-  --header 'Content-Type: application/json' \
-  --header 'accept: application/json' \
-  --data '{
-    "name": "ai-semantic-cache",
-    "instance_name": "ai-semantic-cache",
-    "config": {
-      "embeddings": {
-        "auth": {
-          "header_name": "Authorization",
-          "header_value": "Bearer OPENAI_API_KEY"
-        },
-        "model": {
-          "provider": "openai",
-          "name": "text-embedding-3-large",
-          "options": {
-            "upstream_url": "https://api.openai.com/v1/embeddings"
-          }
-        }
-      },
-      "vectordb": {
-        "dimensions": 3072,
-        "distance_metric": "cosine",
-        "strategy": "redis",
-        "threshold": 0.1,
-        "redis": {
-          "host": "redis-stack.redis.svc.cluster.local",
-          "port": 6379
-        }
-      }
-    }
-  }'
-```
+{% plugin_example %}
+title: OpenAI Example
+plugin: kong-inc/ai_semantic-cache
+name: ai_semantic-cache
+config:
+  embeddings:
+    auth:
+      header_name: Authorization
+      header_value: Bearer OPENAI_API_KEY
+  model:
+    provider: openai
+    name: text-embedding-3-large
+    options:
+      upstream_url: https://api.openai.com/v1/embeddings
+  vectordb:
+    dimensions: 3072
+    distance_metric: cosine
+    strategy: redis
+    threshold: 0.1
+    redis:
+      host: redis-stack.redis.svc.cluster.local
+      port: 6379
+targets:
+  - route
+formats:
+  - curl
+  - kubernetes
+{% endplugin_example %}
 This configures the following:
 * `embeddings.model.name`: The AI model to use for generating embeddings. This example is configured with `text-embedding-3-large`, but you can also choose `text-embedding-3-small` for OpenAI.
 * `vectordb.dimensions`: The dimensionality for the vectors. Since this example uses `text-embedding-3-large`, OpenAI uses `3072` as the [default embedding dimension](https://platform.openai.com/docs/guides/embeddings/how-to-get-embeddings).

--- a/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_openai.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_openai.md
@@ -8,7 +8,7 @@ title: Set up AI Semantic Cache with OpenAI
 * OpenAI account and subscription
 * [Redis configured as a vector database](https://redis.io/docs/latest/develop/get-started/vector-database/)
 * [Redis configured as a cache](https://redis.io/docs/latest/operate/oss_and_stack/management/config/#configuring-redis-as-a-cache)
-* You need a service to contain the route for the LLM provider. Create a service **first**:
+* A service and a route for the LLM provider. You need a service to contain the route for the LLM provider. Create a service **first**:
   ```sh
   curl -X POST http://localhost:8001/services \
   --data "name=ai-semantic-cache" \
@@ -33,11 +33,11 @@ config:
     auth:
       header_name: Authorization
       header_value: Bearer OPENAI_API_KEY
-  model:
-    provider: openai
-    name: text-embedding-3-large
-    options:
-      upstream_url: https://api.openai.com/v1/embeddings
+    model:
+      provider: openai
+      name: text-embedding-3-large
+      options:
+        upstream_url: https://api.openai.com/v1/embeddings
   vectordb:
     dimensions: 3072
     distance_metric: cosine

--- a/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_openai.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/how-to/llm-provider-integration-guides/_openai.md
@@ -16,15 +16,12 @@ title: Set up AI Semantic Cache with OpenAI
   ```
   Remember that the upstream URL can point anywhere empty, as it won’t be used by the plugin.
 
-## Steps
-1. Create a route:
-```sh
-curl -X POST http://localhost:8001/services/ai-semantic-cache/routes \
+  Then, create a route:
+  ```sh
+  curl -X POST http://localhost:8001/services/ai-semantic-cache/routes \
   --data "name=openai-semantic-cache" \
   --data "paths[]=~/openai-semantic-cache$"
-```
-
-1. Set the AI Semantic Cache plugin. This uses Mistral's API Key explicitly, but you can use an environment variable instead if you want.
+  ```
 
 <!--vale off-->
 {% plugin_example %}
@@ -61,7 +58,10 @@ formats:
 <!--vale on-->
 
 This configures the following:
-* `embeddings.model.name`: The AI model to use for generating embeddings. This example is configured with `text-embedding-3-large`, but you can also choose `text-embedding-3-small` for OpenAI.
+* `embeddings.auth.header_value`: The API key for OpenAI. This uses OpenAI's API Key explicitly, but you can use an environment variable instead if you want.
+* `model.provider`: The model provider you want to use. In this example, OpenAI.
+* `model.name`: The AI model to use for generating embeddings. This example is configured with `text-embedding-3-large`, but you can also choose `text-embedding-3-small` for OpenAI.
+* `model.options.upstream_url`: The upstream URL for the LLM provider.
 * `vectordb.dimensions`: The dimensionality for the vectors. Since this example uses `text-embedding-3-large`, OpenAI uses `3072` as the [default embedding dimension](https://platform.openai.com/docs/guides/embeddings/how-to-get-embeddings).
 * `vectordb.distance_metric`: The distance metric to use for vectors. This example uses `cosine` because [OpenAI recommends it](https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use).
 * `vectordb.strategy`: Defines the vector database, in this case, Redis.
@@ -69,7 +69,8 @@ This configures the following:
 * `vectordb.redis.host`: The host of your vector database.
 * `vectordb.redis.port`: The port to use for your vector database.
 * `config.embeddings.name`: The AI model to use for generating embeddings. This example is configured with `text-embedding-3-large`, but you can also choose `text-embedding-3-small` for OpenAI.
-The `threshold` parameter defines the similarity between for accepting semantic search results.
+
+This uses OpenAI's API Key explicitly, but you can use an environment variable instead if you want.
 
 ## More information
 * *Redis Documentation:* [Vectors](https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/vectors/) - Learn how to use vector fields and perform vector searches in Redis

--- a/app/contributing/kong-plugins.md
+++ b/app/contributing/kong-plugins.md
@@ -92,6 +92,86 @@ If you have any diagrams or screenshots that you want to add to your plugin docu
     > *Figure 1: Diagram showing an OAuth2 authentication flow with Keycloak.*
     ```
 
+## Adding plugin examples
+
+You can use `plugin_example` to easily define and format examples using the plugin. 
+
+Here's an example of how to format `plugin_example` using OpenAI and AI Semantic Cache:
+
+<!-- vale off -->
+{% raw %}
+```
+{% plugin_example %}
+title: OpenAI Example
+plugin: kong-inc/ai-semantic-cache
+name: ai-semantic-cache
+config:
+  embeddings:
+    auth:
+      header_name: Authorization
+      header_value: Bearer OPENAI_API_KEY
+  model:
+    provider: openai
+    name: text-embedding-3-large
+    options:
+      upstream_url: https://api.openai.com/v1/embeddings
+  vectordb:
+    dimensions: 3072
+    distance_metric: cosine
+    strategy: redis
+    threshold: 0.1
+    redis:
+      host: redis-stack.redis.svc.cluster.local
+      port: 6379
+targets:
+  - route
+formats:
+  - curl
+  - konnect
+  - yaml
+  - kubernetes
+  - terraform
+{% endplugin_example %}
+```
+{% endraw %}
+<!-- vale on -->
+
+And here's how that example would render:
+
+<!--vale off-->
+{% plugin_example %}
+title: OpenAI Example
+plugin: kong-inc/ai-semantic-cache
+name: ai-semantic-cache
+config:
+  embeddings:
+    auth:
+      header_name: Authorization
+      header_value: Bearer OPENAI_API_KEY
+  model:
+    provider: openai
+    name: text-embedding-3-large
+    options:
+      upstream_url: https://api.openai.com/v1/embeddings
+  vectordb:
+    dimensions: 3072
+    distance_metric: cosine
+    strategy: redis
+    threshold: 0.1
+    redis:
+      host: redis-stack.redis.svc.cluster.local
+      port: 6379
+targets:
+  - route
+formats:
+  - curl
+  - konnect
+  - yaml
+  - kubernetes
+  - terraform
+{% endplugin_example %}
+<!--vale on-->
+
 ## Test and submit plugin
 
 1. Run the docs site locally per the instructions in

--- a/app/contributing/kong-plugins.md
+++ b/app/contributing/kong-plugins.md
@@ -96,6 +96,22 @@ If you have any diagrams or screenshots that you want to add to your plugin docu
 
 You can use `plugin_example` to easily define and format examples using the plugin. 
 
+The example accepts all plugin config, and you can configure it to output any combination of targets and formats that you need.
+
+Possible targets:
+* `service`
+* `route`
+* `consumer`
+* `consumer_group`
+* `global`
+
+Possible formats:
+* `curl`
+* `konnect`
+* `yaml`
+* `kubernetes`
+* `terrafrom`
+
 Here's an example of how to format `plugin_example` using OpenAI and AI Semantic Cache:
 
 <!-- vale off -->


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Converting the LLM examples to use `plugin_example` instead for better consistency.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-4060
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

