### PR TITLE
Fix: missing changelog entry for dependency bump

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -87,6 +87,7 @@ For product versions that have reached the end of sunset support, see the [chang
 
 * Bumped `lua-kong-nginx-module` from 0.11.0 to 0.11.1 to fix an issue where the upstream cert chain wasn't properly set.
 * Bumped `lua-resty-aws` to 1.5.4 to fix a bug inside region prefix generation.
+* Bumped `lua-resty-azure` to 1.6.1 to fix a `GET` request build issue, which was causing problems with Azure secret references.
 
 ## 3.8.0.0
 **Release Date** 2024/09/11
@@ -669,8 +670,8 @@ it can be configured by `pg_iam_auth_sts_endpoint_url` and `pg_ro_iam_auth_sts_e
 
 ### Dependencies
 
-* Bumped lua-resty-aws to 1.5.3 to fix a bug related to STS regional endpoint.
-* Bumped lua-resty-azure to 1.6.1 to fix a GET request build issue.
+* Bumped `lua-resty-aws` to 1.5.3 to fix a bug related to STS regional endpoint.
+* Bumped `lua-resty-azure` to 1.6.1 to fix a `GET` request build issue, which was causing problems with Azure secret references.
 * Made the RPM package relocatable with the default prefix set to `/`.
 
 ## 3.7.1.2
@@ -2683,7 +2684,7 @@ was called multiple times in a request lifecycle.
 * Bumped `LPEG` from 1.0.2 to 1.1.0 to keep the version consistent across all active branches. 
 The version bump includes fixes like UTF-8 ranges, a larger limit for rules and matches, accumulator capture, and more.
 * Bumped `lua-resty-aws` to 1.5.3 to fix a bug related to the STS regional endpoint.
-* Bumped `lua-resty-azure` to 1.6.1 to fix a `GET` request build issue.
+* Bumped `lua-resty-azure` to 1.6.1 to fix a `GET` request build issue, which was causing problems with Azure secret references.
 * Made the RPM package relocatable with the default prefix set to `/`.
 
 ## 3.4.3.12


### PR DESCRIPTION
### Description

Add missing dependency bump changelong entry to 3.8.1.0 ([eng PR here](https://github.com/Kong/kong-ee/pull/10599)) and add detail to capture the customer issue. Support was unable to find the fix in the changelog, since the initial issue wasn't mentioned.

Issue reported on slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1732724038244199

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

