### PR TITLE
kic: add events section to custom entities guide

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -46,6 +46,7 @@ Github
 Gluu
 Goroutine
 Grafana
+hasura
 HTTPie
 istioctl
 Imperva

--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -46,7 +46,7 @@ Github
 Gluu
 Goroutine
 Grafana
-hasura
+Hasura
 HTTPie
 istioctl
 Imperva

--- a/app/_src/kubernetes-ingress-controller/guides/services/custom-entity.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/custom-entity.md
@@ -45,9 +45,9 @@ This example configures custom entities for the `degraphql` plugin, which allows
 
 ## Create a GraphQL Service
 
-The `degraphql` plugin requires an upstream GraphQL API. For this tutorial, we'll use [hasura] to create an example GraphQL service:
+The `degraphql` plugin requires an upstream GraphQL API. For this tutorial, we'll use [Hasura] to create an example GraphQL service:
 
-[hasura]: https://hasura.io/
+[Hasura]: https://hasura.io/
 
 ```bash
 echo 'apiVersion: apps/v1
@@ -215,13 +215,14 @@ which matches the data inserted in the previous steps.
 
 {% if_version gte:3.4.x %}
 
-## Invalid `KongCustomEntity` Configuration
+## Troubleshooting
+### Invalid `KongCustomEntity` Configuration
 
 Each `KongCustomEntity` is validated against the schema from Kong.
-If the configuration is invalid, an `Event` with reason set to `KongConfigurationTranslationFailed` will be emitted.
+If the configuration is invalid, an `Event` with the reason set to `KongConfigurationTranslationFailed` will be emitted.
 The `involvedObject` of this `Event` will be set to the `KongCustomEntity` resource.
 
-For more information on observability with events please consult our [events guide][events_guide].
+For more information on observability with events, see our [events guide][events_guide].
 
 [events_guide]: /kubernetes-ingress-controller/{{page.release}}/production/observability/events
 {% endif_version %}

--- a/app/_src/kubernetes-ingress-controller/guides/services/custom-entity.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/custom-entity.md
@@ -13,7 +13,7 @@ overrides:
 
 {{ site.kic_product_name }} provides an interface to configure {{ site.base_gateway }} entities using CRDs.
 
-Some {{ site.base_gateway }} plugins define custom entities that require configuration. These entities can be configured using the `KongCustomEntity` resource.
+Some {{ site.base_gateway }} plugins define custom entities that require configuration. These entities can be configured using the [`KongCustomEntity` resource][kongcustomentity_crd_ref].
 
 {% if_version lte:3.2.x %}
 {:.note}
@@ -35,6 +35,8 @@ spec:
 
 This corresponds to the `uri` and `query` parameters documented in the [plugin documentation](/hub/kong-inc/degraphql/#available-endpoints)
 
+[kongcustomentity_crd_ref]: /kubernetes-ingress-controller/{{page.release}}/reference/custom-resources/#kongcustomentity
+
 ## Tutorial: DeGraphQL custom entities
 
 {% include /md/kic/prerequisites.md release=page.release disable_gateway_api=false enterprise=true %}
@@ -43,7 +45,9 @@ This example configures custom entities for the `degraphql` plugin, which allows
 
 ## Create a GraphQL Service
 
-The `degraphql` plugin requires an upstream GraphQL API. For this tutorial, we'll use [Hasura] to create an example GraphQL service:
+The `degraphql` plugin requires an upstream GraphQL API. For this tutorial, we'll use [hasura] to create an example GraphQL service:
+
+[hasura]: https://hasura.io/
 
 ```bash
 echo 'apiVersion: apps/v1
@@ -209,8 +213,15 @@ The `curl` command should return
 
 which matches the data inserted in the previous steps.
 
-[hasura]: https://hasura.io/
-<!-- >
-Need to be updated when custom resource reference page is updated.
-[KongCustomEntity]: /reference/custom-resources/
-<-->
+{% if_version gte:3.4.x %}
+
+## Invalid `KongCustomEntity` Configuration
+
+Each `KongCustomEntity` is validated against the schema from Kong.
+If the configuration is invalid, an `Event` with reason set to `KongConfigurationTranslationFailed` will be emitted.
+The `involvedObject` of this `Event` will be set to the `KongCustomEntity` resource.
+
+For more information on observability with events please consult our [events guide][events_guide].
+
+[events_guide]: /kubernetes-ingress-controller/{{page.release}}/production/observability/events
+{% endif_version %}


### PR DESCRIPTION
### Description

Add section about events in KIC's custom entities guide.

### Testing instructions

Preview link: https://deploy-preview-8246--kongdocs.netlify.app/kubernetes-ingress-controller/unreleased/guides/services/custom-entity/#invalid-kongcustomentity-configuration



### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

