### PR TITLE
Feat: Add reserved entity names to References section

### DIFF
--- a/app/_data/docs_nav_gateway_3.9.x.yml
+++ b/app/_data/docs_nav_gateway_3.9.x.yml
@@ -771,5 +771,7 @@ items:
         url: /reference/rate-limiting/
       - text: WebAssembly
         url: /reference/wasm
+      - text: Reserved Entity Names
+        url: /reference/reserved-entity-names/
       - text: FAQ
         url: /reference/faq

--- a/app/_src/gateway/reference/reserved-entity-names.md
+++ b/app/_src/gateway/reference/reserved-entity-names.md
@@ -1,0 +1,55 @@
+---
+title: Reserved Entity Names
+content_type: reference
+badge: enterprise
+---
+
+The {{site.base_gateway}} maintains a list of reserved entity names which cannot be used when naming workspaces or other entities.
+
+* `admins`
+* `applications`
+* `application_instances`
+* `audit_objects`
+* `audit_requests`
+* `ca_certificates`
+* `certificates`
+* `clustering_data_planes`
+* `consumer_group_consumers`
+* `consumer_group_plugins`
+* `consumer_groups`
+* `consumer_reset_secrets`
+* `consumers`
+* `credentials`
+* `developers`
+* `document_objects`
+* `event_hooks`
+* `filter_chains`
+* `files`
+* `group_rbac_roles`
+* `groups`
+* `key_sets`
+* `keyring_keys`
+* `keyring_meta`
+* `keys`
+* `licenses`
+* `legacy_files`
+* `login_attempts`
+* `parameters`
+* `plugins`
+* `rbac_role_endpoints`
+* `rbac_role_entities`
+* `rbac_roles`
+* `rbac_user_groups`
+* `rbac_user_roles`
+* `rbac_users`
+* `routes`
+* `services`
+* `snis`
+* `tags`
+* `targets`
+* `upstreams`
+* `vaults`
+* `workspaces`
+* `workspace_entity_counters`
+
+For example, a workspace cannot be named `consumers` or `vaults`. Doing so will yield a `schema violation` error response.


### PR DESCRIPTION
### Description

Created a file under the References section to display the list of reserved entities which we discourage users from using and may trigger a schema violation error if they attempt it.

This resolves [DOCU-2116](https://konghq.atlassian.net/browse/DOCU-2116).

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.



[DOCU-2116]: https://konghq.atlassian.net/browse/DOCU-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ