### PR TITLE
Update supported Debian versions in upgrade guide table

### DIFF
--- a/app/_data/tables/breaking_changes_lts.yml
+++ b/app/_data/tables/breaking_changes_lts.yml
@@ -115,9 +115,9 @@ entries:
   - area: Deployment
     category: 2
     description: |
-      Deprecated and stopped producing Debian 8 (Jessie) containers and packages.
+      Deprecated and stopped producing Debian 8 (Jessie) and Debian 10 (Buster) containers and packages.
     action: |
-      Debian 10 and 11 are available. Upgrade to one of these versions before 
+      Debian 11 and 12 are available. Upgrade to one of these versions before 
       upgrading to Kong 3.4.
 
   - area: Deployment


### PR DESCRIPTION
### Description

We still list Deb 10 as an upgrade option, but Deb 10 is no longer supported.

Debian 9 was never supported, so we skip mentioning it.

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1727890089951339

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

