### PR TITLE
Update: Adjust decK Konnect flag phrasing to remove ambiguity

### DIFF
--- a/app/_src/deck/guides/konnect.md
+++ b/app/_src/deck/guides/konnect.md
@@ -13,7 +13,7 @@ You _cannot_ use decK to publish content to the Dev Portal, manage application r
 
 ## {{site.konnect_short_name}} flags
 
-You can use decK commands such as `ping`, `diff`, or `sync` with `--konnect` flags to interact with {{site.konnect_short_name}}.
+You can use decK commands such as `ping`, `diff`, or `sync` with `--konnect-*` flags to interact with {{site.konnect_short_name}}.
 
 If you don't pass a {{site.konnect_short_name}} flag to decK, decK looks for a local {{site.base_gateway}} instance instead.
 


### PR DESCRIPTION
### Description

 A user ran into an issue where, based on the doc phrasing, they assumed that `--konnect` is an existing flag for decK.  

 Adjusting the sentence to remove confusion.

Fixes https://github.com/Kong/docs.konghq.com/issues/7950.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

