### PR TITLE
Fix: Consumer groups compatible plugins list

### DIFF
--- a/app/_src/gateway/kong-enterprise/consumer-groups/index.md
+++ b/app/_src/gateway/kong-enterprise/consumer-groups/index.md
@@ -6,12 +6,13 @@ badge: enterprise
 
 Consumer groups enable the organization and categorization of consumers (users or applications) within an API ecosystem. By grouping consumers together, you eliminate the need to manage them individually, providing a scalable, efficient approach to managing configurations. 
 
-
-
-
 {% if_version gte:3.4.x %}
 
-With consumer groups, you can scope plugins to specifically defined consumer groups and a new plugin instance will be created for each individual consumer group, making configurations and customizations more flexible and convenient.
+With consumer groups, you can scope plugins to specifically defined consumer groups and a new plugin instance will be created for each individual consumer group, making configurations and customizations more flexible and convenient. 
+For all plugins available on the consumer groups scope, see the [Plugin Scopes Reference](/hub/plugins/compatibility/#scopes).
+
+{:.note}
+> **Note**: Consumer groups plugin scoping is a feature that was added in {{site.base_gateway}} version 3.4. Running a mixed-version {{site.base_gateway}} cluster (3.4 control plane, and <=3.3 data planes) is not supported when using consumer-group scoped plugins. 
 
 ## Use cases
 
@@ -22,25 +23,6 @@ With consumer groups, you can scope plugins to specifically defined consumer gro
 * Resource quotas and rate limiting: Consumer groups can be used to enforce resource quotas and rate limiting on different sets of consumers. For instance, you can apply different rate limits to different consumer groups based on their subscription plans. 
 
 * Customizing plugin configurations: With the ability to scope plugins specifically to defined groups, different consumer groups can have distinct plugin configurations based on their requirements. For example, one group may require additional request transformations while another may not need them at all.
-
-{:.note}
-> **Note**: Consumer groups plugin scoping is a feature that was added in {{site.base_gateway}} version 3.4. Running a mixed-version {{site.base_gateway}} cluster (3.4 control plane, and <=3.3 data planes) is not supported when using consumer-group scoped plugins. 
-
-
-## Scope plugins 
-You can scope the following plugins to consumer groups: 
-
-* [Rate Limiting Advanced](/hub/kong-inc/rate-limiting-advanced/)
-* [Request Transformer Advanced](/hub/kong-inc/request-transformer-advanced/)
-* [Response transformer Advanced](/hub/kong-inc/request-transformer-advanced/)
-* [Request Transformer](/hub/kong-inc/request-transformer)
-* [Response Transformer](/hub/kong-inc/response-transformer)
-
-{:.note}
-> **Note**: Consumer groups plugin scoping is a feature that was added in {{site.base_gateway}} version 3.4. Running a mixed-version {{site.base_gateway}} cluster (3.4 control plane, and <=3.3 data planes) is not supported when using consumer-group scoped plugins. 
-
-
-
 
 {% endif_version %}
 


### PR DESCRIPTION
### Description

Removing outdated plugin list and replacing with link to plugin scopes, as this list changes with every release.

Also removing a duplicate note.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

