### PR TITLE
Update opentelemetry  _changelog.md to include deprecation of config.endpoint in 3.8

### DIFF
--- a/app/_hub/kong-inc/opentelemetry/_changelog.md
+++ b/app/_hub/kong-inc/opentelemetry/_changelog.md
@@ -3,6 +3,10 @@
 ### {{site.base_gateway}} 3.8.x
 * Added support for OpenTelemetry-formatted logs.
 [#13291](https://github.com/Kong/kong/issues/13291)
+
+  As part of the rework, the following parameter has been deprecated and will be removed in a future major version: 
+  * `config.endpoint`  is deprecated, use `config.traces_endpoint` instead.
+
 * Fixed an issue where migration failed when upgrading from versions earlier than 3.3.x to 3.7.x.
    [#13391](https://github.com/Kong/kong/issues/13391)
 * Removed redundant deprecation warnings.
@@ -19,7 +23,7 @@ options allow better control over the configuration of tracing header propagatio
   As part of the rework, the following parameters have been deprecated and will be removed in a future major version: 
   * `config.header_type`  is deprecated, use `config.propagation` instead.
   * `config.batch_span_count` is deprecated, use `config.queue.max_batch_size` instead.
-  * `config.batch_flush_deplay` is deprecated, use `config.queue.max_coalescing_delay` instead.
+  * `config.batch_flush_delay` is deprecated, use `config.queue.max_coalescing_delay` instead.
     
 * Fixed an OTEL sampling mode Lua panic bug, which happened 
 when the `http_response_header_for_traceid` option was enabled.


### PR DESCRIPTION
### Description

- Update _changelog.md to include deprecation of config.endpoint
- Fix typo in config.batch_flush_delay deprecation
 
`2024/12/05 15:16:04 [warn] 2533#0: *1692 [kong] init.lua:910 OpenTelemetry: config.endpoint is deprecated, please use config.traces_endpoint instead (deprecated after 4.0), client: 172.19.0.1, server: kong_admin, request: "PUT /plugins/924e591e-5544-4ee8-8327-32625f0034f0 HTTP/1.1", host: "localhost:8001"
`

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
