### PR TITLE
Update request-transformer-advanced examples to include replace.uri

### DIFF
--- a/app/_hub/kong-inc/request-transformer-advanced/how-to/_index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/how-to/_index.md
@@ -110,3 +110,34 @@ curl -X POST http://localhost:8001/services/httpbin/plugins \
 | p1=v1&p2=v1 | p2=v1
 | p2=v1 | p2=v1
 
+
+## Example: Replace the relative URI 
+
+Replace the upstream URI with a static path:
+
+```bash
+curl -X POST http://localhost:8001/services/httpbin/plugins \
+ --data "name=request-transformer-advanced" \
+ --data "config.replace.uri=/status/200"
+```
+
+| Service Path | Upstream Proxied URI
+| --------- | -----------
+| /anything | /status/200
+
+
+## Example: Replace the relative URI using capturing groups
+
+Assuming the gateway path definition of ```~/(?<status>\d+)```,
+replace the upstream URI based on the requested path:
+
+```bash
+curl -X POST http://localhost:8001/services/httpbin/plugins \
+  --data "name=request-transformer-advanced" \
+  --data "config.replace.uri=/status/\$(uri_captures['status'])"
+```
+
+| Gateway Path | Upstream Proxied URI
+| --------- | -----------
+| /200 | /status/200
+| /301 | /status/301

--- a/app/_hub/kong-inc/request-transformer-advanced/how-to/_index.md
+++ b/app/_hub/kong-inc/request-transformer-advanced/how-to/_index.md
@@ -128,7 +128,7 @@ curl -X POST http://localhost:8001/services/httpbin/plugins \
 
 ## Example: Replace the relative URI using capturing groups
 
-Assuming the gateway path definition of ```~/(?<status>\d+)```,
+Assuming the gateway path definition of `~/(?<status>\d+)`,
 replace the upstream URI based on the requested path:
 
 ```bash


### PR DESCRIPTION
### Description

Update request-transformer-advanced examples to include replace.uri
- Added examples for replace.uri using static values and capturing groups.
- Improved documentation to clarify usage.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->
