### PR TITLE
fix: Update Service Catalog tile on docs home page

### DIFF
--- a/app/_data/landing_page.yml
+++ b/app/_data/landing_page.yml
@@ -1,24 +1,21 @@
 features:
   - title: Key features
     items:
-      - name: Service Hub
-        description: Build a comprehensive catalog of services to enable discovery, consumption, and management of every API across your entire architecture.
+      - name: Service Catalog
+        description: Build a comprehensive catalog of all services running in your organization, both Konnect-internal applications (like Gateway Manager and Mesh Manager) as well as external applications (like Github and PagerDuty).
         icon: /assets/images/landing-page/card-icons/service-hub.svg
         links:
           - text: Overview
             icon: /assets/images/icons/icn-doc.svg
-            url: /konnect/servicehub/
+            url: /konnect/service-catalog/
 
       - name: Dev Portal
         description: Streamline developer onboarding with a self-service developer experience, letting developers discover, register, and consume published services.
         icon: /assets/images/landing-page/card-icons/dev-portal.svg
         links:
-          - text: Overview (cloud)
+          - text: Overview
             icon: /assets/images/icons/icn-doc.svg
             url: /konnect/dev-portal/
-          - text: Self-managed
-            icon: /assets/images/icons/icn-doc.svg
-            url: /gateway/latest/kong-enterprise/dev-portal/
 
       - name: Advanced Analytics
         description: View granular analytics with Konnect Advanced Analytics to monitor the health of environments and clusters. Gain deep insights into service, route, and application usage.

--- a/app/_data/landing_page.yml
+++ b/app/_data/landing_page.yml
@@ -2,7 +2,7 @@ features:
   - title: Key features
     items:
       - name: Service Catalog
-        description: Build a comprehensive catalog of all services running in your organization, both Konnect-internal applications (like Gateway Manager and Mesh Manager) as well as external applications (like Github and PagerDuty).
+        description: Build a comprehensive catalog of all services running in your organization, both Konnect-internal applications (like Gateway Manager and Mesh Manager) as well as external applications (like GitHub and PagerDuty).
         icon: /assets/images/landing-page/card-icons/service-hub.svg
         links:
           - text: Overview


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->

- Updated our docs home page tile so it says "Service Catalog" instead of "service hub"
- I also noticed that we were still linking to on-prem Dev Portal docs there, so I removed that link

 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
https://kongstrong.slack.com/archives/CDSTDSG9J/p1728660833269209
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

