### PR TITLE
Fix plugins filters after a bad rebase

### DIFF
--- a/app/_data/hub_filters.yml
+++ b/app/_data/hub_filters.yml
@@ -1,17 +1,13 @@
 tiers:
   - name: Free
     slug: free
-  - name: Konnect Paid
-    slug: paid
-  - name: Konnect Premium
-    slug: premium
   - name: Kong Gateway Enterprise
     slug: enterprise
 support:
   - name: Kong
     slug: kong-inc
-  - name: Technical partner
-    slug: third-party-partner
+  - name: Premium partner
+    slug: premium-partner
   - name: Support by 3rd party
     slug: community
 compatibility:

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -39,49 +39,6 @@ repos:
   homebrew: https://github.com/Kong/homebrew-kong
   cloudformation: https://github.com/Kong/kong-dist-cloudformation
 
-# for Kong platform extensions (not Jekyll)
-extensions:
-  categories: &plugin_categories
-    - name: AI
-      slug: ai
-      desc: Govern, secure, and control AI traffic with multi-LLM AI Gateway plugins
-      icon: /assets/images/nav/hub/ai.svg
-    - name: Authentication
-      slug: authentication
-      desc: Protect your services with an authentication layer
-      icon: /assets/images/nav/hub/lock_person.svg
-    - name: Security
-      slug: security
-      desc: Protect your services with additional security layer
-      icon: /assets/images/nav/hub/shield.svg
-    - name: Traffic Control
-      slug: traffic-control
-      desc: Manage, throttle and restrict inbound and outbound API traffic
-      icon: /assets/images/nav/hub/route.svg
-    - name: Serverless
-      slug: serverless
-      desc: Invoke serverless functions in combination with other plugins
-      icon: /assets/images/nav/hub/serverless.svg
-    - name: Analytics & Monitoring
-      slug: analytics-monitoring
-      desc: Visualize, inspect and monitor APIs and microservices traffic
-      icon: /assets/images/nav/hub/bar_chart.svg
-    - name: Transformations
-      slug: transformations
-      desc: Transform request and responses on the fly on Kong
-      icon: /assets/images/nav/hub/swap_horiz.svg
-    - name: Logging
-      slug: logging
-      desc: Log request and response data using the best transport for your infrastructure
-      icon: /assets/images/nav/hub/list_alt.svg
-  types:
-    - name: plugin
-      slug: plugin
-    - name: integration
-      slug: integration
-    # - name: dev portal extension
-    #   slug: dev-mod
-
 exclude:
   - node_modules
   - jekyll-cache
@@ -188,25 +145,6 @@ defaults:
     values:
       layout: "docs-v2"
       no_version: true
-
-hub-filters:
-  tiers:
-    - name: Free
-      slug: free
-    - name: Kong Gateway Enterprise
-      slug: enterprise
-  support:
-    - name: Kong
-      slug: kong-inc
-    - name: Premium partner
-      slug: premium-partner
-    - name: Support by 3rd party
-      slug: community
-  compatibility:
-    - name: Konnect
-      slug: konnect
-  categories:
-    *plugin_categories
 
 # product name vars
 ee_product_name: Kong Gateway Enterprise

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -39,49 +39,6 @@ repos:
   homebrew: https://github.com/Kong/homebrew-kong
   cloudformation: https://github.com/Kong/kong-dist-cloudformation
 
-# for Kong platform extensions (not Jekyll)
-extensions:
-  categories: &plugin_categories
-    - name: AI
-      slug: ai
-      desc: Govern, secure, and control AI traffic with multi-LLM AI Gateway plugins
-      icon: /assets/images/nav/hub/ai.svg
-    - name: Authentication
-      slug: authentication
-      desc: Protect your services with an authentication layer
-      icon: /assets/images/nav/hub/lock_person.svg
-    - name: Security
-      slug: security
-      desc: Protect your services with additional security layer
-      icon: /assets/images/nav/hub/shield.svg
-    - name: Traffic Control
-      slug: traffic-control
-      desc: Manage, throttle and restrict inbound and outbound API traffic
-      icon: /assets/images/nav/hub/route.svg
-    - name: Serverless
-      slug: serverless
-      desc: Invoke serverless functions in combination with other plugins
-      icon: /assets/images/nav/hub/serverless.svg
-    - name: Analytics & Monitoring
-      slug: analytics-monitoring
-      desc: Visualize, inspect and monitor APIs and microservices traffic
-      icon: /assets/images/nav/hub/bar_chart.svg
-    - name: Transformations
-      slug: transformations
-      desc: Transform request and responses on the fly on Kong
-      icon: /assets/images/nav/hub/swap_horiz.svg
-    - name: Logging
-      slug: logging
-      desc: Log request and response data using the best transport for your infrastructure
-      icon: /assets/images/nav/hub/list_alt.svg
-  types:
-    - name: plugin
-      slug: plugin
-    - name: integration
-      slug: integration
-    # - name: dev portal extension
-    #   slug: dev-mod
-
 exclude:
   - app/assets
 
@@ -174,25 +131,6 @@ defaults:
     values:
       layout: "docs-v2"
       no_version: true
-
-hub-filters:
-  tiers:
-    - name: Free
-      slug: free
-    - name: Kong Gateway Enterprise
-      slug: enterprise
-  support:
-    - name: Kong
-      slug: kong-inc
-    - name: Premium partner
-      slug: premium-partner
-    - name: Support by 3rd party
-      slug: community
-  compatibility:
-    - name: Konnect
-      slug: konnect
-  categories:
-    *plugin_categories
 
 # product name vars
 ee_product_name: Kong Gateway Enterprise


### PR DESCRIPTION
### Description

Fix plugin hub filters.
The filters now live in `app/_data/hub_filters.yml` and categories in `app/_data/extensions.yml`
Looks like that when we merged the jp changes there was a conflict and I didn't solve it correctly.
This updates the data files with the new values.


### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

