### PR TITLE
chore(deps): bump kumahq/kuma-website from 754c9419 to 06058d89

### DIFF
--- a/app/_data/docs_nav_mesh_2.10.x.yml
+++ b/app/_data/docs_nav_mesh_2.10.x.yml
@@ -4,7 +4,7 @@ release: 2.10.x
 max_depth: 3
 inherit:
   path: /.repos/kuma/app/_src
-  nav: ../_src/.repos/kuma/app/_data/docs_nav_kuma_dev.yml
+  nav: ../_src/.repos/kuma/app/_data/docs_nav_kuma_2.10.x.yml
   patches:
     - path: [ Introduction ]
       action: modify


### PR DESCRIPTION
Auto upgrade PR log:

06058d8956f90b8ed3052fd5275218d889994c32 chore(mk/run): use npx to execute netlify-cli (kumahq/kuma-website#2081)
2a45090e5ab135a84f162483db5d0e9802846ed6 feat(blog): add 2.9 release blogpost (kumahq/kuma-website#2065)
e7b4096ca65f9720ae43b92488c6f0c8d2306024 chore(deps): update docs from repo source (kumahq/kuma-website#2078)
e2ed501124b8de5e6fdc109f7473bd38aa67ebab fix(js): handle sidebar links without trailing "/" for active link detection (kumahq/kuma-website#2074)
f9202ba2541a41be41227824850e469365ec3de8 Bump jekyll-generator-single-source (kumahq/kuma-website#1623)
113414440922d05dc8fd5e1e6c631b2b4d75e24a feat(guides): update otel collector guide to work with newest otel collector (kumahq/kuma-website#2070)
4de1239a71c0307b76952e06911e04060ba9a225 feat(guides): move guides to use new MeshService by default (kumahq/kuma-website#2069)
b32a28f1d24fde9705a0dc9388f05e995b6e4d86 chore(dev): fix small issuse with netlify conf and cleanup make target (kumahq/kuma-website#2071)
41d8a78bd95c1bdea88f5d03a92d278b7c22c9e8 fix(docs): correct kuma-init container patch example in dpp on k8s (kumahq/kuma-website#2067)
e440b1775df304e833a230a82f27fd1a978bbc45 remove mesh metric otel from experimental (kumahq/kuma-website#2062)
9d909b890c11fd773cde319ec1459cd954ad75ec cleanup(assets): remove old dev generated assets (kumahq/kuma-website#2066)
6e1b4fcf518551b7c74b26e349ddf6829c242afc fix(styles): ensure search results visibility (kumahq/kuma-website#2063)

Triggered by [action](https://github.com/Kong/docs.konghq.com/actions/runs/11808137192).