### PR TITLE
kic: drop 'beta' from feature gates toc heading

### DIFF
--- a/app/_data/docs_nav_kic_3.0.x.yml
+++ b/app/_data/docs_nav_kic_3.0.x.yml
@@ -193,7 +193,7 @@ items:
         url: /reference/annotations
       - text: Configuration Options
         url: /reference/cli-arguments
-      - text: Beta Feature Gates
+      - text: Feature Gates
         url: /reference/feature-gates
       - text: FAQ
         items:

--- a/app/_data/docs_nav_kic_3.1.x.yml
+++ b/app/_data/docs_nav_kic_3.1.x.yml
@@ -194,7 +194,7 @@ items:
       - text: Configuration Options
         url: /reference/cli-arguments/
         src: reference/cli-arguments-3.1.x
-      - text: Beta Feature Gates
+      - text: Feature Gates
         url: /reference/feature-gates
       - text: FAQ
         items:

--- a/app/_data/docs_nav_kic_3.2.x.yml
+++ b/app/_data/docs_nav_kic_3.2.x.yml
@@ -200,7 +200,7 @@ items:
       - text: Configuration Options
         url: /reference/cli-arguments/
         src: reference/cli-arguments-3.2.x
-      - text: Beta Feature Gates
+      - text: Feature Gates
         url: /reference/feature-gates
       - text: FAQ
         items:

--- a/app/_data/docs_nav_kic_3.3.x.yml
+++ b/app/_data/docs_nav_kic_3.3.x.yml
@@ -200,7 +200,7 @@ items:
       - text: Configuration Options
         url: /reference/cli-arguments/
         src: reference/cli-arguments-3.3.x
-      - text: Beta Feature Gates
+      - text: Feature Gates
         url: /reference/feature-gates
       - text: FAQ
         items:

--- a/app/_data/docs_nav_kic_3.4.x.yml
+++ b/app/_data/docs_nav_kic_3.4.x.yml
@@ -198,7 +198,7 @@ items:
       - text: Configuration Options
         url: /reference/cli-arguments/
         src: reference/cli-arguments-3.3.x
-      - text: Beta Feature Gates
+      - text: Feature Gates
         url: /reference/feature-gates
       - text: FAQ
         items:

--- a/app/_src/kubernetes-ingress-controller/reference/feature-gates.md
+++ b/app/_src/kubernetes-ingress-controller/reference/feature-gates.md
@@ -38,11 +38,23 @@ Feature gates consist of a comma-delimited set of `key=value` pairs. For example
 
 To enable features via Helm, set the following in your `values.yaml`:
 
+{% navtabs %}
+{% navtab kong chart %}
 ```yaml
 ingressController:
   env:
     feature_gates: FillIDs=true,RewriteURIs=true
 ```
+{% endnavtab %}
+{% navtab ingress chart %}
+```yaml
+controller:
+  ingressController:
+    env:
+      feature_gates: FillIDs=true,RewriteURIs=true
+```
+{% endnavtab %}
+{% endnavtabs %}
 
 To test a feature gate in an existing deployment, use `kubectl set env`.
 


### PR DESCRIPTION
### Description

Drop 'beta' from feature gates toc heading

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

