### PR TITLE
Fix: Konnect roles reference

### DIFF
--- a/app/konnect/org-management/teams-and-roles/roles-reference.md
+++ b/app/konnect/org-management/teams-and-roles/roles-reference.md
@@ -10,89 +10,96 @@ The following predefined roles are available in {{site.konnect_short_name}}:
 
 ## API products
 
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Admin | Admin of an existing API product. The admins have all write access permissions related to a API product, API product version, etc. |
+| Role          | Description  |
+|---------------|--------------|
+| Admin         | Admin of an existing API product. The admins have all write access permissions related to a API product, API product version, etc. |
 | Application Registration | Access to enable or disable application registration for an API Product. |
-| Creator | Access to create new API product in API Products. The creator becomes the owner of the API product they create, gaining admin access to the API product. This role does not provide access to creating sub-entities in an API product such as API product versions or API specs, or link the API product version to a Gateway service. See the Admin or Maintainer role. |
-| Maintainer | Access to fully manage an API product and its API product versions including app registration, publishing documentation, etc. |
-| Publisher | Access to publish an API product to the Dev Portal. |
-| Viewer | Read-only access on an API product including API product versions and its configuration, analytics, and documentation. |
+| Creator       | Access to create new API product in API Products. The creator becomes the owner of the API product they create, gaining admin access to the API product. This role does not provide access to creating sub-entities in an API product such as API product versions or API specs, or link the API product version to a Gateway service. See the Admin or Maintainer role. |
+| Maintainer    | Access to fully manage an API product and its API product versions including app registration, publishing documentation, etc. |
+| Publisher     | Access to publish an API product to the Dev Portal. |
+| Viewer        | Read-only access on an API product including API product versions and its configuration, analytics, and documentation. |
 
 ## Control Planes
 
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Admin | Owner of an existing control plane group. Admins have write access to control plane nodes, and the control plane group's corresponding data plane nodes.|
-| Creator | Access to create a new control plane group in Gateway Manager. The creator becomes the owner and admin of the control plane group they create. <br><br>This role does not grant access to _existing_ control plane groups, data plane nodes, or their configurations. See the `Admin` or `Deployer` roles. |
-| Certificate Admin | Access to configure certificates for an existing control plane group. |
-| Deployer | Access to deploy a Gateway service across the control plane group. Must also have the Deployer role for the service being deployed.  |
-| Viewer | Read-only access to all the configurations of a control plane group and corresponding data plane nodes. |
-| Consumer Admin | Access to configure consumers for an existing control plane group. |
-| Gateway Service Admin | Access to configure Gateway services for an existing control plane group. |
-| Key Admin | Access to configure keys for an existing control plane group. |
-| Plugin Admin | Access to configure plugins for an existing control plane group. |
-| Route Admin | Access to configure routes for an existing control plane group. |
-| SNI Admin | Access to configure SNIs for an existing control plane group. |
-| Upstream Admin | Access to configure upstreams for an existing control plane group. |
-| Vault Admin | Access to configure vaults for an existing control plane group. |
+| Role                         | Description  |
+|------------------------------|--------------|
+| Admin                        | Owner of an existing control plane group. Admins have write access to control plane nodes, and the control plane group's corresponding data plane nodes.|
+| Certificate Admin            | Access to configure certificates for an existing control plane group. |
+| Cloud Gateway Cluster Admin  | Access to all read and write permissions related to cloud-gateways configurations and custom domains. |
+| Cloud Gateway Cluster Viewer | Access to read-only permissions to cloud-gateways configurations and custom domains. |
+| Consumer Admin               | Access to configure consumers for an existing control plane group. |
+| Creator                      | Access to create a new control plane group in Gateway Manager. The creator becomes the owner and admin of the control plane group they create. <br><br>This role does not grant access to _existing_ control plane groups, data plane nodes, or their configurations. See the `Admin` or `Deployer` roles. |
+| Deployer                     | This role grants full write access to administer services, routes, and plugins necessary to deploy services in Service Catalog. Must also have the Deployer role for the service being deployed. |
+| Gateway Service Admin        | Access to configure Gateway services for an existing control plane group. |
+| Key Admin                    | Access to configure keys for an existing control plane group. |
+| Plugin Admin                 | Access to configure plugins for an existing control plane group. |
+| Route Admin                  | Access to configure routes for an existing control plane group. |
+| Serverless Cluster Admin     | Access to all read and write permissions related to serverless cloud-gateways configurations. | 
+| Serverless Cluster Viewer    | Access to read-only permissions to serverless cloud-gateways configurations. |
+| SNI Admin                    | Access to configure SNIs for an existing control plane group. |
+| Upstream Admin               | Access to configure upstreams for an existing control plane group. |
+| Vault Admin                  | Access to configure vaults for an existing control plane group. |
+| Viewer                       | Read-only access to all the configurations of a control plane group and corresponding data plane nodes. |
 
 ## Mesh control planes 
 
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Admin | Owner of an existing mesh control plane. The owners have all write access related to a control plane and its configuration. |
-| Connector | Access to connect a zone to the mesh control plane in {{site.konnect_short_name}}.|
+| Role    | Description  |
+|---------|--------------|
+| Admin   | Owner of an existing mesh control plane. The owners have all write access related to a control plane and its configuration. |
 | Creator | Access to create a new mesh control plane in Mesh Manager. The creator becomes the owner of the control plane they create, gaining admin access to the new control plane. <br><br>This role does not grant access to _existing_ control planes or their configurations. See the mesh control plane `Admin` role. |
-| Viewer | Read-only access to all the configurations of a {{site.konnect_short_name}} mesh control plane, including zones, Zone Ingress and Egress, meshes, and RBAC. |
+| Viewer  | Read-only access to all the configurations of a {{site.konnect_short_name}} mesh control plane, including zones, Zone Ingress and Egress, meshes, and RBAC. |
+
+## Networks 
+
+| Role            | Description  |
+|-----------------|--------------|
+| Network Admin   | Access to all read and write permissions related to a network. |
+| Network Creator | Access to creating networks. |
+| Network Viewer  | Access to read-only permissions to networks. |
+
 
 ## Service Catalog
 
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Integration Admin | Can view and edit all integrations (install/authorize). |
-| Service Viewer | Can view a select list of services and all resources and discovery rules. |
-| Service Admin | Can view and edit a select list of services, map resources to those services, and manage all resources and discovery rules. | 
-| Service Creator | Can create new services, becomes the service admin for any service they create, and can view, edit, and create all resources and discovery rules.
+| Role               | Description  |
+|--------------------|--------------|
+| Discovery Admin    | Access to all read and write permissions related to service discoveries. |
+| Discovery Viewer   | Access to read-only permissions related to service discoveries. |
+| Integration Admin  | Can view and edit all integrations (install/authorize). |
+| Integration Viewer | Access to read-only permissions to integrations. |
+| Service Admin      | Can view and edit a select list of services, map resources to those services, and manage all resources and discovery rules. | 
+| Service Creator    | Can create new services, becomes the service admin for any service they create, and can view, edit, and create all resources and discovery rules.
+| Service Viewer     | Can view a select list of services and all resources and discovery rules. |
 
-
-## Administration
-
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Identity Management | Access to users, teams, system accounts, tokens, IdP configurations, and authentication settings. |
-| Audit Logs Setup | Access to configuring webhooks to receive region-specific audit logs and to trigger audit log replays. |
-
-<!-- ## Organizations
-
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Admin | Allows a user to view and manage existing organization settings, including billing/usage. Admins have all write access to organization objects. |
-| Creator | Allows a user to create organizations. [*Q: What's stopping a user from creating orgs in general? What does this role actually imply - they can crete new orgs within a company umbrella of orgs?*] |
-| Privileged | Privileged users of an existing organization can change system-level configuration, including the organization's license tier, organization status, (and what else?).
-| Root |  Allows root access for an existing organization. This role grants write access to all organization objects as well as to all {{site.konnect_short_name}} services, control planes, Dev Portal, Analytics reports, applications, and developers. | -->
-
-<!--
 ## Portals
 
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Admin | Owner of an existing Dev Portal instance. The owner has full write access related to any developers and applications in the organization. |
-| Maintainer | Edit, view, and delete Dev Portal applications, and view developers. |
-| Viewer | Read-only access to Dev Portal developers and applications. | -->
+| Role                  | Description  |
+|-----------------------|--------------|
+| Admin                 | Owner of an existing Dev Portal instance. The owner has full write access related to any developers and applications in the organization. |
+| Appearance Maintainer | Access the Portal instance and edit its appearance. |
+| Creator               | Create new Portals. |
+| Maintainer            | Edit, view, and delete Dev Portal applications, and view developers. |
+| Product Publisher     | Manage publishing products to a Dev Portal. |
+| Viewer                | Read-only access to Dev Portal developers and applications. |
 
-<!-- ## Teams
+## Application Auth Strategies
 
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Admin | Create, read, update, and delete teams in the organization. Add or remove users and roles to the team. |
-| Creator | Create teams in Gateway Manager. |
-| Viewer | Read-only access to all the configurations of a team, including attributes, versions, reports, and plugins. | -->
+| Role       | Description  |
+|------------|--------------|
+| Creator    | Create new app auth strategies. |
+| Maintainer | Edit one or all app auth strategies. |
+| Viewer     | Read-only access to one or all app auth strategies. |
 
-<!-- ## Users
+## DCR
 
-| Role                        | Description  |
-|-----------------------------|--------------|
-| Admin | Create, read, update, and delete users in the organization. Add or remove users to and from teams. |
-| Creator | Invite users to the {{site.konnect_short_name}} organization. |
-| Viewer | View users in the {{site.konnect_short_name}} organization, their status, team membership, and individual roles. | -->
+| Role       | Description  |
+|------------|--------------|
+| Creator    | Create new DCR providers. |
+| Maintainer | Edit one or all DCR providers. |
+| Viewer     | Read-only access to one or all DCR providers. |
+
+
+## Identity
+
+| Role  | Description  |
+|-------|--------------|
+| Admin | This role grants full write access to all identity resources. |


### PR DESCRIPTION
### Description

Update the Konnect roles reference to the most recent actual state of Konnect.
Includes the new serverless roles.

Entries pulled from UI text with very light editing. Eventually, I expect we'll be generating this, so we won't want to manually edit.

Issue reported on Slack.

### Testing instructions

Preview link: https://deploy-preview-8065--kongdocs.netlify.app/konnect/org-management/teams-and-roles/roles-reference/
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

