### PR TITLE
OAS Validation: headers

### DIFF
--- a/app/_hub/kong-inc/oas-validation/overview/_index.md
+++ b/app/_hub/kong-inc/oas-validation/overview/_index.md
@@ -166,3 +166,18 @@ For the Validation plugin, event hook events can be enabled when a Validation fa
     "consumer": {}
     }
     ```
+
+## Troubleshooting
+
+### The plugin validates the ETag header with the `If-Match` header
+
+If a request contains the `If-Match` request header, the OAS Validation plugin follows [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt) to validate the ETag response header.
+
+If you don't want the plugin to validate the ETag with the `If-Match` request header,
+send the `If-Match` header with a wildcard (`*`) to skip validation.
+
+For example:
+```sh
+curl http://localhost:8000/example-route \
+  -H 'If-Match:*'
+```


### PR DESCRIPTION
### Description

Adding a troubleshooting entry for the OAS Validation plugin about header validation. 
Fixes https://konghq.atlassian.net/browse/DOCU-4013

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

