### PR TITLE
fix: Replace old KIC images with mermaid diagrams

### DIFF
--- a/app/_src/kubernetes-ingress-controller/concepts/architecture.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/architecture.md
@@ -16,13 +16,20 @@ The figure illustrates how {{site.kic_product_name}} works:
 
 <!--vale off-->
 {% mermaid %}
-flowchart TD
+flowchart LR
     subgraph Kubernetes cluster
         direction LR
         A(<img src="/assets/images/icons/third-party/kubernetes-logo.png" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/> API server) --> |events| B(<img src="/assets/images/logos/konglogo-gradient-secondary.svg" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/>Controller)
         B --> |configuration| C(<img src="/assets/images/logos/konglogo-gradient-secondary.svg" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/>Kong)
         C --> D(services)
     end
+
+    E(Request traffic)
+    E --> C
+
+    %% Change the arrow colors
+    linkStyle 0,1 stroke:#d44324,color:#d44324  
+    linkStyle 2,3 stroke:#b6d7a8
 {% endmermaid %}
 <!--vale on-->
 
@@ -73,6 +80,7 @@ This image describes the relationship between Kubernetes concepts and Kong's Ing
 <!--vale off-->
 {% mermaid %}
 flowchart LR
+    H(Request traffic)
     subgraph Pods
         direction LR
         E(Target)
@@ -80,7 +88,7 @@ flowchart LR
         G(Target)
     end
 
-    subgraph Kubernetes service
+    subgraph Kubernetes Service
         direction TB
         C(Service)
         D(Upstream)
@@ -98,6 +106,7 @@ flowchart LR
     D --> E
     D --> F
     D --> G
+    H --> A
 
     classDef lightBlue fill:#cce7ff;
     classDef lightGreen fill:#c4e1c4;
@@ -108,6 +117,8 @@ flowchart LR
     class C lightBlue;
     class D lightPurple;
     class E,F,G lightGrey;
+
+    linkStyle 6 stroke:#b6d7a8
 {% endmermaid %}
 <!--vale on-->
 

--- a/app/_src/kubernetes-ingress-controller/concepts/architecture.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/architecture.md
@@ -19,8 +19,8 @@ The figure illustrates how {{site.kic_product_name}} works:
 flowchart TD
     subgraph Kubernetes cluster
         direction LR
-        A(<div style="text-align:center;"><img src="/assets/images/icons/third-party/kubernetes-logo.png" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/> API server) --> |events| B(<div style="text-align:center;"><img src="/assets/images/logos/konglogo-gradient-secondary.svg" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/>Controller)
-        B --> |configuration| C(<div style="text-align:center;"><img src="/assets/images/logos/konglogo-gradient-secondary.svg" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/>Kong)
+        A(<img src="/assets/images/icons/third-party/kubernetes-logo.png" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/> API server) --> |events| B(<img src="/assets/images/logos/konglogo-gradient-secondary.svg" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/>Controller)
+        B --> |configuration| C(<img src="/assets/images/logos/konglogo-gradient-secondary.svg" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/>Kong)
         C --> D(services)
     end
 {% endmermaid %}

--- a/app/_src/kubernetes-ingress-controller/concepts/architecture.md
+++ b/app/_src/kubernetes-ingress-controller/concepts/architecture.md
@@ -14,7 +14,17 @@ The {{site.kic_product_name}} configures {{site.base_gateway}} using Ingress or 
 
 The figure illustrates how {{site.kic_product_name}} works:
 
-![high-level-design](/assets/images/products/kubernetes-ingress-controller/high-level-design.png "High Level Design")
+<!--vale off-->
+{% mermaid %}
+flowchart TD
+    subgraph Kubernetes cluster
+        direction LR
+        A(<div style="text-align:center;"><img src="/assets/images/icons/third-party/kubernetes-logo.png" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/> API server) --> |events| B(<div style="text-align:center;"><img src="/assets/images/logos/konglogo-gradient-secondary.svg" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/>Controller)
+        B --> |configuration| C(<div style="text-align:center;"><img src="/assets/images/logos/konglogo-gradient-secondary.svg" style="max-width:25px; display:block; margin:0 auto;" class="no-image-expand"/>Kong)
+        C --> D(services)
+    end
+{% endmermaid %}
+<!--vale on-->
 
 The Controller listens for the changes inside the Kubernetes cluster and updates Kong in response to those changes. So that it can correctly proxy all the traffic. Kong is updated dynamically to respond to changes around scaling, configuration, and failures that occur inside a Kubernetes cluster.
 
@@ -60,7 +70,46 @@ An [Ingress][ingress] resource in Kubernetes defines a set of rules for proxying
 
 This image describes the relationship between Kubernetes concepts and Kong's Ingress configuration.
 
-![translating Kubernetes to Kong](/assets/images/products/kubernetes-ingress-controller/k8s-to-kong.png "Translating k8s resources to Kong")
+<!--vale off-->
+{% mermaid %}
+flowchart LR
+    subgraph Pods
+        direction LR
+        E(Target)
+        F(Target)
+        G(Target)
+    end
+
+    subgraph Kubernetes service
+        direction TB
+        C(Service)
+        D(Upstream)
+    end
+    
+    subgraph Ingress rules
+        direction LR
+        A(Route)
+        B(Route)
+    end
+
+    A --> C
+    B --> C
+    C --> D
+    D --> E
+    D --> F
+    D --> G
+
+    classDef lightBlue fill:#cce7ff;
+    classDef lightGreen fill:#c4e1c4;
+    classDef lightPurple fill:#e6d8eb;
+    classDef lightGrey fill:#f5f5f5;
+
+    class A,B lightGreen;
+    class C lightBlue;
+    class D lightPurple;
+    class E,F,G lightGrey;
+{% endmermaid %}
+<!--vale on-->
 
 [gateway-api]: https://gateway-api.sigs.k8s.io/
 [gateway-api-gateway]: https://gateway-api.sigs.k8s.io/concepts/api-overview/#gateway

--- a/app/_src/kubernetes-ingress-controller/get-started/services-and-routes.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/services-and-routes.md
@@ -11,7 +11,46 @@ A Service inside Kubernetes is a way to abstract an application that is running 
 
 The service object in Kong holds the information of the protocol to use to talk to the upstream service and various other protocol specific settings. The Upstream object defines load-balancing and health-checking behavior.
 
-![translating Kubernetes to Kong](/assets/images/products/kubernetes-ingress-controller/k8s-to-kong.png "Translating k8s resources to Kong")
+<!--vale off-->
+{% mermaid %}
+flowchart LR
+    subgraph Pods
+        direction LR
+        E(Target)
+        F(Target)
+        G(Target)
+    end
+
+    subgraph Kubernetes service
+        direction TB
+        C(Service)
+        D(Upstream)
+    end
+    
+    subgraph Ingress rules
+        direction LR
+        A(Route)
+        B(Route)
+    end
+
+    A --> C
+    B --> C
+    C --> D
+    D --> E
+    D --> F
+    D --> G
+
+    classDef lightBlue fill:#cce7ff;
+    classDef lightGreen fill:#c4e1c4;
+    classDef lightPurple fill:#e6d8eb;
+    classDef lightGrey fill:#f5f5f5;
+
+    class A,B lightGreen;
+    class C lightBlue;
+    class D lightPurple;
+    class E,F,G lightGrey;
+{% endmermaid %}
+<!--vale on-->
 
 Routes are configured using Gateway API or Ingress resources, such as `HTTPRoute`, `TCPRoute`, `GRPCRoute`, `Ingress` and more.
 

--- a/app/_src/kubernetes-ingress-controller/get-started/services-and-routes.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/services-and-routes.md
@@ -14,6 +14,7 @@ The service object in Kong holds the information of the protocol to use to talk 
 <!--vale off-->
 {% mermaid %}
 flowchart LR
+    H(Request traffic)
     subgraph Pods
         direction LR
         E(Target)
@@ -21,7 +22,7 @@ flowchart LR
         G(Target)
     end
 
-    subgraph Kubernetes service
+    subgraph Kubernetes Service
         direction TB
         C(Service)
         D(Upstream)
@@ -39,6 +40,7 @@ flowchart LR
     D --> E
     D --> F
     D --> G
+    H --> A
 
     classDef lightBlue fill:#cce7ff;
     classDef lightGreen fill:#c4e1c4;
@@ -49,6 +51,8 @@ flowchart LR
     class C lightBlue;
     class D lightPurple;
     class E,F,G lightGrey;
+
+    linkStyle 6 stroke:#b6d7a8
 {% endmermaid %}
 <!--vale on-->
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
- Replaced images on the Architecture, Services and routes, and Custom Resources pages with mermaid diagrams
- I pretty much just copy/pasted all the text from the old examples into mermaid
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

