### PR TITLE
Update changelog.md

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -4230,7 +4230,7 @@ instead of the previous 1 (trace all requests).
     Thanks [@PidgeyBE](https://github.com/PidgeyBE) for contributing this change.
     [#10204](https://github.com/Kong/kong/pull/10204) [#10595](https://github.com/Kong/kong/pull/10595)
 
-* Added `KONG_UPSTREAM_DNS_TIME` to `kong.ctx` to record the time it takes for DNS
+* Added `KONG_UPSTREAM_DNS_TIME` to `ngx.ctx` to record the time it takes for DNS
   resolution when Kong proxies to an upstream.
   [#10355](https://github.com/Kong/kong/pull/10355)
 * Dynamic log levels now have a default timeout of 60 seconds.


### PR DESCRIPTION
As per the detail in the pull here: https://github.com/Kong/kong/pull/10355 this value is added to the ngx.ctx table NOT kong.ctx

### Description

Changed reference of location of KONG_UPSTREAM_DNS_TIME to correct internal table as per pull request this change is in respect of.

See also: https://konghq.atlassian.net/browse/FTI-5243

### Testing instructions

N/A typo

### Checklist 

N/A typo
