### PR TITLE
Fix: Konnect supported geos

### DIFF
--- a/app/konnect/geo.md
+++ b/app/konnect/geo.md
@@ -13,11 +13,13 @@ Geographic regions allow you to also operate {{site.konnect_saas}} in a similar 
 
 ### Control planes
 
-{{site.konnect_saas}} currently supports the following geos:
+{{site.konnect_product_name}} currently has the following regions in production:
 
-* AU
-* EU
-* US
+Area | Geo shortform | Region codes and locations
+-----|-----------|---------------------------
+North America - AWS | US | `us-east-2` (Ohio, USA) <br>`us-west-2` (Oregon, USA)
+Europe - AWS | EU | `eu-central-1` (Frankfurt, Germany) <br> `eu-west-1` (Ireland)
+Australia - AWS | AP | `ap-southeast-2` (Sydney, Australia) <br> `ap-southeast-4` (Melbourne, Australia)
 
 ### Dedicated Cloud Gateways
 
@@ -25,40 +27,21 @@ Geographic regions allow you to also operate {{site.konnect_saas}} in a similar 
 {% navtab AWS %}
 {{site.konnect_saas}} Dedicated Cloud Gateways support the following AWS geos: 
 
-
-* North America:
-    * Ohio (`us-east-2`)
-    * Oregon (`us-west-2`)
-    * California, USA (`us-west-1`)
-    * Montreal (`ca-central-1`)
-* Europe:
-    * Frankfurt (`eu-central-1`)
-    * Ireland (`eu-west-1`)
-    * London (`eu-west-2`)
-    * Paris (`eu-west-3`)
-    * Zurich (`eu-central-2`)
-* Asia Pacific:
-    * Tokyo (`ap-northeast-1`)
-    * Singapore (`ap-southeast-1`)
-    * Sydney (`ap-southeast-2`)
-    * Mumbai (`ap-south-1`)
-    * Hyderabad (`ap-south-2`)
-    * Seoul (`ap-northeast-2`)
-    * Jakarta (`ap-southeast-3`)
-* Middle East, and Africa
-    * United Arab Emirates (`me-central-1`)
+Area | Geo shortform | Region codes and locations
+-----|-----------|---------------------------
+North America | US<br>CA | `us-east-2` (Ohio, USA) <br> `us-west-2` (Oregon, USA) <br> `us-west-1` (California, USA) <br> `ca-central-1` (Montreal, Canada)
+Europe | EU |  `eu-central-1` (Frankfurt, Germany) <br> `eu-west-1` (Ireland) <br> `eu-west-2` (London, UK) <br> `eu-west-3` (Paris, France) <br> `eu-central-2` (Zurich, Switzerland)
+Asia Pacific | AP | `ap-northeast-1` (Tokyo, Japan) <br> `ap-southeast-1` (Singapore) <br> `ap-southeast-2` (Sydney, Australia) <br> `ap-south-1` (Mumbai, India) <br> `ap-south-2` (Hyderabad, India) <br> `ap-northeast-2` (Seoul, South Korea) <br> `ap-southeast-3` (Jakarta, Indonesia)
+Middle East and Africa | ME | `me-central-1` (United Arab Emirates)
 
 {% endnavtab %}
 {% navtab Azure %}
 {{site.konnect_saas}} Dedicated Cloud Gateways support the following Azure geos: 
 
-* North America:
-    * Virginia (`eastus2`)
-    * Washington (`westus2`)
-* Europe:
-    * Frankfurt (`germanywestcentral`)
-    * Ireland (`northeurope`)
-    * UK South (`uksouth`)
+Area | Geo shortform | Region codes and locations
+-----|-----------|---------------------------
+North America | US | `eastus2` (Virginia, USA) <br> `westus2` (Washington, USA)
+Europe | EU | `germanywestcentral` (Frankfurt, Germany) <br> `northeurope` (Ireland) <br> `uksouth` (UK South)
 
 {% endnavtab %}
 {% endnavtabs %}


### PR DESCRIPTION
### Description

We are missing a table of the supported Konnect geos. 

Fix requested on Slack: https://kongstrong.slack.com/archives/C04RXLGNB6K/p1732410184765539

Reza mentions in the thread that this is mostly an implementation detail, as users can't choose their specific regions for the CP, they only choose the larger geo. However, it's a talking point for compliance, and is useful to our support teams.

I also reformated the other lists of geos for dedicated CWGs into tables to make them easier to read.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

