### PR TITLE
Fix version variable on old mesh docker installs

### DIFF
--- a/app/_src/mesh/installation/docker.md
+++ b/app/_src/mesh/installation/docker.md
@@ -23,10 +23,10 @@ You have a license for {{site.mesh_product_name}}.
 {{site.mesh_product_name}} provides the following Docker images for all of its
 executables, hosted on Docker Hub:
 
-* **kuma-cp**: at [`kong/kuma-cp:{{page.kong_latest.version}}`](https://hub.docker.com/r/kong/kuma-cp)
-* **kuma-dp**: at [`kong/kuma-dp:{{page.kong_latest.version}}`](https://hub.docker.com/r/kong/kuma-dp)
-* **kumactl**: at [`kong/kumactl:{{page.kong_latest.version}}`](https://hub.docker.com/r/kong/kumactl)
-* **kuma-prometheus-sd**: at [`kong/kuma-prometheus-sd:{{page.kong_latest.version}}`](https://hub.docker.com/r/kong/kuma-prometheus-sd)
+* **kuma-cp**: at [`kong/kuma-cp:{{page.version}}`](https://hub.docker.com/r/kong/kuma-cp)
+* **kuma-dp**: at [`kong/kuma-dp:{{page.version}}`](https://hub.docker.com/r/kong/kuma-dp)
+* **kumactl**: at [`kong/kumactl:{{page.version}}`](https://hub.docker.com/r/kong/kumactl)
+* **kuma-prometheus-sd**: at [`kong/kuma-prometheus-sd:{{page.version}}`](https://hub.docker.com/r/kong/kuma-prometheus-sd)
 
 {:.note}
 > **Note**: {{site.mesh_product_name}} also has UBI images, image names are prefixed with `ubi`. For example `kong/ubi-kuma-cp` instead of `kong/kuma-cp`.
@@ -34,7 +34,7 @@ executables, hosted on Docker Hub:
 `docker pull` each image that you need. For example:
 
 ```sh
-docker pull kong/kuma-cp:{{page.kong_latest.version}}
+docker pull kong/kuma-cp:{{page.version}}
 ```
 
 ## 2. Run {{site.mesh_product_name}}
@@ -108,7 +108,7 @@ mtls:
   enabledBackend: ca-1
   backends:
   - name: ca-1
-    type: builtin" | docker run -i --net="host" kong/kumactl:{{page.kong_latest.version}} kumactl apply -f -
+    type: builtin" | docker run -i --net="host" kong/kumactl:{{page.version}} kumactl apply -f -
 ```
 
 This runs `kumactl` from the Docker


### PR DESCRIPTION
### Description

Fixed the version variable on the Docker Mesh install docs to stop pointing to `latest` and point to current page version instead. Pulled the resulting docker images with no issue.

Checked the rest of the Mesh install docs, this issue only happens on Docker.

Fixes https://github.com/Kong/docs.konghq.com/issues/4991.

### Testing instructions

Preview link: https://deploy-preview-8013--kongdocs.netlify.app/mesh/2.1.x/installation/docker/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

