### PR TITLE
fix: decK latest version

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -278,10 +278,10 @@
   version: "1.38.1"
   edition: "deck"
 - release: "1.39.x"
-  version: "1.39.0"
+  version: "1.39.6"
   edition: "deck"
 - release: "1.40.x"
-  version: "1.40.0"
+  version: "1.40.2"
   edition: "deck"
   latest: true
 - release: "1.41.x"

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -277,13 +277,13 @@
 - release: "1.38.x"
   version: "1.38.1"
   edition: "deck"
-  latest: true
 - release: "1.39.x"
   version: "1.39.0"
   edition: "deck"
 - release: "1.40.x"
   version: "1.40.0"
   edition: "deck"
+  latest: true
 - release: "1.41.x"
   version: "1.41.0"
   edition: "deck"


### PR DESCRIPTION
### Description

decK latest version is set to 1.38 even though 1.40 is already out.

### Testing instructions

Preview link: https://deploy-preview-7944--kongdocs.netlify.app/deck/latest/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

