### PR TITLE
docs(kic): provide correct field name from helm chart values.yaml

### DIFF
--- a/app/_src/gateway-operator/get-started/kic/create-gateway.md
+++ b/app/_src/gateway-operator/get-started/kic/create-gateway.md
@@ -48,7 +48,7 @@ To get the endpoint and the authentication details of the data plane.
     kubectl create secret tls konnect-client-tls --cert=./tls.crt --key=./tls.key
     ```
 
-1. In the **Install the KIC** step 4, find the value of `runtimeGroupID`. Replace `YOUR_CP_ID` with the control plane ID in the following manifest.
+1. In the **Install the KIC** step 4, find the value of `controlPlaneID`. Replace `YOUR_CP_ID` with the control plane ID in the following manifest.
 1. In the **Install the KIC** step 4, find the value of `cluster_telemetry_endpoint`. The first segment of that value is the control plane endpoint for your cluster. For example, if the value of `cluster_telemetry_endpoint` is `36fc5d01be.us.cp0.konghq.com`, then the control plane endpoint of the cluster is `36fc5d01be`. Replace `YOUR_CP_ENDPOINT` with your control plane ID in the following manifest.
 1. Deploy the data plane with `kubectl apply`:
 


### PR DESCRIPTION
### Description

The docs tell you to copy the value from `runtimeGroupID` but it appears to have changed to `controlPlaneID` in Konnect.
<img width="1788" alt="Screenshot 2024-12-17 at 2 16 33 PM" src="https://github.com/user-attachments/assets/068fbdc1-ddb5-4faf-9a37-079c8058694c" />
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

