### PR TITLE
kic: add /debug/config/raw-error mention for KIC 3.4+

### DIFF
--- a/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
+++ b/app/_src/kubernetes-ingress-controller/reference/troubleshooting.md
@@ -200,10 +200,9 @@ successfully, reviewing the generated configuration manually and/or applying it
 in a test environment can help locate potential causes.
 
 Under normal operation, the controller does not store generated configuration;
-it is only sent to Kong's Admin API. The `--dump-config` flag enables a
-diagnostic mode where the controller also saves generated configuration to a
-temporary file. You can retrieve this file via the web interface of the diagnostic
-server at `host:10256/debug/config`.
+it is only sent to Kong's Admin API.
+The `--dump-config` flag enables a diagnostic mode where the controller also saves generated configuration and {{ site.base_gateway }} responses to memory.
+You can retrieve these via the web interface of the diagnostic server at `host:10256/debug/config`.
 
 To use the diagnostic mode:
 
@@ -232,6 +231,14 @@ To use the diagnostic mode:
    curl -svo last_good.json localhost:10256/debug/config/successful
    curl -svo last_bad.json localhost:10256/debug/config/failed
    ```
+{% if_version gte:3.4.x %}
+1. Retrieve the last error response body received from {{ site.base_gateway }}:
+   ```bash
+   curl -svo raw_error_body.json localhost:10256/debug/config/raw-error
+   ```
+{% endif_version %}
+
+### Using dumped configuration
 
 Once you have dumped configuration, take one of the following
 approaches to isolate issues:
@@ -250,6 +257,8 @@ approaches to isolate issues:
 
   Once this image is running, run `curl http://localhost:8001/config @last_bad.json`
   to try applying the configuration and see any errors.
+
+You can also analyze the returned error response body from {{ site.base_gateway }} to understand the issue.
 
 ## Inspecting network traffic with a tcpdump sidecar
 


### PR DESCRIPTION
### Description

Adds documentation about KIC's diagnostics server `/debug/config/raw-error` endpoint.

Closes #7548

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

