### PR TITLE
chore: Gateway 3.6 moves into sunset support

### DIFF
--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -100,11 +100,6 @@ Kong supports the following versions of {{site.ee_product_name}}:
     {% include_cached gateway-support.html version="3.7" data=site.data.tables.support.gateway.versions.37 eol="May 2025" %}
   {% endnavtab %}
   {% endif_version %}
-  {% if_version gte: 3.6.x %}
-  {% navtab 3.6 %}
-    {% include_cached gateway-support.html version="3.6" data=site.data.tables.support.gateway.versions.36 eol="Feb 2025" %}
-  {% endnavtab %}
-  {% endif_version %}
   {% navtab 3.4 LTS %}
     {% include_cached gateway-support.html version="3.4" data=site.data.tables.support.gateway.versions.34 eol="August 2026" %}
   {% endnavtab %}
@@ -144,6 +139,7 @@ These versions have reached the end of full support.
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  3.6.x.x |  2024-02-12   |     2025-02-12      |      2026-02-12       |
 |  3.5.x.x |  2023-11-08   |     2024-11-08      |      2025-11-08       |
 |  3.3.x.x |  2023-05-19   |     2024-05-19      |      2025-05-19       |
 |  3.2.x.x |  2023-02-28   |     2024-02-28      |      2025-02-28       |

--- a/app/_src/gateway/support/third-party.md
+++ b/app/_src/gateway/support/third-party.md
@@ -26,11 +26,6 @@ Unless otherwise noted, Kong supports the last 2 versions any third party tool, 
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.37 %}
   {% endnavtab %}
   {% endif_version %}
-  {% if_version gte: 3.6.x %}
-  {% navtab 3.6 %}
-    {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.36 %}
-  {% endnavtab %}
-  {% endif_version %}
   {% navtab 3.4 LTS %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.34 %}
   {% endnavtab %}


### PR DESCRIPTION
### Description
Gateway 3.6 reached end of full support and entered sunset support on Feb 12th.
Removing the support tabs for this version and adding an entry into the sunset support table.

### Testing instructions

https://deploy-preview-8468--kongdocs.netlify.app/gateway/latest/support-policy/#supported-versions
https://deploy-preview-8468--kongdocs.netlify.app/gateway/latest/support/third-party/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

