### PR TITLE
Add tool to error with missing unreleased version

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -120,3 +120,18 @@ jobs:
           reviewdog_url: https://github.com/mheap/reviewdog/releases/download/v10.0.0/reviewdog_10.0.0_Linux_x86_64.tar.gz
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+  unreleased-version:
+    needs: check
+    if: needs.check.outputs.result == 'false'
+    name: Unreleased Version
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Check Unreleased label
+        run: |
+          cd tools/check-unreleased-label
+          npm ci
+          node run.js

--- a/tools/check-unreleased-label/package-lock.json
+++ b/tools/check-unreleased-label/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "check-unreleased-label",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "check-unreleased-label",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    }
+  }
+}

--- a/tools/check-unreleased-label/package.json
+++ b/tools/check-unreleased-label/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "check-unreleased-label",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "description": "",
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  }
+}

--- a/tools/check-unreleased-label/run.js
+++ b/tools/check-unreleased-label/run.js
@@ -1,0 +1,25 @@
+const yaml = require("js-yaml");
+const fs = require("fs");
+
+const unreleasedProducts = {
+  gateway: false,
+  deck: false,
+  "kubernetes-ingress-controller": false,
+};
+
+const versionsFile = __dirname + "/../../app/_data/kong_versions.yml";
+const labels = yaml.load(fs.readFileSync(versionsFile, "utf8"));
+
+for (const product of labels) {
+  if (product.label == "unreleased") {
+    unreleasedProducts[product.edition] = true;
+  }
+}
+
+let exitCode = 0;
+for (const product in unreleasedProducts) {
+  if (!unreleasedProducts[product]) {
+    console.error(`Error: ${product} is missing an 'unreleased' version`);
+    exitCode = 1;
+  }
+}


### PR DESCRIPTION
### Description

Fails the build if gateway/deck/kubernetes-ingress-controller does not have a version with `label: unreleased`

### Testing instructions

Preview link: N/A