### PR TITLE
Fix Konnect cluster and telemetry hostnames

### DIFF
--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -46,8 +46,8 @@ add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `au.api.konghq.com` | The {{site.konnect_short_name}} API for the AU geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.au.portal.konghq.com` | The URL for the Dev Portal in the AU geo. |
-| `CONTROL_PLANE_ID.au.cp0.konghq.com` | Handles configuration for a control plane in the AU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.au.tp0.konghq.com` | Gathers telemetry data for a control plane in the AU geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.au.cp0.konghq.com` | Handles configuration for a control plane in the AU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.au.tp0.konghq.com` | Gathers telemetry data for a control plane in the AU geo. This hostname is unique to each organization and control plane. |
 
 ### EU geo
 
@@ -58,7 +58,7 @@ add the following hostnames to the firewall allowlist (depending on the [geograp
 | `eu.api.konghq.com` | The {{site.konnect_short_name}} API for the EU geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.eu.portal.konghq.com` | The URL for the Dev Portal in the EU geo. |
 | `CONTROL_PLANE_DNS_PREFIX.eu.cp0.konghq.com` | Handles configuration for a control plane in the EU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.eu.tp0.konghq.com` | Gathers telemetry data for a control plane in the EU geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.eu.tp0.konghq.com` | Gathers telemetry data for a control plane in the EU geo. This hostname is unique to each organization and control plane. |
 
 ### IN geo
 
@@ -68,8 +68,8 @@ add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `in.api.konghq.com` | The {{site.konnect_short_name}} API for the IN geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.in.portal.konghq.com` | The URL for the Dev Portal in the IN geo. |
-| `CONTROL_PLANE_ID.in.cp0.konghq.com` | Handles configuration for a control plane in the IN geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.in.tp0.konghq.com` | Gathers telemetry data for a control plane in the IN geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.in.cp0.konghq.com` | Handles configuration for a control plane in the IN geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.in.tp0.konghq.com` | Gathers telemetry data for a control plane in the IN geo. This hostname is unique to each organization and control plane. |
 
 ### ME geo
 
@@ -79,8 +79,8 @@ add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `me.api.konghq.com` | The {{site.konnect_short_name}} API for the ME geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.me.portal.konghq.com` | The URL for the Dev Portal in the ME geo. |
-| `CONTROL_PLANE_ID.me.cp0.konghq.com` | Handles configuration for a control plane in the ME geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.me.tp0.konghq.com` | Gathers telemetry data for a control plane in the ME geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.me.cp0.konghq.com` | Handles configuration for a control plane in the ME geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.me.tp0.konghq.com` | Gathers telemetry data for a control plane in the ME geo. This hostname is unique to each organization and control plane. |
 
 ### US geo
 
@@ -90,8 +90,8 @@ add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `us.api.konghq.com` | The {{site.konnect_short_name}} API for the US geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.us.portal.konghq.com` | The URL for the Dev Portal in the US geo. |
-| `CONTROL_PLANE_ID.us.cp0.konghq.com` | Handles configuration for a control plane in the US geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.us.tp0.konghq.com` | Gathers telemetry data for a control plane in the US geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.us.cp0.konghq.com` | Handles configuration for a control plane in the US geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.us.tp0.konghq.com` | Gathers telemetry data for a control plane in the US geo. This hostname is unique to each organization and control plane. |
 
 ### Find configuration and telemetry hostnames
 
@@ -166,8 +166,8 @@ Add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `au.api.konghq.com` | The {{site.konnect_short_name}} API for the AU geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.au.portal.konghq.com` | The URL for the Dev Portal in the AU geo. |
-| `CONTROL_PLANE_ID.au.cp0.konghq.com` | Handles configuration for a control plane in the AU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.au.tp0.konghq.com` | Gathers telemetry data for a control plane in the AU geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.au.cp0.konghq.com` | Handles configuration for a control plane in the AU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.au.tp0.konghq.com` | Gathers telemetry data for a control plane in the AU geo. This hostname is unique to each organization and control plane. |
 
 ### EU geo
 
@@ -177,8 +177,8 @@ Add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `eu.api.konghq.com` | The {{site.konnect_short_name}} API for the EU geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.eu.portal.konghq.com` | The URL for the Dev Portal in the EU geo. |
-| `CONTROL_PLANE_ID.eu.cp0.konghq.com` | Handles configuration for a control plane in the EU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.eu.tp0.konghq.com` | Gathers telemetry data for a control plane in the EU geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.eu.cp0.konghq.com` | Handles configuration for a control plane in the EU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.eu.tp0.konghq.com` | Gathers telemetry data for a control plane in the EU geo. This hostname is unique to each organization and control plane. |
 
 ### IN geo
 
@@ -188,8 +188,8 @@ Add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `in.api.konghq.com` | The {{site.konnect_short_name}} API for the IN geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.in.portal.konghq.com` | The URL for the Dev Portal in the IN geo. |
-| `CONTROL_PLANE_ID.in.cp0.konghq.com` | Handles configuration for a control plane in the IN geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.in.tp0.konghq.com` | Gathers telemetry data for a control plane in the IN geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.in.cp0.konghq.com` | Handles configuration for a control plane in the IN geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.in.tp0.konghq.com` | Gathers telemetry data for a control plane in the IN geo. This hostname is unique to each organization and control plane. |
 
 ### ME geo
 
@@ -199,8 +199,8 @@ Add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `me.api.konghq.com` | The {{site.konnect_short_name}} API for the ME geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.me.portal.konghq.com` | The URL for the Dev Portal in the ME geo. |
-| `CONTROL_PLANE_ID.me.cp0.konghq.com` | Handles configuration for a control plane in the ME geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.me.tp0.konghq.com` | Gathers telemetry data for a control plane in the ME geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.me.cp0.konghq.com` | Handles configuration for a control plane in the ME geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.me.tp0.konghq.com` | Gathers telemetry data for a control plane in the ME geo. This hostname is unique to each organization and control plane. |
 
 ### US geo
 
@@ -210,8 +210,8 @@ Add the following hostnames to the firewall allowlist (depending on the [geograp
 | `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
 | `us.api.konghq.com` | The {{site.konnect_short_name}} API for the US geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
 | `PORTAL_ID.us.portal.konghq.com` | The URL for the Dev Portal in the US geo. |
-| `CONTROL_PLANE_ID.us.cp0.konghq.com` | Handles configuration for a control plane in the US geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.us.tp0.konghq.com` | Gathers telemetry data for a control plane in the US geo. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.us.cp0.konghq.com` | Handles configuration for a control plane in the US geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.us.tp0.konghq.com` | Gathers telemetry data for a control plane in the US geo. This hostname is unique to each organization and control plane. |
 
 ### Find configuration and telemetry hostnames
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Changed the existing cluster and telemetry hostnames to `CONTROL_PLANE_DNS_PREFIX` to match feedback I got here: https://kongstrong.slack.com/archives/C04RXLGNB6K/p1740607033227059
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

