### PR TITLE
Update: Gateway LTS policy

### DIFF
--- a/app/_assets/stylesheets/blockquote-notes.less
+++ b/app/_assets/stylesheets/blockquote-notes.less
@@ -47,13 +47,13 @@
       padding: 15px;
       border-radius: 2px;
 
-      p {
+      p, table {
         margin-left: 24px;
       }
     }
 
     &.no-icon {
-      p {
+      p, table {
         margin-left: unset;
       }  
     }

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -7,8 +7,42 @@ Kong adopts a structured approach to versioning its products.
 Products follow a pattern of `{MAJOR}.{MINOR}.{PATCH}.{ENTERPRISE_PATCH}`.
 The `ENTERPRISE_PATCH` segment identifies a sub-patch for {{site.ee_product_name}} based on {{site.ce_product_name}}. 
 
-{:.note}
-> **Note**: This policy **only** applies to {{site.base_gateway}} and {{site.ee_product_name}}. For the {{site.konnect_product_name}} version support policy, review the [{{site.konnect_product_name}} policy](/konnect/compatibility/#kong-gateway-version-compatibility).
+This policy **only** applies to {{site.base_gateway}} and {{site.ee_product_name}}. 
+For the {{site.konnect_product_name}} version support policy, review the [{{site.konnect_product_name}} policy](/konnect/compatibility/#kong-gateway-version-compatibility).
+
+{:.important}
+> **Long Term Support Policy Update**
+> <br><br>
+> We are planning to release our next LTS version, 3.10, in late March*, and moving forward we plan to release 4 minor versions per year every year: one in March, one in June, one in September and the last one in December. Each year, the first version we release will become an LTS release, so starting from 3.10 we will have 1 LTS every year in March of that year. 
+> <br><br>
+Example of planned LTS schedule for next 4 years:
+> <table>
+>  <thead>
+>    <th>LTS Version</th>
+>    <th>Planned release date</th>
+>  </thead>
+>  <tbody>
+>    <tr>
+>      <td>3.10</td>
+>      <td>March 2025</td>
+>    </tr>
+>    <tr>
+>      <td>3.14</td>
+>      <td>March 2026</td>
+>    </tr>
+>    <tr>
+>      <td>3.18</td>
+>      <td>March 2027</td>
+>    </tr>
+>    <tr>
+>      <td>3.22</td>
+>      <td>March 2028</td>
+>    </tr>
+>  </tbody>
+> </table>
+> Each LTS is supported for 3 years from date of release. This will allow adjacent LTS releases to have a support overlap of 2 years in which customers can plan their upgrade.
+> <br><br>
+> _* Release timeframes are subject to change_
 
 ## Versioning
 
@@ -34,7 +68,7 @@ Due to backports, new features and breaking changes are possible at any version 
 To avoid issues, do not upgrade to any new version automatically, and 
 make sure to review all relevant [changelog entries](/gateway/changelog/) before manually upgrading your deployments.
 
-### Long-term support
+### Long-term support (LTS) {#long-term-support}
 
 Kong may designate a specific minor version as a **Long-Term Support (LTS)** version. Kong provides technical support for the LTS version on a given distribution for the duration of the distribution’s lifecycle, or for 3 years from LTS version release, whichever comes sooner. An LTS version is backwards compatible within its major version sequence. An LTS version receives all security fixes. Additionally, an LTS version may receive certain non-security patches at Kong's discretion. At any time, there will be at least 1 active LTS {{site.ee_product_name}} version.
 

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -45,7 +45,7 @@ For the {{site.konnect_product_name}} version support policy, review the [{{site
 > Each LTS is supported for 3 years from the date of release. 
 > This will allow adjacent LTS releases to have a support overlap of 2 years in which customers can plan their upgrades.
 > <br><br>
-> _* Release timeframes are subject to change_
+> _* Release timeframes are subject to change._
 
 ## Versioning
 

--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -10,12 +10,14 @@ The `ENTERPRISE_PATCH` segment identifies a sub-patch for {{site.ee_product_name
 This policy **only** applies to {{site.base_gateway}} and {{site.ee_product_name}}. 
 For the {{site.konnect_product_name}} version support policy, review the [{{site.konnect_product_name}} policy](/konnect/compatibility/#kong-gateway-version-compatibility).
 
-{:.important}
+{:.note}
 > **Long Term Support Policy Update**
 > <br><br>
-> We are planning to release our next LTS version, 3.10, in late March*, and moving forward we plan to release 4 minor versions per year every year: one in March, one in June, one in September and the last one in December. Each year, the first version we release will become an LTS release, so starting from 3.10 we will have 1 LTS every year in March of that year. 
+> Beginning in March 2025, we plan to release 4 minor versions per year, every year: one in March, one in June, one in September, and the last one in December. 
+> Each year, the first version we release will become an LTS release. 
+> Starting from 3.10, we will have 1 LTS release every year, in March* of that year.
 > <br><br>
-Example of planned LTS schedule for next 4 years:
+> Example of planned LTS schedule for next 4 years:
 > <table>
 >  <thead>
 >    <th>LTS Version</th>
@@ -40,7 +42,8 @@ Example of planned LTS schedule for next 4 years:
 >    </tr>
 >  </tbody>
 > </table>
-> Each LTS is supported for 3 years from date of release. This will allow adjacent LTS releases to have a support overlap of 2 years in which customers can plan their upgrade.
+> Each LTS is supported for 3 years from the date of release. 
+> This will allow adjacent LTS releases to have a support overlap of 2 years in which customers can plan their upgrades.
 > <br><br>
 > _* Release timeframes are subject to change_
 


### PR DESCRIPTION
### Description

Adding an announcement banner to the support policy Gateway doc. 
This is to increase visibility over a potential blog, and to warn customers before 3.10 goes out.

No conditional version tags needed here. The banner is relevant to anyone on any version.

Once 3.10 goes out, we can add this same notice to the changelog, and integrate the LTS information directly into the support policy.

https://konghq.atlassian.net/browse/DOCU-4181

### Testing instructions

Preview link: https://deploy-preview-8355--kongdocs.netlify.app/gateway/latest/support-policy/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

