### PR TITLE
Fix: remove link to get.konghq.com repo

### DIFF
--- a/app/_src/gateway/get-started/index.md
+++ b/app/_src/gateway/get-started/index.md
@@ -48,7 +48,8 @@ This script uses Docker to run {{site.base_gateway}} and a [PostgreSQL](https://
    ```
 
    {:.note}
-   > **Note**: The quickstart script runs {{site.ee_product_name}} in Free mode. You may run Kong with a license by passing the license to the script via an environment variable. For instructions on this and other advanced usage, see the [code repository documentation](https://github.com/Kong/get.konghq.com).
+   > **Note**: The quickstart script runs {{site.ee_product_name}} in Free mode. You may run Kong with a license by passing the license to the script via an environment variable.
+   > For instructions on this and other advanced usage, pass the `-h` flag to the script: `curl -Ls https://get.konghq.com/quickstart | bash -- -h`.
 
    This script runs Docker containers for {{site.base_gateway}} and the supporting PostgreSQL database.
    The script also creates a Docker network for those containers to communicate over. Finally, the database is 

--- a/app/_src/gateway/get-started/index.md
+++ b/app/_src/gateway/get-started/index.md
@@ -49,7 +49,11 @@ This script uses Docker to run {{site.base_gateway}} and a [PostgreSQL](https://
 
    {:.note}
    > **Note**: The quickstart script runs {{site.ee_product_name}} in Free mode. You may run Kong with a license by passing the license to the script via an environment variable.
-   > For instructions on this and other advanced usage, pass the `-h` flag to the script: `curl -Ls https://get.konghq.com/quickstart | bash -- -h`.
+   > For instructions on this and other advanced usage, pass the `-h` flag to the script:
+   > 
+   > ```sh
+   > curl -Ls https://get.konghq.com/quickstart | bash -- -h
+   > ```
 
    This script runs Docker containers for {{site.base_gateway}} and the supporting PostgreSQL database.
    The script also creates a Docker network for those containers to communicate over. Finally, the database is 


### PR DESCRIPTION
### Description

The get.konghq.com repo is private, so we shouldn't link to it from docs.
Replaced it with instructions on how to see all options for the script.

Fixes https://github.com/Kong/docs.konghq.com/issues/5539.

### Testing instructions

Preview link: https://deploy-preview-7987--kongdocs.netlify.app/gateway/latest/get-started/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

