### PR TITLE
fix(portal): replace GATEWAY_SERVICE_ID with API_PRODUCT_ID [TDX-4644]

### DIFF
--- a/app/konnect/dev-portal/access-and-approval/manage-teams.md
+++ b/app/konnect/dev-portal/access-and-approval/manage-teams.md
@@ -302,8 +302,9 @@ The {{site.konnect_short_name}} API uses [Personal Access Token (PAT)](/konnect/
       --header 'accept: application/json' \
       --data '{
       "role_name": "API Consumer",
-      "entity_id": "GATEWAY_SERVICE_ID",
-      "entity_type_name": "Services"
+      "entity_id": "API_PRODUCT_ID",
+      "entity_type_name": "Services",
+      "entity_region": "us"
       }'
     ```
 
@@ -329,7 +330,7 @@ The {{site.konnect_short_name}} API uses [Personal Access Token (PAT)](/konnect/
       --header 'accept: application/json' \
       --data '{
       "role_name": "API Viewer",
-      "entity_id": "GATEWAY_SERVICE_ID",
+      "entity_id": "API_PRODUCT_ID",
       "entity_type_name": "Services",
       "entity_region": "us"
       }'


### PR DESCRIPTION
### Description

This PR updates the docs for portal RBAC 

- replace `GATEWAY_SERVICE_ID` with `API_PRODUCT_ID` in assigned-roles example
-  add missing `entity_region` in assigned-roles example

### Testing instructions
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/f3a99a26-b5a4-4baa-ab1d-bdd116792de8">

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/7e711090-1ab3-4a11-be84-77d989e8e055">


Preview link: https://deploy-preview-7969--kongdocs.netlify.app/konnect/dev-portal/access-and-approval/manage-teams/#create-developer-teams

### Checklist 

- [x] Review label added <!-- (see below) -->

