### PR TITLE
Fix: Heading level in KIC custom entities guide

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/services/custom-entity.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/custom-entity.md
@@ -28,7 +28,7 @@ spec:
 
 This corresponds to the `uri` and `query` parameters documented in the [plugin documentation](/hub/kong-inc/degraphql/#available-endpoints)
 
-# Tutorial: DeGraphQL custom entities
+## Tutorial: DeGraphQL custom entities
 
 {% include /md/kic/prerequisites.md release=page.release disable_gateway_api=false enterprise=true %}
 


### PR DESCRIPTION
### Description

The heading was set to H1, which is massive and we don't use H1s in text.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

