### PR TITLE
KGO: add guide for kongpluginbinding

### DIFF
--- a/app/_src/gateway-operator/guides/konnect-plugin-binding.md
+++ b/app/_src/gateway-operator/guides/konnect-plugin-binding.md
@@ -211,7 +211,7 @@ NAME                            PLUGIN-KIND   PLUGIN-NAME                  PROGR
 rate-limiting-minute-10-a0z1x   KongPlugin    rate-limiting-minute-10      True
 ```
 
-#### Attaching Plugins to Multiple Entities
+#### Attaching plugins to multiple entities
 
 Similar to those introduced above, you can also attach a plugin to multiple entities by configuring annotations of attached entities. If a plugin appears in the `konghq.com/plugins` annotation of multiple entities, a `KongPluginBinding` will be created for the binding relationship between the plugin and the combination of these entities. Taking the example above where a plugin is attached to a service and a consumer:
 

--- a/app/_src/gateway-operator/guides/konnect-plugin-binding.md
+++ b/app/_src/gateway-operator/guides/konnect-plugin-binding.md
@@ -79,8 +79,8 @@ Then the plugin will be successfully attached to the service in {{ site.konnect_
 
 {{ site.kgo_product_name }} also supports to attach plugins to combination of multiple entities by `KongPluginBinding`. Supported combinations includes: 
 * `Service` and `Route`; 
-* Service` and `Consumer`
-* Service` and `ConsumerGroup`
+* `Service` and `Consumer`
+* `Service` and `ConsumerGroup`
 * `Service`, `Route` and `Consumer`
 * `Service`, `Route` and `ConsumerGroup` 
 * `Consumer` and `ConsumerGroup`. 

--- a/app/_src/gateway-operator/guides/konnect-plugin-binding.md
+++ b/app/_src/gateway-operator/guides/konnect-plugin-binding.md
@@ -1,0 +1,122 @@
+---
+title: Managing Plugin Bindings by CRD
+---
+
+The `KongPluginBinding` is the CRD used to manage binding relationship between plugins and attached Konnect entities, including services, routes, consumers and consumer groups, or supported comblination of these entities.
+
+### Introduction of `KongPluginBinding` CRD
+
+A `KongPluginBinding` resource describes a binding relationship of a plugin and an attached entity or a combination of possible entities. It has two parts for describing the binding in its specification: `spec.pluginRef` to refer to a `KongPlugin` resource which contains the plugin name and configuration of the plugin, and `spec.targets` to refer to the entity or combination of entities that the plugin attached to. The `spec.controlPlaneRef` refers to the Konnect ControlPlane this KongPluginBinding is associated with.
+
+### Using an Unmannaged `KongPluginBinding`
+
+You can directly create a `KongPluginBinding` to bind your plugin to a Konnect entity. Assume that you have an existing and programmed `KonnectGatewayControlPlane` with name `cp` in `default` namespace.
+
+First, Create a service and a plugin by `KongService` and `KongPlugin` CRD:
+
+```bash
+# Create a KongService for a service in Konnect
+echo '
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  namespace: default
+  name: service-example
+spec:
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f - 
+```
+
+Then, create a `KongPlugin`:
+
+```bash
+# Create a KongPlugin
+echo '
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  namespace: default
+  name: rate-limiting-minute-10
+plugin: rate-limiting
+config:
+  policy: local
+  minute: 10
+' | kubectl apply -f - 
+```
+
+And we can create a `KongPluginBinding` to bind them together.
+
+```bash
+echo '
+kind: KongPluginBinding
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  namespace: default
+  name: binding-service-example-rate-limiting
+spec:
+  pluginRef:
+    kind: KongPlugin
+    name: rate-limiting-minute-10
+  targets:
+    serviceRef:
+      group: configuration.konghq.com
+      kind: KongService
+      name: service-example
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f - 
+```
+
+Then the plugin will be successfully attached to the service in {{ site.konnect_short_name }}.
+
+### Using Annotations to Bind Plugins to Other Entities
+
+We can also use the `konghq.com/plugins` annotation to attach plugins to other entities like what we used in {{ site.kic_product_name }}. The {{ site.kgo_product_name }} will create `KongPluginBinding` resources for the annotations and configure them in {{ site.konnect_short_name }}.
+
+For the example above, we can create a `KongPlugin` and a `KongService` like this:
+
+```bash
+echo '
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  namespace: default
+  name: rate-limiting-minute-10
+plugin: rate-limiting
+config:
+  policy: local
+  minute: 10
+' | kubectl apply -f - 
+```
+
+```bash
+echo '
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  namespace: default
+  name: service-example
+  annotations:
+    konghq.com/plugins: rate-limiting-minute-10
+spec:
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f -
+```
+
+Then you can also see the plugin is attached to the service in {{ site.konnect_short_name }}. You can also check the `KongPluginBinding` resource by `kubectl get kongpluginbindings`. You can see the created `KongPluginBinding` like:
+
+```
+kubectl get kongpluginbinding
+NAME                            PLUGIN-KIND   PLUGIN-NAME                  PROGRAMMED
+rate-limiting-minute-10-r4xvt   KongPlugin    rate-limiting-minute-10      True
+```

--- a/app/_src/gateway-operator/guides/konnect-plugin-binding.md
+++ b/app/_src/gateway-operator/guides/konnect-plugin-binding.md
@@ -2,15 +2,15 @@
 title: Managing Plugin Bindings by CRD
 ---
 
-The `KongPluginBinding` is the CRD used to manage binding relationship between plugins and attached Konnect entities, including services, routes, consumers and consumer groups, or supported comblination of these entities.
+The `KongPluginBinding` is the CRD used to manage binding relationship between plugins and attached Konnect entities, including services, routes, consumers and consumer groups, or supported combination of these entities.
 
 ### Introduction of `KongPluginBinding` CRD
 
 A `KongPluginBinding` resource describes a binding relationship of a plugin and an attached entity or a combination of possible entities. It has two parts for describing the binding in its specification: `spec.pluginRef` to refer to a `KongPlugin` resource which contains the plugin name and configuration of the plugin, and `spec.targets` to refer to the entity or combination of entities that the plugin attached to. The `spec.controlPlaneRef` refers to the Konnect ControlPlane this KongPluginBinding is associated with.
 
-### Using an Unmannaged `KongPluginBinding`
+### Using an Unmanaged `KongPluginBinding`
 
-You can directly create a `KongPluginBinding` to bind your plugin to a Konnect entity. Assume that you have an existing and programmed `KonnectGatewayControlPlane` with name `cp` in `default` namespace.
+You can directly create a `KongPluginBinding` to bind your plugin to a Konnect entity. Assume that you have an existing and programmed `KonnectGatewayControlPlane` with name `cp` in the `default` namespace.
 
 First, Create a service and a plugin by `KongService` and `KongPlugin` CRD:
 
@@ -48,7 +48,7 @@ config:
 ' | kubectl apply -f - 
 ```
 
-And we can create a `KongPluginBinding` to bind them together.
+And you can create a `KongPluginBinding` to bind them together.
 
 ```bash
 echo '
@@ -75,11 +75,94 @@ spec:
 
 Then the plugin will be successfully attached to the service in {{ site.konnect_short_name }}.
 
+#### Attaching Plugins to Multiple Entities
+
+{{ site.kgo_product_name }} also supports to attach plugins to combination of multiple entities by `KongPluginBinding`. Supported combinations includes: `Service` and `Route`; `Service` and `Consumer`; `Service` and `ConsumerGroup`; `Service`, `Route` and `Consumer`; `Service`, `Route` and `ConsumerGroup`; `Consumer` and `ConsumerGroup`. For example, we can configure a `rate-limiting` plugin to a service and a consumer like this:
+
+Create a service:
+
+```bash
+echo '
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  namespace: default
+  name: service-plugin-binding-combination
+spec:
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f - 
+```
+
+Create a consumer:
+
+```bash
+echo '
+kind: KongConsumer
+apiVersion: configuration.konghq.com/v1
+metadata:
+  namespace: default
+  name: consumer-plugin-binding-combination
+username: consumer-test
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f -
+```
+
+Create a plugin:
+
+```bash
+echo '
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  namespace: default
+  name: rate-limiting-minute-10
+plugin: rate-limiting
+config:
+  policy: local
+  minute: 10
+' | kubectl apply -f - 
+```
+
+Then, you can create a `KongPluginBinding` including both references to the `KongService` and the `KongCosumer` to attach the plugin to the service and the consumer:
+
+```bash
+echo '
+kind: KongPluginBinding
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  namespace: default
+  name: binding-combination-service-consumer
+spec:
+  pluginRef:
+    kind: KongPlugin
+    name: rate-limiting-minute-10
+  targets:
+    serviceRef:
+      group: configuration.konghq.com
+      kind: KongService
+      name: service-plugin-binding-combination
+    consumerRef:
+      name: consumer-plugin-binding-combination
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f - 
+```
+
 ### Using Annotations to Bind Plugins to Other Entities
 
-We can also use the `konghq.com/plugins` annotation to attach plugins to other entities like what we used in {{ site.kic_product_name }}. The {{ site.kgo_product_name }} will create `KongPluginBinding` resources for the annotations and configure them in {{ site.konnect_short_name }}.
+You can also use the `konghq.com/plugins` annotation to attach plugins to other entities like what we used in {{ site.kic_product_name }}. The {{ site.kgo_product_name }} will create `KongPluginBinding` resources for the annotations and configure them in {{ site.konnect_short_name }}.
 
-For the example above, we can create a `KongPlugin` and a `KongService` like this:
+For the example above, you can create a `KongPlugin` and a `KongService` like this:
 
 ```bash
 echo '
@@ -118,5 +201,93 @@ Then you can also see the plugin is attached to the service in {{ site.konnect_s
 ```
 kubectl get kongpluginbinding
 NAME                            PLUGIN-KIND   PLUGIN-NAME                  PROGRAMMED
-rate-limiting-minute-10-r4xvt   KongPlugin    rate-limiting-minute-10      True
+rate-limiting-minute-10-a0z1x   KongPlugin    rate-limiting-minute-10      True
+```
+
+#### Attaching Plugins to Multiple Entities
+
+Similar to introduced above, you can also attach a plugin to multiple entities by configuring annotations of attached entities. If a plugin appeared in the `konghq.com/plugins` annotation of multiple entities, a `KongPluginBinding` will be created for the binding relationship between the plugin and the combination of these entities. Taking the example above where a plugin is attached to a service and a consumer:
+
+```bash
+echo '
+kind: KongPlugin
+apiVersion: configuration.konghq.com/v1
+metadata:
+  namespace: default
+  name: rate-limiting-minute-10
+plugin: rate-limiting
+config:
+  policy: local
+  minute: 10
+' | kubectl apply -f - 
+```
+
+```bash
+echo '
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  namespace: default
+  name: service-plugin-binding-combination
+  annotations:
+    konghq.com/plugins: rate-limiting-minute-10
+spec:
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f -
+```
+
+```bash
+echo '
+kind: KongConsumer
+apiVersion: configuration.konghq.com/v1
+metadata:
+  namespace: default
+  name: consumer-plugin-binding-combination
+  annotations:
+    konghq.com/plugins: rate-limiting-minute-10
+username: consumer-test
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f -
+```
+
+A `KongPluginBinding` with both `serviceRef` and `consumerRef` in its `spec.targets` will be created like:
+
+```yaml
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongPluginBinding
+metadata:
+  creationTimestamp: "2024-10-14T07:14:05Z"
+  generateName: rate-limiting-minute-10-
+  name: rate-limiting-minute-10-xyz98
+  namespace: default
+  ownerReferences:
+  - apiVersion: configuration.konghq.com/v1
+    blockOwnerDeletion: true
+    kind: KongPlugin
+    name: rate-limiting-minute-10
+    uid: 01234567-89ab-cdef-fdec-ba9876543210
+spec:
+  controlPlaneRef:
+    konnectNamespacedRef:
+      name: test1
+      namespace: default
+    type: konnectNamespacedRef
+  pluginRef:
+    kind: KongPlugin
+    name: rate-limiting-minute-10
+  targets:
+    consumerRef:
+      name: consumer-plugin-binding-combination
+    serviceRef:
+      group: configuration.konghq.com
+      kind: KongService
+      name: service-plugin-binding-combination
 ```

--- a/app/_src/gateway-operator/guides/konnect-plugin-binding.md
+++ b/app/_src/gateway-operator/guides/konnect-plugin-binding.md
@@ -2,17 +2,17 @@
 title: Managing Plugin Bindings by CRD
 ---
 
-The `KongPluginBinding` is the CRD used to manage binding relationship between plugins and attached Konnect entities, including services, routes, consumers and consumer groups, or supported combination of these entities.
+The `KongPluginBinding` is the CRD used to manage the binding relationship between plugins and attached Konnect entities, including services, routes, consumers, and consumer groups, or a supported combination of these entities.
 
 ### Introduction of `KongPluginBinding` CRD
 
-A `KongPluginBinding` resource describes a binding relationship of a plugin and an attached entity or a combination of possible entities. It has two parts for describing the binding in its specification: `spec.pluginRef` to refer to a `KongPlugin` resource which contains the plugin name and configuration of the plugin, and `spec.targets` to refer to the entity or combination of entities that the plugin attached to. The `spec.controlPlaneRef` refers to the Konnect ControlPlane this KongPluginBinding is associated with.
+A `KongPluginBinding` resource describes a binding relationship between a plugin and an attached entity or a combination of possible entities. It has two parts for the binding description in its specification: `spec.pluginRef` to refer to a `KongPlugin` resource which contains the plugin name and configuration of the plugin, and `spec.targets` to refer to the entity or combination of entities that the plugin attached to. The `spec.controlPlaneRef` refers to the {{site.konnect_product_name}} control plane this `KongPluginBinding` is associated with.
 
 ### Using an Unmanaged `KongPluginBinding`
 
-You can directly create a `KongPluginBinding` to bind your plugin to a Konnect entity. Assume that you have an existing and programmed `KonnectGatewayControlPlane` with name `cp` in the `default` namespace.
+You can directly create a `KongPluginBinding` to bind your plugin to a Konnect entity. Assume that you have an existing and programmed `KonnectGatewayControlPlane` with the name `cp` in the `default` namespace.
 
-First, Create a service and a plugin by `KongService` and `KongPlugin` CRD:
+First, create a service and a plugin by `KongService` and `KongPlugin` CRD:
 
 ```bash
 # Create a KongService for a service in Konnect
@@ -75,9 +75,16 @@ spec:
 
 Then the plugin will be successfully attached to the service in {{ site.konnect_short_name }}.
 
-#### Attaching Plugins to Multiple Entities
+#### Attaching plugins to multiple entities
 
-{{ site.kgo_product_name }} also supports to attach plugins to combination of multiple entities by `KongPluginBinding`. Supported combinations includes: `Service` and `Route`; `Service` and `Consumer`; `Service` and `ConsumerGroup`; `Service`, `Route` and `Consumer`; `Service`, `Route` and `ConsumerGroup`; `Consumer` and `ConsumerGroup`. For example, we can configure a `rate-limiting` plugin to a service and a consumer like this:
+{{ site.kgo_product_name }} also supports to attach plugins to combination of multiple entities by `KongPluginBinding`. Supported combinations includes: 
+* `Service` and `Route`; 
+* Service` and `Consumer`
+* Service` and `ConsumerGroup`
+* `Service`, `Route` and `Consumer`
+* `Service`, `Route` and `ConsumerGroup` 
+* `Consumer` and `ConsumerGroup`. 
+For example, we can configure a `rate-limiting` plugin to a service and a consumer like this:
 
 Create a service:
 
@@ -158,11 +165,11 @@ spec:
 ' | kubectl apply -f - 
 ```
 
-### Using Annotations to Bind Plugins to Other Entities
+### Using annotations to bind plugins to other entities
 
 You can also use the `konghq.com/plugins` annotation to attach plugins to other entities like what we used in {{ site.kic_product_name }}. The {{ site.kgo_product_name }} will create `KongPluginBinding` resources for the annotations and configure them in {{ site.konnect_short_name }}.
 
-For the example above, you can create a `KongPlugin` and a `KongService` like this:
+In the example above, you can create a `KongPlugin` and a `KongService` like this:
 
 ```bash
 echo '
@@ -206,7 +213,7 @@ rate-limiting-minute-10-a0z1x   KongPlugin    rate-limiting-minute-10      True
 
 #### Attaching Plugins to Multiple Entities
 
-Similar to introduced above, you can also attach a plugin to multiple entities by configuring annotations of attached entities. If a plugin appeared in the `konghq.com/plugins` annotation of multiple entities, a `KongPluginBinding` will be created for the binding relationship between the plugin and the combination of these entities. Taking the example above where a plugin is attached to a service and a consumer:
+Similar to those introduced above, you can also attach a plugin to multiple entities by configuring annotations of attached entities. If a plugin appears in the `konghq.com/plugins` annotation of multiple entities, a `KongPluginBinding` will be created for the binding relationship between the plugin and the combination of these entities. Taking the example above where a plugin is attached to a service and a consumer:
 
 ```bash
 echo '


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Add guide page for using `KongPluginBinding` to configure plugins with Konnect.

Fixes https://github.com/Kong/gateway-operator/issues/568.

Dependent on #8034 for adding navigator page for KGO 1.4. 

<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

