### PR TITLE
Update log_custom_fields_by_lua.md with note of using dots

### DIFF
--- a/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
+++ b/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
@@ -20,7 +20,7 @@ curl -i -X POST http://localhost:8001/plugins \
 
 Dots `.` in the field key creates nested fields. You can use a backslash `\` to escape dots if you want to keep them in the field name.
 
-For example, if you configure a field in File Log with both dot and escaped dot:
+For example, if you configure a field in the File Log plugin with both a regular dot and an escaped dot:
 
 ```sh
 curl -i -X POST http://localhost:8001/plugins/ \
@@ -28,7 +28,7 @@ curl -i -X POST http://localhost:8001/plugins/ \
   --data config.name=file-log \
   --data config.custom_fields_by_lua[my_file.log\.field]="return foo"
 ```
-You will see below field in file log:
+The field will look like this in the log:
 ```sh
 "my_file": {
   "log.field": "foo"

--- a/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
+++ b/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
@@ -18,7 +18,7 @@ curl -i -X POST http://localhost:8001/plugins \
 
 ### Special characters
 
-Dots `.` in the field key creates nested fields. You can use a backslash `\` to escape dots if you want to keep them in the field name.
+Dot characters (`.`) in the field key create nested fields. You can use a backslash `\` to escape a dot if you want to keep it in the field name.
 
 For example, if you configure a field in the File Log plugin with both a regular dot and an escaped dot:
 

--- a/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
+++ b/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
@@ -16,6 +16,7 @@ curl -i -X POST http://localhost:8001/plugins \
   --data config.custom_fields_by_lua.header="return kong.request.get_header('h1')"
 ```
 
+{% if_version gte:3.10.x %}
 ### Special characters
 
 Dot characters (`.`) in the field key create nested fields. You can use a backslash `\` to escape a dot if you want to keep it in the field name.
@@ -34,6 +35,7 @@ The field will look like this in the log:
   "log.field": "foo"
 }
 ```
+{% endif_version %}
 
 ### Plugin precedence and managing fields
 

--- a/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
+++ b/app/_includes/md/plugins-hub/log_custom_fields_by_lua.md
@@ -16,6 +16,25 @@ curl -i -X POST http://localhost:8001/plugins \
   --data config.custom_fields_by_lua.header="return kong.request.get_header('h1')"
 ```
 
+### Special characters
+
+Dots `.` in the field key creates nested fields. You can use a backslash `\` to escape dots if you want to keep them in the field name.
+
+For example, if you configure a field in File Log with both dot and escaped dot:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins/ \
+...
+  --data config.name=file-log \
+  --data config.custom_fields_by_lua[my_file.log\.field]="return foo"
+```
+You will see below field in file log:
+```sh
+"my_file": {
+  "log.field": "foo"
+}
+```
+
 ### Plugin precedence and managing fields
 
 All logging plugins use the same table for logging. 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Update log_custom_fields_by_lua.md with note of using dots for nested fields and using backslash to escape dots.
Added an example with both dot and escaped dot to demonstrate the use case.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

### Functional change PR
* https://github.com/Kong/kong/pull/14324