### PR TITLE
kong2tf -g typically used in combination with gateway dump --with-id

### DIFF
--- a/app/_src/deck/reference/deck_file_kong2tf.md
+++ b/app/_src/deck/reference/deck_file_kong2tf.md
@@ -783,7 +783,7 @@ deck file kong2tf -s ./kong.yaml --generate-imports-for-control-plane-id "0dea9a
 ## Flags
 
 `-g`, `--generate-imports-for-control-plane-id`
-: `import` blocks will be added to Terraform to adopt existing resources.
+: `import` blocks will be added to Terraform to adopt existing resources. Typically used after `deck gateway dump --with-id` to obtain the IDs of all entities.
 
 `--ignore-credential-changes`
 : credentials will be ignored until they are destroyed and recreated.


### PR DESCRIPTION
Explain that the `-g` flag is typically used in combination with`deck gateway dump --with-id`.

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
