### PR TITLE
Feat: RHEL UBI 9 support

### DIFF
--- a/app/_data/tables/install_options.yml
+++ b/app/_data/tables/install_options.yml
@@ -61,7 +61,7 @@ features:
         support: true
         url: /gateway/VERSION/install/docker/build-custom-images/
         icon: /assets/images/icons/third-party/debian-logo.jpg
-      - name: "RHEL (8-ubi)"
+      - name: "RHEL (8-ubi and 9-ubi)"
         oss: true
         enterprise: true
         support: true

--- a/app/_src/gateway/install/docker/build-custom-images.md
+++ b/app/_src/gateway/install/docker/build-custom-images.md
@@ -83,13 +83,16 @@ RUN set -ex; \
 
 {% navtab Ubuntu %}
 ```dockerfile
-
-{% if_version lte:3.0.x %}
+ 
+{% if_version lte:3.0.x -%}
 FROM ubuntu:20.04
-{% endif_version %}
-{% if_version gte:3.1.x %}
+{%- endif_version -%}
+{%- if_version gte:3.1.x lte:3.8.x -%}
 FROM ubuntu:22.04
-{% endif_version %}
+{%- endif_version -%}
+{%- if_version gte:3.9.x -%}
+FROM ubuntu:24.04
+{%- endif_version %}
 
 COPY kong.deb /tmp/kong.deb
 
@@ -112,7 +115,12 @@ RUN set -ex; \
 {% navtab RHEL %}
 ```dockerfile
 
+{% if_version lte:3.8.x -%}
 FROM registry.access.redhat.com/ubi8/ubi:8.1
+{%- endif_version -%}
+{%- if_version gte:3.9.x -%}
+FROM registry.access.redhat.com/ubi9/ubi:9.5
+{%- endif_version %}
 
 COPY kong.rpm /tmp/kong.rpm
 


### PR DESCRIPTION
### Description

Bump UBI version and Ubuntu version in docker custom build doc.

Note: I pointed the instructions at ubi:9.5 because we also set a specific patch for ubi-8 (8.1, though the latest is now 8.10). We can also just point to latest, but I think that's bad practice?

### Testing instructions

Preview link: 

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

