### PR TITLE
Fix: Clean up diagram description

### DIFF
--- a/app/konnect/gateway-manager/control-plane-groups/index.md
+++ b/app/konnect/gateway-manager/control-plane-groups/index.md
@@ -58,7 +58,10 @@ flowchart LR
 
 In a control plane group setup, each team still administers their own control plane, but the data plane nodes are shared. 
 
-The following diagram illustrates using a control plane group for a federated platform administrator model. In this example, Team Blue configures Control Plane Blue, which is then combined with the configuration from Team Green. In addition, the control plane group contains Control Plane Green, which is managed by a central platform team. The central team provides global plugin configuration, which is added to any configuration that teams Blue and Green provide.
+The following diagram illustrates using a control plane group for a federated platform administrator model. In this example:
+* Team Blue configures Control Plane Blue, which is then combined with the configuration from Team Green.
+* The control plane group also contains Control Plane Purple, which is managed by a central platform team.
+* The central team manages global plugin configuration in Control Plane Purple, which is added to any configuration that teams Blue and Green provide.
 
 The data plane nodes in the cluster use the combined configuration from all three groups.
 

--- a/app/konnect/gateway-manager/control-plane-groups/index.md
+++ b/app/konnect/gateway-manager/control-plane-groups/index.md
@@ -61,7 +61,7 @@ In a control plane group setup, each team still administers their own control pl
 The following diagram illustrates using a control plane group for a federated platform administrator model. In this example:
 * Team Blue configures Control Plane Blue, which is then combined with the configuration from Team Green.
 * The control plane group also contains Control Plane Purple, which is managed by a central platform team.
-* The central team manages global plugin configuration in Control Plane Purple, which is added to any configuration that teams Blue and Green provide.
+* The central platform team manages global plugin configuration in Control Plane Purple, which is added to any configuration that teams Blue and Green provide.
 
 The data plane nodes in the cluster use the combined configuration from all three groups.
 


### PR DESCRIPTION
### Description

The diagram description was referring to the wrong group. Fixed that and broke it into bullet points for easier flow.

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1729691071079309

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

