### PR TITLE
Fix: select tag docs

### DIFF
--- a/app/_src/deck/guides/distributed-configuration.md
+++ b/app/_src/deck/guides/distributed-configuration.md
@@ -81,9 +81,16 @@ configuration of other teams. You no longer need to maintain Kong's
 configuration in a single repository, where multiple teams need to
 co-ordinate.
 
-The `--select-tag` flag is present on those two commands for use cases where
-the file cannot have `select_tags` defined inside it. It is strongly advised
-that you do not supply select-tags to sync and diff commands via flags.
+### Select-tag in sync and diff
+
+The `--select-tag` flag in `diff` and `sync` is meant only for use cases where
+the file cannot have `select_tags` defined inside it.
+
+This flag will only look for decK files where `select_tags` matches the provided value.
+It _cannot_ filter a full configuration based on values found in `tags`, therefore you can't use this 
+flag to sync a subset of a decK file.
+
+We strongly recommend not using select-tags to sync and diff commands via the `--select-tag` flag.
 This is because the tag information should be part of the declarative
 configuration file itself in order to provide a practical declarative file.
 The tagging information and entity definitions should be present in one place,

--- a/app/_src/deck/reference/deck_diff.md
+++ b/app/_src/deck/reference/deck_diff.md
@@ -52,6 +52,10 @@ and exit code 1 if an error occurs. (Default: `false`)
 :  only entities matching tags specified via this flag are diffed.
 When this setting has multiple tag values, entities must match each of them.
 
+: This flag will only look for decK files where `select_tags` matches the provided value.
+It _cannot_ filter a full configuration based on values found in `tags`, therefore you can't use this 
+flag to diff a subset of a decK file.
+
 {% if_version gte:1.8.x %}
 
 `--silence-events`

--- a/app/_src/deck/reference/deck_sync.md
+++ b/app/_src/deck/reference/deck_sync.md
@@ -47,6 +47,10 @@ See `db_update_propagation` in `kong.conf`. (Default: `0`)
 :  only entities matching tags specified via this flag are synced.
 When this setting has multiple tag values, entities must match every tag.
 
+: This flag will only look for decK files where `select_tags` matches the provided value.
+It _cannot_ filter a full configuration based on values found in `tags`, therefore you can't use this 
+flag to sync a subset of a decK file.
+
 {% if_version gte:1.8.x %}
 
 `--silence-events`


### PR DESCRIPTION
### Description

The `--select-tag` feature is confusing and the doc doesn't really explain it well. 

Draft for update, waiting on verification in https://konghq.atlassian.net/browse/FTI-6295. 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

