### PR TITLE
Fix: Clean out "unreleased" links 

### DIFF
--- a/app/_hub/kong-inc/graphql-proxy-cache-advanced/_changelog.md
+++ b/app/_hub/kong-inc/graphql-proxy-cache-advanced/_changelog.md
@@ -6,4 +6,4 @@
 ### {{site.base_gateway}} 3.7.x
 
 * Added Redis strategy support.
-* Added the ability to resolve unhandled errors with bypass, with the request going upstream. Enable it using the [`bypass_on_err`](/hub/kong-inc/graphql-proxy-cache-advanced/unreleased/configuration/#config-bypass_on_err) configuration option.
+* Added the ability to resolve unhandled errors with bypass, with the request going upstream. Enable it using the [`bypass_on_err`](/hub/kong-inc/graphql-proxy-cache-advanced/configuration/#config-bypass_on_err) configuration option.

--- a/app/_src/gateway-operator/guides/konnect-entities/faq.md
+++ b/app/_src/gateway-operator/guides/konnect-entities/faq.md
@@ -22,7 +22,7 @@ New resources are created immediately using the Konnect API.
 
 Existing resources are processed once per minute by default. This is customizable, but we recommend keeping the default value so that you do not hit the {{ site.konnect_short_name }} API rate limit.
 
-For more information, see [how it works](/gateway-operator/unreleased/guides/konnect-entities/architecture/#how-it-works).
+For more information, see [how it works](/gateway-operator/{{page.release}}/guides/konnect-entities/architecture/#how-it-works).
 
 ## I deleted a resource in the UI, but it wasn't recreated by the operator. Why?
 
@@ -30,7 +30,7 @@ Wait 60 seconds, then check the UI again. The reconcile loop only runs once per 
 
 ## Can I use Secrets for consumer credentials like in {{ site.kic_product_name }}?
 
-{{ site.kgo_product_name }} uses new `Credential` CRDs for managing [consumer credentials]((/gateway-operator/unreleased/guides/konnect-entities/consumer-and-consumergroup/#associate-the-consumer-with-credentials)). We plan to support Kubernetes `Secret` resources in a future release. [#618](https://github.com/Kong/gateway-operator/issues/618).
+{{ site.kgo_product_name }} uses new `Credential` CRDs for managing [consumer credentials](/gateway-operator/{{page.release}}/guides/konnect-entities/consumer-and-consumergroup/#associate-the-consumer-with-credentials). We plan to support Kubernetes `Secret` resources in a future release. [#618](https://github.com/Kong/gateway-operator/issues/618).
 
 ## Can I adopt existing {{ site.konnect_short_name }} entities?
 

--- a/app/_src/kubernetes-ingress-controller/plugins/custom.md
+++ b/app/_src/kubernetes-ingress-controller/plugins/custom.md
@@ -8,7 +8,7 @@ purpose: |
 Install a custom plugin in Kong without using a Docker build.
 
 {:.note}
-> The recommended way to install custom plugins is with {{ site.kgo_product_name }}. See [Kong custom plugin distribution with KongPluginInstallation](/gateway-operator/unreleased/guides/plugin-distribution/) for more information.
+> The recommended way to install custom plugins is with {{ site.kgo_product_name }}. See [Kong custom plugin distribution with KongPluginInstallation](/gateway-operator/{{page.release}}/guides/plugin-distribution/) for more information.
 
 {% include md/custom-plugin.md %}
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1245,7 +1245,7 @@ options allow better control over the configuration of tracing header propagatio
 
 * [**GraphQL Proxy Cache Advanced**](/hub/kong-inc/graphql-proxy-cache-advanced/)
   * Added Redis strategy support.
-  * Added the ability to resolve unhandled errors with bypass, with the request going upstream. Enable it using the [`bypass_on_err`](/hub/kong-inc/graphql-proxy-cache-advanced/unreleased/configuration/#config-bypass_on_err) configuration option.
+  * Added the ability to resolve unhandled errors with bypass, with the request going upstream. Enable it using the [`bypass_on_err`](/hub/kong-inc/graphql-proxy-cache-advanced/configuration/#config-bypass_on_err) configuration option.
 
 * [**JWT Signer**](/hub/kong-inc/jwt-signer/) (`jwt-signer`)
   * Added support for basic authentication and mTLS authentication to external JWKS services.


### PR DESCRIPTION
### Description

Removing the hardcoded `unreleased` version from links, which likely made its way in because the links were breaking at the time, and that seemed like the right fix. `unreleased` should never be part of a production URL.

Fixes https://github.com/Kong/docs.konghq.com/issues/8192

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

