### PR TITLE
docs(plugin/request-validator): clarify supported validators

### DIFF
--- a/app/_hub/kong-inc/request-validator/overview/_index.md
+++ b/app/_hub/kong-inc/request-validator/overview/_index.md
@@ -26,6 +26,15 @@ Request body validation is only performed for requests with `application/json` C
 
 For requests with any other allowed Content-Type, body validation is skipped. In that case, the request is proxied to  the upstream without validating the body.
 
+Either Kong's own schema validator (`config.version=kong`) or a JSON Schema Draft 4 compliant validator (`config.version=draft4`) can be used to validate the request body.
+
+## Parameter validation
+
+Only JSON Schema Draft 4 compliant validator is supported for parameter validation.
+
+{:.important}
+> Even if `config.version` is set to `kong`, the parameter validation will still use the JSON Schema Draft 4 compliant validator.
+
 ## Examples
 
 ### Overview

--- a/app/_hub/kong-inc/request-validator/overview/_index.md
+++ b/app/_hub/kong-inc/request-validator/overview/_index.md
@@ -30,7 +30,7 @@ Either Kong's own schema validator (`config.version=kong`) or a JSON Schema Draf
 
 ## Parameter validation
 
-Only JSON Schema Draft 4 compliant validator is supported for parameter validation.
+Only the JSON Schema Draft 4 compliant validator is supported for parameter validation.
 
 {:.important}
 > Even if `config.version` is set to `kong`, the parameter validation will still use the JSON Schema Draft 4 compliant validator.


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
request-validator plugin only supports json schema validator for parameters.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
[FTI-5619](https://konghq.atlassian.net/browse/FTI-5619)

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->



[FTI-5619]: https://konghq.atlassian.net/browse/FTI-5619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ