### PR TITLE
Fix: Inaccurate OS support for AppD C SDK agent

### DIFF
--- a/app/_hub/kong-inc/app-dynamics/overview/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/overview/_index.md
@@ -16,10 +16,19 @@ Before using the plugin, download and install the [AppDynamics C/C++ Application
 
 ### Platform support
 
+{% if_version gte:3.4.x %}
 The AppDynamics C SDK supports Linux distributions based on glibc 2.5+.
 {{site.base_gateway}} must be running on a glibc-based distribution like RHEL, CentOS, Debian, or Ubuntu to support this plugin.
 
 The AppDynamics C/C++ SDK **does not** support ARM64 architecture.
+{% endif_version %}
+
+{% if_version lte:3.3.x %}
+The AppDynamics C SDK supports Linux distributions based on glibc 2.5+, and Alpine.
+{{site.base_gateway}} must be running on Alpine or a glibc-based distribution like RHEL, CentOS, Debian, or Ubuntu to support this plugin.
+
+The AppDynamics C/C++ SDK **does not** support ARM64 architecture.
+{% endif_version %}
 
 See the [AppDynamics C/C++ SDK Supported Environments](https://docs.appdynamics.com/appd/21.x/21.12/en/application-monitoring/install-app-server-agents/c-c++-sdk/c-c++-sdk-supported-environments) document for more information.
 

--- a/app/_hub/kong-inc/app-dynamics/overview/_index.md
+++ b/app/_hub/kong-inc/app-dynamics/overview/_index.md
@@ -16,12 +16,10 @@ Before using the plugin, download and install the [AppDynamics C/C++ Application
 
 ### Platform support
 
-The AppDynamics C SDK supports Linux distributions based on glibc 2.5+. 
+The AppDynamics C SDK supports Linux distributions based on glibc 2.5+.
 {{site.base_gateway}} must be running on a glibc-based distribution like RHEL, CentOS, Debian, or Ubuntu to support this plugin.
 
-The AppDynamics C/C++ SDK **does not** support the following:
-* MUSL-based distributions like the Alpine distribution, which is popular for container usage
-* ARM64 architecture
+The AppDynamics C/C++ SDK **does not** support ARM64 architecture.
 
 See the [AppDynamics C/C++ SDK Supported Environments](https://docs.appdynamics.com/appd/21.x/21.12/en/application-monitoring/install-app-server-agents/c-c++-sdk/c-c++-sdk-supported-environments) document for more information.
 


### PR DESCRIPTION
### Description

Removed the mention of Alpine from AppD docs.

Although the AppD agent does [support Alpine as of May 2022](https://docs.appdynamics.com/appd/23.x/latest/en/product-and-release-announcements/past-releases/past-agent-releases#PastAgentReleases-Version22.3.1-March15,2022), Kong stopped supporting Alpine in 3.3.x, so the older versions get a mention of Alpine, while it's completely removed from the newest ones.

https://konghq.atlassian.net/browse/DOCU-4121 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

