### PR TITLE
feat(gw): SBOMs now hosted on Cloudsmith

### DIFF
--- a/app/_src/gateway/support/sbom.md
+++ b/app/_src/gateway/support/sbom.md
@@ -5,7 +5,8 @@ toc: false
 
 A software bill of materials (SBOM) is an inventory of all software components (proprietary and open source), open source licenses, and dependencies in a given product. A software bill of materials (SBOM) provides visibility into the software supply chain and any license compliance, security, and quality risks that may exist.
 
-Starting in {{site.ee_product_name}} 3.3, we are generating SBOMs for our artifact images:
+Starting in {{site.ee_product_name}} 3.3, we are generating SBOMs for our artifact images.
+See the following links to directly download the SBOM for your {{site.ee_product_name}} version:
 * [{{site.base_gateway}} 3.3.0.0 SBOM](https://packages.konghq.com/public/gateway-33/raw/versions/3.3.0.0/security-assets.tar.gz)
 * [{{site.base_gateway}} 3.4.0.0 SBOM](https://packages.konghq.com/public/gateway-34/raw/versions/3.4.0.0/security-assets.tar.gz)
 * [{{site.base_gateway}} 3.5.0.0 SBOM](https://packages.konghq.com/public/gateway-35/raw/versions/3.5.0.0/security-assets.tar.gz)

--- a/app/_src/gateway/support/sbom.md
+++ b/app/_src/gateway/support/sbom.md
@@ -5,10 +5,11 @@ toc: false
 
 A software bill of materials (SBOM) is an inventory of all software components (proprietary and open source), open source licenses, and dependencies in a given product. A software bill of materials (SBOM) provides visibility into the software supply chain and any license compliance, security, and quality risks that may exist.
 
-Starting in {{site.ee_product_name}} 3.3, we are generating SBOMs for our artifact images.
-You can learn more about this from our software bill of materials knowledge base page:
-* [{{site.base_gateway}} 3.3.0.0 SBOM](https://support.konghq.com/support/s/article/SBOM-Artifacts-for-Kong-Gateway-3-3-0-0).
-* [{{site.base_gateway}} 3.4.0.0 SBOM](https://support.konghq.com/support/s/article/SBOM-Artifacts-for-Kong-Gateway-3-4-0-0)
-* [{{site.base_gateway}} 3.5.0.0 SBOM](https://support.konghq.com/support/s/article/SBOM-Artifacts-for-Kong-Gateway-3-5-0-0).
-* [{{site.base_gateway}} 3.6.0.0 SBOM](https://support.konghq.com/support/s/article/SBOM-Artifacts-for-Kong-Gateway-3-6-0-0).
-* [{{site.base_gateway}} 3.7.0.0 SBOM](https://support.konghq.com/support/s/article/SBOM-Artifacts-for-Kong-Gateway-3-7-0-0).
+Starting in {{site.ee_product_name}} 3.3, we are generating SBOMs for our artifact images:
+* [{{site.base_gateway}} 3.3.0.0 SBOM](https://packages.konghq.com/public/gateway-33/raw/versions/3.3.0.0/security-assets.tar.gz)
+* [{{site.base_gateway}} 3.4.0.0 SBOM](https://packages.konghq.com/public/gateway-34/raw/versions/3.4.0.0/security-assets.tar.gz)
+* [{{site.base_gateway}} 3.5.0.0 SBOM](https://packages.konghq.com/public/gateway-35/raw/versions/3.5.0.0/security-assets.tar.gz)
+* [{{site.base_gateway}} 3.6.0.0 SBOM](https://packages.konghq.com/public/gateway-36/raw/versions/3.6.0.0/security-assets.tar.gz)
+* [{{site.base_gateway}} 3.7.0.0 SBOM](https://packages.konghq.com/public/gateway-37/raw/versions/3.7.0.0/security-assets.tar.gz)
+* [{{site.base_gateway}} 3.8.0.0 SBOM](https://packages.konghq.com/public/gateway-38/raw/versions/3.8.0.0/security-assets.tar.gz)
+* [{{site.base_gateway}} 3.9.0.0 SBOM](https://packages.konghq.com/public/gateway-39/raw/versions/3.9.0.0/security-assets.tar.gz)


### PR DESCRIPTION
### Description

This PR changes the links that previous pointed to Salesforce, so that they now point to Cloudsmith, where I have manually mirrored the SBOM data.

See also: https://github.com/Kong/kong-ee/pull/11530

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

#_[KAG-6491]_

[KAG-6491]: https://konghq.atlassian.net/browse/KAG-6491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ