### PR TITLE
Fix versioning issues with OAS and insomnia buttons

### DIFF
--- a/api-specs/Gateway-EE/3.9/kong-ee.yaml
+++ b/api-specs/Gateway-EE/3.9/kong-ee.yaml
@@ -6236,7 +6236,7 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   title: Enterprise Kong Admin API
-  version: 3.8.0
+  version: 3.9.0
 openapi: 3.0.0
 paths:
   /:

--- a/api-specs/Gateway-EE/latest/kong-ee.yaml
+++ b/api-specs/Gateway-EE/latest/kong-ee.yaml
@@ -6112,7 +6112,7 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   title: Enterprise Kong Admin API
-  version: 3.8.0
+  version: 3.9.0
 openapi: 3.0.0
 paths:
   /:

--- a/api-specs/Gateway-OSS/3.9/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/3.9/kong-oss.yaml
@@ -3622,7 +3622,7 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   title: Kong Admin API
-  version: 3.8.0
+  version: 3.9.0
 openapi: 3.0.0
 paths:
   /:

--- a/api-specs/Gateway-OSS/latest/kong-oss.yaml
+++ b/api-specs/Gateway-OSS/latest/kong-oss.yaml
@@ -3622,7 +3622,7 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   title: Kong Admin API
-  version: 3.8.0
+  version: 3.9.0
 openapi: 3.0.0
 paths:
   /:

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -57,7 +57,6 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.4.x"
-  short-version: "3.4"
   ee-version: "3.4.3.16"
   ce-version: "3.4.2"
   edition: "gateway"
@@ -73,7 +72,6 @@
   lua_doc: true
   lts: true
 - release: "3.5.x"
-  short-version: "3.5"
   ee-version: "3.5.0.7"
   ce-version: "3.5.0"
   edition: "gateway"
@@ -88,7 +86,6 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.6.x"
-  short-version: "3.6"
   ee-version: "3.6.1.8"
   ce-version: "3.6.1"
   edition: "gateway"
@@ -103,7 +100,6 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.7.x"
-  short-version: "3.7"
   ee-version: "3.7.1.3"
   ce-version: "3.7.1"
   edition: "gateway"
@@ -118,7 +114,6 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.8.x"
-  short-version: "3.8"
   ee-version: "3.8.1.0"
   ce-version: "3.8.1"
   edition: "gateway"
@@ -133,7 +128,6 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.9.x"
-  short-version: "3.9"
   ee-version: "3.9.0.1"
   ce-version: "3.9.0"
   edition: "gateway"
@@ -149,7 +143,6 @@
   lua_doc: true
   latest: true
 - release: "3.10.x"
-  short-version: "3.10"
   ee-version: "3.10.0.0"
   ce-version: "3.10.0"
   edition: "gateway"

--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -57,6 +57,7 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.4.x"
+  short-version: "3.4"
   ee-version: "3.4.3.16"
   ce-version: "3.4.2"
   edition: "gateway"
@@ -72,6 +73,7 @@
   lua_doc: true
   lts: true
 - release: "3.5.x"
+  short-version: "3.5"
   ee-version: "3.5.0.7"
   ce-version: "3.5.0"
   edition: "gateway"
@@ -86,6 +88,7 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.6.x"
+  short-version: "3.6"
   ee-version: "3.6.1.8"
   ce-version: "3.6.1"
   edition: "gateway"
@@ -100,6 +103,7 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.7.x"
+  short-version: "3.7"
   ee-version: "3.7.1.3"
   ce-version: "3.7.1"
   edition: "gateway"
@@ -114,6 +118,7 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.8.x"
+  short-version: "3.8"
   ee-version: "3.8.1.0"
   ce-version: "3.8.1"
   edition: "gateway"
@@ -128,6 +133,7 @@
     pcre: 8.45
   lua_doc: true
 - release: "3.9.x"
+  short-version: "3.9"
   ee-version: "3.9.0.1"
   ce-version: "3.9.0"
   edition: "gateway"
@@ -143,6 +149,7 @@
   lua_doc: true
   latest: true
 - release: "3.10.x"
+  short-version: "3.10"
   ee-version: "3.10.0.0"
   ce-version: "3.10.0"
   edition: "gateway"

--- a/app/_plugins/generators/pages/version_data.rb
+++ b/app/_plugins/generators/pages/version_data.rb
@@ -49,6 +49,9 @@ module Jekyll
 
         # Add a `major_minor_version` property which is used for cloudsmith install pages
         @page.data['major_minor_version'] = release.value.gsub('.x', '').gsub('.', '')
+
+        # Add a `short_version` property which is used for spec filenames
+        @page.data['short_version'] = release.value.gsub('.x', '')
       end
 
       def release

--- a/app/_src/gateway/admin-api/index_latest.md
+++ b/app/_src/gateway/admin-api/index_latest.md
@@ -24,16 +24,16 @@ The Kong Admin API is documented in OpenAPI format:
 
 | Spec | Insomnia link |
 |-------|---------------|
-| [Enterprise API](/gateway/api/admin-ee/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%20{{page.release.versions.short}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F{{page.release.versions.short}}%2Fkong-ee-{{page.release.versions.short}}.yaml" target="_blank"> <img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
-|  [Open source API](/gateway/api/admin-oss/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20OSS%20{{page.release.versions.short}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F{{page.release.versions.short}}%2Fkong-oss-{{page.release.versions.short}}.yaml" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
+| [Enterprise API](/gateway/api/admin-ee/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%20{{page.short_version}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F{{page.short_version}}%2Fkong-ee-{{page.short_version}}.yaml" target="_blank"> <img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
+|  [Open source API](/gateway/api/admin-oss/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20OSS%20{{page.short_version}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F{{page.short_version}}%2Fkong-oss-{{page.short_version}}.yaml" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
 
 {% endif_version %}
 {% if_version gte:3.8.x %}
 
 | Spec | Insomnia link |
 |-------|---------------|
-| [Enterprise API](/gateway/api/admin-ee/latest/){:target="_blank"} |<a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%20{{page.release.versions.short}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F{{page.release.versions.short}}%2Fkong-ee.yaml" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
-|  [Open source API](/gateway/api/admin-oss/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20OSS%20{{page.release.versions.short}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F{{page.release.versions.short}}%2Fkong-oss.yaml" target="_blank"> <img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
+| [Enterprise API](/gateway/api/admin-ee/latest/){:target="_blank"} |<a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%20{{page.short_version}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F{{page.short_version}}%2Fkong-ee.yaml" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
+|  [Open source API](/gateway/api/admin-oss/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20OSS%20{{page.short_version}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F{{page.short_version}}%2Fkong-oss.yaml" target="_blank"> <img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
 
 {% endif_version %}
 

--- a/app/_src/gateway/admin-api/index_latest.md
+++ b/app/_src/gateway/admin-api/index_latest.md
@@ -20,10 +20,22 @@ title: Kong Gateway Admin API
 
 The Kong Admin API is documented in OpenAPI format:
 
+{% if_version lte:3.7.x %}
+
 | Spec | Insomnia link |
 |-------|---------------|
-| [Enterprise API](/gateway/api/admin-ee/latest/){:target="_blank"} |<a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F3.4%2Fkong-ee-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>  |
-|  [Open source API](/gateway/api/admin-oss/latest/){:target="_blank"} |  <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Open%20Source%203.4&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F3.4%2Fkong-oss-3.4.json" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia"></a>|
+| [Enterprise API](/gateway/api/admin-ee/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%20{{page.release.versions.short}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F{{page.release.versions.short}}%2Fkong-ee-{{page.release.versions.short}}.yaml" target="_blank"> <img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
+|  [Open source API](/gateway/api/admin-oss/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20OSS%20{{page.release.versions.short}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F{{page.release.versions.short}}%2Fkong-oss-{{page.release.versions.short}}.yaml" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
+
+{% endif_version %}
+{% if_version gte:3.8.x %}
+
+| Spec | Insomnia link |
+|-------|---------------|
+| [Enterprise API](/gateway/api/admin-ee/latest/){:target="_blank"} |<a href="https://insomnia.rest/run/?label=Kong%20Gateway%20Enterprise%20{{page.release.versions.short}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-EE%2F{{page.release.versions.short}}%2Fkong-ee.yaml" target="_blank"><img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
+|  [Open source API](/gateway/api/admin-oss/latest/){:target="_blank"} | <a href="https://insomnia.rest/run/?label=Kong%20Gateway%20OSS%20{{page.release.versions.short}}&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FGateway-OSS%2F{{page.release.versions.short}}%2Fkong-oss.yaml" target="_blank"> <img src="https://insomnia.rest/images/run.svg" alt="Run in Insomnia" class="no-image-expand"></a> |
+
+{% endif_version %}
 
 See the following links for individual entity documentation:
 


### PR DESCRIPTION
### Description

Fixing two issues with our Gateway Admin EE and OSS specs:
1. The version number in the specs for 3.9 and latest is incorrect, both should be 3.9 but are showing 3.8. The content of the files are correct for 3.9 though, I tracked down the file histories and it just looks like the version number update was missed.
2. The insomnia buttons to the versioned specs are incorrect. Easiest solution, added a shortcode for the version from 3.4 onward that we can access via `{{page.release.versions.short}}`.

Specs are already updated in Konnect Dev Portal.

Tested the buttons, they all import the correct specs. Note that the filename format changed in 3.8, so that's why I had to version tag the URLs.

Issue reported on Slack.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

