### PR TITLE
Fix: RHEL7 deprecation version

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -3065,7 +3065,7 @@ The version bump includes fixes like UTF-8 ranges, a larger limit for rules and 
 ### Deprecations
 
 * Debian 10, CentOS 7, and RHEL 7 reached their End of Life (EOL) dates on June 30, 2024. 
-As of this patch, Kong is not building Kong Gateway 3.7.x installation packages or Docker images for these operating systems.
+As of this patch, Kong is not building Kong Gateway 3.4.x installation packages or Docker images for these operating systems.
 Kong is no longer providing official support for any Kong version running on these systems.
 
 ### Features


### PR DESCRIPTION
### Description

The deprecation notice for rhel7 mentions the wrong kong version.
Checked all the other version entries (2.8 onward), all the rest are correct.

Issue reported on slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1736248819331859

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

