### PR TITLE
Add minimum decK version to Konnect docs

### DIFF
--- a/app/_src/deck/guides/konnect.md
+++ b/app/_src/deck/guides/konnect.md
@@ -3,6 +3,9 @@ title: Using decK with Kong Konnect
 content_type: reference
 ---
 
+{:.important}
+> Konnect requires decK v1.40.0 or above. Versions below this will see inconsistent `deck gateway diff` results.
+
 You can manage {{site.base_gateway}} core entity configuration in your {{site.konnect_short_name}} organization using decK.
 
 decK can only target one control plane at a time.


### PR DESCRIPTION
### Description

Deck versions < 1.40.0 show incorrect `deck diff` information. This PR adds a warning to the Konnect/deck guide

### Testing instructions

Preview link: [/deck/latest/guides/konnect/](https://deploy-preview-8314--kongdocs.netlify.app/deck/latest/guides/konnect/)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
