### PR TITLE
docs(mesh): fix navbar to use kong-mesh instead of kuma

### DIFF
--- a/app/_data/docs_nav_mesh_2.10.x.yml
+++ b/app/_data/docs_nav_mesh_2.10.x.yml
@@ -92,6 +92,10 @@ inherit:
       text: Deploy Kong Mesh on Kubernetes
       action: modify
       items: []
+    - path: [ Quickstart, Deploy Kuma on Universal ]
+      text: Deploy Kong Mesh on Universal
+      action: modify
+      items: []
     - path: [ Using Kuma ]
       title: Using Kong Mesh
       action: modify

--- a/app/_data/docs_nav_mesh_2.6.x.yml
+++ b/app/_data/docs_nav_mesh_2.6.x.yml
@@ -77,6 +77,10 @@ inherit:
       text: Deploy Kong Mesh on Kubernetes
       action: modify
       items: []
+    - path: [ Quickstart, Deploy Kuma on Universal ]
+      text: Deploy Kong Mesh on Universal
+      action: modify
+      items: []
     - path: [ Using Kuma ]
       title: Using Kong Mesh
       action: modify

--- a/app/_data/docs_nav_mesh_2.7.x.yml
+++ b/app/_data/docs_nav_mesh_2.7.x.yml
@@ -82,6 +82,10 @@ inherit:
       text: Deploy Kong Mesh on Kubernetes
       action: modify
       items: []
+    - path: [ Quickstart, Deploy Kuma on Universal ]
+      text: Deploy Kong Mesh on Universal
+      action: modify
+      items: []
     - path: [ Using Kuma ]
       title: Using Kong Mesh
       action: modify

--- a/app/_data/docs_nav_mesh_2.8.x.yml
+++ b/app/_data/docs_nav_mesh_2.8.x.yml
@@ -87,6 +87,10 @@ inherit:
       text: Deploy Kong Mesh on Kubernetes
       action: modify
       items: []
+    - path: [ Quickstart, Deploy Kuma on Universal ]
+      text: Deploy Kong Mesh on Universal
+      action: modify
+      items: []
     - path: [ Using Kuma ]
       title: Using Kong Mesh
       action: modify

--- a/app/_data/docs_nav_mesh_2.9.x.yml
+++ b/app/_data/docs_nav_mesh_2.9.x.yml
@@ -92,6 +92,10 @@ inherit:
       text: Deploy Kong Mesh on Kubernetes
       action: modify
       items: []
+    - path: [ Quickstart, Deploy Kuma on Universal ]
+      text: Deploy Kong Mesh on Universal
+      action: modify
+      items: []
     - path: [ Using Kuma ]
       title: Using Kong Mesh
       action: modify


### PR DESCRIPTION
### Description

We missed one navbar element
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

fix: https://github.com/kumahq/kuma-website/issues/2158

