### PR TITLE
Update: Add AI Gateway tile to landing page

### DIFF
--- a/app/_assets/stylesheets/pages/landing-page.less
+++ b/app/_assets/stylesheets/pages/landing-page.less
@@ -377,7 +377,7 @@ header.navbar {
     .cards-container {
       display: grid;
       grid-gap: 24px;
-      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr;
 
       .card {
         align-self: stretch;

--- a/app/_data/landing_page.yml
+++ b/app/_data/landing_page.yml
@@ -1,6 +1,13 @@
 features:
   - title: Key features
     items:
+      - name: AI Gateway
+        description: Deploy a multi-LLM AI Gateway for GenAI infrastructure to semantically route, secure, observe, accelerate, and govern AI provider use and implementation.
+        icon: /assets/images/icons/documentation/icn-ai.svg
+        links:
+          - text: Overview
+            icon: /assets/images/icons/icn-doc.svg
+            url: /gateway/latest/ai-gateway/
       - name: Service Catalog
         description: Build a comprehensive catalog of all services running in your organization, both Konnect-internal applications (like Gateway Manager and Mesh Manager) as well as external applications (like GitHub and PagerDuty).
         icon: /assets/images/landing-page/card-icons/service-hub.svg


### PR DESCRIPTION
### Description

Adding AI Gateway as a key feature to our docs landing page.

Changed the rows to a two-column max because otherwise it's a 3-3-1 tile overhang. Not sure if I like this more, please take a look.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

