### PR TITLE
chore: Add link to logging module

### DIFF
--- a/app/_hub/kong-inc/opentelemetry/overview/_index.md
+++ b/app/_hub/kong-inc/opentelemetry/overview/_index.md
@@ -160,6 +160,12 @@ In addition to the above, when **tracing** is enabled, request-scoped logs inclu
 - `TraceID`: Request trace ID.
 - `SpanID`: Request span ID.
 - `TraceFlags`: W3C trace flag.
+
+#### Logging for custom plugins
+
+The custom plugin PDK [`kong.telemetry.log`](/gateway/latest/plugin-development/pdk/kong.telemetry.log/) module lets you configure OTLP logging for a custom plugin. 
+The module records a structured log entry, which is reported via the OpenTelemetry plugin.
+
 {% endif_version %}
 
 {% if_version gte:3.3.x %}


### PR DESCRIPTION
### Description

The new logging OTEL/OTLP feature also comes with a kong.telemetry.log PDK module. Adding a link to the module from the page that describes the feature.

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1730248794886169

### Testing instructions

Preview link: https://deploy-preview-8104--kongdocs.netlify.app/hub/kong-inc/opentelemetry/#logging-for-custom-plugins

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

