### PR TITLE
Fix: Add missing mesh variables

### DIFF
--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -169,6 +169,9 @@ mesh_ignored_links_regex:
 mesh_raw_generated_paths:
   - app/assets/mesh
   - app/_src/.repos/kuma/app/assets
+mesh_product_name_path: kong-mesh
+mesh_cp_zone_sync_name_prefix: kong-mesh-
+mesh_docker_org: kong
 # Helm commands
 set_flag_values_prefix: kuma.
 mesh_helm_repo_url: https://kong.github.io/kong-mesh-charts

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -155,6 +155,9 @@ mesh_ignored_links_regex:
 mesh_raw_generated_paths:
   - app/assets/mesh
   - app/_src/.repos/kuma/app/assets
+mesh_product_name_path: kong-mesh
+mesh_cp_zone_sync_name_prefix: kong-mesh-
+mesh_docker_org: kong
 # Helm commands
 set_flag_values_prefix: kuma.
 mesh_helm_repo_url: https://kong.github.io/kong-mesh-charts


### PR DESCRIPTION
### Description

The Kuma docs have had a few variables added to them that we didn't have in the docs.konghq.com config files, so the variables were resolving to nothing.

Issue reported on slack.

### Testing instructions

Preview link: 
https://deploy-preview-8384--kongdocs.netlify.app/mesh/latest/introduction/install/ - Mesh packages link
https://deploy-preview-8384--kongdocs.netlify.app/mesh/latest/production/cp-deployment/multi-zone/ - `kong-mesh-global-zone-sync`

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

