### PR TITLE
chore(kgo): bump to CRD docs 1.4.1

### DIFF
--- a/app/_src/gateway-operator/reference/custom-resources/1.4.x.md
+++ b/app/_src/gateway-operator/reference/custom-resources/1.4.x.md
@@ -483,7 +483,7 @@ It is used to reference a Control Plane entity.
 
 | Field | Description |
 | --- | --- |
-| `type` _string_ | Type can be one of: - konnectID - konnectNamespacedRef - kic |
+| `type` _string_ | Type indicates the type of the control plane being referenced. Allowed values: - konnectID - konnectNamespacedRef - kic<br /><br /> The default is kic, which implies that the Control Plane is KIC. |
 | `konnectID` _string_ | KonnectID is the schema for the KonnectID type. This field is required when the Type is konnectID. |
 | `konnectNamespacedRef` _[KonnectNamespacedRef](#konnectnamespacedref)_ | KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster. It contains the name of the Konnect Control Plane. This field is required when the Type is konnectNamespacedRef. |
 
@@ -1139,19 +1139,18 @@ _Appears in:_
 #### KongObjectRef
 
 
-KongObjectRef is a reference to another object representing a Kong entity with deterministic type.<br /><br />
-TODO: https://github.com/Kong/kubernetes-configuration/issues/96
-change other types to use the generic `KongObjectRef` and move it to a common package to prevent possible import cycles.
+KongObjectRef is a reference to another object representing a Kong entity with deterministic type.
 
 
 
 | Field | Description |
 | --- | --- |
-| `name` _string_ | Name is the name of the entity.<br /><br /> NOTE: the `Required` validation rule does not reject empty strings so we use `MinLength` to reject empty string here. |
+| `name` _string_ | Name is the name of the entity. |
 
 
 _Appears in:_
 - [KongSNISpec](#kongsnispec)
+- [ServiceRef](#serviceref)
 
 #### KongPluginBindingSpec
 
@@ -1240,7 +1239,7 @@ _Appears in:_
 #### KongRouteSpec
 
 
-KongRouteSpec defines specification of a Kong Route.
+KongRouteSpec defines spec of a Kong Route.
 
 
 
@@ -1289,7 +1288,7 @@ _Appears in:_
 #### KongSNIAPISpec
 
 
-KongSNIAPISpec defines specification of an SNI.
+KongSNIAPISpec defines the spec of an SNI.
 
 
 
@@ -1338,7 +1337,7 @@ _Appears in:_
 #### KongServiceAPISpec
 
 
-KongServiceAPISpec defines specification of a Kong Service.
+KongServiceAPISpec defines the specification of a Kong Service.
 
 
 
@@ -1428,8 +1427,7 @@ _Appears in:_
 #### KongTargetSpec
 
 
-KongTargetSpec defines the specification of a Kong Target.
-KongTargetSpec defines the desired state of KongTarget.
+KongTargetSpec defines the spec of KongTarget.
 
 
 
@@ -1495,7 +1493,7 @@ _Appears in:_
 #### KongUpstreamSpec
 
 
-KongUpstreamSpec defines specification of a Kong Upstream.
+KongUpstreamSpec defines the spec of Kong Upstream.
 
 
 
@@ -1605,22 +1603,6 @@ Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
 _Appears in:_
 - [ControllerReference](#controllerreference)
 
-#### NamespacedServiceRef
-
-
-NamespacedServiceRef is a namespaced reference to a KongService.<br /><br />
-NOTE: currently cross namespace references are not supported.
-
-
-
-| Field | Description |
-| --- | --- |
-| `name` _string_ |  |
-
-
-_Appears in:_
-- [ServiceRef](#serviceref)
-
 #### ObjectName
 _Underlying type:_ `string`
 
@@ -1678,7 +1660,7 @@ ServiceRef is a reference to a KongService.
 | Field | Description |
 | --- | --- |
 | `type` _string_ | Type can be one of: - namespacedRef |
-| `namespacedRef` _[NamespacedServiceRef](#namespacedserviceref)_ | NamespacedRef is a reference to a KongService. |
+| `namespacedRef` _[KongObjectRef](#kongobjectref)_ | NamespacedRef is a reference to a KongService. |
 
 
 _Appears in:_


### PR DESCRIPTION
### Description

Follow up on #8193 for KGO 1.4.1

Part of https://github.com/Kong/gateway-operator/issues/893

### Testing instructions

Preview link: https://deploy-preview-8199--kongdocs.netlify.app/gateway-operator/latest/reference/custom-resources/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

