### PR TITLE
Fix: adjust datakit doc to clear jekyll warning

### DIFF
--- a/app/_src/gateway/kong-enterprise/datakit/configuration.md
+++ b/app/_src/gateway/kong-enterprise/datakit/configuration.md
@@ -162,7 +162,7 @@ Create a template for parsing the output of an external API call to a coordinate
   - first: FIRST.body
   output: service_request.body
   template: |
-    Coordinates for {{ first.places.0.[place name] }}, {{ first.places.0.state }}, {{ first.country }} are ({{ first.places.0.latitude }}, {{ first.places.0.longitude }}).
+    {% raw %}Coordinates for {{ first.places.0.[place name] }}, {{ first.places.0.state }}, {{ first.country }} are ({{ first.places.0.latitude }}, {{ first.places.0.longitude }}){% endraw %}.
 ```
 
 ### `exit` node type


### PR DESCRIPTION
### Description

Set datakit template varibles in jekyll `raw` tags so that it doesn't get confused and complain about liquid syntax.

<img width="1379" alt="Screenshot 2024-12-12 at 10 07 29 PM" src="https://github.com/user-attachments/assets/d44f1b79-0bdd-48d2-ab4a-d9ebcf7c3446" />

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after

 PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

