### PR TITLE
Remove unstable warning from WebSocket plugin handler docs

### DIFF
--- a/app/_src/gateway/plugin-development/custom-logic.md
+++ b/app/_src/gateway/plugin-development/custom-logic.md
@@ -322,11 +322,6 @@ methods.
 ## WebSocket Plugin Development
 {:.badge .enterprise}
 
-{:.warning}
-> **Warning**: The WebSocket PDK is under active development and is
-considered unstable at this time. Backwards-incompatible changes may be made
-to these functions.
-
 ### Handler Functions
 
 Requests to services with the `ws` or `wss` protocol take a different path through


### PR DESCRIPTION
### Description

This actually should have been done in 0d121e25e3 when we removed the same warning from the WebSocket PDK docs.

### Testing instructions

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

