### PR TITLE
remove -o from deck dump command

### DIFF
--- a/app/_src/deck/guides/kong-enterprise.md
+++ b/app/_src/deck/guides/kong-enterprise.md
@@ -156,7 +156,7 @@ deck dump --all-workspaces
 {% endif_version %}
 {% if_version gte:1.28.x %}
 ```sh
-deck gateway dump -o kong.yaml --all-workspaces
+deck gateway dump --all-workspaces
 ```
 {% endif_version %}
 


### PR DESCRIPTION
I can only dump multiple workspaces using 
`deck gateway dump --all-workspaces`

Which dumps them in yaml files sorted by name. 