### PR TITLE
docs(kgo): add global KongPluginBinding description

### DIFF
--- a/app/_data/docs_nav_kgo_1.5.x.yml
+++ b/app/_data/docs_nav_kgo_1.5.x.yml
@@ -1,0 +1,162 @@
+product: gateway-operator
+release: 1.5.x
+generate: true
+assume_generated: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    items:
+      - text: Overview
+        url: /gateway-operator/1.4.x/
+        absolute_url: true
+      - text: Deployment Topologies
+        items:
+          - text: Hybrid Mode
+            url: /topologies/hybrid/
+          - text: DB-less Mode
+            url: /topologies/dbless/
+      - text: Key Concepts
+        items:
+          - text: Gateway API
+            url: /concepts/gateway-api
+          - text: Gateway Configuration
+            url: /concepts/gateway-configuration
+          - text: Managed Gateways
+            url: /concepts/managed-gateways
+      - text: Changelog
+        url: /gateway-operator/changelog
+        absolute_url: true
+      - text: Version Support Policy
+        url: /support
+      - text: FAQ
+        url: /faq
+  - title: Get Started
+    icon: /assets/images/icons/documentation/icn-learning.svg
+    items:
+      - text: Konnect
+        items:
+          - text: Install Gateway Operator
+            url: /get-started/konnect/install/
+          - text: Deploy a Data Plane
+            url: /get-started/konnect/deploy-data-plane/
+          - text: Create a Route
+            url: /get-started/konnect/create-route/
+      - text: Kong Ingress Controller
+        items:
+          - text: Install Gateway Operator
+            url: /get-started/kic/install/
+          - text: Create a Gateway
+            url: /get-started/kic/create-gateway/
+          - text: Create a Route
+            url: /get-started/kic/create-route/
+  - title: Production Deployment
+    icon: /assets/images/icons/icn-server.svg
+    items:
+      - text: Overview
+        url: /production/
+      - text: Install
+        url: /install/
+      - text: Enterprise License
+        url: /license/
+      - text: Monitoring
+        items:
+          - text: Metrics
+            url: /production/monitoring/metrics/
+          - text: Status fields
+            items:
+              - text: Overview
+                url: /production/monitoring/status/overview/
+              - text: DataPlane
+                url: /production/monitoring/status/dataplane/
+              - text: ControlPlane
+                url: /production/monitoring/status/controlplane/
+              - text: Gateway
+                url: /production/monitoring/status/gateway/
+      - text: Upgrade Gateway Operator
+        url: /production/upgrade/gateway-operator/
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: AI Gateway
+        url: /guides/ai-gateway/
+      - text: Customization
+        items:
+          - text: Set data plane image
+            url: /customization/data-plane-image/
+          - text: Deploying Sidecars
+            url: /customization/sidecars/
+          - text: Customizing PodTemplateSpec
+            url: /customization/pod-template-spec/
+          - text: Defining PodDisruptionBudget for DataPlane
+            url: /customization/pod-disruption-budget/
+      - text: Autoscaling Kong Gateway
+        url: /guides/autoscaling-kong/
+      - text: Autoscaling Workloads
+        items:
+          - text: Overview
+            url: /guides/autoscaling-workloads/overview/
+          - text: Prometheus
+            url: /guides/autoscaling-workloads/prometheus/
+          - text: Datadog
+            url: /guides/autoscaling-workloads/datadog/
+      - text: Upgrading Data Planes
+        items:
+          - text: Rolling Deployment
+            url: /guides/upgrade/data-plane/rolling/
+          - text: Blue / Green Deployment
+            url: /guides/upgrade/data-plane/blue-green/
+      - text: Kong Custom Plugin Distribution
+        url: guides/plugin-distribution/
+      - text: Managing Konnect entities
+        items:
+          - text: Architecture overview
+            url: /guides/konnect-entities/architecture/
+          - text: Gateway Control Plane
+            url: /guides/konnect-entities/gatewaycontrolplane/
+          - text: Service and Route
+            url: /guides/konnect-entities/service-and-route/
+          - text: Consumer, Credentials and Consumer Groups
+            url: /guides/konnect-entities/consumer-and-consumergroup/
+          - text: Key and Key Set
+            url: /guides/konnect-entities/key-and-keyset/
+          - text: Upstream and Targets
+            url: /guides/konnect-entities/upstream-and-target/
+          - text: Certificate and CA Certificate
+            url: /guides/konnect-entities/certificate-and-cacertificate/
+          - text: Vault
+            url: /guides/konnect-entities/vault/
+          - text: Data Plane Client Certificate
+            url: /guides/konnect-entities/dpcertificate/
+          - text: Tagging and Labeling
+            url: /guides/konnect-entities/tagging-and-labeling/
+          - text: Managing Plugin Bindings by CRD
+            url: /guides/konnect-entities/konnect-plugin-binding/
+          - text: FAQ
+            url: /guides/konnect-entities/faq/
+  - title: Reference
+    icon: /assets/images/icons/icn-magnifying-glass.svg
+    items:
+      - text: Custom Resources
+        items:
+          - text: Overview
+            url: /reference/custom-resources/
+            src: reference/custom-resources/1.4.x
+          - text: GatewayConfiguration
+            url: /reference/custom-resources/#gatewayconfiguration
+            generate: false
+          - text: ControlPlane
+            url: /reference/custom-resources/#controlplane
+            generate: false
+          - text: DataPlane
+            url: /reference/custom-resources/#dataplane
+            generate: false
+          - text: KongPluginInstallation
+            url: /reference/custom-resources/#kongplugininstallation
+            generate: false
+      - text: Configuration Options
+        url: /reference/cli-arguments/
+        src: reference/cli-arguments/1.4.x
+      - text: License
+        url: /reference/license
+      - text: Version Compatibility
+        url: /reference/version-compatibility

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -339,6 +339,12 @@
   releaseDate: "2024-11-28"
   endOfLifeDate: "2025-11-28"
   latest: true
+- edition: gateway-operator
+  version: 1.5.0
+  release: 1.5.x
+  releaseDate: "TBA"
+  endOfLifeDate: "TBA"
+  label: unreleased
 - edition: mesh
   version: 2.2.9
   release: 2.2.x

--- a/app/_src/gateway-operator/guides/konnect-entities/konnect-plugin-binding.md
+++ b/app/_src/gateway-operator/guides/konnect-entities/konnect-plugin-binding.md
@@ -10,14 +10,17 @@ with-control-plane=true %}
 
 ## Introduction of `KongPluginBinding` CRD
 
-The `KongPluginBinding` is the CRD used to manage the binding relationship between plugins and attached {{site.konnect_short_name}} entities, including services, routes, consumers, and consumer groups, or a supported combination of these entities.
+The `KongPluginBinding` is the CRD used to manage the binding relationship between plugins and attached {{site.konnect_short_name}} 
+entities, including services, routes, consumers, and consumer groups, or a supported combination of these entities.
+{% if_version gte:1.5.x %} It can also be used to bind a plugin globally to a control plane when `spec.scope` is set to `GlobalInControlPlane`. {% endif_version %} 
+Each `KongPluginBinding` represents a single plugin instance on {{ site.konnect_short_name }}.
 
-This CRD has two parts for the binding description in its specification: 
-* `spec.pluginRef`: Refers to a `KongPlugin` resource which contains the plugin name and configuration of the plugin.
-* `spec.targets`: Refers to the entity or combination of entities that the plugin is attached to.
-The `spec.controlPlaneRef` refers to the {{site.konnect_product_name}} control plane this `KongPluginBinding` is associated with.
+This CRD has the following fields:
+* `spec.pluginRef`: Refers to a `KongPlugin` object which contains the plugin name and configuration of the plugin.
+* `spec.targets`: Refers to the entity or combination of entities that the plugin is attached to.{% if_version gte:1.5.x %} At least one target has to be specified when `spec.scope` is `OnlyTargets` (default). {% endif_version %}
+* `spec.controlPlaneRef`: Refers to the {{site.konnect_product_name}} control plane this `KongPluginBinding` is associated with.
 
-Each `KongPluginBinding` represents a plugin on {{ site.konnect_short_name }}.
+You can refer to the CR [API](/gateway-operator/{{ page.release }}/reference/custom-resources/#kongpluginbinding) to see all the available fields.
 
 ## Using an unmanaged `KongPluginBinding`
 
@@ -176,6 +179,36 @@ spec:
       name: cp
 ' | kubectl apply -f -
 ```
+
+{% if_version gte:1.5.x %}
+### Attaching plugins globally to a control plane
+
+You can also attach a plugin globally to a control plane by setting the `spec.scope` field to `GlobalInControlPlane` in the `KongPluginBinding` CRD.
+
+Create a `KongPluginBinding` to attach a plugin globally to a control plane like this:
+
+```shell
+echo '
+kind: KongPluginBinding
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  namespace: default
+  name: binding-global-rate-limiting
+spec:
+  # This indicates that the plugin is attached globally to the control plane and allows leaving targets empty.
+  scope: GlobalInControlPlane
+  pluginRef:
+    kind: KongPlugin
+    name: rate-limiting-minute-10
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: cp
+' | kubectl apply -f -
+```
+
+Having the `KongPluginBinding` created, the plugin will be attached globally to the control plane in {{ site.konnect_short_name }}.
+{% endif_version %}
 
 ## Using annotations to bind plugins to other entities
 


### PR DESCRIPTION
### Description

Describes global `KongPluginBinding` usage.

Closes https://github.com/Kong/gateway-operator/issues/440.

### Testing instructions

Preview link: https://deploy-preview-8351--kongdocs.netlify.app/gateway-operator/unreleased/guides/konnect-entities/konnect-plugin-binding/
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

