### PR TITLE
chore: Update 3.9 support tables

### DIFF
--- a/app/_data/tables/support/gateway/packages.yml
+++ b/app/_data/tables/support/gateway/packages.yml
@@ -138,3 +138,10 @@ _packages:
     arm: false
     fips: false
     graviton: false
+  ubuntu2404: &ubuntu2404
+    os: Ubuntu
+    version: 24.04
+    package: true
+    arm: true
+    fips: true
+    graviton: true

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -48,6 +48,11 @@ After the product hits the end of the support period, Kong will provide limited 
 Kong supports the following versions of {{site.ee_product_name}}: 
 
 {% navtabs %}
+  {% if_version gte: 3.9.x %}
+  {% navtab 3.9 %}
+    {% include_cached gateway-support.html version="3.9" data=site.data.tables.support.gateway.versions.39 eol="Dec 2025" %}
+  {% endnavtab %}
+  {% endif_version %}
   {% if_version gte: 3.8.x %}
   {% navtab 3.8 %}
     {% include_cached gateway-support.html version="3.8" data=site.data.tables.support.gateway.versions.38 eol="Sept 2025" %}

--- a/app/_src/gateway/support/third-party.md
+++ b/app/_src/gateway/support/third-party.md
@@ -11,6 +11,11 @@ Unless otherwise noted, Kong supports the last 2 versions any third party tool, 
 > Some third party tools below do not have a version number. These tools are managed services and Kong provides compatibility with the currently released version
 
 {% navtabs %}
+  {% if_version gte: 3.9.x %}
+  {% navtab 3.9 %}
+    {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.39 %}
+  {% endnavtab %}
+  {% endif_version %}
   {% if_version gte: 3.8.x %}
   {% navtab 3.8 %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.38 %}


### PR DESCRIPTION
### Description

Add tabs for 3.9 support tables + add ubuntu 24.04 to the data file (it's already in 39.yml, was just missing from here).

### Testing instructions

Preview link: 
https://deploy-preview-8210--kongdocs.netlify.app/gateway/unreleased/support-policy/#supported-versions
https://deploy-preview-8210--kongdocs.netlify.app/gateway/unreleased/support/third-party/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

