### PR TITLE
Fix: Admins examples broken steps formatting

### DIFF
--- a/app/_src/gateway/production/access-control/register-admin-api.md
+++ b/app/_src/gateway/production/access-control/register-admin-api.md
@@ -37,15 +37,16 @@ Extract and store the token from the registration URL, either by manually creati
 
 1. Send a request to the registration URL
 
-```bash
-curl -i http://localhost:8001/$WORKSPACE/admins/$USERNAME?generate_register_url=true \
-  -H Kong-Admin-Token:$TOKEN
-```
+  ```bash
+  curl -i http://localhost:8001/$WORKSPACE/admins/$USERNAME?generate_register_url=true \
+    -H Kong-Admin-Token:$TOKEN
+  ```
 
 2. Copy the response and export as an environment variable, for example:
-```bash
-export REGISTER_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NDUwNjc0NjUsImlkIjoiM2IyNzY3MzEtNjIxZC00ZjA3LTk3YTQtZjU1NTg0NmJkZjJjIn0.gujRDi2pX_E7u2zuhYBWD4MoPFKe3axMAq-AUcORg2g
-```
+  ```bash
+  export REGISTER_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NDUwNjc0NjUsImlkIjoiM2IyNzY3MzEtNjIxZC00ZjA3LTk3YTQtZjU1NTg0NmJkZjJjIn0.gujRDi2pX_E7u2zuhYBWD4MoPFKe3axMAq-AUcORg2g
+  ```
+
 {% endnavtab %}
 {% navtab Programmatic method (requires jq) %}
 

--- a/app/_src/gateway/production/access-control/register-admin-api.md
+++ b/app/_src/gateway/production/access-control/register-admin-api.md
@@ -36,7 +36,6 @@ Extract and store the token from the registration URL, either by manually creati
 {% navtab Manual method example %}
 
 1. Send a request to the registration URL
-
   ```bash
   curl -i http://localhost:8001/$WORKSPACE/admins/$USERNAME?generate_register_url=true \
     -H Kong-Admin-Token:$TOKEN


### PR DESCRIPTION
### Description

Fixing this step formatting issue:

![Screenshot 2024-10-22 at 8 51 00 AM](https://github.com/user-attachments/assets/ff4cb7dc-a1c7-4dfe-8efd-25f9a1b33f67)


### Testing instructions

Preview link: https://deploy-preview-8073--kongdocs.netlify.app/gateway/latest/production/access-control/register-admin-api/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

