### PR TITLE
docs(api): add minimum length to tags pagination parameter

### DIFF
--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -225,6 +225,7 @@ components:
       name: tags
       schema:
         type: string
+        minLength: 1
     filter_chain_id:
       name: filter_chain_id
       in: path

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -22,6 +22,7 @@ components:
       name: tags
       schema:
         type: string
+        minLength: 1
     service_id_or_name:
       name: service_id_or_name
       description: ID **or** name of the service to lookup


### PR DESCRIPTION
### Description
When quering entities by tags a user could sent a request `tags=''` and it used to make Kong crash. Such request is invalid as either the tags should be specified or they should not be in the query params.

Documents the fix in: https://github.com/Kong/kong/pull/13723

KAG-5496

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

