### PR TITLE
kic: add update guide for gateway API 1.2

### DIFF
--- a/app/_src/kubernetes-ingress-controller/upgrade/kic.md
+++ b/app/_src/kubernetes-ingress-controller/upgrade/kic.md
@@ -80,13 +80,20 @@ complete the following steps to upgrade to version v1.1 of the CRD:
 Starting from version 3.4, {{ site.kic_product_name }} supports Gateway API version 1.2.
 There is a breaking change in gateway API 1.2 to remove the `v1alpha2` version of `GRPCRoute` and `ReferenceGrant`.
 
-If you have been using gateway API v1.1 and {{ site.kic_product_name }} 3.2 and above, and there are no `GRPCRoute` and `ReferenceGrant` resources stored in `v1alpha2` version, you can directly upgrade gateway API from v1.1 to v1.2.
+If you have been using gateway API v1.1 and {{ site.kic_product_name }} 3.2 and above, and there are no `GRPCRoute` and `ReferenceGrant` resources stored in `v1alpha2` version, you can directly upgrade gateway API from v1.1 to v1.2. 
+You can use the following script to ensure your `GRPCRoute` and `ReferenceGrant` CRDs are not using `v1alpha2` storage version:
 
-If the conditions to directly update gateway API to v1.2 is not satisfied, you can upgrade gateway API and {{ site.kic_product_name }} by the following steps:
+```bash
+kubectl get grpcroutes -A -o jsonpath='{.items[*].apiVersion}' | tr ' ' '\n' | sort | uniq -c
+kubectl get referencegrants -A -o jsonpath='{.items[*].apiVersion}' | tr ' ' '\n' | sort | uniq -c
+```
+If any of the output contains `v1alpha2`, it means that there are `GRPCRoute` or `ReferenceGrant` (or both) using `v1alpha2` storage version and you need to update the manifests before upgrading.
 
-1. If you have installed gateway API 1.0, upgrade it to 1.1 by the steps in the section above.
-2. Upgrade your {{ site.kic_product_name }} to 3.2 if the version is below 3.2.
-3. Update all your manifests to use `v1` instead of `v1alpha2` for `GRPCRoute` and `v1beta1` instead of `v1alpha2` for `ReferenceGrant`. You can follow the [upgrade guide][gateway-api-v12-upgrade-notes] to ensure the `GRPCRoute` and `ReferenceGrant` are all updated to the latest storage version.
+Otherwise, upgrade gateway API and {{ site.kic_product_name }} following these steps:
+
+1. Ensure you are using Gateway API 1.1 (you can upgrade by following the steps in the section above).
+2. Ensure your are using {{ site.kic_product_name }} version 3.2 (or above).
+3. Update all your `GRPCRoute` manifests to use `v1` instead of `v1alpha2` and your `ReferenceGrant` manifests to use `v1beta1` instead of `v1alpha2`. This can be done by following the [upgrade guide from Gateway API][gateway-api-v12-upgrade-notes].
 4. Install the wanted channel of gateway API 1.2.
 
 [gateway-api-v12-upgrade-notes]: https://gateway-api.sigs.k8s.io/guides/?h=v1.2#v12-upgrade-notes

--- a/app/_src/kubernetes-ingress-controller/upgrade/kic.md
+++ b/app/_src/kubernetes-ingress-controller/upgrade/kic.md
@@ -47,7 +47,7 @@ ingressController:
 
 ### Update Gateway API 
 
-#### Update Gateway API from v1.0 to v1.1
+#### From v1.0 to v1.1
 
 Starting from version 3.2, {{ site.kic_product_name }} supports Gateway API version 1.1.
 The primary change in Gateway API v1.1 is the promotion of GRPCRoute from v1alpha2 to v1.
@@ -77,7 +77,7 @@ complete the following steps to upgrade to version v1.1 of the CRD:
 
 {% if_version gte:3.4.x %}
 
-#### Update Gateway API from v1.1 to v1.2
+#### From v1.1 to v1.2
 
 Starting from version 3.4, {{ site.kic_product_name }} supports Gateway API version 1.2.
 There is a breaking change in gateway API 1.2 to remove the `v1alpha2` version of `GRPCRoute` and `ReferenceGrant`.
@@ -89,9 +89,10 @@ You can use the following script to ensure your `GRPCRoute` and `ReferenceGrant`
 kubectl get grpcroutes -A -o jsonpath='{.items[*].apiVersion}' | tr ' ' '\n' | sort | uniq -c
 kubectl get referencegrants -A -o jsonpath='{.items[*].apiVersion}' | tr ' ' '\n' | sort | uniq -c
 ```
-If any of the output contains `v1alpha2`, it means that there are `GRPCRoute` or `ReferenceGrant` (or both) using `v1alpha2` storage version and you need to update the manifests before upgrading.
 
-Otherwise, upgrade gateway API and {{ site.kic_product_name }} following these steps:
+If the output contains `v1alpha2`, it means that there are `GRPCRoute`s or `ReferenceGrant`s (or both) using `v1alpha2` storage version and you need to update the manifests before upgrading.
+
+Otherwise, upgrade Gateway API and {{ site.kic_product_name }} following these steps:
 
 1. Ensure you are using Gateway API 1.1 (you can upgrade by following the steps in the section above).
 2. Ensure your are using {{ site.kic_product_name }} version 3.2 (or above).

--- a/app/_src/kubernetes-ingress-controller/upgrade/kic.md
+++ b/app/_src/kubernetes-ingress-controller/upgrade/kic.md
@@ -45,7 +45,9 @@ ingressController:
 
 {% if_version gte:3.2.x %}
 
-### Update Gateway API from v1.0 to v1.1
+### Update Gateway API 
+
+#### Update Gateway API from v1.0 to v1.1
 
 Starting from version 3.2, {{ site.kic_product_name }} supports Gateway API version 1.1.
 The primary change in Gateway API v1.1 is the promotion of GRPCRoute from v1alpha2 to v1.
@@ -75,7 +77,7 @@ complete the following steps to upgrade to version v1.1 of the CRD:
 
 {% if_version gte:3.4.x %}
 
-### Update Gateway API from v1.1 to v1.2
+#### Update Gateway API from v1.1 to v1.2
 
 Starting from version 3.4, {{ site.kic_product_name }} supports Gateway API version 1.2.
 There is a breaking change in gateway API 1.2 to remove the `v1alpha2` version of `GRPCRoute` and `ReferenceGrant`.

--- a/app/_src/kubernetes-ingress-controller/upgrade/kic.md
+++ b/app/_src/kubernetes-ingress-controller/upgrade/kic.md
@@ -73,6 +73,26 @@ complete the following steps to upgrade to version v1.1 of the CRD:
 
 {% endif_version %}
 
+{% if_version gte:3.4.x %}
+
+### Update Gateway API from v1.1 to v1.2
+
+Starting from version 3.4, {{ site.kic_product_name }} supports Gateway API version 1.2.
+There is a breaking change in gateway API 1.2 to remove the `v1alpha2` version of `GRPCRoute` and `ReferenceGrant`.
+
+If you have been using gateway API v1.1 and {{ site.kic_product_name }} 3.2 and above, and there are no `GRPCRoute` and `ReferenceGrant` resources stored in `v1alpha2` version, you can directly upgrade gateway API from v1.1 to v1.2.
+
+If the conditions to directly update gateway API to v1.2 is not satisfied, you can upgrade gateway API and {{ site.kic_product_name }} by the following steps:
+
+1. If you have installed gateway API 1.0, upgrade it to 1.1 by the steps in the section above.
+2. Upgrade your {{ site.kic_product_name }} to 3.2 if the version is below 3.2.
+3. Update all your manifests to use `v1` instead of `v1alpha2` for `GRPCRoute` and `v1beta1` instead of `v1alpha2` for `ReferenceGrant`. You can follow the [upgrade guide][gateway-api-v12-upgrade-notes] to ensure the `GRPCRoute` and `ReferenceGrant` are all updated to the latest storage version.
+4. Install the wanted channel of gateway API 1.2.
+
+[gateway-api-v12-upgrade-notes]: https://gateway-api.sigs.k8s.io/guides/?h=v1.2#v12-upgrade-notes
+
+{% endif_version %}
+
 ### Upgrade
 
 Run the following command, specifying the old release name, the namespace where


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

Add section to guide KIC users to upgrade gateway API to 1.2 as KIC 3.4 has bumped the gateway API version.
Fixes #8282.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

