### PR TITLE
fix(mesh): add lost SBOM sections in 2.9 and 2.10

### DIFF
--- a/app/_data/docs_nav_mesh_2.10.x.yml
+++ b/app/_data/docs_nav_mesh_2.10.x.yml
@@ -33,6 +33,11 @@ inherit:
       action: insert
       index: -3
     - path: [ Introduction ]
+      text: Software Bill of Materials
+      url: /sbom
+      action: insert
+      index: -3
+    - path: [ Introduction ]
       text: Vulnerability patching process
       url: /vulnerability-patching-process/
       action: insert
@@ -170,6 +175,14 @@ inherit:
           url: /features/access-audit
         - text: MeshGlobalRateLimit (beta)
           url: /features/meshglobalratelimit
+        - text: Verify signatures for signed Kong Mesh images
+          url: /features/signed-images
+        - text: Build provenance
+          items:
+            - text: Verify build provenance for signed Kong Mesh images
+              url: /features/provenance-verification-images
+            - text: Verify build provenance for signed Kong Mesh binaries
+              url: /features/provenance-verification-binaries
     - path: [ Reference ]
       action: modify
       icon: /assets/images/icons/documentation/icn-references-color.svg

--- a/app/_data/docs_nav_mesh_2.9.x.yml
+++ b/app/_data/docs_nav_mesh_2.9.x.yml
@@ -33,6 +33,11 @@ inherit:
       action: insert
       index: -3
     - path: [ Introduction ]
+      text: Software Bill of Materials
+      url: /sbom
+      action: insert
+      index: -3
+    - path: [ Introduction ]
       text: Vulnerability patching process
       url: /vulnerability-patching-process/
       action: insert
@@ -170,6 +175,14 @@ inherit:
           url: /features/access-audit
         - text: MeshGlobalRateLimit (beta)
           url: /features/meshglobalratelimit
+        - text: Verify signatures for signed Kong Mesh images
+          url: /features/signed-images
+        - text: Build provenance
+          items:
+            - text: Verify build provenance for signed Kong Mesh images
+              url: /features/provenance-verification-images
+            - text: Verify build provenance for signed Kong Mesh binaries
+              url: /features/provenance-verification-binaries
     - path: [ Reference ]
       action: modify
       icon: /assets/images/icons/documentation/icn-references-color.svg


### PR DESCRIPTION
### Description

We lost these sections between releases. This fixes this

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

