### PR TITLE
fix(mesh): remove Beta from MeshOPA sidebar

### DIFF
--- a/app/_data/docs_nav_mesh_2.10.x.yml
+++ b/app/_data/docs_nav_mesh_2.10.x.yml
@@ -144,7 +144,7 @@ inherit:
           url: /features/cert-manager
         - text: OPA policy support
           url: /features/opa
-        - text: MeshOPA (beta)
+        - text: MeshOPA
           url: /features/meshopa
         - text: Multi-zone authentication
           url: /features/kds-auth

--- a/app/_data/docs_nav_mesh_2.8.x.yml
+++ b/app/_data/docs_nav_mesh_2.8.x.yml
@@ -144,7 +144,7 @@ inherit:
           url: /features/cert-manager
         - text: OPA policy support
           url: /features/opa
-        - text: MeshOPA (beta)
+        - text: MeshOPA
           url: /features/meshopa
         - text: Multi-zone authentication
           url: /features/kds-auth

--- a/app/_data/docs_nav_mesh_2.9.x.yml
+++ b/app/_data/docs_nav_mesh_2.9.x.yml
@@ -144,7 +144,7 @@ inherit:
           url: /features/cert-manager
         - text: OPA policy support
           url: /features/opa
-        - text: MeshOPA (beta)
+        - text: MeshOPA
           url: /features/meshopa
         - text: Multi-zone authentication
           url: /features/kds-auth


### PR DESCRIPTION
### Description
Sidebar was still showing MeshOPA as beta, this is not beta since 2.8

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

