### PR TITLE
chore(kgo): bump to 1.4.1

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -311,10 +311,10 @@
   releaseDate: "2024-06-24"
   endOfLifeDate: "2025-06-24"
 - edition: gateway-operator
-  version: 1.4.0
+  version: 1.4.1
   release: 1.4.x
-  releaseDate: "2024-10-31"
-  endOfLifeDate: "2025-10-31"
+  releaseDate: "2024-11-28"
+  endOfLifeDate: "2025-11-28"
   latest: true
 - edition: mesh
   version: 1.2.6

--- a/app/gateway-operator/changelog.md
+++ b/app/gateway-operator/changelog.md
@@ -5,6 +5,23 @@ no_version: true
 
 Changelog for supported {{ site.kgo_product_name }} versions.
 
+## 1.4.1
+
+**Release Date** 2024/11/28
+
+- Fix setting the `ServiceAccountName` for `DataPlane`'s `Deployment`.
+  [#897](https://github.com/Kong/gateway-operator/pull/897)
+- Fixed setting `ExternalTrafficPolicy` on `DataPlane`'s ingress `Service` when
+  the requested value is empty.
+  [#898](https://github.com/Kong/gateway-operator/pull/898)
+- Set 0 members on `KonnectGatewayControlPlane` which type is set to group.
+  [#896](https://github.com/Kong/gateway-operator/pull/896)
+- Fixed a `panic` in `KonnectAPIAuthConfigurationReconciler` occurring when nil
+  response was returned by Konnect API when fetching the organization information.
+  [#901](https://github.com/Kong/gateway-operator/pull/901)
+- Bump sdk-konnect-go version to 0.1.10 to fix handling global API endpoints.
+  [#894](https://github.com/Kong/gateway-operator/pull/894)
+
 ## 1.4.0
 
 **Release Date** 2024/10/31
@@ -125,34 +142,34 @@ Changelog for supported {{ site.kgo_product_name }} versions.
 
 ### Fixes
 
-* Fix the `ControlPlane` extensions controller to gracefully handle the
+- Fix the `ControlPlane` extensions controller to gracefully handle the
   absence of a {{site.ee_product_name}} license on startup.
-* Do not require existence of `certmanager.io/v1.certificates` CRD when
+- Do not require existence of `certmanager.io/v1.certificates` CRD when
   `KonnectCertificateOptions` is empty in `DataPlane`.
-* Fix version reporting in logs and via `-version` CLI arg
-* Fix enforcing up to date `ControlPlane`'s `ValidatingWebhookConfiguration`
+- Fix version reporting in logs and via `-version` CLI arg
+- Fix enforcing up to date `ControlPlane`'s `ValidatingWebhookConfiguration`
 
 ### Changes
 
-* `Gateway` do not have their `Ready` status condition set anymore.
-* This aligns with Gateway API and its conformance test suite.
-* `Gateway`s' listeners now have their `attachedRoutes` count filled in status.
-* Detect when `ControlPlane` has its admission webhook disabled via
-* `CONTROLLER_ADMISSION_WEBHOOK_LISTEN` environment variable and ensure that
-* relevant webhook resources are not created/deleted.
-* The `OwnerReferences` on cluster-wide resources to indicate their owner are now
-* replaced by a proper set of labels to identify `kind`, `namespace`, and
-* `name` of the owning object.
-* Default version of `ControlPlane` is bumped to 3.2.0
+- `Gateway` do not have their `Ready` status condition set anymore.
+- This aligns with Gateway API and its conformance test suite.
+- `Gateway`s' listeners now have their `attachedRoutes` count filled in status.
+- Detect when `ControlPlane` has its admission webhook disabled via
+- `CONTROLLER_ADMISSION_WEBHOOK_LISTEN` environment variable and ensure that
+- relevant webhook resources are not created/deleted.
+- The `OwnerReferences` on cluster-wide resources to indicate their owner are now
+- replaced by a proper set of labels to identify `kind`, `namespace`, and
+- `name` of the owning object.
+- Default version of `ControlPlane` is bumped to 3.2.0
 
 ### Breaking Changes
 
-* Changes project layout to match `kubebuilder` `v4`. Some import paths (due to dir renames) have changed
+- Changes project layout to match `kubebuilder` `v4`. Some import paths (due to dir renames) have changed
   `apis` -> `api` and `controllers` -> `controller`.
 
 ### Added
 
-* Add `ExternalTrafficPolicy` to `DataPlane`'s `ServiceOptions`
+- Add `ExternalTrafficPolicy` to `DataPlane`'s `ServiceOptions`
 
 ## 1.2.3
 
@@ -160,14 +177,14 @@ Changelog for supported {{ site.kgo_product_name }} versions.
 
 ### Fixes
 
-* Fixed an issue where the managed `Gateway`s controller wasn't able to reduce
+- Fixed an issue where the managed `Gateway`s controller wasn't able to reduce
   the created `DataPlane` objects when too many were created.
-* `Gateway` controller will no longer set `DataPlane` deployment's replicas
+- `Gateway` controller will no longer set `DataPlane` deployment's replicas
   to the default value when `DataPlaneOptions` in `GatewayConfiguration` define
   a scaling strategy. This effectively allows users to use `DataPlane` horizontal
   autoscaling with `GatewayConfiguration` because the generated `DataPlane` deployment
   won't be rejected.
-* Made creating a `DataPlane` index conditional based on enabling the `ControlPlane`
+- Made creating a `DataPlane` index conditional based on enabling the `ControlPlane`
   controller. This allows KGO to run without the `ControlPlane` CRD with its controller
   disabled.
 
@@ -189,13 +206,13 @@ v1.2.3 contains all the changes that v1.2.2 intended to contain.
 
 ### Fixes
 
-* Fixed an issue where operator wasn't able to update `ControlPlane` `ClusterRole` or `ClusterRoleBinding`
+- Fixed an issue where operator wasn't able to update `ControlPlane` `ClusterRole` or `ClusterRoleBinding`
   when they got out of date.
-* Add missing watch RBAC policy rule for cert-manager's Certificate resources
+- Add missing watch RBAC policy rule for cert-manager's Certificate resources
 
 ### Changes
 
-* KGO now uses `GATEWAY_OPERATOR_` prefix for all flags, including the `zap` related logging flags.
+- KGO now uses `GATEWAY_OPERATOR_` prefix for all flags, including the `zap` related logging flags.
 
 ## 1.2.0
 
@@ -203,96 +220,96 @@ v1.2.3 contains all the changes that v1.2.2 intended to contain.
 
 ## Highlights
 
-* 🎓 The Managed `Gateway`s feature is now GA.
-* 🎓 `ControlPlane` and `GatewayConfig` APIs have been promoted to `v1beta1`.
-* ✨ `DataPlane`s managed by `Gateway`s can be now scaled horizontally through the
+- 🎓 The Managed `Gateway`s feature is now GA.
+- 🎓 `ControlPlane` and `GatewayConfig` APIs have been promoted to `v1beta1`.
+- ✨ `DataPlane`s managed by `Gateway`s can be now scaled horizontally through the
   `GatewayConfiguration` API.
-* ✨ `Gateway` listeners are dynamically mapped to the `DataPlane` proxy service ports.
-* 🧠 The new feature `AIGateway` has been released in `alpha` stage.
-* ✨ {{site.kgo_product_name}} exposes metrics with latency that can be used for autoscaling of your workloads.
-* ✨ Automated handling of certificates for Konnect's PKI mode with cert-manager.
+- ✨ `Gateway` listeners are dynamically mapped to the `DataPlane` proxy service ports.
+- 🧠 The new feature `AIGateway` has been released in `alpha` stage.
+- ✨ {{site.kgo_product_name}} exposes metrics with latency that can be used for autoscaling of your workloads.
+- ✨ Automated handling of certificates for Konnect's PKI mode with cert-manager.
 
 ## Added
 
-* Added support for specifying command line flags through environment
+- Added support for specifying command line flags through environment
   variables having the `GATEWAY_OPERATOR_` prefix.
-* Add horizontal autoscaling for `DataPlane`s using its `scaling.horizontal` spec
+- Add horizontal autoscaling for `DataPlane`s using its `scaling.horizontal` spec
   field.
-* `ControlPlane`s now use Gateway Discovery by default, with Service DNS Strategy.
+- `ControlPlane`s now use Gateway Discovery by default, with Service DNS Strategy.
   Additionally, the `DataPlane` readiness probe has been changed to `/status/ready`
   when the `DataPlane` is managed by a `Gateway`.
-* `Gateway`s and `Listener`s `Accepted` and `Conflicted` conditions are now set
+- `Gateway`s and `Listener`s `Accepted` and `Conflicted` conditions are now set
   and enforced based on the Gateway API specifications.
-* `ControlPlane` `ClusterRole`s and `ClusterRoleBinding`s are enforced and kept
+- `ControlPlane` `ClusterRole`s and `ClusterRoleBinding`s are enforced and kept
   up to date by the `ControlPlane` controller.
-* The `Gateway` listeners are now dynamically mapped to `DataPlane` ingress service
+- The `Gateway` listeners are now dynamically mapped to `DataPlane` ingress service
   ports. This means that the change of a `Gateway` spec leads to a `DataPlane` reconfiguration,
   along with an ingress service update.
-* `--enable-controller-gateway` and `--enable-controller-controlplane` command
+- `--enable-controller-gateway` and `--enable-controller-controlplane` command
   line flags are set to `true` by default to enable controllers for `Gateway`s
   and `ControlPlane`s.
-* When the `Gateway` controller provisions a `ControlPlane`, it sets the `CONTROLLER_GATEWAY_TO_RECONCILE`
+- When the `Gateway` controller provisions a `ControlPlane`, it sets the `CONTROLLER_GATEWAY_TO_RECONCILE`
   env variable to let the `ControlPlane` reconcile
   that specific `Gateway` only.
-* `ControlPlane` is now deployed with a validating webhook server turned on. This
+- `ControlPlane` is now deployed with a validating webhook server turned on. This
   involves creating `ValidatingWebhookConfiguration`, a `Service` that exposes the
   webhook and a `Secret` that holds a TLS certificate. The `Secret` is mounted in
   the `ControlPlane`'s `Pod` for the webhook server to use it.
-* Added `konnectCertificate` field to the DataPlane resource.
-* Added `v1alpha1.AIGateway` as an experimental API. This can be enabled by
+- Added `konnectCertificate` field to the DataPlane resource.
+- Added `v1alpha1.AIGateway` as an experimental API. This can be enabled by
   manually deploying the `AIGateway` CRD and enabling the feature on the
   controller manager with the `--enable-controller-aigateway` flag.
-* Added validation on checking if ports in `KONG_PORT_MAPS` and `KONG_PROXY_LISTEN`
+- Added validation on checking if ports in `KONG_PORT_MAPS` and `KONG_PROXY_LISTEN`
   environment variables of deployment options in `DataPlane` match the `ports`
   in the ingress service options of the `DataPlane`.
-* Support for KongLicense CRD to manage {{site.ee_product_name}} licenses.
-* New ControlPlane extensions controller to manage control plane extensions with initial support for `DataPlaneMetricsExtension`.
-* DataPlane Prometheus metrics scrapping support for `DataPlaneMetricsExtension`.
-* DataPlane resources can provision cert-manager Certificate resources from a (Cluster) Issuer for use with Konnect's PKI mode.
-* ControlPlane extensions controller now checks for a valid Kong enterprise license.
+- Support for KongLicense CRD to manage {{site.ee_product_name}} licenses.
+- New ControlPlane extensions controller to manage control plane extensions with initial support for `DataPlaneMetricsExtension`.
+- DataPlane Prometheus metrics scrapping support for `DataPlaneMetricsExtension`.
+- DataPlane resources can provision cert-manager Certificate resources from a (Cluster) Issuer for use with Konnect's PKI mode.
+- ControlPlane extensions controller now checks for a valid Kong enterprise license.
 
 ### Changes
 
-* The `GatewayConfiguration` API has been promoted from `v1alpha1` to `v1beta1`.
-* The `ControlPlane` API has been promoted from `v1alpha1` to `v1beta1`.
-* The CRD's short names of `ControlPlane`, `DataPlane` and `GatewayConfiguration`
+- The `GatewayConfiguration` API has been promoted from `v1alpha1` to `v1beta1`.
+- The `ControlPlane` API has been promoted from `v1alpha1` to `v1beta1`.
+- The CRD's short names of `ControlPlane`, `DataPlane` and `GatewayConfiguration`
   has been changed to `kocp`, `kodp` and `kogc`.
-* `ControlPlane` ({{site.kic_product_name}}) default and minimum version has been
+- `ControlPlane` ({{site.kic_product_name}}) default and minimum version has been
   bumped to 3.1.2.
-* `DataPlane` ({{site.base_gateway}}) default version has been bumped to `v3.6.0`.
+- `DataPlane` ({{site.base_gateway}}) default version has been bumped to `v3.6.0`.
 
 ### Fixes
 
-* Fixed a problem where the operator would not set the defaults to `PodTemplateSpec`
+- Fixed a problem where the operator would not set the defaults to `PodTemplateSpec`
   patch and because of that it would detect a change and try to reconcile the owned
   resource where in fact the change was not there.
   One of the symptoms of this bug could have been a `StartupProbe` set in `PodSpec`
   preventing the `DataPlane` from getting correct status information.
-* If the Gateway controller is enabled, `DataPlane` and `ControlPlane` controllers
+- If the Gateway controller is enabled, `DataPlane` and `ControlPlane` controllers
   get enabled as well.
-* Fix applying the `PodTemplateSpec` patch so that it's not applied when the
+- Fix applying the `PodTemplateSpec` patch so that it's not applied when the
   calculated patch (resulting from the generated manifest and current in-cluster
   state) is empty.
   One of the symptoms of this bug was that when users tried to apply a `ReadinessProbe`
   which specified a port name instead of a number (which is what's generated by
   the operator) it would never reconcile and the status conditions would never get
   up to date `ObservedGeneration`.
-* Fix manager RBAC permissions which prevented the operator from being able to
+- Fix manager RBAC permissions which prevented the operator from being able to
   create `ControlPlane`'s `ClusterRole`s, list pods or list `EndpointSlices`.
-* `DataPlane`s with BlueGreen rollout strategy enabled will now have its Ready status
+- `DataPlane`s with BlueGreen rollout strategy enabled will now have its Ready status
   condition updated to reflect "live" `Deployment` and `Service`s status.
-* The `ControlPlane` `election-id` has been changed so that every `ControlPlane`
+- The `ControlPlane` `election-id` has been changed so that every `ControlPlane`
   has its own `election-id`, based on the `ControlPlane` name. This prevents `pod`s
   belonging to different `ControlPlane`s from competing for the same lease.
-* Fill in the defaults for `env` and `volumes` when comparing the in-cluster spec
+- Fill in the defaults for `env` and `volumes` when comparing the in-cluster spec
   with the generated spec.
-* Do not flap `DataPlane`'s `Ready` status condition when e.g. ingress `Service`
+- Do not flap `DataPlane`'s `Ready` status condition when e.g. ingress `Service`
   can't get an address assigned and `spec.network.services.ingress.`annotations`
   is non-empty.
-* Update or recreate a `ClusterRoleBinding` for control planes if the existing
+- Update or recreate a `ClusterRoleBinding` for control planes if the existing
   one does not contain the `ServiceAccount` used by `ControlPlane`, or
   `ClusterRole` is changed.
-* Retry reconciling `Gateway`s when provisioning owned `DataPlane` fails.
+- Retry reconciling `Gateway`s when provisioning owned `DataPlane` fails.
 
 ## 1.1.0
 
@@ -300,16 +317,16 @@ v1.2.3 contains all the changes that v1.2.2 intended to contain.
 
 ### Added
 
-* Add support for `ControlPlane` `v3.0` by updating the generated `ClusterRole`.
+- Add support for `ControlPlane` `v3.0` by updating the generated `ClusterRole`.
 
 ### Changes
 
-* Bump `ControlPlane` default version to `v3.0`.
-* Bump Gateway API to v1.0.
+- Bump `ControlPlane` default version to `v3.0`.
+- Bump Gateway API to v1.0.
 
 ### Fixes
 
-* Operator `Role` generation is fixed. As a result it contains now less rules
+- Operator `Role` generation is fixed. As a result it contains now less rules
   hence the operator needs less permissions to run.
 
 ## 1.0.3
@@ -318,12 +335,12 @@ v1.2.3 contains all the changes that v1.2.2 intended to contain.
 
 ### Fixes
 
-* Fix an issue where operator is upgraded from an older version and it orphans
+- Fix an issue where operator is upgraded from an older version and it orphans
   old `DataPlane` resources.
 
 ### Added
 
-* Setting `spec.deployment.podTemplateSpec.spec.volumes` and
+- Setting `spec.deployment.podTemplateSpec.spec.volumes` and
   `spec.deployment.podTemplateSpec.spec.containers[*].volumeMounts` on `ControlPlane`s
   is now allowed.
 
@@ -333,7 +350,7 @@ v1.2.3 contains all the changes that v1.2.2 intended to contain.
 
 ### Changed
 
-* Bump dependencies
+- Bump dependencies
 
 ## 1.0.1
 
@@ -341,12 +358,12 @@ v1.2.3 contains all the changes that v1.2.2 intended to contain.
 
 ### Fixes
 
-* Fix flapping of `Gateway` managed `ControlPlane` `spec` field when applied without `controlPlaneOptions` set.
+- Fix flapping of `Gateway` managed `ControlPlane` `spec` field when applied without `controlPlaneOptions` set.
 
 ### Changes
 
-* Bump `ControlPlane` default version to `v2.12`.
-* Bump `WebhookCertificateConfigBaseImage` to `v1.3.0`.
+- Bump `ControlPlane` default version to `v2.12`.
+- Bump `WebhookCertificateConfigBaseImage` to `v1.3.0`.
 
 ## 1.0.0
 
@@ -354,6 +371,6 @@ v1.2.3 contains all the changes that v1.2.2 intended to contain.
 
 ### Features
 
-* Deploy and configure {{ site.base_gateway }} services
-* Customise deployments using `PodTemplateSpec` to deploy sidecars, set node affinity and more.
-* Upgrade Data Planes using a rolling restart or blue/green deployments
+- Deploy and configure {{ site.base_gateway }} services
+- Customise deployments using `PodTemplateSpec` to deploy sidecars, set node affinity and more.
+- Upgrade Data Planes using a rolling restart or blue/green deployments


### PR DESCRIPTION
### Description

Bump KGO to 1.4.1

OSS release: https://github.com/Kong/gateway-operator/releases/tag/v1.4.1
EE release https://github.com/Kong/gateway-operator-enterprise/releases/tag/v1.4.1

### Testing instructions

Preview link: https://deploy-preview-8193--kongdocs.netlify.app/gateway-operator/changelog/#141

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

