### PR TITLE
docs(mesh/rbac): add warning about unbounded access actions granting full access

### DIFF
--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -159,7 +159,7 @@ rules:
 >
 > For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no defined `types` allows modifying any resource, including secrets. Even without `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and use them to generate tokens manually.
 >
-> To prevent this, always bind access actions to specific resource types. Instead of unrestricted access, explicitly define allowed types, such as `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshGatewayRoute"]`, to ensure the role can only manage those resources and not secrets or other sensitive data.
+> To prevent this, always bind access actions to specific resource types. Instead of unrestricted access, explicitly define allowed types, such as `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshTrace"]`, to ensure the role can only manage those resources and not secrets or other sensitive data.
 
 ### AccessRoleBinding
 

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -154,6 +154,38 @@ rules:
 {% endnavtab %}
 {% endnavtabs %}
 
+{:.important}
+> **Important:** Specifying access actions without binding them to specific resources grants access to all resources, including Secrets and GlobalSecrets, which can lead to security risks.
+>
+> For example, consider the following AccessRole:
+>
+> ```yaml
+> type: AccessRole
+> name: custom-role
+> rules:
+> - access: ["CREATE", "UPDATE", "DELETE"]
+> ```
+>
+> If assigned to a user, this role allows them to get, create, update, and delete any resource in the system, including secrets. This means that even without explicitly granting actions like:
+>
+> ```yaml
+> access: ["GENERATE_DATAPLANE_TOKEN", "GENERATE_USER_TOKEN", "GENERATE_ZONE_CP_TOKEN", "GENERATE_ZONE_TOKEN"]
+> ```
+>
+> The user could manually retrieve secrets used for signing tokens and generate them.
+>
+> To avoid unintended access, always specify access actions carefully and bind them to specific resource types. For example:
+>
+> ```yaml
+> type: AccessRole
+> name: restricted-role
+> rules:
+> - types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshGatewayRoute"]
+>   access: ["CREATE", "UPDATE", "DELETE"]
+> ```
+>
+> This ensures that the user can only perform the specified actions on `MeshHTTPRoute`, `MeshTCPRoute`, and `MeshGatewayRoute` resources, preventing access to secrets or other sensitive data.
+
 ### AccessRoleBinding
 
 `AccessRoleBinding` assigns a set of `AccessRoles` to a set of subjects (users and groups).

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -155,36 +155,17 @@ rules:
 {% endnavtabs %}
 
 {:.important}
-> **Important:** Specifying access actions without binding them to specific resources grants access to all resources, including Secrets and GlobalSecrets, which can lead to security risks.
+> **Important:** Granting access actions without binding them to specific resource types  
+> provides full access, including to Secrets and GlobalSecrets, posing security risks.
 >
-> For example, consider the following AccessRole:
+> For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no  
+> defined `types` allows modifying any resource, including secrets. Even without  
+> `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or  
+> `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and generate tokens manually.
 >
-> ```yaml
-> type: AccessRole
-> name: custom-role
-> rules:
-> - access: ["CREATE", "UPDATE", "DELETE"]
-> ```
->
-> If assigned to a user, this role allows them to get, create, update, and delete any resource in the system, including secrets. This means that even without explicitly granting actions like:
->
-> ```yaml
-> access: ["GENERATE_DATAPLANE_TOKEN", "GENERATE_USER_TOKEN", "GENERATE_ZONE_CP_TOKEN", "GENERATE_ZONE_TOKEN"]
-> ```
->
-> The user could manually retrieve secrets used for signing tokens and generate them.
->
-> To avoid unintended access, always specify access actions carefully and bind them to specific resource types. For example:
->
-> ```yaml
-> type: AccessRole
-> name: restricted-role
-> rules:
-> - types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshGatewayRoute"]
->   access: ["CREATE", "UPDATE", "DELETE"]
-> ```
->
-> This ensures that the user can only perform the specified actions on `MeshHTTPRoute`, `MeshTCPRoute`, and `MeshGatewayRoute` resources, preventing access to secrets or other sensitive data.
+> To prevent this, always bind access actions to specific resource types. Instead of  
+> unrestricted access, explicitly define allowed types, such as  
+> `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshGatewayRoute"]`.
 
 ### AccessRoleBinding
 

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -156,9 +156,9 @@ rules:
 
 {:.important}
 > **Important:** Granting access actions without binding them to specific resource types provides full access, including to Secrets and GlobalSecrets, posing security risks.
->
+> <br><br>
 > For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no defined `types` allows modifying any resource, including secrets. Even without `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and use them to generate tokens manually.
->
+> <br><br>
 > To prevent this, always bind access actions to specific resource types. Instead of unrestricted access, explicitly define allowed types, such as `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshTrace"]`, to ensure the role can only manage those resources and not secrets or other sensitive data.
 
 ### AccessRoleBinding

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -157,9 +157,9 @@ rules:
 {:.important}
 > **Important:** Granting access actions without binding them to specific resource types provides full access, including to Secrets and GlobalSecrets, posing security risks.
 >
-> For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no defined `types` allows modifying any resource, including secrets. Even without `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and generate tokens manually.
+> For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no defined `types` allows modifying any resource, including secrets. Even without `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and use them to generate tokens manually.
 >
-> To prevent this, always bind access actions to specific resource types. Instead of unrestricted access, explicitly define allowed types, such as `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshGatewayRoute"]`.
+> To prevent this, always bind access actions to specific resource types. Instead of unrestricted access, explicitly define allowed types, such as `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshGatewayRoute"]`, to ensure the role can only manage those resources and not secrets or other sensitive data.
 
 ### AccessRoleBinding
 

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -155,17 +155,11 @@ rules:
 {% endnavtabs %}
 
 {:.important}
-> **Important:** Granting access actions without binding them to specific resource types  
-> provides full access, including to Secrets and GlobalSecrets, posing security risks.
+> **Important:** Granting access actions without binding them to specific resource types provides full access, including to Secrets and GlobalSecrets, posing security risks.
 >
-> For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no  
-> defined `types` allows modifying any resource, including secrets. Even without  
-> `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or  
-> `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and generate tokens manually.
+> For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no defined `types` allows modifying any resource, including secrets. Even without `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and generate tokens manually.
 >
-> To prevent this, always bind access actions to specific resource types. Instead of  
-> unrestricted access, explicitly define allowed types, such as  
-> `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshGatewayRoute"]`.
+> To prevent this, always bind access actions to specific resource types. Instead of unrestricted access, explicitly define allowed types, such as `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshGatewayRoute"]`.
 
 ### AccessRoleBinding
 


### PR DESCRIPTION
### Description

Added a warning to the RBAC documentation explaining the security risks of specifying access actions without binding them to specific resource types. Included an example of a misconfigured role and a corrected version to guide users in securing their permissions.

### Testing instructions

Preview link: https://deploy-preview-8473--kongdocs.netlify.app/mesh/latest/features/rbac/#accessrole

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

