### PR TITLE
fix: correct config store queries

### DIFF
--- a/app/konnect/gateway-manager/configuration/config-store.md
+++ b/app/konnect/gateway-manager/configuration/config-store.md
@@ -14,11 +14,11 @@ You can store your sensitive data directly in {{site.konnect_short_name}} via th
 Create a config store entity in {{site.konnect_short_name}} and save the `config_store_id` from the response body.
 
 ```sh 
-curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/core-entities/vaults/ \
-  --header 'Authorization: Bearer{kpat_token}' \
+curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/config-stores \
+  --header 'Authorization: Bearer {kpat_token}' \
   --header 'Content-Type: application/json' \
   --data '{
-	"name": "konnect"
+	"name": "my-config-store"
 }'
 ```
 
@@ -30,11 +30,11 @@ curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane
   --header 'Content-Type: application/json' \
   --data '{
 	"config":{
-		"config_store_id": "7f1daa91-d386-4eb8-83c9-a78099f9c9d5"
+		"config_store_id": "{my-config-store-id}"
 	},
 	"description": "Description of your vault",
 	"name": "konnect",
-	"prefix": "mysecretvault"
+	"prefix": "my-vault"
 }'
 ```
 
@@ -64,7 +64,15 @@ vaults:
 
 ## Reference {{site.konnect_short_name}} Config Store secrets
 
-You can now store secrets in the {{site.konnect_short_name}} Config Store and reference them throughout the control plane. For instance, a secret in the {{site.konnect_short_name}} Config Store named `secret-name` can hold multiple key-value pairs:
+You can now store secrets in the {{site.konnect_short_name}} Config Store and reference them throughout the control plane. 
+
+For instance, a secret named `secret-name` can be referenced using:
+
+```sh
+{vault://my-vault/secret-name}
+```
+
+This allows {{site.base_gateway}} to recognize and retrieve the stored secrets. Additionally, a secret can hold multiple key-value pairs if needed:
 
 ```json
 {
@@ -73,14 +81,13 @@ You can now store secrets in the {{site.konnect_short_name}} Config Store and re
 }
 ```
 
-To make these secrets accessible to {{site.base_gateway}}, reference the environment variables using a specific URL format. For the example above, the references would be:
+To make these secrets accessible to {{site.base_gateway}}, reference the valut using a specific URL format. For the example above, the references would be:
 
 ```sh
-{vault://konnect/secret-name/foo}
-{vault://konnect/secret-name/snip}
+{vault://my-vault/secret-name/foo}
+{vault://my-vault/secret-name/snip}
 ```
 
-This allows {{site.base_gateway}} to recognize and retrieve the stored secrets.
 
 ## Supported fields
 
@@ -88,4 +95,4 @@ This allows {{site.base_gateway}} to recognize and retrieve the stored secrets.
 |---------------------|-------------------|---------------------------------------------------------------------------------------------------------|
 | `vaults.description`   | Description       | An optional description for your vault.                                                                 |
 | `vaults.name`         | Name              | The type of vault. Accepts one of: `konnect`, `env`, `gcp`, `aws`, or `hcv`. |
-| `vaults.prefix`       | Prefix            | The reference prefix. You need this prefix to access secrets stored in this vault. For example, `{vault://konnect-vault/<some-secret>}`. |
+| `vaults.prefix`       | Prefix            | The reference prefix. You need this prefix to access secrets stored in this vault. For example, `{vault://<vault-prefix>/<some-secret>}`. |

--- a/app/konnect/gateway-manager/configuration/config-store.md
+++ b/app/konnect/gateway-manager/configuration/config-store.md
@@ -81,7 +81,7 @@ This allows {{site.base_gateway}} to recognize and retrieve the stored secrets. 
 }
 ```
 
-To make these secrets accessible to {{site.base_gateway}}, reference the valut using a specific URL format. For the example above, the references would be:
+To make these secrets accessible to {{site.base_gateway}}, reference the vault using a specific URL format. For the example above, the references would be:
 
 ```sh
 {vault://my-vault/secret-name/foo}


### PR DESCRIPTION



### Description

Correct config store queries and references.
<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

