### PR TITLE
Add Enterprise badges to websocket PDK references

### DIFF
--- a/app/_src/gateway/plugin-development/pdk/kong.websocket.client.md
+++ b/app/_src/gateway/plugin-development/pdk/kong.websocket.client.md
@@ -11,6 +11,7 @@ pdk: true
 toc: true
 source_url: https://github.com/Kong/kong-ee/tree/master/kong/pdk/websocket/client.lua
 enterprise: true
+badge: enterprise
 ---
 
 <!-- vale off -->

--- a/app/_src/gateway/plugin-development/pdk/kong.websocket.upstream.md
+++ b/app/_src/gateway/plugin-development/pdk/kong.websocket.upstream.md
@@ -11,6 +11,7 @@ pdk: true
 toc: true
 source_url: https://github.com/Kong/kong-ee/tree/master/kong/pdk/websocket/upstream.lua
 enterprise: true
+badge: enterprise
 ---
 
 <!-- vale off -->


### PR DESCRIPTION
### Description

The websocket PDK pages are missing Enterprise badges, so users think that the functionality is available in OSS.

Fixes https://github.com/Kong/docs.konghq.com/issues/5555. 

### Testing instructions

Preview link: 
https://deploy-preview-8012--kongdocs.netlify.app/gateway/latest/plugin-development/pdk/kong.websocket.client/
https://deploy-preview-8012--kongdocs.netlify.app/gateway/latest/plugin-development/pdk/kong.websocket.upstream/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

