### PR TITLE
kic: minor fixes in ACL guide

### DIFF
--- a/app/_includes/md/kic/http-test-routing-resource.md
+++ b/app/_includes/md/kic/http-test-routing-resource.md
@@ -18,18 +18,18 @@ echo "
 apiVersion: gateway.networking.k8s.io/{{ gwapi_version }}
 kind: HTTPRoute
 metadata:
-  name: {{ name }}
-  {% unless .namespace == '' %}namespace: {{ namespace }}   {% endunless %}
+  name: {{ name }}{% unless .namespace == '' %}
+  namespace: {{ namespace }}{% endunless %}
   annotations:{% if include.annotation_rewrite %}
     konghq.com/rewrite: '{{ include.annotation_rewrite }}'{% endif %}
     konghq.com/strip-path: 'true'
 spec:
   parentRefs:
-  - name: kong
-    {% unless .namespace == '' %}namespace: {{ namespace }}{% endunless %}
-{% unless include.skip_host %}  hostnames:
-  - '{{ hostname }}'
-{% endunless %}  rules:
+  - name: kong{% unless .namespace == '' %}
+    namespace: {{ namespace }}{% endunless %}{% unless include.skip_host %}
+  hostnames:
+  - '{{ hostname }}'{% endunless %}
+  rules:
   - matches:
     - path:
         type: {{ include.route_type }}


### PR DESCRIPTION
### Description

Minor fixes to KIC's ACL guide.

Fixing whitespaces.


Before:
<img width="409" alt="image" src="https://github.com/user-attachments/assets/788db8e5-13bb-4efb-91ea-674b3c234d6d" />

After:
<img width="411" alt="image" src="https://github.com/user-attachments/assets/da4ab4d5-a95a-493b-b4cb-5253ea5e422e" />

Also not requiring `secret` field for non HMAC JWT credentials (ref: https://github.com/Kong/kubernetes-ingress-controller/pull/6848).

### Testing instructions

Preview link: /kubernetes-ingress-controller/unreleased/plugins/acl

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

