### PR TITLE
Fix: update konnect predefined teams

### DIFF
--- a/app/konnect/org-management/teams-and-roles/teams-reference.md
+++ b/app/konnect/org-management/teams-and-roles/teams-reference.md
@@ -17,9 +17,8 @@ Keywords:
 | Organization Admin             | Users can fully manage all entities and configuration in the organization. |
 | Organization Admin (Read Only) | Users can view all entities and configuration in the organization. |
 | Portal Admin                   | Users can fully manage all Dev Portal content, which includes {{site.konnect_short_name}} service pages and supporting content, as well as Dev Portal configuration and service connections. <br> To manage app registration requests, members must also be assigned to the Admin or Maintainer roles for the corresponding services.|
-| Data Plane Node Admin                  | Users can configure data plane nodes for the organization. They can also manage global configuration of the following entities: Gateway services, routes, plugins, upstreams, SNIs, and certificates.
-| API Product Admin                  | Users can create and manage API products, including publishing API product versions to Dev Portal and enabling application registration.|  
-| API Product Developer              | Users can create and manage versions of API products. |
-| Service Admin | Users can view and edit a select list of services, map resources to those services, and manage all resources and discovery rules. | 
+| API Product Admin              | Users can create and manage API products, including publishing API product versions to Dev Portal and enabling application registration.|  
+| API Product Developer          | Users can create and manage versions of API products. |
+| Control Plane Admin            | Users can create and manage control planes. | 
 
 To set up a custom team, see [Manage Teams and Roles](/konnect/org-management/teams-and-roles/).


### PR DESCRIPTION
### Description

The Data Plane Node Admin and Service Admin roles no longer exist.  Looks like that's been the case for at least a year: https://github.com/Kong/kong-api-tests/blob/main/fixtures/kauth/kauth_teams.ts

Removed non-existent roles and added Control Plane Admin. Verified via UI and link above.

Issue reported on Slack.

### Testing instructions

Preview link: https://deploy-preview-7986--kongdocs.netlify.app/konnect/org-management/teams-and-roles/teams-reference/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

