### PR TITLE
ACME plugin storage types

### DIFF
--- a/app/_hub/kong-inc/acme/how-to/_index.md
+++ b/app/_hub/kong-inc/acme/how-to/_index.md
@@ -54,7 +54,7 @@ If not, add a route and a dummy service to catch this route.
     ```
 
 This example uses `kong` storage for demo purposes, which stores the certificate in the Kong database.
-`kong` storage is not supported in DB-less mode, use one of the other [storage options](/hub/kong-inc/acme/#storage-options) instead.
+`kong` storage is not supported in DB-less mode or {{site.konnect_short_name}}, use one of the other [storage options](/hub/kong-inc/acme/#storage-options) instead.
 
 Setting `tos_accepted` to *true* implies that you have read and accepted
 [terms of service](https://letsencrypt.org/repository/).

--- a/app/_hub/kong-inc/acme/how-to/_index.md
+++ b/app/_hub/kong-inc/acme/how-to/_index.md
@@ -29,28 +29,32 @@ If not, add a route and a dummy service to catch this route.
 
     ```sh
     curl http://localhost:8001/services \
-      -d name=acme-example \
-      -d url=http://127.0.0.1:65535
+      --data "name=acme-example" \
+      --data "url=http://127.0.0.1:65535"
     ```
 
 2. Add a sample route if needed:
 
-    ```
+    ```bash
     curl http://localhost:8001/routes \
-      -d name=acme-example \
-      -d paths[]=/.well-known/acme-challenge \
-      -d service.name=acme-example
+      --data "name=acme-example" \
+      --data "paths[]=/.well-known/acme-challenge" \
+      --data "service.name=acme-example"
     ```
 
 3. Enable the plugin:
 
     ```sh
     curl http://localhost:8001/plugins \
-      -d name=acme \
-      -d config.account_email=yourname@yourdomain.com \
-      -d config.tos_accepted=true \
-      -d config.domains[]=my.secret.domains.com
+      --data "name=acme" \
+      --data "config.account_email=yourname@yourdomain.com" \
+      --data "config.tos_accepted=true" \
+      --data "config.domains[]=my.secret.domains.com" \
+      --data "config.storage=kong"
     ```
+
+This example uses `kong` storage for demo purposes, which stores the certificate in the Kong database.
+`kong` storage is not supported in DB-less mode, use one of the other [storage options](/hub/kong-inc/acme/#storage-options) instead.
 
 Setting `tos_accepted` to *true* implies that you have read and accepted
 [terms of service](https://letsencrypt.org/repository/).
@@ -68,8 +72,8 @@ Assume Kong proxy is accessible via http://mydomain.com and https://mydomain.com
 
     ```sh
     curl http://localhost:8001/acme \
-    -d host=mydomain.com \
-    -d test_http_challenge_flow=true
+      --data "host=mydomain.com" \
+      --data "test_http_challenge_flow=true"
     ```
 
 1. Trigger certificate creation:

--- a/app/_hub/kong-inc/acme/how-to/_local-testing-development.md
+++ b/app/_hub/kong-inc/acme/how-to/_local-testing-development.md
@@ -3,62 +3,73 @@ nav_title: Local testing and development
 title: Local testing and development
 ---
 
-## Local testing and development
-
-### Run ngrok
+## Run ngrok
 
 [ngrok](https://ngrok.com) exposes a local URL to the internet. [Download ngrok](https://ngrok.com/download) and install.
 
-*`ngrok` is only needed for local testing or development, it's **not** a requirement for the plugin itself.*
+{:.note}
+> `ngrok` is only needed for local testing or development, it's **not** a requirement for the plugin itself.
 
-Run ngrok with:
+Run ngrok:
 
 ```bash
 ./ngrok http localhost:8000
-# Shows something like
-# ...
-# Forwarding                    http://e2e034a5.ngrok.io -> http://localhost:8000
-# Forwarding                    https://e2e034a5.ngrok.io -> http://localhost:8000
-# ...
-# Substitute "e2e034a5.ngrok.io" with the host shows in your ngrok output
-export NGROK_HOST=e2e034a5.ngrok.io
+```
+
+The output includes your generated hostname:
+```bash
+Forwarding    http://example-host-12345.ngrok.io -> http://localhost:8000
+Forwarding    https://example-host-12345.ngrok.io -> http://localhost:8000
+```
+
+Substitute `example-host-12345.ngrok.io` with the host shown in your ngrok output 
+and export the hostname to an environment variable:
+
+```bash
+export NGROK_HOST=example-host-12345.ngrok.io
 ```
 
 Leave the process running.
 
-### Configure and test the plugin
+## Configure the plugin
 
 1. Configure a service:
 
     ```bash
     curl http://localhost:8001/services \
-    -d name=acme-test \
-    -d url=http://httpbin.org
+      --data "name=acme-test" \
+      --data "url=http://httpbin.org"
     ```
 
 1. Configure a route:
-    ```
+    ```bash
     curl http://localhost:8001/routes \
-    -d service.name=acme-test \
-    -d hosts=$NGROK_HOST
+      --data "service.name=acme-test" \
+      --data "hosts=$NGROK_HOST"
     ```
 
 1. Enable the plugin:
 
     ```bash
     curl localhost:8001/plugins \
-    -d name=acme \
-    -d config.account_email=test@test.com \
-    -d config.tos_accepted=true \
-    -d config.domains[]=$NGROK_HOST
+      --data "name=acme" \
+      --data "config.account_email=test@test.com" \
+      --data "config.tos_accepted=true" \
+      --data "config.domains[]=$NGROK_HOST" \
+      --data "config.storage=kong"
     ```
+
+    This example uses `kong` storage for demo purposes, which stores the certificate in the Kong database.
+    `kong` storage is not supported in DB-less mode, use one of the other [storage options](/hub/kong-inc/acme/#storage-options) instead.
+
+## Validate
 
 1. Trigger certificate creation:
 
     ```bash
     curl https://$NGROK_HOST:8443 --resolve $NGROK_HOST:8443:127.0.0.1 -vk
-    # Wait for several seconds
     ```
+    This might take a few seconds.
 
 1. Check the new certificate:
 

--- a/app/_hub/kong-inc/acme/how-to/_local-testing-development.md
+++ b/app/_hub/kong-inc/acme/how-to/_local-testing-development.md
@@ -60,7 +60,7 @@ Leave the process running.
     ```
 
     This example uses `kong` storage for demo purposes, which stores the certificate in the Kong database.
-    `kong` storage is not supported in DB-less mode, use one of the other [storage options](/hub/kong-inc/acme/#storage-options) instead.
+    `kong` storage is not supported in DB-less mode or {{site.konnect_short_name}}, use one of the other [storage options](/hub/kong-inc/acme/#storage-options) instead.
 
 ## Validate
 

--- a/app/_hub/kong-inc/acme/overview/_index.md
+++ b/app/_hub/kong-inc/acme/overview/_index.md
@@ -15,7 +15,7 @@ own certificate.
 
 ## Supported storage types
 
-You can set the backend storage for the plugin using the [`config.storage`](/) parameter.
+You can set the backend storage for the plugin using the [`config.storage`](/hub/kong-inc/acme/configuration/#config-storage) parameter.
 The backend storage available depends on the [topology](/gateway/latest/production/deployment-topologies/) of your {{site.base_gateway}} environment: 
 
 Storage type | Description   | Traditional mode | Hybrid mode | DB-less | {{site.konnect_short_name}}
@@ -45,7 +45,7 @@ response.
 
 ## Workflow
 
-A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME server is described below:
+An `http-01` challenge workflow between the {{site.base_gateway}} and the ACME server is described below:
 
 1. The client sends a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
 2. The {{site.base_gateway}} sends a request to the ACME server to start the validation process.
@@ -69,11 +69,11 @@ A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME se
 8. The Kong control plane propagates the new certificates to the Kong data plane.
 9. The Kong data plane uses the new certificate to serve TLS requests.
 
-All external storage types work as usual in hybrid mode. Note both the control plane and data planes
+All external storage types work as usual in hybrid mode. Both the control plane and data planes
 need to connect to the same external storage cluster. It's also a good idea to set up replicas to avoid
 connecting to same node directly for external storage.
 
-External storage in hybrid mode (`redis`, `consul`, or `vault`) works in following flow:
+External storage in hybrid mode (`redis`, `consul`, or `vault`) works in the following way:
 
 1. The client send a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
 2. The Kong control plane or data plane requests the ACME server to start the validation process.
@@ -88,7 +88,7 @@ External storage in hybrid mode (`redis`, `consul`, or `vault`) works in followi
 
 ## EAB support
 
-External account binding (EAB) is supported as long as `eab_kid` and `eab_hmac_key` are provided.
+External account binding (EAB) is supported as long as the `eab_kid` and `eab_hmac_key` values are provided.
 
 The following CA provider's external account can be registered automatically, without specifying
 the `eab_kid` or `eab_hmac_key`:

--- a/app/_hub/kong-inc/acme/overview/_index.md
+++ b/app/_hub/kong-inc/acme/overview/_index.md
@@ -21,7 +21,7 @@ The backend storage available depends on the [topology](/gateway/latest/producti
 Storage type | Description   | Traditional mode | Hybrid mode | DB-less | {{site.konnect_short_name}}
 -------------|---------------|------------------|-------------|---------|----------------------------
 `shm` | Lua shared dict storage. <br> This storage is volatile between Nginx restarts (not reloads). | ✅ | ❌ | ✅ | ❌
-`kong`| Kong database storage. | ✅ | ✅ <sup>1</sup> | ❌ | ✅ <sup>1</sup>
+`kong`| Kong database storage. | ✅ | ✅ <sup>1</sup> | ❌ | ❌
 `redis` | [Redis-based](https://redis.io/docs/latest/) storage.    | ✅ | ✅ | ✅ | ✅
 `consul` | [HashiCorp Consul](https://www.consul.io/) storage.    | ✅ | ✅ | ✅ | ✅
 `vault` | [HashiCorp Vault](https://www.vaultproject.io/) storage. <br> Only the [KV V2](https://www.vaultproject.io/api/secret/kv/kv-v2.html) backend is supported. | ✅ | ✅ | ✅ | ✅

--- a/app/_hub/kong-inc/acme/overview/_index.md
+++ b/app/_hub/kong-inc/acme/overview/_index.md
@@ -13,6 +13,36 @@ IP and a resolvable DNS. Kong also needs to accept proxy traffic from port `80`.
 > * A wildcard or star (`*`) certificate is not supported. Each domain must have its
 own certificate.
 
+## Supported storage types
+
+You can set the backend storage for the plugin using the [`config.storage`](/) parameter.
+The backend storage available depends on the [topology](/gateway/latest/production/deployment-topologies/) of your {{site.base_gateway}} environment: 
+
+Storage type | Description   | Traditional mode | Hybrid mode | DB-less | {{site.konnect_short_name}}
+-------------|---------------|------------------|-------------|---------|----------------------------
+`shm` | Lua shared dict storage. <br> This storage is volatile between Nginx restarts (not reloads). | ✅ | ❌ | ✅ | ❌
+`kong`| Kong database storage. | ✅ | ✅ <sup>1</sup> | ❌ | ✅ <sup>1</sup>
+`redis` | [Redis-based](https://redis.io/docs/latest/) storage.    | ✅ | ✅ | ✅ | ✅
+`consul` | [HashiCorp Consul](https://www.consul.io/) storage.    | ✅ | ✅ | ✅ | ✅
+`vault` | [HashiCorp Vault](https://www.vaultproject.io/) storage. <br> Only the [KV V2](https://www.vaultproject.io/api/secret/kv/kv-v2.html) backend is supported. | ✅ | ✅ | ✅ | ✅
+
+{:.note .no-icon}
+> **\[1\]**: Due to current the limitations of hybrid mode, `kong` storage only supports certificate generation from
+the Admin API but not the proxy side, as the data planes don't have access to the Kong database. 
+See the [hybrid mode workflow](#hybrid-mode-workflow) for details. 
+
+To configure a storage type other than `kong`, see [lua-resty-acme](https://github.com/fffonion/lua-resty-acme#storage-adapters) for example configurations.
+
+## Running with or without a database
+
+In a database-backed deployment, the plugin creates an SNI and certificate entity in Kong to
+serve the certificate. If the SNI or certificate for the current request is already set
+in the database, it will be overwritten.
+
+In DB-less mode, the plugin takes over certificate handling. If the SNI or
+certificate entity is already defined in Kong, it will be overridden by the
+response.
+
 ## Workflow
 
 A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME server is described below:
@@ -27,49 +57,34 @@ A `http-01` challenge workflow between the {{site.base_gateway}} and the ACME se
 
 ### Hybrid mode workflow
 
-`"shm"` storage type is not available in Hybrid Mode.
-
-Due to current the limitations of Hybrid Mode, `"kong"` storage only supports certificate generation from
-the Admin API but not the proxy side.
-
-`"kong"` storage in Hybrid Mode works in following flow:
+`kong` storage in hybrid mode works in following flow:
 
 1. The client sends an Admin API request that triggers certificate generation for `mydomain.com`.
-2. The Kong Control Plane requests the ACME server to start the validation process.
-3. The ACME server returns a challenge response detail to the Kong Control Plane.
-4. The Kong Control Plane propagates the challenge response detail to the Kong Data Plane.
-5. `mydomain.com` is publicly resolvable to the Kong Data Plane that serves the challenge response.
+2. The Kong control plane requests the ACME server to start the validation process.
+3. The ACME server returns a challenge response detail to the Kong control plane.
+4. The Kong control plane propagates the challenge response detail to the Kong data plane.
+5. `mydomain.com` is publicly resolvable to the Kong data plane that serves the challenge response.
 6. The ACME server checks if the previous challenge has a response at `mydomain.com`.
-7. The Kong Control Plane checks the challenge status and if passed, downloads the certificate from the ACME server.
-8. The Kong Control Plane propagates the new certificates to the Kong Data Plane.
-9. The Kong Data Plane uses the new certificate to serve TLS requests.
+7. The Kong control plane checks the challenge status and if passed, downloads the certificate from the ACME server.
+8. The Kong control plane propagates the new certificates to the Kong data plane.
+9. The Kong data plane uses the new certificate to serve TLS requests.
 
-All external storage types work as usual in Hybrid Mode. Note both the Control Plane and Data Planes
-need to connect to the same external storage cluster. It's also a good idea to setup replicas to avoid
+All external storage types work as usual in hybrid mode. Note both the control plane and data planes
+need to connect to the same external storage cluster. It's also a good idea to set up replicas to avoid
 connecting to same node directly for external storage.
 
-External storage in Hybrid Mode works in following flow:
+External storage in hybrid mode (`redis`, `consul`, or `vault`) works in following flow:
 
 1. The client send a proxy or Admin API request that triggers certificate generation for `mydomain.com`.
-2. The Kong Control Plane or Data Plane requests the ACME server to start the validation process.
+2. The Kong control plane or data plane requests the ACME server to start the validation process.
 3. The ACME server returns a challenge response detail to the {{site.base_gateway}}.
-4. The Kong Control Plane or Data Plane stores the challenge response detail in external storage.
-5. `mydomain.com` is publicly resolvable to the Kong Data Plane that reads and serves the challenge response from external storage.
+4. The Kong control plane or data plane stores the challenge response detail in external storage.
+5. `mydomain.com` is publicly resolvable to the Kong data plane that reads and serves the challenge response from external storage.
 6. The ACME server checks if the previous challenge has a response at `mydomain.com`.
-7. The Kong Control Plane or Data Plane checks the challenge status and if passed, downloads the certificate from the ACME server.
-8. The Kong Control Plane or Data Plane stores the new certificates in external storage.
-9. The Kong Data Plane reads from external storage and uses the new certificate to serve TLS requests.
+7. The Kong control plane or data plane checks the challenge status and if passed, downloads the certificate from the ACME server.
+8. The Kong control plane or data plane stores the new certificates in external storage.
+9. The Kong data plane reads from external storage and uses the new certificate to serve TLS requests.
 
-
-## Running with or without a database
-
-In database mode, the plugin creates an SNI and Certificate entity in Kong to
-serve the certificate. If SNI or Certificate for the current request is already set
-in the database, they will be overwritten.
-
-In DB-less mode, the plugin takes over certificate handling. If the SNI or
-Certificate entity is already defined in Kong, they will be overridden by the
-response.
 
 ## EAB support
 
@@ -125,7 +140,6 @@ the `eab_kid` or `eab_hmac_key`:
     }
 ```
 
-To configure a storage type other than `kong`, refer to [lua-resty-acme](https://github.com/fffonion/lua-resty-acme#storage-adapters).
 
 ## Get started with the ACME plugin
 


### PR DESCRIPTION
### Description

* Added a table comparing the types of storage, what they are (info from [lua-resty-acme](https://github.com/fffonion/lua-resty-acme#storage-adapters)), and where they're available
* Minor adjustments to the ACME overview page for better flow with the table
* Tested the local storage guide and fixed it up to make it work + made the curl formatting consistent

Fixes https://github.com/Kong/docs.konghq.com/issues/7966 and https://konghq.atlassian.net/browse/DOCU-2910.

### Testing instructions

Preview link: 
https://deploy-preview-7996--kongdocs.netlify.app/hub/kong-inc/acme/
https://deploy-preview-7996--kongdocs.netlify.app/hub/kong-inc/acme/how-to/local-testing-development/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

