### PR TITLE
Fix: Add missing queue parameter to table

### DIFF
--- a/app/_src/gateway/kong-plugins/queue/reference.md
+++ b/app/_src/gateway/kong-plugins/queue/reference.md
@@ -24,6 +24,10 @@ The unified queue parameter set consists of the following parameters:
 |`max_retry_time` | fraction | seconds | 60 | Maximum time that a batch is retried. This can be set to a negative value to disable retries. |
 |`initial_retry_delay` | fraction | seconds | 0.01 | Initial delay before retrying after processing a failed batch. |
 |`max_retry_delay` | fraction | seconds | 60 | Maximum time to wait between retries. |
+{% if_version gte:3.8.x %}
+|`concurrency_limit` | integer | count | 1 | The maximum number of delivery timers in the queue. Note that setting `concurrency_limit` to `-1` means no limit at all, and each HTTP log entry would create an individual timer for sending. |
+{% endif_version %}
+
 
 Queues are not shared between workers and queueing parameters are
 scoped to one worker.  For whole-system capacity planning, the number

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -516,8 +516,7 @@ Kong is no longer providing official support for any Kong version running on the
 
 #### Core
 
-* Added the new configuration parameter [`concurrency_limit`](/gateway/3.8.x/reference/configuration/#concurrency_limit)
- (integer, defaults to 1), which lets you specify the number of delivery timers in the queue.
+* Added the new queue configuration parameter `concurrency_limit` (integer, defaults to 1), which lets you specify the number of delivery timers in the queue.
   Note that setting `concurrency_limit` to `-1` means no limit at all, and each HTTP log entry would create an individual timer for sending.
  [#13332](https://github.com/Kong/kong/issues/13332)
 * Kong Gateway now appends gateway info to the upstream `Via` header in the format `1.1 kong/3.8.0`, and optionally to the


### PR DESCRIPTION
### Description

We missed documenting the `concurrency_limit` queue parameter in 3.8.
Removed the link to kong.conf from the changelog; these params aren't in kong.conf, they're in plugins.

Fixes https://github.com/Kong/docs.konghq.com/issues/8291.

### Testing instructions

Preview link: https://deploy-preview-8397--kongdocs.netlify.app/gateway/latest/kong-plugins/queue/reference/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

