### PR TITLE
Chore: Add AI Gateway to sidebar dropdown

### DIFF
--- a/app/_includes/docs-sidebar.html
+++ b/app/_includes/docs-sidebar.html
@@ -31,6 +31,9 @@
           <a href="/mesh/latest/" {% if include.edition == 'mesh' %}class="active"{% endif %}>Kong Mesh</a>
         </li>
         <li role="menuitem" tabindex="-1">
+          <a href="/hub/?category=ai">Kong AI Gateway</a>
+        </li>
+        <li role="menuitem" tabindex="-1">
           <a href="/hub/">Plugin Hub</a>
         </li>
         <li role="menuitem" tabindex="-1" {% if include.edition == 'deck' %} class="active"{% endif %}>


### PR DESCRIPTION
### Description

Adding AI Gateway to the docs left sidebar dropdown, and linking to the hub.

Putting it under Mesh to mimic the order on the Kong site.

Request from Marco.

### Testing instructions

Preview link: Check any page with a products dropdown, eg https://deploy-preview-7946--kongdocs.netlify.app/gateway/latest/.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

