### PR TITLE
fix: Add notes about OpenAPI spec version compatibility

### DIFF
--- a/app/konnect/api-products/service-documentation.md
+++ b/app/konnect/api-products/service-documentation.md
@@ -39,6 +39,9 @@ You can insert Mermaid and PlantUML diagrams by using a language-specific identi
 API specifications, or specs, can be uploaded and attached to a specific API product version within API products.
 {{site.konnect_short_name}} accepts OpenAPI (Swagger) specs in YAML or JSON.
 
+{:.note}
+> **Note:** Supported version fields are `swagger: "2.0"` and those that match `openapi: x.y.z` (for example: `openapi: 3.1.0`). OpenAPI spec versions 2.0 or later are supported.
+
 Once you've uploaded the spec, you can also preview the way the spec will render, including the methods available, endpoint descriptions, and example values. You'll also be able to filter by tag when in full-page view. 
 
 

--- a/app/konnect/dev-portal/publish-service.md
+++ b/app/konnect/dev-portal/publish-service.md
@@ -60,6 +60,9 @@ use the [sample Analytics spec](/konnect/vitalsSpec.yaml) for testing.
     The spec must be in YAML or JSON format. To test this functionality, you
     can use [vitalsSpec.yaml](/konnect/vitalsSpec.yaml) as a sample spec.
 
+    {:.note}
+    > **Note:** Supported version fields are `swagger: "2.0"` and those that match `openapi: x.y.z` (for example: `openapi: 3.1.0`). OpenAPI spec versions 2.0 or later are supported.
+
 This OpenAPI spec will be shown under the version name when this service is
 published to the Dev Portal.
 


### PR DESCRIPTION
### Description

I updated our Dev Portal docs to state which versions of Swagger and OpenAPI are supported for uploaded API specs. 

I tested this by trying to upload example OpenAPI specs created by ChatGPT:

- 1.1 ❌ 
- 2.0 ✅ 
- 3.0 ✅ 
- 3.2 ✅ 

 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
DOCU-3594

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

