### PR TITLE
Add redirects to api specs

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -15,6 +15,10 @@
 /gateway/*          https://docs.konghq.com/gateway/:splat
 /hub/               https://docs.konghq.com/hub/
 /hub/*              https://docs.konghq.com/hub/:splat
+/dev-portal/api/*       https://docs.konghq.com/dev-portal/api/:splat
+/konnect-portal/api/*   https://docs.konghq.com/konnect-portal/api/:splat
+/konnect/api/*          https://docs.konghq.com/konnect/api/:splat
+/gateway/api/*          https://docs.konghq.com/gateway/api/:splat
 
 # FREE TRIALS, GENERAL LICENSING
 /free-trial/guide/                    https://konghq.com/install


### PR DESCRIPTION
### Description

Add redirects to api specs in docs.konghq.com.
There's a link to the dev-portal api in the gateway 3.0 docs but we haven't migrated the api specs yet (oldest one is 3.3.x I think).
This adds redirects to the api specs in the docs.konghq.com

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

