### PR TITLE
Fix: Add missing prerequisite for Rewrite URI annotation

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-annotation.md
+++ b/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-annotation.md
@@ -13,7 +13,7 @@ This definition creates a route that matches the path `/users/(\w+)` and rewrite
 
 ## Prerequisite
 
-The `RewriteURIs` [feature gate](https://docs.konghq.com/kubernetes-ingress-controller/latest/reference/feature-gates/) must be enabled.
+The `RewriteURIs` [feature gate](/kubernetes-ingress-controller/{{page.release}}/reference/feature-gates/) must be enabled.
 
 ##  Rewriting the path
 

--- a/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-annotation.md
+++ b/app/_src/kubernetes-ingress-controller/guides/requests/rewrite-annotation.md
@@ -9,7 +9,13 @@ purpose: |
 
 The annotation can be used on `Ingress` and `HTTPRoute` resources, and configures a [request-transformer](/hub/kong-inc/request-transformer/) plugin within Kong when added to a route.
 
-This definition creates a route that matches the path `/users/(\w+)` and rewrites it to `/requests/users_svc/$1` before sending the request upstream.
+This definition creates a route that matches the path `/users/(\w+)` and rewrites it to `/requests/users_svc/$1` before sending the request upstream. 
+
+## Prerequisite
+
+The `RewriteURIs` [feature gate](https://docs.konghq.com/kubernetes-ingress-controller/latest/reference/feature-gates/) must be enabled.
+
+##  Rewriting the path
 
 {% include /md/kic/http-test-routing-resource.md release=page.release path='/users/(\w+)' name='user' service='users' port='80' skip_host=true route_type='RegularExpression' no_results=true annotation_rewrite="/requests/users_svc/$1" %}
 


### PR DESCRIPTION
### Description

Added prerequisite to call out that the `RewriteURIs` feature gate needs to be enabled for this annotation to work. 

Fixes an issue discovered when troubleshooting support case #00049247.

### Testing instructions

N/A

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.