### PR TITLE
Fix: use prereq styling for KIC and KGO

### DIFF
--- a/app/_assets/stylesheets/collapsible-sections.less
+++ b/app/_assets/stylesheets/collapsible-sections.less
@@ -1,49 +1,44 @@
 details {
-    &:not(.custom) {
-        summary {
-            border-radius: 3px;
-            margin-bottom: 8px;
-            font-size: 1.1em;
-            font-weight: 500;
-            background-color: #f8f8fa;
-            padding: 8px;
+    summary {
+        border-radius: 3px;
+        margin-bottom: 8px;
+        font-size: 1.1em;
+        font-weight: 500;
+        background-color: #f8f8fa;
+        padding: 8px;
 
-            &:before {
-            content: "\f105";
-            font-family: FontAwesome, "Font Awesome", FontAwesome;
-            margin-right: 8px;
-            float: left;
-            }
-            
-            &:hover {
-            cursor: pointer;
-            opacity: 0.8;
-            }
+        &:before {
+        content: "\f105";
+        font-family: FontAwesome, "Font Awesome", FontAwesome;
+        margin-right: 8px;
+        float: left;
         }
+        
+        &:hover {
+        cursor: pointer;
+        opacity: 0.8;
+        }
+    }
 
-    &.collapsible-note {
-        border-top: none;
+&.collapsible-note {
+    border-top: none;
 
-        summary {
-            font-size: unset;
-            font-weight: unset;
-            margin: unset;
-            }
+    summary {
+        font-size: unset;
+        font-weight: unset;
+        margin: unset;
         }
     }
 }
 
 details[open] { 
     padding-bottom: 15px;
-    &:not(.custom) {
-        summary {
-            &:before {
-                content: "\f105";
-                font-family: FontAwesome, "Font Awesome", FontAwesome;
-                transform: rotate(90deg);
-                float: left;
-            }
-
+    summary {
+        &:before {
+            content: "\f105";
+            font-family: FontAwesome, "Font Awesome", FontAwesome;
+            transform: rotate(90deg);
+            float: left;
         }
     }
 }

--- a/app/_includes/md/kgo/prerequisites.md
+++ b/app/_includes/md/kgo/prerequisites.md
@@ -1,9 +1,7 @@
 {% unless include.disable_accordian %}
-<details class="custom" markdown="1">
+<details markdown="1">
 <summary>
-<blockquote class="note">
-  <p style="cursor: pointer">Before you begin, ensure that you have <u>installed the {{site.kgo_product_name}}</u> in your Kubernetes cluster{% if include.aiGateway %} with AI Gateway support enabled{% endif %}{% if include.kongPluginInstallation %} with KongPluginInstallation support enabled{% endif %}{% if include.kconfCRDs %} with Kong's Kubernetes Configuration CRDs enabled{% endif %}. {% if include.enterprise %}This guide requires an enterprise license.{% endif %}</p>
-</blockquote>
+  <strong>Prerequisites:</strong> Install the {{site.kgo_product_name}} in your Kubernetes cluster{% if include.aiGateway %} with AI Gateway support enabled.{% endif %}{% if include.kongPluginInstallation %} with KongPluginInstallation support enabled.{% endif %}{% if include.kconfCRDs %} with Kong's Kubernetes Configuration CRDs enabled.{% endif %} {% if include.enterprise %}This guide requires an enterprise license.{% endif %}
 </summary>
 
 ## Prerequisites

--- a/app/_includes/md/kic/prerequisites.md
+++ b/app/_includes/md/kic/prerequisites.md
@@ -1,9 +1,7 @@
 {% unless include.disable_accordian %}
-<details class="custom" markdown="1">
+<details markdown="1">
 <summary>
-<blockquote class="note">
-  <p style="cursor: pointer">Before you begin ensure that you have <u>Installed {{site.kic_product_name}}</u> {% unless include.disable_gateway_api %}with Gateway API support {% endunless %}in your Kubernetes cluster and are able to connect to Kong. {% if include.enterprise %}This guide requires <strong>{{site.ee_product_name}}</strong>.{% endif %}</p>
-</blockquote>
+  <strong>Prerequisites:</strong> Install {{site.kic_product_name}} {% unless include.disable_gateway_api %}with Gateway API support {% endunless %}in your Kubernetes cluster and connect to Kong. {% if include.enterprise %}This guide requires <strong>{{site.ee_product_name}}</strong>.{% endif %}
 </summary>
 
 ## Prerequisites


### PR DESCRIPTION
### Description

We've gotten multiple reports from users that they can't tell that the KIC and KGO prereq notes are supposed to be clickable & expandable. Changing these notes to use the styling that we use for the plugins.

Had to shorten the prereqs to be more concise, but they still look a bit weird. This styling is really not meant for full sentences. At the same time, I don't want to put anymore time into this, as this is temporary anyway.

https://konghq.atlassian.net/browse/DOCU-4124

### Testing instructions

Preview links for example pages: 
https://deploy-preview-8180--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/services/http/
https://deploy-preview-8180--kongdocs.netlify.app/gateway-operator/latest/guides/plugin-distribution/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

