### PR TITLE
Fix: Update decK compatible version with Konnect

### DIFF
--- a/app/_src/deck/faqs.md
+++ b/app/_src/deck/faqs.md
@@ -82,7 +82,8 @@ versions of Kong.
 ### I'm a {{site.konnect_short_name}} user, can I use decK?
 
 Yes, decK is compatible with {{site.konnect_short_name}}. We recommend
-upgrading to decK 1.12 to take advantage of the new `--konnect` CLI flags.
+upgrading to decK to 1.40.0 at minimum, or use the latest available version 
+for continued compatibility with {{site.konnect_short_name}}.
 
 ### I use Cassandra as a data store for Kong, can I use decK?
 

--- a/app/_src/deck/guides/konnect.md
+++ b/app/_src/deck/guides/konnect.md
@@ -4,7 +4,7 @@ content_type: reference
 ---
 
 {:.important}
-> Konnect requires decK v1.40.0 or above. Versions below this will see inconsistent `deck gateway diff` results.
+> {{site.konnect_short_name}} requires decK v1.40.0 or above. Versions below this will see inconsistent `deck gateway diff` results.
 
 You can manage {{site.base_gateway}} core entity configuration in your {{site.konnect_short_name}} organization using decK.
 

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -40,6 +40,11 @@ To use [Mesh Manager](/konnect/mesh-manager/), you must also use a compatible ve
 | {{site.mesh_product_name}} 2.4.x | <i class="fa fa-check"></i> | 2.4.1
 | {{site.mesh_product_name}} 2.3.x or earlier | <i class="fa fa-times"></i> | -
 
+## decK version compatibility
+
+{{site.konnect_short_name}} requires decK v1.40.0 or above. 
+Versions below this will see inconsistent `deck gateway diff` results and other potential issues.
+
 ## Plugin compatibility
 
 Most {{site.base_gateway}} plugins are compatible with {{site.konnect_short_name}}.

--- a/app/konnect/gateway-manager/control-plane-groups/migrate.md
+++ b/app/konnect/gateway-manager/control-plane-groups/migrate.md
@@ -16,7 +16,7 @@ Therefore, when migrating, you will need at least two new groups: a control plan
 ## Prerequisites
 
 * **Control plane admin** permissions
-* decK v1.12 or later [installed](/deck/latest/installation/)
+* decK v1.40.0 or later [installed](/deck/latest/installation/)
 * You have a Konnect access token and you have [made sure that decK can connect to your account](/konnect/gateway-manager/declarative-config/)
 
 ## Prepare control planes for migration

--- a/app/konnect/gateway-manager/declarative-config.md
+++ b/app/konnect/gateway-manager/declarative-config.md
@@ -29,7 +29,7 @@ registration, or configure custom plugins.
 
 ## Prerequisites
 
-* decK v1.12.0 or later [installed](/deck/latest/installation/).
+* decK v1.40.0 or later [installed](/deck/latest/installation/).
 * Optional: To test your configuration, [set up a simple data plane node](/konnect/getting-started/configure-data-plane-node/).
 * A [personal access token (PAT)](/konnect/org-management/access-tokens/).
 
@@ -85,7 +85,7 @@ configured, decK creates the file with only the format version and control plane
 name:
 
 ```yaml
-_format_version: "1.1"
+_format_version: "3.0"
 _konnect:
   control_plane_name: default
 ```
@@ -107,7 +107,7 @@ For this example, let's add a new service.
 1. Add the following snippet to your `konnect.yaml` file:
 
     ```yaml
-    _format_version: "1.1"
+    _format_version: "3.0"
     _konnect:
       control_plane_name: default
     services:
@@ -275,7 +275,7 @@ You can also use decK to migrate or duplicate configuration between control plan
 1. In the file, change the control plane name to the new group:
 
     ```yaml
-    _format_version: "1.1"
+    _format_version: 3.0"
     _konnect:
       control_plane_name: staging
     ```


### PR DESCRIPTION
### Description

Versions of decK before 1.4 have some inconsistency issues when used with Konnect. We need to tell our users to use 1.40 with Konnect at a minimum.

issue reported on slack: https://kongstrong.slack.com/archives/C03NRECFJPM/p1734711282132209

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

