### PR TITLE
Fix: OIDC plugin params listed as strings instead of arrays

### DIFF
--- a/app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
@@ -86,8 +86,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8440/auth/realms/master"
-  client_id: "cert_bound"
-  client_secret: "cf4c655a-0622-4ce6-a0de-d3353ef0b714"
+  client_id: 
+    - "cert_bound"
+  client_secret: 
+    - "cf4c655a-0622-4ce6-a0de-d3353ef0b714"
   auth_methods:
     - "bearer"
   proof_of_possession_dpop: "strict"

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_authorization-code-flow.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_authorization-code-flow.md
@@ -96,8 +96,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "authorization_code"
     - "session"

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_client-credentials.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_client-credentials.md
@@ -68,8 +68,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "client_credentials"
   client_credentials_param_type: 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
@@ -70,8 +70,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "introspection"
     - "password"

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_jwt-access-token.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_jwt-access-token.md
@@ -65,8 +65,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "bearer"
     - "password"
@@ -96,8 +98,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "bearer"
     - "password"

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_kong-oauth-token.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_kong-oauth-token.md
@@ -104,8 +104,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "kong_oauth2"
   bearer_token_param_type:

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_password-grant.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_password-grant.md
@@ -66,8 +66,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "password"
   password_param_type: 

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_refresh-token.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_refresh-token.md
@@ -71,8 +71,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "refresh_token"
     - "password"

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
@@ -63,8 +63,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "session"
     - "password"

--- a/app/_hub/kong-inc/openid-connect/how-to/authentication/_user-info.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authentication/_user-info.md
@@ -70,8 +70,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "userinfo"
     - "password"

--- a/app/_hub/kong-inc/openid-connect/how-to/authorization/_acl.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authorization/_acl.md
@@ -29,8 +29,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - "password"
   authenticated_groups_claim:

--- a/app/_hub/kong-inc/openid-connect/how-to/authorization/_claims.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authorization/_claims.md
@@ -42,8 +42,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - password
   scopes_claim:

--- a/app/_hub/kong-inc/openid-connect/how-to/authorization/_consumer.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/authorization/_consumer.md
@@ -49,8 +49,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "kong"
-  client_auth: "private_key_jwt"
+  client_id: 
+    - "kong"
+  client_auth: 
+    - "private_key_jwt"
   auth_methods:
     - password
   consumer_claim:

--- a/app/_hub/kong-inc/openid-connect/how-to/client-authentication/_mtls.md
+++ b/app/_hub/kong-inc/openid-connect/how-to/client-authentication/_mtls.md
@@ -80,8 +80,10 @@ plugin: kong-inc/openid-connect
 name: openid-connect
 config:
   issuer: "http://keycloak.test:8080/auth/realms/master"
-  client_id: "client-tls-auth"
-  client_auth: "tls_client_auth"
+  client_id: 
+    - "client-tls-auth"
+  client_auth: 
+    - "tls_client_auth"
   auth_methods:
     - "password"
   tls_client_auth_cert_id: "1e0721c1-fd43-494c-9864-007bbba98c8c"


### PR DESCRIPTION
### Description
In the OIDC plugin, `client_id`, `client_secret`, and` client_auth` must be arrays. See the config schema to verify:  https://docs.konghq.com/hub/kong-inc/openid-connect/configuration/

Fixes #8343 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

