### PR TITLE
remove try-in-konnect for incompatible plugins

### DIFF
--- a/app/_includes/plugins/sidebar.html
+++ b/app/_includes/plugins/sidebar.html
@@ -13,7 +13,7 @@
     {% for item in include.sidenav.nav_items %}
       {% include_cached sidebar/item.html item=item id=forloop.index %}
     {% endfor %}
-    {% if page.extn_publisher == "kong-inc" %}
+    {% if page.extn_publisher == "kong-inc" and page.konnect %}
       <li>
         <a id="konnect-cta" href="https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_campaign=gateway-konnect&utm_content={{ page.extn_slug }}" class="sidebar-button" target="_blank">
           Try it in {{site.konnect_short_name}}

--- a/spec/templates/plugin_with_versions_spec.rb
+++ b/spec/templates/plugin_with_versions_spec.rb
@@ -52,8 +52,5 @@ RSpec.describe 'Plugin page with multiple versions' do
       expect(nested_how_tos).to have_css('.sidebar-item', text: 'Nested Tutorial Nav title with Min and Max')
     end
 
-    it 'renders a Konnect CTA button' do
-      expect(html).to have_css('.sidebar-button', text: 'Try it in Konnect')
-    end
   end
 end


### PR DESCRIPTION
### Description

Removes the "Try In Konnect" sidebar button for plugins which don't support Konnect.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

