### PR TITLE
Fix: Add missing vault config link

### DIFF
--- a/app/konnect/gateway-manager/configuration/vaults/how-to.md
+++ b/app/konnect/gateway-manager/configuration/vaults/how-to.md
@@ -22,6 +22,7 @@ Set up a new vault. For this example, we're going to use the environment variabl
 1. Choose a vault type. 
 1. Enter the configuration settings for your vault. For more information about how to configure settings, see the following {{site.base_gateway}} documentation:
     * [Konnect Config Store options](/konnect/gateway-manager/configuration/config-store/#supported-fields)
+    * [Environment variables vault configuration options](/gateway/latest/kong-enterprise/secrets-management/backends/env/#vault-configuration-options)
     * [AWS vault configuration options](/gateway/latest/kong-enterprise/secrets-management/backends/aws-sm/#vault-configuration-options)
     * [Google Cloud vault configuration options](/gateway/latest/kong-enterprise/secrets-management/backends/gcp-sm/#vault-entity-configuration-options)
     * [HashiCorp vault configuration options](/gateway/latest/kong-enterprise/secrets-management/backends/hashicorp-vault/#vault-configuration-options)


### PR DESCRIPTION
### Description

Add link to environment variable vault config options.

Issue reported on Slack.

### Testing instructions

Preview link: https://deploy-preview-8245--kongdocs.netlify.app/konnect/gateway-manager/configuration/vaults/how-to/

### Checklist 

- [x] Review label added <!-- (see below) -->
