### PR TITLE
fix the status code in the 1st Demonstration

### DIFF
--- a/app/_hub/kong-inc/exit-transformer/overview/_index.md
+++ b/app/_hub/kong-inc/exit-transformer/overview/_index.md
@@ -239,7 +239,7 @@ response in the following step:
     Response:
 
     ```json
-        HTTP/1.1 200 OK
+        HTTP/1.1 401 Unauthorized
         ...
         X-Some-Header: some value
         {


### PR DESCRIPTION
The status code is not updated in the lua script so it should remain 401.

### Description

<!-- What did you change and why? -->
After follow the Demonstration, I got an 401 status code but the doc says it is a 200. 

```
❯ http  localhost:8000 Host:example.com
HTTP/1.1 401 Unauthorized
Connection: keep-alive
Content-Length: 73
Content-Type: application/json; charset=utf-8
Date: Wed, 18 Dec 2024 15:17:35 GMT
Server: kong/3.8.0.0-enterprise-edition
X-Kong-Request-Id: 10e6903070b3246162eeac7756792938
X-Kong-Response-Latency: 3
x-some-header: some value

{
    "error": true,
    "message": "No API key found in request, arr!",
    "status": 401
}
```
