### PR TITLE
docs: update the key calculation expression of proxy cache

### DIFF
--- a/app/_hub/kong-inc/proxy-cache/overview/_index.md
+++ b/app/_hub/kong-inc/proxy-cache/overview/_index.md
@@ -21,6 +21,7 @@ Proxy Cache plugin with Redis and Redis Sentinel support.
 
 ## Cache Key
 
+{% if_version lte:3.0.x %}
 Kong keys each cache elements based on the request method, the full client request (e.g., the request path and query parameters), and the UUID of either the API or Consumer associated with the request. This also implies that caches are distinct between APIs and/or Consumers. Currently the cache key format is hard-coded and cannot be adjusted. Internally, cache keys are represented as a hexadecimal-encoded MD5 sum of the concatenation of the constituent parts. This is calculated as follows:
 
 ```
@@ -28,6 +29,17 @@ key = md5(UUID | method | request)
 ```
 
 Where `method` is defined via the OpenResty `ngx.req.get_method()` call, and `request` is defined via the Nginx `$request` variable. Kong will return the cache key associated with a given request as the `X-Cache-Key` response header. It is also possible to precalculate the cache key for a given request as noted above.
+{% endif_version %}
+
+{% if_version gte:3.1.x %}
+Kong keys each cache elements based on the request method, the full client request (e.g., the request path and query parameters), and the UUID of either the API or Consumer associated with the request. This also implies that caches are distinct between APIs and/or Consumers. Currently the cache key format is hard-coded and cannot be adjusted. Internally, cache keys are represented as a hexadecimal-encoded SHA256 sum of the concatenation of the constituent parts. This is calculated as follows:
+
+```
+key = sha256(UUID | method | request | query_params | headers)
+```
+
+Where `method`, `query_params ` and `headers` are defined via the OpenResty `ngx.req.get_method()`, `ngx.req.get_uri_args()` and `ngx.req.get_headers()` call respectively, and `request` is defined via the Nginx `$request` variable. Kong will return the cache key associated with a given request as the `X-Cache-Key` response header. It is also possible to precalculate the cache key for a given request as noted above.
+{% endif_version %}
 
 ## Cache Control
 


### PR DESCRIPTION
### Description

In [the description of Proxy Cache](https://docs.konghq.com/hub/kong-inc/proxy-cache/), it is explained that the cache key is calculated using the following expression.

```
key = md5(UUID | method | request)
```

However, in the source code of Proxy Cache (3.9.0), the cache key is calculated from the following five elements.

https://github.com/Kong/kong/blob/3.9.0/kong/plugins/proxy-cache/cache_key.lua#L111-L112

Because of that, I have updated the expression in the documentation to match it with the one of source code.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

