### PR TITLE
feat: Public labels search syntax for Dev Portal

### DIFF
--- a/app/konnect/reference/search.md
+++ b/app/konnect/reference/search.md
@@ -89,6 +89,7 @@ Selectors are used to define the criteria of the search. The following table des
 | `name:{value}` | Searches for a match on `name`. |`name:default`|
 | `description:{value}` | Searches for a match on `description`. |`description:temporary`|
 | `labels.{label_key}:{label_value}` | Searches for an exact match for a labeled entity. |`labels.env:prod`|
+| `public_labels.{label_key}:{label_value}` | Searches for an exact match for a labeled entity in Dev Portal. |`public_labels.env:prod`|
 | `@{attribute_key}:{attribute_value}` | Searches for an exact match for an entity specific attribute. |`@email:"admin@domain.com"`|
 
 ### Reserved Characters

--- a/app/konnect/reference/search.md
+++ b/app/konnect/reference/search.md
@@ -89,7 +89,7 @@ Selectors are used to define the criteria of the search. The following table des
 | `name:{value}` | Searches for a match on `name`. |`name:default`|
 | `description:{value}` | Searches for a match on `description`. |`description:temporary`|
 | `labels.{label_key}:{label_value}` | Searches for an exact match for a labeled entity. |`labels.env:prod`|
-| `public_labels.{label_key}:{label_value}` | Searches for an exact match for a labeled entity in Dev Portal. |`public_labels.env:prod`|
+| `@public_labels.{label_key}:{label_value}` | Searches for an exact match for a labeled entity in Dev Portal. |`@public_labels.env:prod`|
 | `@{attribute_key}:{attribute_value}` | Searches for an exact match for an entity specific attribute. |`@email:"admin@domain.com"`|
 
 ### Reserved Characters


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Addition of `public_labels` KSearch syntax. Public labels are meant to provide a client-facing search syntax in KSearch for API Products in Developer Portals. This emulates the same syntax as `labels`, but for API clients browsing the Developer Portal
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

