### PR TITLE
Chore: update public keys

### DIFF
--- a/app/_data/installation/gateway.yml
+++ b/app/_data/installation/gateway.yml
@@ -1,4 +1,10 @@
 # e.g.: https://cloudsmith.io/~kong/repos/internal-gateway-37/pub-keys/
+"310":
+  rsa_key: F95F9D51CE8D04A7
+  gpg_key: 5F07A9706C09A6C6
+"39":
+  rsa_key: EE30089B2CC28C9A
+  gpg_key: B9DCD032B1696A89
 "38":
   rsa_key: E4186B13EAE1A2D5
   gpg_key: 8F87A07D181DAA6B


### PR DESCRIPTION
### Description

Updating the public RSA and GPG keys for 3.9 and 3.10, required for installation.
https://cloudsmith.io/~kong/repos/gateway-39/pub-keys/
https://cloudsmith.io/~kong/repos/gateway-310/pub-keys/

The 3.10 keys won't affect anything for now, this just preps us for the next release.

### Testing instructions

Preview link: https://deploy-preview-8231--kongdocs.netlify.app/gateway/unreleased/install/linux/ubuntu/?tab=apt-repository

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

