### PR TITLE
Fix: dynatrace tile category

### DIFF
--- a/app/_hub/dynatrace/dynatrace/_metadata/_index.yml
+++ b/app/_hub/dynatrace/dynatrace/_metadata/_index.yml
@@ -19,10 +19,7 @@ premiumpartner: true
 enterprise: false
 konnect: true
 
-desc: Set up Dynatrace with the OpenTelemetry plugin to send logs and metrics to Dynatrace
-
-# support_url: 
-# source_code: 
+desc: Set up Dynatrace with the OpenTelemetry plugin to send metrics, logs, and traces to Dynatrace
 
 kong_version_compatibility:
     community_edition:
@@ -36,3 +33,6 @@ kong_version_compatibility:
 
 dbless_compatible: yes
 
+custom_support_banner: |
+  {:.partner-plugin no-icon}
+  > **Partner Integration:** This integration is **developed, tested, and maintained** by Kong.

--- a/app/_hub/dynatrace/dynatrace/_metadata/_index.yml
+++ b/app/_hub/dynatrace/dynatrace/_metadata/_index.yml
@@ -19,7 +19,7 @@ premiumpartner: true
 enterprise: false
 konnect: true
 
-desc: Set up Dynatrace with the OpenTelemetry plugin to send metrics, logs, and traces to Dynatrace
+desc: Set up Dynatrace with the OpenTelemetry plugin to send traces, metrics, and logs to Dynatrace
 
 kong_version_compatibility:
     community_edition:

--- a/app/_hub/dynatrace/dynatrace/_metadata/_index.yml
+++ b/app/_hub/dynatrace/dynatrace/_metadata/_index.yml
@@ -3,7 +3,7 @@ publisher: Dynatrace
 
 categories:
   - premium-partner
-  - security
+  - analytics-monitoring
 
 search_aliases:
   - opentelemetry

--- a/app/_includes/md/plugins-hub/dynatrace.md
+++ b/app/_includes/md/plugins-hub/dynatrace.md
@@ -1,7 +1,6 @@
 
 ## Prerequisites
-* Install the `contrib` version of the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/installation/).
-  The `contrib` version is necessary for generating metrics.
+* Install the [Dynatrace Collector](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/collector)
 * {{site.base_gateway}} 3.8+
 
 ## Configure {{site.base_gateway}}
@@ -15,7 +14,7 @@ tracing_sampling_rate = 1.0
 
 ## Configure the OpenTelemetry plugin
 
-Adjust the `{OPENTELEMETRY_COLLECTOR}` variable with your own collector endpoint:
+Adjust the `{your-environment-id}` variable with your own Collector endpoint:
 
 <!--vale off-->
 {% plugin_example %}
@@ -42,7 +41,7 @@ formats:
 
 ## Configure the OpenTelemetry Collector
 
-Configure your OpenTelemetry Collector to send data to the Dynatrace environment. 
+Configure your Dynatrace OpenTelemetry Collector to send data to the Dynatrace environment. 
 
 The following example OpenTelemetry configuration shows how to export traces and logs:
 
@@ -72,6 +71,8 @@ service:
 ```
 
 ## Export application span metrics
+
+Kong relies on the OpenTelemetry Collector to calculate the metrics based on the traces the OpenTelemetry plugin generates.
 
 To include span metrics for application traces, configure the collector exporters section of 
 the OpenTelemetry Collector configuration file: 

--- a/app/_layouts/extension.html
+++ b/app/_layouts/extension.html
@@ -15,8 +15,12 @@ breadcrumbs:
 
 {% unless page.extn_publisher == "kong-inc" %}
     {% if page.premiumpartner %}
+      {% if page.custom_support_banner %}
+        {{ page.custom_support_banner | markdownify }}
+      {% else %}
       <blockquote class="partner-plugin no-icon">
         <b>Partner Plugin:</b> This plugin is <b>developed, tested, and maintained</b> by {{ page.publisher }}
+      {% endif %}
     {% else %}
       <blockquote class="community-plugin no-icon">
         <b>Contact 3rd party for support:</b> This plugin is <b>developed, tested, and maintained</b> by {{ page.publisher }}


### PR DESCRIPTION
### Description

Moving the tile into the analytics and monitoring category.

The custom banner is because this isn't even a plugin - this is very much an edge case.

### Testing instructions

Preview link: https://deploy-preview-8289--kongdocs.netlify.app/hub/?search=dynatrace

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

