### PR TITLE
fix: step formatting in Secure Comms

### DIFF
--- a/app/konnect/gateway-manager/data-plane-nodes/secure-communications.md
+++ b/app/konnect/gateway-manager/data-plane-nodes/secure-communications.md
@@ -29,7 +29,7 @@ Consider the following scenarios with this example cert chain:
 
 When you use the {{site.konnect_short_name}} wizard to create a data plane node, it generates a certificate key pair. Data planes can establish a connection with this certificate key pair (pinned cert).
 
-1. 1.  Navigate to [**Gateway Manager**](https://cloud.konghq.com/gateway-manager/) in {{site.konnect_short_name}}.
+1. Navigate to [**Gateway Manager**](https://cloud.konghq.com/gateway-manager/) in {{site.konnect_short_name}}.
 1. Click on the control plane you want to create a data plane node for.
 1. Click **Data Plane Nodes** in the sidebar.
 1. Click **Create a New Data Plane Node**. 
@@ -39,7 +39,7 @@ When you use the {{site.konnect_short_name}} wizard to create a data plane node,
 
 Using the {{site.konnect_short_name}} UI, you can generate a CA certificate, which allows data planes to connect using a certificate signed by that CA (PKI). Alternatively you can upload your own CA using the upload option.
 
-1.  Navigate to [**Gateway Manager**](https://cloud.konghq.com/gateway-manager/) in {{site.konnect_short_name}}.
+1. Navigate to [**Gateway Manager**](https://cloud.konghq.com/gateway-manager/) in {{site.konnect_short_name}}.
 1. Click on the control plane you want to create a data plane node for.
 1. From the Action menu, select **Data Plane Certificates**. 
 1. Either upload or generate a certificate.


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Fixed the formatting of the certificate steps, it was messed up.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

