### PR TITLE
Fix: label KIC 3.4 as LTS

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -308,6 +308,7 @@
   version: "3.4.1"
   edition: "kubernetes-ingress-controller"
   latest: true
+  lts: true
 - release: "3.5.x"
   version: "3.5.0"
   edition: "kubernetes-ingress-controller"


### PR DESCRIPTION
### Description

KIC 3.4.0 is an LTS release, but the LTS label is missing: https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md/#340

Fixes https://github.com/Kong/docs.konghq.com/issues/8368.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

