### PR TITLE
Fix: upgrade paths in 3.1.x

### DIFF
--- a/app/_includes/md/gateway/upgrade-paths.md
+++ b/app/_includes/md/gateway/upgrade-paths.md
@@ -3,15 +3,15 @@
 
 | **Current version** | **Topology** | **Direct upgrade possible?** | **Upgrade path** |
 | ------------------- | ------------ | ---------------------------- | ---------------- |
-| 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), then upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, then upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 2.x–2.7.x | DB-less | No | Upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 2.8.x | Traditional | No | Upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 2.8.x | Hybrid | No | Upgrade to 3.0.x, and then upgrade to 3.1.1.3. |
-| 2.8.x | DB-less | No | Upgrade to 3.0.x, and then upgrade to 3.1.x. |
-| 3.0.x | Traditional | Yes | Upgrade to 3.1.x. |
-| 3.0.x | Hybrid | Yes | Upgrade to 3.1.x. |
-| 3.0.x | DB-less | Yes | Upgrade to 3.1.x. |
+| 2.x–2.7.x | Traditional | No | Upgrade to 2.8.2.x (required for blue/green deployments only), upgrade to 3.0.x, and then upgrade to 3.1.1.3 or later 3.1.x patches. |
+| 2.x–2.7.x | Hybrid | No | Upgrade to 2.8.2.x, then upgrade to 3.0.x, and then upgrade to 3.1.1.3 or later 3.1.x patches. |
+| 2.x–2.7.x | DB-less | No | Upgrade to 2.8.x, and then upgrade to 3.1.1.3 or later 3.1.x patches. |
+| 2.8.x | Traditional | Yes | Upgrade to 3.1.1.3 or later 3.1.x patches.|
+| 2.8.x | Hybrid | Yes | Upgrade to 3.1.1.3 or later 3.1.x patches. |
+| 2.8.x | DB-less | Yes | Upgrade to 3.1.1.3 or later 3.1.x patches. |
+| 3.0.x | Traditional | Yes | Upgrade to 3.1.1.3 or later 3.1.x patches.|
+| 3.0.x | Hybrid | Yes | Upgrade to 3.1.1.3 or later 3.1.x patches. |
+| 3.0.x | DB-less | Yes | Upgrade to 3.1.1.3 or later 3.1.x patches. |
 
 {% endif_version %}
 


### PR DESCRIPTION
### Description

Update the 3.1.x upgrade paths table to tell people to migrade to 3.1.1.x directly, as per the [changelog.](https://docs.konghq.com/gateway/changelog/#3113)

Fixes #5755.

### Testing instructions

Preview link: https://deploy-preview-8010--kongdocs.netlify.app/gateway/3.1.x/upgrade/#guaranteed-upgrade-paths
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

