### PR TITLE
docs(workspace): Add warnings to kong migrations

### DIFF
--- a/app/_includes/md/enterprise/migration-finish-warning.md
+++ b/app/_includes/md/enterprise/migration-finish-warning.md
@@ -1,1 +1,1 @@
-When adding new plugins to the existing installation (either manually or via the extension of `bundled` plugins), the `kong migrations finish` command must be run with `-f` flag to forcely upgrade the plugin schemas.
+When adding new plugins to the existing installation (either manually or via the extension of `bundled` plugins), the `kong migrations finish` or `kong migrations up` must be run with `-f` flag to forcely upgrade the plugin schemas.

--- a/app/_includes/md/enterprise/migration-finish-warning.md
+++ b/app/_includes/md/enterprise/migration-finish-warning.md
@@ -1,0 +1,1 @@
+When adding new plugins to the existing installation (either manually or via the extension of `bundled` plugins), the `kong migrations finish` command must be run with `-f` flag to forcely upgrade the plugin schemas.

--- a/app/_includes/md/enterprise/migration-finish-warning.md
+++ b/app/_includes/md/enterprise/migration-finish-warning.md
@@ -1,1 +1,1 @@
-When adding new plugins to the existing installation (either manually or via the extension of `bundled` plugins), the `kong migrations finish` or `kong migrations up` must be run with `-f` flag to forcely upgrade the plugin schemas.
+When adding new plugins to the existing installation (either manually or via the extension of `bundled` plugins), the `kong migrations finish` or `kong migrations up` must be run with the `-f` flag to forcefully upgrade the plugin schemas.

--- a/app/_src/gateway/admin-api/workspaces/reference.md
+++ b/app/_src/gateway/admin-api/workspaces/reference.md
@@ -301,7 +301,7 @@ Attributes | Description
 `cascade` | The `cascade` option lets you delete a workspace and all of its entities in one request.
 
 {:.important}
-> **Caution**: If deleting with the `cascade` option fails with `foreign key violation`, you may need to upgrade schema with `kong migrations -f finish`.
+> **Caution**: If deleting with the `cascade` option fails with a `foreign key violation` error, you may need to upgrade the schema with `kong migrations -f finish`.
 
 
 **Response**

--- a/app/_src/gateway/admin-api/workspaces/reference.md
+++ b/app/_src/gateway/admin-api/workspaces/reference.md
@@ -300,6 +300,9 @@ Attributes | Description
 `name or id`<br>**required** | The unique identifier **or** the name of the workspace to delete
 `cascade` | The `cascade` option lets you delete a workspace and all of its entities in one request.
 
+{:.important}
+> **Caution**: If deleting with the `cascade` option fails with `foreign key violation`, you may need to upgrade schema with `kong migrations -f finish`.
+
 
 **Response**
 

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -88,3 +88,5 @@ The `/consumer_groups/:id/overrides` endpoint has been deprecated. While this en
 Some referenceable configuration fields, such as the `http_endpoint` field
 of the `http-log` plugin and the `endpoint` field of the `opentelemetry` plugin,
 do not accept reference values due to incorrect field validation.
+
+{% include /md/enterprise/migration-finish-warning.md %}

--- a/app/_src/gateway/breaking-changes/34x.md
+++ b/app/_src/gateway/breaking-changes/34x.md
@@ -89,4 +89,4 @@ Some referenceable configuration fields, such as the `http_endpoint` field
 of the `http-log` plugin and the `endpoint` field of the `opentelemetry` plugin,
 do not accept reference values due to incorrect field validation.
 
-{% include /md/enterprise/migration-finish-warning.md %}
+{% include_cached /md/enterprise/migration-finish-warning.md %}

--- a/app/_src/gateway/migrate-ce-to-ke.md
+++ b/app/_src/gateway/migrate-ce-to-ke.md
@@ -34,7 +34,7 @@ to be up to date on any pending migration:
    ```
 
    {:.important}
-   > **Caution**: {% include /md/enterprise/migration-finish-warning.md %}
+   > **Caution**: {% include_cached /md/enterprise/migration-finish-warning.md %}
 
 2. Confirm that all of the entities are now available on your
    {{site.ee_product_name}} node.

--- a/app/_src/gateway/migrate-ce-to-ke.md
+++ b/app/_src/gateway/migrate-ce-to-ke.md
@@ -30,8 +30,11 @@ to be up to date on any pending migration:
 
    ```shell
    kong migrations up [-c configuration_file]
-   kong migrations finish [-c configuration_file]
+   kong migrations -f finish [-c configuration_file]
    ```
+
+   {:.important}
+   > **Caution**: {% include /md/enterprise/migration-finish-warning.md %}
 
 2. Confirm that all of the entities are now available on your
    {{site.ee_product_name}} node.

--- a/app/_src/gateway/reference/cli.md
+++ b/app/_src/gateway/reference/cli.md
@@ -285,7 +285,7 @@ Options:
 ```
 
 {:.important}
-> **Caution**: {% include /md/enterprise/migration-finish-warning.md %}
+> **Caution**: {% include_cached /md/enterprise/migration-finish-warning.md %}
 ---
 
 

--- a/app/_src/gateway/reference/cli.md
+++ b/app/_src/gateway/reference/cli.md
@@ -284,6 +284,8 @@ Options:
 
 ```
 
+{:.important}
+> **Caution**: {% include /md/enterprise/migration-finish-warning.md %}
 ---
 
 

--- a/app/_src/gateway/upgrade/blue-green.md
+++ b/app/_src/gateway/upgrade/blue-green.md
@@ -138,3 +138,6 @@ Write updates to {{site.base_gateway}} can now be performed, though we suggest y
 {:.note}
 > **Note**: This upgrade strategy is not the same thing as the [Blue-green (Canary) Deployment](/gateway/{{page.release}}/production/canary/). 
 That process is meant for upgrading your upstream services and is not related to {{site.base_gateway}} upgrades.
+
+{:.important}
+> **Caution**: {% include /md/enterprise/migration-finish-warning.md %}

--- a/app/_src/gateway/upgrade/blue-green.md
+++ b/app/_src/gateway/upgrade/blue-green.md
@@ -140,4 +140,4 @@ Write updates to {{site.base_gateway}} can now be performed, though we suggest y
 That process is meant for upgrading your upstream services and is not related to {{site.base_gateway}} upgrades.
 
 {:.important}
-> **Caution**: {% include /md/enterprise/migration-finish-warning.md %}
+> **Caution**: {% include_cached /md/enterprise/migration-finish-warning.md %}

--- a/app/_src/gateway/upgrade/in-place.md
+++ b/app/_src/gateway/upgrade/in-place.md
@@ -97,4 +97,4 @@ Write updates to {{site.base_gateway}} can now be performed, though we suggest y
 
 
 {:.important}
-> **Caution**: {% include /md/enterprise/migration-finish-warning.md %}
+> **Caution**: {% include_cached /md/enterprise/migration-finish-warning.md %}

--- a/app/_src/gateway/upgrade/in-place.md
+++ b/app/_src/gateway/upgrade/in-place.md
@@ -96,3 +96,5 @@ Prioritize the database-level restoration method over the application-level meth
 Write updates to {{site.base_gateway}} can now be performed, though we suggest you keep monitoring metrics for a while.
 
 
+{:.important}
+> **Caution**: {% include /md/enterprise/migration-finish-warning.md %}

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -3511,6 +3511,8 @@ hang when attempting to expand an API.
   of the `http-log` plugin and the `endpoint` field of the `opentelemetry` plugin,
   do not accept reference values due to incorrect field validation.
 
+* {% include /md/enterprise/migration-finish-warning.md %}
+
 ## 3.3.1.1
 **Release Date** 2023/10/12
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -3511,7 +3511,7 @@ hang when attempting to expand an API.
   of the `http-log` plugin and the `endpoint` field of the `opentelemetry` plugin,
   do not accept reference values due to incorrect field validation.
 
-* {% include /md/enterprise/migration-finish-warning.md %}
+* {% include_cached /md/enterprise/migration-finish-warning.md %}
 
 ## 3.3.1.1
 **Release Date** 2023/10/12


### PR DESCRIPTION
### Description

We currently need force upgrading to make sure the schema is correct and up-to-date.
This PR adds warnings to the upgrading guide, API doc, and CLI doc.

KAG-5040

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

