### PR TITLE
feat: serverless provisioning clarification

### DIFF
--- a/app/konnect/gateway-manager/serverless-gateways/index.md
+++ b/app/konnect/gateway-manager/serverless-gateways/index.md
@@ -5,6 +5,9 @@ title: Serverless Gateways
 {:.note}
 > **Note:** Serverless Gateways are currently only supported in {{site.konnect_short_name}} Plus. If you are an enterprise tier customer and are interested in Serverless Gateways, please contact your account team.
 
+{:.note}
+> **Note:** Serverless Gateways are not guaranteed to be provisioned in your local Konnect region.
+
 Serverless gateways are lightweight data plane nodes that are fully managed by Kong in {{site.konnect_short_name}}.
 
 Serverless gateways offer the following benefits:

--- a/app/konnect/gateway-manager/serverless-gateways/provision-serverless-gateway.md
+++ b/app/konnect/gateway-manager/serverless-gateways/provision-serverless-gateway.md
@@ -92,7 +92,7 @@ The {{site.konnect_short_name}} API uses [Personal Access Token (PAT)](/konnect/
 	* `region`: The region you want to deploy the data plane in.
 
 	{:.note}
-	> **Note:** The Serverless Gateway data plane can only be provisioned in the `na`, `eu`, or `au` regions. However your data plane and control plane be different (e.g. it's possible to attach an `eu` data plane to an `me` control plane.)
+	> **Note:** The Serverless Gateway data plane can only be provisioned in the `na`, `eu`, or `au` regions. However your data plane and control plane regions can be different (e.g. it's possible to attach an `eu` data plane to an `me` control plane.)
 
     You should get a `201` response which means your serverless gateway is now provisoned. You can use it like you would any other {{site.base_gateway}} in {{site.konnect_short_name}}.
 

--- a/app/konnect/gateway-manager/serverless-gateways/provision-serverless-gateway.md
+++ b/app/konnect/gateway-manager/serverless-gateways/provision-serverless-gateway.md
@@ -91,6 +91,9 @@ The {{site.konnect_short_name}} API uses [Personal Access Token (PAT)](/konnect/
 	* `control_plane_geo`: The geo of the control plane.
 	* `region`: The region you want to deploy the data plane in.
 
+	{:.note}
+	> **Note:** The Serverless Gateway data plane can only be provisioned in the `na`, `eu`, or `au` regions. However your data plane and control plane be different (e.g. it's possible to attach an `eu` data plane to an `me` control plane.)
+
     You should get a `201` response which means your serverless gateway is now provisoned. You can use it like you would any other {{site.base_gateway}} in {{site.konnect_short_name}}.
 
 {% endnavtab %}


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->

Quick clarification change to ensure users know that Serverless Gateways may not be provisioned in their current Konnect region.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

