### PR TITLE
chore: Adjust messaging around Vitals sustaining mode

### DIFF
--- a/app/_src/gateway/breaking-changes/35x.md
+++ b/app/_src/gateway/breaking-changes/35x.md
@@ -13,22 +13,21 @@ custom plugins, for example.
 
 ## Dev Portal and Vitals
 
-As of this release, the product component known as Kong Enterprise Portal is no longer included in the Kong Gateway Enterprise (previously known as Kong Enterprise) software package. Existing customers who have purchased Kong Enterprise Portal can continue to use it and be supported via a dedicated mechanism. 
-  
-If you have purchased Kong Enterprise Portal in the past and would like to continue to use it with this release or a future release of Kong Gateway Enterprise, contact [Kong Support](https://support.konghq.com/support/s/) for more information.
+As of this release, the product component known as Kong Enterprise Portal is no longer included in the {{site.ee_product_name}} (previously known as Kong Enterprise) software package. Existing customers who have purchased Kong Enterprise Portal can continue to use it and be supported via a dedicated mechanism. 
 
-In addition, the product component known as Vitals is deprecated and is no longer included in Kong Gateway Enterprise.
-Kong Konnect users can take advantage of our [API Analytics](/konnect/analytics/) offering, which provides a superset of Vitals functionality. 
+In addition, the product component known as Vitals is no longer included in {{site.ee_product_name}}. 
+Existing customers who have purchased Kong Vitals can continue to use it and be supported via a dedicated mechanism. 
+{{site.konnect_product_name}} users can take advantage of our [API Analytics](/konnect/analytics/) offering, which provides a superset of Vitals functionality. 
 
-Vitals continues to be supported for existing customers until August 2026 via the Kong Enterprise 3.4 LTS release.
+If you have purchased Kong Enterprise Portal or Vitals in the past and would like to continue to use it with this release or a future release of {{site.ee_product_name}}, contact [Kong Support](https://support.konghq.com/support/s/) for more information.
 
 ## Plugin Changes
 
-Kong Gateway now requires an Enterprise license to use dynamic plugin ordering.
+{{site.base_gateway}} now requires an Enterprise license to use dynamic plugin ordering.
 
 ### Session Plugin 
 
-Kong Gateway 3.5.x introduced the new configuration field `read_body_for_logout` with a default value of `false`. This change alters the behavior of `logout_post_arg` in such a way that it is no longer considered, unless `read_body_for_logout` is explicitly set to `true`. This adjustment prevents the Session plugin from automatically reading request bodies for logout detection, particularly on POST requests.
+{{site.base_gateway}} 3.5.x introduced the new configuration field `read_body_for_logout` with a default value of `false`. This change alters the behavior of `logout_post_arg` in such a way that it is no longer considered, unless `read_body_for_logout` is explicitly set to `true`. This adjustment prevents the Session plugin from automatically reading request bodies for logout detection, particularly on POST requests.
 
 ## Configuration changes
 

--- a/app/_src/gateway/breaking-changes/35x.md
+++ b/app/_src/gateway/breaking-changes/35x.md
@@ -13,6 +13,7 @@ custom plugins, for example.
 
 ## Dev Portal and Vitals
 
+<!--vale off-->
 As of this release, the product component known as Kong Enterprise Portal is no longer included in the {{site.ee_product_name}} (previously known as Kong Enterprise) software package. Existing customers who have purchased Kong Enterprise Portal can continue to use it and be supported via a dedicated mechanism. 
 
 In addition, the product component known as Vitals is no longer included in {{site.ee_product_name}}. 
@@ -20,6 +21,7 @@ Existing customers who have purchased Kong Vitals can continue to use it and be 
 {{site.konnect_product_name}} users can take advantage of our [API Analytics](/konnect/analytics/) offering, which provides a superset of Vitals functionality. 
 
 If you have purchased Kong Enterprise Portal or Vitals in the past and would like to continue to use it with this release or a future release of {{site.ee_product_name}}, contact [Kong Support](https://support.konghq.com/support/s/) for more information.
+<!--vale on-->
 
 ## Plugin Changes
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -2712,10 +2712,11 @@ unless `read_body_for_logout` is explicitly set to `true`. This adjustment preve
   
   If you have purchased Kong Enterprise Portal in the past and would like to continue to use it with this release or a future release of Kong Gateway Enterprise, contact [Kong Support](https://support.konghq.com/support/s/) for more information.
 
-* As of this release, the product component known as Vitals is deprecated and is no longer included in Kong Gateway Enterprise.
+* As of this release, the product component known as Vitals is no longer included in Kong Gateway Enterprise. 
+Existing customers who have purchased Kong Vitals can continue to use it and be supported via a dedicated mechanism. 
 Kong Konnect users can take advantage of our [API Analytics](/konnect/analytics/) offering, which provides a superset of Vitals functionality. 
 
-  Vitals continues to be supported for existing customers until August 2026 via the Kong Enterprise 3.4 LTS release.
+  If you have purchased Vitals in the past and would like to continue to use it with this release or a future release of Kong Gateway Enterprise, contact [Kong Support](https://support.konghq.com/support/s/) for more information.
 
 * The default value of the [`dns_no_sync`](/gateway/3.5.x/reference/configuration/#dns_no_sync) option has been changed to `on`.
 [#11871](https://github.com/kong/kong/pull/11871).


### PR DESCRIPTION
### Description

Vitals is supported indefinitely for existing customer that have purchased it in the past, same as Dev Portal. Adjusting the docs to reflect this.

### Testing instructions

Preview link: https://deploy-preview-8365--kongdocs.netlify.app/gateway/3.5.x/breaking-changes/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

