### PR TITLE
Fix: Remove old security policy

### DIFF
--- a/app/_data/docs_nav_gateway_3.10.x.yml
+++ b/app/_data/docs_nav_gateway_3.10.x.yml
@@ -230,8 +230,6 @@ items:
             url: /production/tracing/api
       - text: Resource Sizing Guidelines
         url: /production/sizing-guidelines
-      - text: Security Update Process
-        url: /production/security-update-process
       - text: Blue-Green Deployments
         url: /production/blue-green
       - text: Canary Deployments

--- a/app/_data/docs_nav_gateway_3.5.x.yml
+++ b/app/_data/docs_nav_gateway_3.5.x.yml
@@ -222,8 +222,6 @@ items:
             url: /production/tracing/api
       - text: Resource Sizing Guidelines
         url: /production/sizing-guidelines
-      - text: Security Update Process
-        url: /production/security-update-process
       - text: Blue-Green Deployments
         url: /production/blue-green
       - text: Canary Deployments

--- a/app/_data/docs_nav_gateway_3.6.x.yml
+++ b/app/_data/docs_nav_gateway_3.6.x.yml
@@ -224,8 +224,6 @@ items:
             url: /production/tracing/api
       - text: Resource Sizing Guidelines
         url: /production/sizing-guidelines
-      - text: Security Update Process
-        url: /production/security-update-process
       - text: Blue-Green Deployments
         url: /production/blue-green
       - text: Canary Deployments

--- a/app/_data/docs_nav_gateway_3.7.x.yml
+++ b/app/_data/docs_nav_gateway_3.7.x.yml
@@ -226,8 +226,6 @@ items:
             url: /production/tracing/api
       - text: Resource Sizing Guidelines
         url: /production/sizing-guidelines
-      - text: Security Update Process
-        url: /production/security-update-process
       - text: Blue-Green Deployments
         url: /production/blue-green
       - text: Canary Deployments

--- a/app/_data/docs_nav_gateway_3.8.x.yml
+++ b/app/_data/docs_nav_gateway_3.8.x.yml
@@ -230,8 +230,6 @@ items:
             url: /production/tracing/api
       - text: Resource Sizing Guidelines
         url: /production/sizing-guidelines
-      - text: Security Update Process
-        url: /production/security-update-process
       - text: Blue-Green Deployments
         url: /production/blue-green
       - text: Canary Deployments

--- a/app/_data/docs_nav_gateway_3.9.x.yml
+++ b/app/_data/docs_nav_gateway_3.9.x.yml
@@ -232,8 +232,6 @@ items:
             url: /production/tracing/api
       - text: Resource Sizing Guidelines
         url: /production/sizing-guidelines
-      - text: Security Update Process
-        url: /production/security-update-process
       - text: Blue-Green Deployments
         url: /production/blue-green
       - text: Canary Deployments

--- a/app/_redirects
+++ b/app/_redirects
@@ -188,7 +188,8 @@
 
 # 3.4
 
-/gateway/latest/production/security-update-process /gateway/latest/support/vulnerability-patching-process
+/gateway/latest/production/security-update-process /gateway/latest/support/vulnerability-patching-process/
+/gateway/:version/production/security-update-process /gateway/:version/support/vulnerability-patching-process/
 /gateway/latest/kong-enterprise/consumer-groups /gateway/latest/key-concepts/consumer-groups
 /gateway/latest/admin-api/consumer-groups/reference  /gateway/api/admin-ee/latest/#/consumer_groups/get-consumer_groups
 /konnect/runtime-manager/configuration/consumer-groups /hub/kong-inc/rate-limiting-advanced/how-to/


### PR DESCRIPTION
### Description

We have two contradictory copies of the vulnerability update policy for Kong Gateway. 

One was supposed to be removed in 3.4, however it was only removed from the 3.4 nav file and not from 3.5 onward. There was already a 3.5 release branch at that time, which wasn't updated and caused us to end up with duplicate policies. See https://github.com/Kong/docs.konghq.com/pull/6000

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

