### PR TITLE
docs(mesh/rbac): add subsection to restrict default AccessRoleBinding

### DIFF
--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -209,14 +209,14 @@ metadata:
   name: default
 spec:
   subjects:
-    - type: Group
-      name: mesh-system:admin
-    # The `system:serviceaccounts:kube-system` group is required by Kubernetes controllers to manage {{site.mesh_product_name}} 
-    # resources, for example, cleaning up data plane objects when a namespace is removed.
-    - type: Group
-      name: system:serviceaccounts:kube-system
+  - type: Group
+    name: mesh-system:admin
+  # The `system:serviceaccounts:kube-system` group is required by Kubernetes controllers to manage {{site.mesh_product_name}} 
+  # resources, for example, cleaning up data plane objects when a namespace is removed.
+  - type: Group
+    name: system:serviceaccounts:kube-system
   roles:
-    - admin
+  - admin
 ```
 {% endnavtab %}
 {% navtab Universal %}
@@ -224,10 +224,10 @@ spec:
 type: AccessRoleBinding
 name: default
 subjects:
-  - type: Group
-    name: mesh-system:admin
+- type: Group
+  name: mesh-system:admin
 roles:
-  - admin
+- admin
 ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -232,8 +232,6 @@ roles:
 {% endnavtab %}
 {% endnavtabs %}
 
-With this configuration, only users in the `mesh-system:admin` group will have admin rights.
-
 ## Example roles
 
 Let's go through example roles in the organization that can be created using {{site.mesh_product_name}} RBAC.

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -21,7 +21,7 @@ It is global-scoped, which means it is not bound to a mesh.
 {% navtab "targetRef" selectors %}
 For policies using the `targetRef` selector. You can specify which `targetRef` kinds users should have access to.
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -96,7 +96,7 @@ For example, the `when` element with a specific `from` section allows the user t
 If the policy contains multiple `to` elements, you must specify an RBAC qualifier for every single `to` element.
 {% endnavtab %}
 {% navtab Source and Destination selectors %}
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -155,18 +155,13 @@ rules:
 {% endnavtabs %}
 
 {:.important}
-> **Important:** Granting access actions without binding them to specific resource types provides full access, including to Secrets and GlobalSecrets, posing security risks.
-> <br><br>
-> For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no defined `types` allows modifying any resource, including secrets. Even without `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and use them to generate tokens manually.
-> <br><br>
-> To prevent this, always bind access actions to specific resource types. Instead of unrestricted access, explicitly define allowed types, such as `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshTrace"]`, to ensure the role can only manage those resources and not secrets or other sensitive data.
+> **Important:** Granting access actions without binding them to specific resource types provides full access, including to Secrets and GlobalSecrets, posing security risks. For example, an AccessRole with `access: ["CREATE", "UPDATE", "DELETE"]` and no defined `types` allows modifying any resource, including secrets. Even without `GENERATE_DATAPLANE_TOKEN`, `GENERATE_USER_TOKEN`, `GENERATE_ZONE_CP_TOKEN`, or `GENERATE_ZONE_TOKEN`, the user can retrieve secrets and use them to generate tokens manually. To prevent this, always bind access actions to specific resource types. Instead of unrestricted access, explicitly define allowed types, such as `types: ["MeshHTTPRoute", "MeshTCPRoute", "MeshTrace"]`, to ensure the role can only manage those resources and not secrets or other sensitive data.
 
 ### AccessRoleBinding
 
-`AccessRoleBinding` assigns a set of `AccessRoles` to a set of subjects (users and groups).
-It is global-scoped, which means it is not bound to a mesh.
+`AccessRoleBinding` assigns a set of `AccessRoles` to a list of subjects (users or groups). Because these bindings are global in scope, they apply across all meshes, allowing centralized management of permissions.
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -174,12 +169,12 @@ kind: AccessRoleBinding
 metadata:
   name: binding-1
 spec:
-  subjects: # a list of subjects that will be assigned roles
-  - type: User # type of the subject. Available values: ("User", "Group")
-    name: john.doe@example.com # name of the subject.
+  subjects:
+  - type: User
+    name: john.doe@example.com
   - type: Group
     name: team-a
-  roles: # a list of roles that will be assigned to the list of subjects.
+  roles:
   - role-1
 ```
 {% endnavtab %}
@@ -187,16 +182,57 @@ spec:
 ```yaml
 type: AccessRoleBinding
 name: binding-1
-subjects: # a list of subjects that will be assigned roles
-- type: User # type of the subject. Available values: ("User", "Group")
-  name: john.doe@example.com # name of the subject.
+subjects:
+- type: User
+  name: john.doe@example.com
 - type: Group
   name: team-a
-roles: # a list of roles that will be assigned to the list of subjects.
+roles:
 - role-1
 ```
 {% endnavtab %}
 {% endnavtabs %}
+
+#### Restricting the default AccessRoleBinding
+
+{:.important}
+> **Important:** [By default](/mesh/{{page.release}}/features/rbac/#default), {{site.mesh_product_name}} assigns the `admin` role to everyone in the `mesh-system:authenticated` and `mesh-system:unauthenticated` groups. This means every user automatically gets admin rights, even if you create a custom binding for them, they will also inherit the default admin role.
+
+To limit admin privileges to a specific group, update the default binding. For example, to grant admin rights only to members of the `mesh-system:admin` group, replace the default binding with the following:
+
+{% navtabs codeblock %}
+{% navtab Kubernetes %}
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: AccessRoleBinding
+metadata:
+  name: default
+spec:
+  subjects:
+    - type: Group
+      name: mesh-system:admin
+    # The `system:serviceaccounts:kube-system` group is required by Kubernetes controllers to manage {{site.mesh_product_name}} 
+    # resources, for example, cleaning up data plane objects when a namespace is removed.
+    - type: Group
+      name: system:serviceaccounts:kube-system
+  roles:
+    - admin
+```
+{% endnavtab %}
+{% navtab Universal %}
+```yaml
+type: AccessRoleBinding
+name: default
+subjects:
+  - type: Group
+    name: mesh-system:admin
+roles:
+  - admin
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+With this configuration, only users in the `mesh-system:admin` group will have admin rights.
 
 ## Example roles
 
@@ -206,7 +242,7 @@ Let's go through example roles in the organization that can be created using {{s
 
 Mesh operator is a part of infrastructure team responsible for {{site.mesh_product_name}} deployment.
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -237,7 +273,7 @@ This way {{site.mesh_product_name}} operators can execute any action.
 
 Service owner is a part of team responsible for given service. Let's take a `backend` service as an example.
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 [//]: # (MeshTCPRoute was added in `2.3.0`)
 {% if_version eq:2.2.x %}
@@ -421,7 +457,7 @@ rules:
 We may also have an infrastructure team which is responsible for the logging/metrics/tracing systems in the organization.
 Currently, those features are configured on `Mesh`, `MeshAccessLog`, and `MeshTrace` objects.
 
-{% navtabs %}
+{% navtabs codeblock%}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -460,7 +496,7 @@ This way an observability operator can:
 {{site.mesh_product_name}} lets us segment the deployment into many logical service meshes configured by Mesh object.
 We may want to give access to one specific Mesh and all objects connected with this Mesh.
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -516,7 +552,7 @@ In a standalone deployment, the `default` `AccessRoleBinding` assigns this role 
 In a multi-zone deployment, the `default` `AccessRoleBinding` on the global control plane assigns this role to every authenticated and unauthenticated user.
 However, on the zone control plane, the `default` `AccessRoleBinding` is restricted to the `admin` `AccessRole` only.
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -567,7 +603,7 @@ roles:
 
 To restrict access to `admin` only, change the default `AccessRole` policy:
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -580,12 +616,13 @@ spec:
     name: mesh-system:admin
   - type: Group
     name: system:masters
+  # The `system:serviceaccounts:kube-system` group is required by Kubernetes controllers to manage {{site.mesh_product_name}} 
+  # resources, for example, cleaning up data plane objects when a namespace is removed.
   - type: Group
     name: system:serviceaccounts:kube-system
   roles:
   - admin
 ```
-`system:serviceaccounts:kube-system` is required for Kubernetes controllers to manage {{site.mesh_product_name}} resources -- for example, to remove data plane objects when a namespace is removed.
 {% endnavtab %}
 {% navtab Universal %}
 ```yaml
@@ -1161,7 +1198,7 @@ You can perform partial tag value matching using `*` wildcards.
 
 For example, the following role:
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1
@@ -1203,7 +1240,7 @@ rules:
 
 would allow a subject to create the following resource:
 
-{% navtabs %}
+{% navtabs codeblock %}
 {% navtab Kubernetes %}
 ```yaml
 apiVersion: kuma.io/v1alpha1


### PR DESCRIPTION
### Description

Add a new subsection under AccessRoleBinding that explains how to restrict the default binding which assigns the admin role to all users in the `mesh-system:authenticated` and `mesh-system:unauthenticated` groups. This prevents unintended admin access by showing how to limit admin privileges to a specific group (using `mesh-system:admin`).

Also, update most navtabs to use codeblocks for a better appearance and remove extra blank lines from the warning message.

### Testing instructions

Preview link:
- https://deploy-preview-8484--kongdocs.netlify.app/mesh/latest/features/rbac/#restricting-the-default-accessrolebinding
- https://deploy-preview-8484--kongdocs.netlify.app/mesh/latest/features/rbac/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.