### PR TITLE
Add v3 API Builder API, insomnia fixes for other portal v3 APIs

### DIFF
--- a/api-specs/Konnect/v3/yaml/api-builder.yaml
+++ b/api-specs/Konnect/v3/yaml/api-builder.yaml
@@ -1,0 +1,2987 @@
+openapi: 3.0.3
+info:
+  title: Konnect API Builder
+  version: 3.0.0
+  description: The management API for building APIs for Konnect Dev Portals.
+  contact:
+    name: Kong
+    url: 'https://cloud.konghq.com'
+servers:
+  - url: 'https://us.api.konghq.com/v3'
+    description: United-States Production region
+  - url: 'https://eu.api.konghq.com/v3'
+    description: Europe Production region
+  - url: 'https://au.api.konghq.com/v3'
+    description: Australia Production region
+  - url: 'https://me.api.konghq.com/v3'
+    description: Middle-East Production region
+  - url: 'https://in.api.konghq.com/v3'
+    description: India Production region
+security:
+  - konnectAccessToken: []
+  - personalAccessToken: []
+  - systemAccountAccessToken: []
+tags:
+  - name: API
+  - name: API Documentation
+  - name: API Specification
+  - name: API Publication
+  - name: API Implementation
+paths:
+  /apis:
+    post:
+      summary: Create API
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Creates an API.
+      operationId: create-api
+      responses:
+        '201':
+          $ref: '#/components/responses/ApiResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ApiNameBadRequestExample:
+                  $ref: '#/components/examples/ApiNameBadRequestExample'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+      tags:
+        - API
+      requestBody:
+        $ref: '#/components/requestBodies/CreateApiRequest'
+    get:
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/ApiFilters'
+        - $ref: '#/components/parameters/ApiSort'
+      summary: List APIs
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns a collection of all APIs.
+      operationId: list-apis
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApiResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                InvalidApiSortQueryBadRequestExample:
+                  $ref: >-
+                    #/components/examples/InvalidApiSortQueryNameBadRequestExample
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API
+  '/apis/{apiId}':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+    get:
+      summary: Fetch API
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Fetches an API.
+      operationId: fetch-api
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiResponse'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API
+    patch:
+      summary: Update API
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Updates an API.
+      operationId: update-api
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ApiNameBadRequestExample:
+                  $ref: '#/components/examples/ApiNameBadRequestExample'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+      tags:
+        - API
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateApiRequest'
+    delete:
+      summary: Delete API
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Deletes an API.
+      operationId: delete-api
+      responses:
+        '204':
+          description: API was deleted successfully.
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API
+  '/apis/{apiId}/documents':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+    post:
+      summary: Create API Document
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Publish a new document attached to an API.
+
+
+        All configuration options may be provided in the frontmatter section of
+        `content`. If you set values in both the `POST` request _and_ in the
+        frontmatter, the values in the `POST` request will take precedence.
+      operationId: create-api-document
+      responses:
+        '201':
+          $ref: '#/components/responses/ApiDocumentResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ApiNameBadRequestExample:
+                  $ref: '#/components/examples/ApiDocumentBadRequestExample'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+        '409':
+          $ref: '#/components/responses/ApiSlugConflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateApiDocumentRequest'
+      tags:
+        - API Documentation
+    get:
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/ApiDocumentFilters'
+      summary: List API Documents
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns a collection of all documents for an API.
+      operationId: list-api-documents
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApiDocumentResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                InvalidApiSortQueryBadRequestExample:
+                  $ref: '#/components/examples/InvalidApiSortQueryBadRequestExample'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Documentation
+  '/apis/{apiId}/documents/{documentId}':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+      - $ref: '#/components/parameters/DocumentId'
+    get:
+      summary: Fetch API Document
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns a document for the API.
+      operationId: fetch-api-document
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiDocumentResponse'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Documentation
+    patch:
+      summary: Update API Document
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Updates a document for an API.
+      operationId: update-api-document
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiDocumentResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ApiNameBadRequestExample:
+                  $ref: '#/components/examples/ApiDocumentBadRequestExample'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+        '409':
+          $ref: '#/components/responses/ApiSlugConflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+      tags:
+        - API Documentation
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateApiDocumentRequest'
+    delete:
+      summary: Delete API Documentation
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Removes a document from an API.
+      operationId: delete-api-document
+      responses:
+        '204':
+          description: Document for the API was deleted successfully.
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Documentation
+  '/apis/{apiId}/documents/{documentId}/move':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+      - $ref: '#/components/parameters/DocumentId'
+    put:
+      summary: Move API Documentation
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        This api allows the user to move a document within the document tree
+        using the parameters parent_document_id and index. If parent_document_id
+        is not provided, the document will be placed at the top level of the
+        document tree. index represents a zero-indexed document order relative
+        to its siblings under the same parent. For example, if we want to put
+        the document at top level in first position we would send
+        parent_document_id: null and index: 0. This api also supports using a
+        negative index to count backwards from the end of the document list,
+        which means you can put the document in last position by using index:
+        -1.
+      operationId: move-api-document
+      requestBody:
+        $ref: '#/components/requestBodies/MoveDocumentRequest'
+      responses:
+        '204':
+          description: Document for the API was moved successfully.
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - API Documentation
+  '/apis/{apiId}/specifications':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+    post:
+      summary: Create API Specification
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Creates a specification for an API.
+        **Note:** You can only have one specification for an API.
+      operationId: create-api-spec
+      responses:
+        '201':
+          $ref: '#/components/responses/ApiSpecResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ApiSpecContentBadRequestExample:
+                  $ref: '#/components/examples/ApiSpecContentBadRequestExample'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+        '409':
+          $ref: '#/components/responses/ApiSpecConflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+      tags:
+        - API Specification
+      requestBody:
+        $ref: '#/components/requestBodies/CreateApiSpecRequest'
+    get:
+      summary: List API Specifications
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns a list of specifications for an API.
+        **Note:** You can only have one specification for an API.
+      operationId: list-api-specs
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/ApiSpecFilters'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApiSpecResponse'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Specification
+  '/apis/{apiId}/specifications/{specId}':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+      - $ref: '#/components/parameters/SpecId'
+    get:
+      summary: Fetch API Specification
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Fetches the specification of an API.
+      operationId: fetch-api-spec
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiSpecResponse'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Specification
+    patch:
+      summary: Update API Specification
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Updates the specification of an API.
+      operationId: update-api-spec
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiSpecResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ApiSpecContentBadRequestExample:
+                  $ref: '#/components/examples/ApiSpecContentBadRequestExample'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+        '409':
+          $ref: '#/components/responses/ApiSpecHiddenConflict'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
+      tags:
+        - API Specification
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateApiSpecRequest'
+    delete:
+      summary: Delete API Specification
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Deletes the specification of an API.
+      operationId: delete-api-spec
+      responses:
+        '204':
+          description: API Specification was deleted successfully.
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Specification
+  '/apis/{apiId}/publications/{portalId}':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+      - $ref: '#/components/parameters/PortalId'
+    put:
+      summary: Publish API
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Publish an API to a portal.
+      operationId: publish-api-to-portal
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiPublicationResponse'
+        '400':
+          $ref: '#/components/responses/ApiPublicationBadRequest'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Publication
+      requestBody:
+        $ref: '#/components/requestBodies/PutApiPublicationRequest'
+    get:
+      summary: Fetch Publication
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Retrieve an API's publication in a portal.
+        If the API is not published to the portal, a 404 response is returned.
+      operationId: fetch-publication
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiPublicationResponse'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Publication
+    delete:
+      summary: Delete Publication
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Unpublish an API from a portal.
+      operationId: delete-publication
+      responses:
+        '204':
+          description: API was successfully unpublished from portal.
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Publication
+  /api-publications:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/ApiPublicationFilters'
+        - $ref: '#/components/parameters/ApiPublicationSort'
+      summary: List Publications
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns a collection of all API Publications.
+      operationId: list-api-publications
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApiPublicationResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Publication
+  '/apis/{apiId}/implementations':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+    post:
+      summary: Create API Implementation
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Creates an implementation for an API.
+        An API can be implemented by a single Gateway Service.
+      operationId: create-api-implementation
+      responses:
+        '201':
+          $ref: '#/components/responses/ApiImplementationResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ApiImplementationBadRequestExample:
+                  $ref: '#/components/examples/ApiImplementationBadRequestExample'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+        '409':
+          $ref: '#/components/responses/ApiImplementationConflict'
+      tags:
+        - API Implementation
+      requestBody:
+        $ref: '#/components/requestBodies/CreateApiImplementationRequest'
+  '/apis/{apiId}/implementations/{implementationId}':
+    parameters:
+      - $ref: '#/components/parameters/ApiId'
+      - $ref: '#/components/parameters/ImplementationId'
+    get:
+      summary: Fetch API Implementation
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Retrieve a gateway implementation for this API
+      operationId: fetch-api-implementation
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiImplementationResponse'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Implementation
+    delete:
+      summary: Delete API Implementation
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Unlink a gateway implementation from this API
+      operationId: delete-api-implementation
+      responses:
+        '204':
+          description: API implementation was unlinked successfully.
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Implementation
+  /api-implementations:
+    get:
+      summary: List API Implementations
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        List gateway implementations for this API
+      operationId: list-api-implementations
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/ApiImplementationFilters'
+        - $ref: '#/components/parameters/ApiImplementationSort'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApiImplementationsResponse'
+        '401':
+          $ref: '#/components/responses/ApiUnauthorized'
+        '403':
+          $ref: '#/components/responses/ApiForbidden'
+        '404':
+          $ref: '#/components/responses/ApiNotFound'
+      tags:
+        - API Implementation
+components:
+  parameters:
+    ApiId:
+      schema:
+        type: string
+        format: uuid
+        example: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+      name: apiId
+      in: path
+      required: true
+      description: The UUID API identifier
+    DocumentId:
+      schema:
+        type: string
+        format: uuid
+        example: de5c9818-be5c-42e6-b514-e3d4bc30ddeb
+      name: documentId
+      description: The document identifier related to the API
+      in: path
+      required: true
+    SpecId:
+      schema:
+        type: string
+        format: uuid
+        example: d32d905a-ed33-46a3-a093-d8f536af9a8a
+      name: specId
+      description: The API specification identifier
+      in: path
+      required: true
+    PortalId:
+      schema:
+        type: string
+        format: uuid
+        example: f32d905a-ed33-46a3-a093-d8f536af9a8a
+      name: portalId
+      in: path
+      required: true
+      description: The Portal identifier
+    ImplementationId:
+      schema:
+        type: string
+        format: uuid
+        example: 032d905a-ed33-46a3-a093-d8f536af9a8a
+      name: implementationId
+      in: path
+      required: true
+      description: The Portal identifier
+    ApiFilters:
+      name: filter
+      description: Filters APIs in the response.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/ApiFilterParameters'
+      style: deepObject
+    ApiSort:
+      name: sort
+      description: |
+        Sorts a collection of APIs. Supported sort attributes are:
+          - name
+          - version
+          - created_at
+          - updated_at
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/SortQuery'
+    ApiDocumentFilters:
+      name: filter
+      description: Filters API Documents in the response.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/ApiDocumentFilterParameters'
+      style: deepObject
+    ApiSpecFilters:
+      name: filter
+      description: Filters API Specs in the response.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/ApiSpecFilterParameters'
+      style: deepObject
+    ApiPublicationFilters:
+      name: filter
+      description: Filters API Publications in the response.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/ApiPublicationFilterParameters'
+      style: deepObject
+    ApiPublicationSort:
+      name: sort
+      description: |
+        Sorts a collection of API publications. Supported sort attributes are:
+          - portal_id
+          - portal_name
+          - api_id
+          - api_name
+          - created_at
+          - updated_at
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/SortQuery'
+    ApiImplementationFilters:
+      name: filter
+      description: Filters APIs in the response.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/ApiImplementationFilterParameters'
+      style: deepObject
+    ApiImplementationSort:
+      name: sort
+      description: >
+        Sorts a collection of API implementations. Supported sort attributes
+        are:
+          - id
+          - api_id
+          - control_plane_id
+          - service_id
+          - created_at
+          - updated_at
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/SortQuery'
+    PageSize:
+      name: 'page[size]'
+      description: >-
+        The maximum number of items to include per page. The last page of a
+        collection may include fewer items.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: integer
+        example: 10
+    PageNumber:
+      name: 'page[number]'
+      description: Determines which page of the entities to retrieve.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: integer
+        example: 1
+  requestBodies:
+    CreateApiRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            title: API
+            type: object
+            additionalProperties: false
+            properties:
+              id:
+                type: string
+                format: uuid
+                example: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+                description: The API identifier.
+                readOnly: true
+              name:
+                type: string
+                maxLength: 255
+                minLength: 1
+                description: >
+                  The name of your API. The `name + version` combination must be
+                  unique for each API you publish.
+                example: MyAPI
+              description:
+                type: string
+                description: >-
+                  A description of your API. Will be visible on your live
+                  Portal.
+                nullable: true
+              version:
+                type: string
+                maxLength: 255
+                minLength: 1
+                description: >-
+                  An optional version for your API. Leave this empty if your API
+                  is unversioned.
+                nullable: true
+              deprecated:
+                type: boolean
+                default: false
+                description: Marks this API as deprecated.
+              slug:
+                type: string
+                pattern: '^[\w-]+$'
+                description: >
+                  The `slug` is used in generated URLs to provide human readable
+                  paths.
+
+
+                  Defaults to `slugify(name + version)`
+                example: my-api-v1
+                nullable: true
+              portals:
+                readOnly: true
+                type: array
+                nullable: false
+                uniqueItems: true
+                description: The list of portals which this API is published to.
+                items:
+                  type: object
+                  additionalProperties: false
+                  required:
+                    - id
+                    - name
+                    - display_name
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                      example: 25a2624c-49fc-4764-99e1-224ed819f200
+                      description: The portal identifier.
+                    name:
+                      type: string
+                      example: My Portal
+                      description: >-
+                        The name of the portal, used to distinguish it from
+                        other portals.
+                    display_name:
+                      type: string
+                      example: My Portal
+                      description: >-
+                        The display name of the portal. This value will be the
+                        portal's `name` in Portal API.
+              labels:
+                $ref: '#/components/schemas/Labels'
+              public_labels:
+                $ref: '#/components/schemas/PublicLabels'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+            required:
+              - name
+          examples:
+            CreateApiMinimal:
+              $ref: '#/components/examples/CreateApiRequestMinimalExample'
+            CreateApiFull:
+              $ref: '#/components/examples/CreateApiRequestFullExample'
+    CreateApiSpecRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            title: API Specification
+            type: object
+            additionalProperties: false
+            properties:
+              id:
+                type: string
+                format: uuid
+                example: 7710d5c4-d902-410b-992f-18b814155b53
+                description: The API specification identifier.
+                readOnly: true
+              content:
+                type: string
+                description: |
+                  The raw content of your API specification.
+                example: >-
+                  {"openapi":"3.0.3","info":{"title":"Example
+                  API","version":"1.0.0"},"paths":{"/example":{"get":{"summary":"Example
+                  endpoint","responses":{"200":{"description":"Successful
+                  response"}}}}}}
+              type:
+                $ref: '#/components/schemas/ApiSpecType'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+            required:
+              - content
+          examples:
+            CreateApiSpecRequestExample:
+              $ref: '#/components/examples/CreateApiSpecRequestExample'
+    CreateApiDocumentRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            title: API Document
+            additionalProperties: false
+            properties:
+              id:
+                $ref: '#/components/schemas/ApiDocumentId'
+              content:
+                $ref: '#/components/schemas/ApiDocumentContent'
+              title:
+                $ref: '#/components/schemas/ApiDocumentTitle'
+              slug:
+                $ref: '#/components/schemas/ApiDocumentSlug'
+              status:
+                $ref: '#/components/schemas/ApiDocumentStatus'
+              parent_document_id:
+                $ref: '#/components/schemas/ApiDocumentParentDocumentId'
+              labels:
+                $ref: '#/components/schemas/Labels'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+            required:
+              - content
+          examples:
+            CreateApiDocumentRequestMinimalExample:
+              $ref: '#/components/examples/CreateApiDocumentRequestMinimalExample'
+            CreateApiDocumentRequestExample:
+              $ref: '#/components/examples/CreateApiDocumentRequestExample'
+    UpdateApiRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            title: API
+            type: object
+            additionalProperties: false
+            properties:
+              id:
+                type: string
+                format: uuid
+                example: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+                description: The API identifier.
+                readOnly: true
+              name:
+                type: string
+                maxLength: 255
+                minLength: 1
+                description: >
+                  The name of your API. The `name + version` combination must be
+                  unique for each API you publish.
+                example: MyAPI
+              description:
+                type: string
+                description: >-
+                  A description of your API. Will be visible on your live
+                  Portal.
+                nullable: true
+              version:
+                type: string
+                maxLength: 255
+                minLength: 1
+                description: >-
+                  An optional version for your API. Leave this empty if your API
+                  is unversioned.
+                nullable: true
+              deprecated:
+                type: boolean
+                default: false
+                description: Marks this API as deprecated.
+              slug:
+                type: string
+                pattern: '^[\w-]+$'
+                description: >
+                  The `slug` is used in generated URLs to provide human readable
+                  paths.
+
+
+                  Defaults to `slugify(name + version)`
+                example: my-api-v1
+                nullable: true
+              portals:
+                readOnly: true
+                type: array
+                nullable: false
+                uniqueItems: true
+                description: The list of portals which this API is published to.
+                items:
+                  type: object
+                  additionalProperties: false
+                  required:
+                    - id
+                    - name
+                    - display_name
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                      example: 25a2624c-49fc-4764-99e1-224ed819f200
+                      description: The portal identifier.
+                    name:
+                      type: string
+                      example: My Portal
+                      description: >-
+                        The name of the portal, used to distinguish it from
+                        other portals.
+                    display_name:
+                      type: string
+                      example: My Portal
+                      description: >-
+                        The display name of the portal. This value will be the
+                        portal's `name` in Portal API.
+              labels:
+                $ref: '#/components/schemas/LabelsUpdate'
+              public_labels:
+                $ref: '#/components/schemas/PublicLabelsUpdate'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+          examples:
+            UpdateApiName:
+              $ref: '#/components/examples/UpdateApiNameRequestExample'
+            UpdateApiVersion:
+              $ref: '#/components/examples/UpdateApiVersionRequestExample'
+    UpdateApiDocumentRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiDocument'
+          examples:
+            UpdateApiDocumentAttributes:
+              $ref: '#/components/examples/UpdateApiDocumentAttributesRequestExample'
+            UpdateApiDocumentContent:
+              $ref: '#/components/examples/UpdateApiDocumentContentRequestExample'
+            UpdateApiDocumentAttributesAndContent:
+              $ref: >-
+                #/components/examples/UpdateApiDocumentAttributesAndContentRequestExample
+    UpdateApiSpecRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiSpec'
+          examples:
+            UpdateApiSpecContentRequest:
+              $ref: '#/components/examples/UpdateApiSpecContentRequestExample'
+    PutApiPublicationRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiPublication'
+    CreateApiImplementationRequest:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiImplementation'
+          examples:
+            CreateApiImplementationRequest:
+              $ref: '#/components/examples/CreateApiImplementationRequestExample'
+    MoveDocumentRequest:
+      required: true
+      description: move document
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MoveDocumentRequestPayload'
+  responses:
+    ApiSlugConflict:
+      description: Conflict - `slug` property must be unique
+      content:
+        application/problem+json:
+          schema:
+            type: object
+            required:
+              - status
+              - title
+              - instance
+            properties:
+              status:
+                type: number
+              title:
+                type: string
+              type:
+                type: string
+              instance:
+                type: string
+          examples:
+            ApiSlugConflictExample:
+              $ref: '#/components/examples/ApiSlugConflictExample'
+    ApiSpecConflict:
+      description: Conflict - An API may only have one specification
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictError'
+          examples:
+            ApiSpecConflictExample:
+              $ref: '#/components/examples/ApiSpecConflictExample'
+    ApiSpecHiddenConflict:
+      description: Conflict - name attribute must be unique across specifications
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictError'
+          examples:
+            ApiSpecConflictExample:
+              $ref: '#/components/examples/ApiSpecHiddenConflictExample'
+    ApiImplementationConflict:
+      description: Conflict - A gateway service can only be linked to a single API
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictError'
+          examples:
+            ApiImplementationServiceConflictExample:
+              $ref: '#/components/examples/ApiImplementationServiceConflictExample'
+            ApiImplementationCountConflictExample:
+              $ref: '#/components/examples/ApiImplementationCountConflictExample'
+    ApiUnauthorized:
+      description: ApiUnauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
+          examples:
+            ApiUnauthorizedExample:
+              $ref: '#/components/examples/ApiUnauthorizedExample'
+    ApiNotFound:
+      description: Not Found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/NotFoundError'
+          examples:
+            ApiNotFoundExample:
+              $ref: '#/components/examples/ApiNotFoundExample'
+    ApiForbidden:
+      description: ApiForbidden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ForbiddenError'
+          examples:
+            ApiForbiddenExample:
+              $ref: '#/components/examples/ApiForbiddenExample'
+    ApiPublicationBadRequest:
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BadRequestError'
+    ApiResponse:
+      description: API
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiResponseSchema'
+          examples:
+            CreateApiResponse:
+              $ref: '#/components/examples/ApiExample'
+    ListApiResponse:
+      description: List of APIs
+      content:
+        application/json:
+          schema:
+            title: ListApiResponse
+            type: object
+            required:
+              - data
+              - meta
+            additionalProperties: false
+            properties:
+              meta:
+                $ref: '#/components/schemas/PaginatedMeta'
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiResponseSchema'
+          examples:
+            ApiCollection:
+              value:
+                data:
+                  - id: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+                    name: myAPI
+                    version: v1
+                    public_labels:
+                      group: accounts
+                    labels:
+                      env: test
+                    slug: my-api-v1
+                    portals:
+                      - id: 25a2624c-49fc-4764-99e1-224ed819f200
+                        name: My-Portal
+                        display_name: My Portal
+                    deprecated: false
+                    created_at: '2023-01-01T00:00:00.000Z'
+                    updated_at: '2023-01-01T00:00:00.000Z'
+                meta:
+                  page:
+                    number: 1
+                    size: 1
+                    total: 10
+    ApiDocumentResponse:
+      description: API document
+      content:
+        application/json:
+          schema:
+            type: object
+            title: API Document
+            additionalProperties: false
+            properties:
+              id:
+                $ref: '#/components/schemas/ApiDocumentId'
+              content:
+                $ref: '#/components/schemas/ApiDocumentContent'
+              title:
+                $ref: '#/components/schemas/ApiDocumentTitle'
+              slug:
+                $ref: '#/components/schemas/ApiDocumentSlug'
+              status:
+                $ref: '#/components/schemas/ApiDocumentStatus'
+              parent_document_id:
+                $ref: '#/components/schemas/ApiDocumentParentDocumentId'
+              labels:
+                $ref: '#/components/schemas/Labels'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+            required:
+              - id
+              - parent_document_id
+              - title
+              - slug
+              - status
+              - content
+              - labels
+              - updated_at
+              - created_at
+          examples:
+            CreateApiDocumentResponse:
+              $ref: '#/components/examples/ApiDocumentExample'
+    ListApiDocumentResponse:
+      description: List of API documents
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+              - meta
+            additionalProperties: false
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiDocumentSummaryWithChildren'
+              meta:
+                $ref: '#/components/schemas/PaginatedMeta'
+    ApiSpecResponse:
+      description: API specification
+      content:
+        application/json:
+          schema:
+            title: API Specification
+            type: object
+            additionalProperties: false
+            properties:
+              id:
+                type: string
+                format: uuid
+                example: 7710d5c4-d902-410b-992f-18b814155b53
+                description: The API specification identifier.
+                readOnly: true
+              content:
+                type: string
+                description: |
+                  The raw content of your API specification.
+                example: >-
+                  {"openapi":"3.0.3","info":{"title":"Example
+                  API","version":"1.0.0"},"paths":{"/example":{"get":{"summary":"Example
+                  endpoint","responses":{"200":{"description":"Successful
+                  response"}}}}}}
+              type:
+                $ref: '#/components/schemas/ApiSpecType'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+            required:
+              - id
+              - content
+              - type
+              - created_at
+              - updated_at
+          examples:
+            ApiSpecResponse:
+              $ref: '#/components/examples/ApiSpecExample'
+    ListApiSpecResponse:
+      description: List of API specifications
+      content:
+        application/json:
+          schema:
+            title: ListApiSpecResponse
+            type: object
+            required:
+              - data
+              - meta
+            additionalProperties: false
+            properties:
+              meta:
+                $ref: '#/components/schemas/PaginatedMeta'
+              data:
+                type: array
+                items:
+                  title: API Specification Summary
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                      example: 7710d5c4-d902-410b-992f-18b814155b53
+                      description: The API specification identifier.
+                      readOnly: true
+                    type:
+                      $ref: '#/components/schemas/ApiSpecType'
+                    created_at:
+                      $ref: '#/components/schemas/CreatedAt'
+                    updated_at:
+                      $ref: '#/components/schemas/UpdatedAt'
+                  required:
+                    - id
+                    - type
+                    - created_at
+                    - updated_at
+          examples:
+            ListApiSpecResponse:
+              $ref: '#/components/examples/ListApiSpecExample'
+    ApiPublicationResponse:
+      description: An API publication in a portal
+      content:
+        application/json:
+          schema:
+            title: API Publication
+            type: object
+            description: An API publication in a portal
+            additionalProperties: false
+            properties:
+              auto_approve_registrations:
+                $ref: '#/components/schemas/AutoApproveRegistrations'
+              auth_strategy_ids:
+                $ref: '#/components/schemas/ApiPublicationAuthStrategyIds'
+              visibility:
+                $ref: '#/components/schemas/ApiPublicationVisibility'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+            required:
+              - visibility
+              - created_at
+              - updated_at
+              - auth_strategy_ids
+    ListApiPublicationResponse:
+      description: Paginated list of API publications
+      content:
+        application/json:
+          schema:
+            title: ListApiPublications
+            type: object
+            required:
+              - data
+              - meta
+            additionalProperties: false
+            properties:
+              meta:
+                $ref: '#/components/schemas/PaginatedMeta'
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiPublicationListItem'
+    ApiImplementationResponse:
+      description: An API implementation
+      content:
+        application/json:
+          schema:
+            title: API Implementation
+            type: object
+            description: An entity that implements an API
+            additionalProperties: false
+            required:
+              - service
+              - id
+              - created_at
+              - updated_at
+            properties:
+              id:
+                $ref: '#/components/schemas/UUID'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+              service:
+                $ref: '#/components/schemas/ApiImplementationService'
+    ListApiImplementationsResponse:
+      description: Paginated list of API implementations
+      content:
+        application/json:
+          schema:
+            title: ListApiImplementations
+            type: object
+            required:
+              - data
+              - meta
+            additionalProperties: false
+            properties:
+              meta:
+                $ref: '#/components/schemas/PaginatedMeta'
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiImplementationListItem'
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/UnsupportedMediaTypeError'
+          examples:
+            UnsupportedMediaTypeExample:
+              $ref: '#/components/examples/UnsupportedMediaTypeExample'
+    Conflict:
+      description: Conflict
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictError'
+  schemas:
+    ApiResponseSchema:
+      title: API
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+          description: The API identifier.
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: >
+            The name of your API. The `name + version` combination must be
+            unique for each API you publish.
+          example: MyAPI
+        description:
+          type: string
+          description: A description of your API. Will be visible on your live Portal.
+          nullable: true
+        version:
+          type: string
+          maxLength: 255
+          minLength: 1
+          description: >-
+            An optional version for your API. Leave this empty if your API is
+            unversioned.
+          nullable: true
+        deprecated:
+          type: boolean
+          default: false
+          description: Marks this API as deprecated.
+        slug:
+          type: string
+          pattern: '^[\w-]+$'
+          description: >
+            The `slug` is used in generated URLs to provide human readable
+            paths.
+
+
+            Defaults to `slugify(name + version)`
+          example: my-api-v1
+          nullable: true
+        portals:
+          readOnly: true
+          type: array
+          nullable: false
+          uniqueItems: true
+          description: The list of portals which this API is published to.
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - id
+              - name
+              - display_name
+            properties:
+              id:
+                type: string
+                format: uuid
+                example: 25a2624c-49fc-4764-99e1-224ed819f200
+                description: The portal identifier.
+              name:
+                type: string
+                example: My Portal
+                description: >-
+                  The name of the portal, used to distinguish it from other
+                  portals.
+              display_name:
+                type: string
+                example: My Portal
+                description: >-
+                  The display name of the portal. This value will be the
+                  portal's `name` in Portal API.
+        labels:
+          $ref: '#/components/schemas/Labels'
+        public_labels:
+          $ref: '#/components/schemas/PublicLabels'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      required:
+        - id
+        - name
+        - version
+        - labels
+        - public_labels
+        - deprecated
+        - created_at
+        - updated_at
+        - slug
+        - portals
+    ApiDocumentId:
+      title: API Document ID
+      type: string
+      format: uuid
+      example: de5c9818-be5c-42e6-b514-e3d4bc30ddeb
+      description: The API document identifier.
+      readOnly: true
+    ApiDocumentContent:
+      title: API Document Content
+      type: string
+      description: Raw markdown content to display in your Portal
+    ApiDocumentTitle:
+      title: API Document Title
+      type: string
+      description: >-
+        The title of the document. Used to populate the `<title>` tag for the
+        page
+      example: API Document
+    ApiDocumentStatus:
+      type: string
+      enum:
+        - published
+        - unpublished
+      description: If `status=published` the document will be visible in your live portal
+      default: unpublished
+    ApiDocumentParentDocumentId:
+      title: API Document Parent Document ID
+      type: string
+      format: uuid
+      nullable: true
+      description: >
+        API Documents may be rendered as a tree of files.
+
+
+        Specify the `id` of another API Document as the `parent_document_id` to
+        add some heirarchy do your documents.
+      example: null
+    ApiDocumentSlug:
+      title: API Document Slug
+      type: string
+      pattern: '^[\w-]+$'
+      description: |
+        The `slug` is used in generated URLs to provide human readable paths.
+
+        Defaults to `slugify(title)`
+      example: api-document
+    ApiDocumentSummaryWithChildren:
+      title: API Document Summary
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - slug
+        - status
+        - parent_document_id
+        - labels
+        - created_at
+        - updated_at
+        - children
+      properties:
+        id:
+          $ref: '#/components/schemas/ApiDocumentId'
+        title:
+          $ref: '#/components/schemas/ApiDocumentTitle'
+        slug:
+          $ref: '#/components/schemas/ApiDocumentSlug'
+        status:
+          $ref: '#/components/schemas/ApiDocumentStatus'
+        parent_document_id:
+          $ref: '#/components/schemas/ApiDocumentParentDocumentId'
+        labels:
+          $ref: '#/components/schemas/Labels'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiDocumentSummaryWithChildren'
+    ApiDocument:
+      type: object
+      title: API Document
+      additionalProperties: false
+      properties:
+        id:
+          $ref: '#/components/schemas/ApiDocumentId'
+        content:
+          $ref: '#/components/schemas/ApiDocumentContent'
+        title:
+          $ref: '#/components/schemas/ApiDocumentTitle'
+        slug:
+          $ref: '#/components/schemas/ApiDocumentSlug'
+        status:
+          $ref: '#/components/schemas/ApiDocumentStatus'
+        parent_document_id:
+          $ref: '#/components/schemas/ApiDocumentParentDocumentId'
+        labels:
+          $ref: '#/components/schemas/Labels'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+    MoveDocumentRequestPayload:
+      type: object
+      title: Move document
+      description: move document request payload
+      properties:
+        parent_document_id:
+          type: string
+          format: uuid
+          description: parent document id
+          example: dd4e1b98-3629-4dd3-acc0-759a726ffee2
+        index:
+          type: integer
+          description: index of the document in the parent document's children
+          example: 1
+    ApiSpec:
+      title: API Specification
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 7710d5c4-d902-410b-992f-18b814155b53
+          description: The API specification identifier.
+          readOnly: true
+        content:
+          type: string
+          description: |
+            The raw content of your API specification.
+          example: >-
+            {"openapi":"3.0.3","info":{"title":"Example
+            API","version":"1.0.0"},"paths":{"/example":{"get":{"summary":"Example
+            endpoint","responses":{"200":{"description":"Successful
+            response"}}}}}}
+        type:
+          $ref: '#/components/schemas/ApiSpecType'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+    ApiPublicationVisibility:
+      title: API Publication Visibility
+      type: string
+      enum:
+        - public
+        - private
+      default: private
+      description: >
+        The visibility of the API in the portal.
+
+        Public API publications do not require authentication to view and
+        retrieve information about them.
+
+        Private API publications require authentication to retrieve information
+        about them.
+    ApiPublicationAuthStrategyIds:
+      title: API Publication Auth Strategy IDs
+      type: array
+      nullable: true
+      description: >
+        The auth strategy the API enforces for applications in the portal.
+
+        Omitting this property means the portal's default application auth
+        strategy will be used.
+
+        Setting to null means the API will not require application
+        authentication.
+
+        DCR support for application registration is currently in development.
+      maxItems: 1
+      minItems: 1
+      items:
+        type: string
+        format: uuid
+    ApiPublicationListItem:
+      title: API Publication List Item
+      type: object
+      description: An API publication in a portal
+      additionalProperties: false
+      required:
+        - api_id
+        - portal_id
+        - visibility
+        - created_at
+        - updated_at
+        - auth_strategy_ids
+      properties:
+        api_id:
+          type: string
+          format: uuid
+          example: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+          description: The API identifier.
+          readOnly: true
+        portal_id:
+          type: string
+          format: uuid
+          example: 7710d5c4-d902-410b-992f-18b814155b53
+          description: The portal identifier.
+          readOnly: true
+        visibility:
+          $ref: '#/components/schemas/ApiPublicationVisibility'
+        auth_strategy_ids:
+          $ref: '#/components/schemas/ApiPublicationAuthStrategyIds'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+    AutoApproveRegistrations:
+      title: Auto Approve Registrations
+      description: >-
+        Whether the application registration auto approval on this portal for
+        the api is enabled. If set to false, fallbacks on portal's
+        auto_approve_applications value.
+      type: boolean
+    ApiPublication:
+      title: API Publication
+      type: object
+      description: An API publication in a portal
+      additionalProperties: false
+      properties:
+        auto_approve_registrations:
+          $ref: '#/components/schemas/AutoApproveRegistrations'
+        auth_strategy_ids:
+          $ref: '#/components/schemas/ApiPublicationAuthStrategyIds'
+        visibility:
+          $ref: '#/components/schemas/ApiPublicationVisibility'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+    ApiImplementationService:
+      title: API Implementation Service
+      type: object
+      description: A Gateway service that implements an API
+      additionalProperties: false
+      required:
+        - control_plane_id
+        - id
+      properties:
+        control_plane_id:
+          type: string
+          format: uuid
+          example: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+        id:
+          type: string
+          format: uuid
+          example: 7710d5c4-d902-410b-992f-18b814155b53
+    ApiImplementationListItem:
+      title: API Implementation List Item
+      type: object
+      description: An entity that implements an API
+      additionalProperties: false
+      required:
+        - id
+        - api_id
+        - created_at
+        - updated_at
+        - service
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        api_id:
+          type: string
+          format: uuid
+          example: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+          description: The API identifier.
+          readOnly: true
+        service:
+          $ref: '#/components/schemas/ApiImplementationService'
+    ApiImplementation:
+      title: API Implementation
+      type: object
+      description: An entity that implements an API
+      additionalProperties: false
+      required:
+        - service
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        service:
+          $ref: '#/components/schemas/ApiImplementationService'
+    ApiFilterParameters:
+      title: API Filter Parameters
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        name:
+          $ref: '#/components/schemas/StringFieldFilter'
+        version:
+          $ref: '#/components/schemas/StringFieldFilter'
+        labels:
+          $ref: '#/components/schemas/LabelsFieldFilter'
+        public_labels:
+          $ref: '#/components/schemas/PublicLabelsFieldFilter'
+        deprecated:
+          $ref: '#/components/schemas/BooleanFieldFilter'
+        created_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+        updated_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+    ApiDocumentFilterParameters:
+      title: API Document Filter Parameters
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/StringFieldFilter'
+    ApiSpecFilterParameters:
+      title: API Spec Filter Parameters
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/StringFieldFilter'
+    ApiPublicationFilterParameters:
+      title: API Publication Filter Parameters
+      type: object
+      properties:
+        portal_id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        portal_name:
+          $ref: '#/components/schemas/StringFieldFilter'
+        api_id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        api_name:
+          $ref: '#/components/schemas/StringFieldFilter'
+        auth_strategy_id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+    ApiImplementationFilterParameters:
+      title: API Implementation Filter Parameters
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        api_id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        service_id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        control_plane_id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        created_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+        updated_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+    StringFieldEqualsFilter:
+      title: StringFieldEqualsFilter
+      description: Filters on the given string field value by exact match.
+      oneOf:
+        - type: string
+        - type: object
+          title: StringFieldEqualsComparison
+          additionalProperties: false
+          properties:
+            eq:
+              type: string
+          required:
+            - eq
+      x-examples:
+        example-1: equals-some-value
+        example-2:
+          eq: some-value
+    StringFieldOEQFilter:
+      title: StringFieldOEQFilter
+      description: >-
+        Returns entities that exact match any of the comma-delimited phrases in
+        the filter string.
+      type: object
+      additionalProperties: false
+      properties:
+        oeq:
+          type: string
+      required:
+        - oeq
+      x-examples:
+        example-1:
+          oeq: 'some-value,some-other-value'
+    StringFieldNEQFilter:
+      title: StringFieldNEQFilter
+      description: Filters on the given string field value by exact match inequality.
+      type: object
+      additionalProperties: false
+      properties:
+        neq:
+          type: string
+      required:
+        - neq
+      x-examples:
+        example-1:
+          neq: not-this-value
+    UuidFieldFilter:
+      title: UuidFieldFilter
+      description: Filters on the given UUID field value by exact match.
+      oneOf:
+        - $ref: '#/components/schemas/StringFieldEqualsFilter'
+        - $ref: '#/components/schemas/StringFieldOEQFilter'
+        - $ref: '#/components/schemas/StringFieldNEQFilter'
+      x-examples:
+        example-1: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-2:
+          eq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-3:
+          oeq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-4:
+          neq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+    StringFieldContainsFilter:
+      title: StringFieldContainsFilter
+      description: Filters on the given string field value by fuzzy match.
+      type: object
+      additionalProperties: false
+      properties:
+        contains:
+          type: string
+      required:
+        - contains
+      x-examples:
+        example-1:
+          contains: some-value
+    StringFieldOContainsFilter:
+      title: StringFieldOContainsFilter
+      description: >-
+        Returns entities that fuzzy-match any of the comma-delimited phrases in
+        the filter string.
+      type: object
+      additionalProperties: false
+      properties:
+        ocontains:
+          type: string
+      required:
+        - ocontains
+      x-examples:
+        example-1:
+          ocontains: 'this-value,or-that-value'
+    StringFieldFilter:
+      title: StringFieldFilter
+      description: Filters on the given string field value by either exact or fuzzy match.
+      oneOf:
+        - $ref: '#/components/schemas/StringFieldEqualsFilter'
+        - $ref: '#/components/schemas/StringFieldContainsFilter'
+        - $ref: '#/components/schemas/StringFieldOContainsFilter'
+        - $ref: '#/components/schemas/StringFieldOEQFilter'
+        - $ref: '#/components/schemas/StringFieldNEQFilter'
+      x-examples:
+        example-1: equals-some-value
+        example-2:
+          eq: some-value
+        example-3:
+          contains: some-value
+        example-4:
+          ocontains: 'some-potential,value'
+        example-5:
+          oeq: 'some-potential,value'
+        example-6:
+          neq: not-this-value
+    LabelsFieldFilter:
+      allOf:
+        - title: LabelsFieldFilter
+          description: >
+            Filters on the resource's `labels` field. Filters must use
+            dot-notation to identify
+
+            the label key that will be used to filter the results. For example:
+              - `filter[labels.owner]`
+              - `filter[labels.owner][neq]=kong`
+              - `filter[labels.env]=dev`
+              - `filter[labels.env][ocontains]=dev,test`
+        - $ref: '#/components/schemas/StringFieldFilter'
+    PublicLabelsFieldFilter:
+      title: StringFieldFilter
+      description: Filters on the given string field value by either exact or fuzzy match.
+      oneOf:
+        - $ref: '#/components/schemas/StringFieldEqualsFilter'
+        - $ref: '#/components/schemas/StringFieldContainsFilter'
+        - $ref: '#/components/schemas/StringFieldOContainsFilter'
+        - $ref: '#/components/schemas/StringFieldOEQFilter'
+        - $ref: '#/components/schemas/StringFieldNEQFilter'
+      x-examples:
+        example-1: equals-some-value
+        example-2:
+          eq: some-value
+        example-3:
+          contains: some-value
+        example-4:
+          ocontains: 'some-potential,value'
+        example-5:
+          oeq: 'some-potential,value'
+        example-6:
+          neq: not-this-value
+    BooleanFieldFilter:
+      title: BooleanFieldFilter
+      description: Filter by a boolean value (true/false).
+      type: boolean
+      x-examples:
+        example-1: true
+    DateTimeFieldFilter:
+      title: DateTimeFieldFilter
+      description: Filters on the given datetime (RFC-3339) field value.
+      oneOf:
+        - type: string
+          format: date-time
+          description: Value strictly equals given RFC-3339 formatted timestamp in UTC
+          example: '2022-03-30T07:20:50Z'
+        - type: object
+          title: DateTimeFieldEqualsFilter
+          additionalProperties: false
+          properties:
+            eq:
+              type: string
+              format: date-time
+              description: Value strictly equals given RFC-3339 formatted timestamp in UTC
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - eq
+        - type: object
+          title: DateTimeFieldLTFilter
+          additionalProperties: false
+          properties:
+            lt:
+              type: string
+              format: date-time
+              description: Value is less than the given RFC-3339 formatted timestamp in UTC
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - lt
+        - type: object
+          title: DateTimeFieldLTEFilter
+          additionalProperties: false
+          properties:
+            lte:
+              type: string
+              format: date-time
+              description: >-
+                Value is less than or equal to the given RFC-3339 formatted
+                timestamp in UTC
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - lte
+        - type: object
+          title: DateTimeFieldGTFilter
+          additionalProperties: false
+          properties:
+            lt:
+              type: string
+              format: date-time
+              description: >-
+                Value is greater than the given RFC-3339 formatted timestamp in
+                UTC
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - gt
+        - type: object
+          title: DateTimeFieldGTEFilter
+          additionalProperties: false
+          properties:
+            lte:
+              type: string
+              format: date-time
+              description: >-
+                Value is greater than or equal to the given RFC-3339 formatted
+                timestamp in UTC
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - gte
+      x-examples:
+        datetime_field_1: '2022-03-30T07:20:50Z'
+        datetime_field_2:
+          eq: '2022-03-30T07:20:50Z'
+        datetime_field_3:
+          lt: '2022-03-30T07:20:50Z'
+        datetime_field_4:
+          lte: '2022-03-30T07:20:50Z'
+        datetime_field_5:
+          gt: '2022-03-30T07:20:50Z'
+        datetime_field_6:
+          gte: '2022-03-30T07:20:50Z'
+    SortQuery:
+      title: SortQuery
+      type: string
+      example: 'name,created_at desc'
+      description: >
+        The `asc` suffix is optional as the default sort order is ascending.
+
+        The `desc` suffix is used to specify a descending order.
+
+        Multiple sort attributes may be provided via a comma separated list.
+
+        JSONPath notation may be used to specify a sub-attribute (eg: 'foo.bar
+        desc').
+    PageMeta:
+      type: object
+      description: >-
+        Contains pagination query parameters and the total number of objects
+        returned.
+      required:
+        - number
+        - size
+        - total
+      properties:
+        number:
+          type: number
+          example: 1
+        size:
+          type: number
+          example: 10
+        total:
+          type: number
+          example: 100
+    PaginatedMeta:
+      type: object
+      title: PaginatedMeta
+      description: returns the pagination information
+      properties:
+        page:
+          $ref: '#/components/schemas/PageMeta'
+      required:
+        - page
+    Labels:
+      title: Labels
+      type: object
+      example:
+        env: test
+      maxProperties: 50
+      description: >
+        Labels store metadata of an entity that can be used for filtering an
+        entity list or for searching across entity types. 
+
+
+        Keys must be of length 1-63 characters, and cannot start with "kong",
+        "konnect", "mesh", "kic", or "_".
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+    PublicLabels:
+      title: PublicLabels
+      type: object
+      example:
+        category: finance
+      maxProperties: 50
+      description: >
+        Public labels store information about an entity that can be used for
+        filtering a list of objects.
+
+
+        Public labels are intended to store **PUBLIC** metadata. 
+
+
+        Keys must be of length 1-63 characters, and cannot start with "kong",
+        "konnect", "mesh", "kic", or "_".
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+    CreatedAt:
+      type: string
+      format: date-time
+      example: '2022-11-04T20:10:06.927Z'
+      description: An ISO-8601 timestamp representation of entity creation date.
+      readOnly: true
+    UpdatedAt:
+      type: string
+      format: date-time
+      example: '2022-11-04T20:10:06.927Z'
+      description: An ISO-8601 timestamp representation of entity update date.
+      readOnly: true
+    BaseError:
+      type: object
+      title: Error
+      description: standard error
+      required:
+        - status
+        - title
+        - instance
+        - detail
+      properties:
+        status:
+          type: integer
+          description: >
+            The HTTP status code of the error. Useful when passing the response
+
+            body to child properties in a frontend UI. Must be returned as an
+            integer.
+          readOnly: true
+        title:
+          type: string
+          description: |
+            A short, human-readable summary of the problem. It should not
+            change between occurences of a problem, except for localization.
+            Should be provided as "Sentence case" for direct use in the UI.
+          readOnly: true
+        type:
+          type: string
+          description: The error type.
+          readOnly: true
+        instance:
+          type: string
+          description: |
+            Used to return the correlation ID back to the user, in the format
+            kong:trace:<correlation_id>. This helps us find the relevant logs
+            when a customer reports an issue.
+          readOnly: true
+        detail:
+          type: string
+          description: >
+            A human readable explanation specific to this occurence of the
+            problem.
+
+            This field may contain request/entity data to help the user
+            understand
+
+            what went wrong. Enclose variable values in square brackets. Should
+            be
+
+            provided as "Sentence case" for direct use in the UI.
+          readOnly: true
+    InvalidRules:
+      description: invalid parameters rules
+      type: string
+      readOnly: true
+      nullable: true
+      enum:
+        - required
+        - is_array
+        - is_base64
+        - is_boolean
+        - is_date_time
+        - is_integer
+        - is_null
+        - is_number
+        - is_object
+        - is_string
+        - is_uuid
+        - is_fqdn
+        - is_arn
+        - unknown_property
+        - missing_reference
+        - is_label
+        - matches_regex
+        - invalid
+        - is_supported_network_availability_zone_list
+        - is_supported_network_cidr_block
+        - is_supported_provider_region
+    InvalidParameterStandard:
+      type: object
+      additionalProperties: false
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          $ref: '#/components/schemas/InvalidRules'
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+      required:
+        - field
+        - reason
+    InvalidParameterMinimumLength:
+      type: object
+      additionalProperties: false
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          readOnly: true
+          nullable: false
+          enum:
+            - min_length
+            - min_digits
+            - min_lowercase
+            - min_uppercase
+            - min_symbols
+            - min_items
+            - min
+        minimum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must have at least 8 characters
+          readOnly: true
+      required:
+        - field
+        - reason
+        - rule
+        - minimum
+    InvalidParameterMaximumLength:
+      type: object
+      additionalProperties: false
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          readOnly: true
+          nullable: false
+          enum:
+            - max_length
+            - max_items
+            - max
+        maximum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must not have more than 8 characters
+          readOnly: true
+      required:
+        - field
+        - reason
+        - rule
+        - maximum
+    InvalidParameterChoiceItem:
+      type: object
+      additionalProperties: false
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          readOnly: true
+          nullable: false
+          enum:
+            - enum
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+        choices:
+          type: array
+          uniqueItems: true
+          readOnly: true
+          nullable: false
+          minItems: 1
+          items: {}
+        source:
+          type: string
+          example: body
+      required:
+        - field
+        - reason
+        - rule
+        - choices
+    InvalidParameterDependentItem:
+      type: object
+      additionalProperties: false
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          readOnly: true
+          nullable: true
+          enum:
+            - dependent_fields
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+        dependents:
+          type: array
+          uniqueItems: true
+          nullable: true
+          items: {}
+          readOnly: true
+        source:
+          type: string
+          example: body
+      required:
+        - field
+        - rule
+        - reason
+        - dependents
+    InvalidParameters:
+      type: array
+      nullable: false
+      uniqueItems: true
+      minItems: 1
+      description: invalid parameters
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/InvalidParameterStandard'
+          - $ref: '#/components/schemas/InvalidParameterMinimumLength'
+          - $ref: '#/components/schemas/InvalidParameterMaximumLength'
+          - $ref: '#/components/schemas/InvalidParameterChoiceItem'
+          - $ref: '#/components/schemas/InvalidParameterDependentItem'
+    BadRequestError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - invalid_parameters
+          properties:
+            invalid_parameters:
+              $ref: '#/components/schemas/InvalidParameters'
+    UnauthorizedError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 401
+            title:
+              example: Unauthorized
+            type:
+              example: 'https://httpstatuses.com/401'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Invalid credentials
+    ForbiddenError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 403
+            title:
+              example: Forbidden
+            type:
+              example: 'https://httpstatuses.com/403'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Forbidden
+    NotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 404
+            title:
+              example: Not Found
+            type:
+              example: 'https://httpstatuses.com/404'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Not found
+    UnsupportedMediaTypeError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 415
+            title:
+              example: UnsupportedMediaType
+            type:
+              example: 'https://httpstatuses.com/415'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: UnsupportedMediaType
+    LabelsUpdate:
+      type: object
+      nullable: true
+      description: >
+        Labels store metadata of an entity that can be used for filtering an
+        entity list or for searching across entity types. 
+
+
+        Labels are intended to store **INTERNAL** metadata.
+
+
+        Keys must be of length 1-63 characters, and cannot start with "kong",
+        "konnect", "mesh", "kic", or "_".
+      example:
+        env: test
+      maxProperties: 50
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+        nullable: true
+      writeOnly: true
+    PublicLabelsUpdate:
+      title: PublicLabelsUpdate
+      type: object
+      example:
+        category: finance
+      maxProperties: 50
+      description: >
+        Public labels store information about an entity that can be used for
+        filtering a list of objects.
+
+
+        Public labels are intended to store **PUBLIC** metadata.
+
+
+        Keys must be of length 1-63 characters, and cannot start with "kong",
+        "konnect", "mesh", "kic", or "_".
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+        nullable: true
+      writeOnly: true
+    ConflictError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 409
+            title:
+              example: Conflict
+            type:
+              example: 'https://httpstatuses.com/409'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Conflict
+    ApiSpecType:
+      title: API Spec Type
+      type: string
+      example: oas3
+      description: >
+        The type of specification being stored. This allows us to render the
+        specification correctly.
+
+
+        If this field is not set, it will be autodetected from `content`
+      enum:
+        - oas3
+        - asyncapi
+    UUID:
+      type: string
+      format: uuid
+      example: 5f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+      description: Contains a unique identifier used for this resource.
+      readOnly: true
+  securitySchemes:
+    konnectAccessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >
+        The Konnect access token is meant to be used by the Konnect dashboard
+        and the decK CLI authenticate with.
+    personalAccessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Token
+      description: >
+        The personal access token is meant to be used as an alternative to
+        basic-auth when accessing Konnect via APIs.
+
+        You can generate a Personal Access Token (PAT) from the [personal access
+        token page](https://cloud.konghq.com/global/tokens/) in the Konnect
+        dashboard.
+
+        The PAT token must be passed in the header of a request, for example:
+
+        `curl -X GET 'https://global.api.konghq.com/v2/users/' --header
+        'Authorization: Bearer kpat_xgfT...'`
+    systemAccountAccessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Token
+      description: >
+        The system account access token is meant for automations and
+        integrations that are not directly associated with a human identity.
+
+        You can generate a system account Access Token by creating a system
+        account and then obtaining a system account access token for that
+        account.
+
+        The access token must be passed in the header of a request, for example:
+
+        `curl -X GET 'https://global.api.konghq.com/v2/users/' --header
+        'Authorization: Bearer spat_i2Ej...'`
+  examples:
+    ApiExample:
+      value:
+        id: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+        name: myAPI
+        version: v1
+        labels:
+          env: test
+        public_labels: {}
+        description: My API
+        deprecated: false
+        created_at: '2023-01-01T00:00:00.000Z'
+        updated_at: '2023-01-01T00:00:00.000Z'
+        slug: my-api-v1
+        portals:
+          - id: 25a2624c-49fc-4764-99e1-224ed819f200
+            name: My-Portal
+            display_name: My Portal
+    ApiSpecExample:
+      value:
+        id: 7710d5c4-d902-410b-992f-18b814155b53
+        content: >-
+          {"openapi":"3.0.3","info":{"title":"Example
+          API","version":"1.0.0"},"paths":{"/example":{"get":{"summary":"Example
+          endpoint","responses":{"200":{"description":"Successful
+          response"}}}}}}
+        type: oas3
+        created_at: '2023-01-01T00:00:00.000Z'
+        updated_at: '2023-01-01T00:00:00.000Z'
+    ListApiSpecExample:
+      value:
+        data:
+          - id: 7710d5c4-d902-410b-992f-18b814155b53
+            type: oas3
+            created_at: '2023-01-01T00:00:00.000Z'
+            updated_at: '2023-01-01T00:00:00.000Z'
+        meta:
+          page:
+            number: 1
+            size: 1
+            total: 1
+    CreateApiRequestMinimalExample:
+      summary: Create API Request (Minimal)
+      value:
+        name: myAPI
+    CreateApiRequestFullExample:
+      summary: Create API Request (Full)
+      value:
+        name: myAPI
+        version: v1
+        slug: my-api-v1
+        labels:
+          env: test
+    CreateApiSpecRequestExample:
+      summary: Create API Specification Request
+      value:
+        content: >-
+          {"openapi":"3.0.3","info":{"title":"Example
+          API","version":"1.0.0"},"paths":{"/example":{"get":{"summary":"Example
+          endpoint","responses":{"200":{"description":"Successful
+          response"}}}}}}
+        type: oas3
+    UpdateApiNameRequestExample:
+      summary: Update API Name
+      value:
+        name: new API name
+    UpdateApiVersionRequestExample:
+      summary: Update API Version
+      value:
+        version: v2
+    UpdateApiSpecContentRequestExample:
+      summary: Update API Spec Content
+      value:
+        content: >-
+          {"openapi":"3.0.3","info":{"title":"Example
+          API","version":"1.0.1"},"paths":{"/example":{"get":{"summary":"Example
+          endpoint","responses":{"200":{"description":"Successful
+          response"}}}}}}
+    ApiDocumentExample:
+      value:
+        id: de5c9818-be5c-42e6-b514-e3d4bc30ddeb
+        parent_document_id: null
+        title: API Document
+        slug: api-document
+        status: published
+        content: '# API Document Header'
+        labels:
+          type: tutorial
+        created_at: '2023-01-01T00:00:00.000Z'
+        updated_at: '2023-01-01T00:00:00.000Z'
+    CreateApiDocumentRequestExample:
+      summary: Create API Document Request
+      value:
+        slug: api-document
+        status: published
+        title: API Document
+        content: '# API Document Header'
+        parent_document_id: 417a2aed-9a75-4eca-a943-fa7d88ed6a73
+    CreateApiDocumentRequestMinimalExample:
+      summary: Create API Document Request (Minimal)
+      value:
+        slug: api-document
+        status: published
+        title: API Document
+        content: '# API Document Header'
+    UpdateApiDocumentAttributesRequestExample:
+      summary: Update API Document Attributes Request
+      value:
+        parent_document_id: dd4e1b98-3629-4dd3-acc0-759a726ffee2
+        slug: api-document
+        status: published
+        title: API Document
+    UpdateApiDocumentContentRequestExample:
+      summary: Update API Document Content Request
+      value:
+        content: '# Updated API Document Header'
+    UpdateApiDocumentAttributesAndContentRequestExample:
+      summary: Update API Document Attributes and Content Request
+      value:
+        parent_document_id: dd4e1b98-3629-4dd3-acc0-759a726ffee2
+        slug: api-document
+        status: published
+        title: API Document
+        content: '# Updated API Document Header'
+    CreateApiImplementationRequestExample:
+      value:
+        service:
+          control_plane_id: fd4e1b98-3629-4dd3-acc0-759a726ffee2
+          id: dd4e1b98-3629-4dd3-acc0-759a726ffee2
+    ApiNameBadRequestExample:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:8405749052424858251'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: name
+            rule: min_length
+            minimum: 1
+            reason: name must be longer than or equal to 1 characters
+    ApiDocumentBadRequestExample:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:5832302153563197721'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: slug
+            rule: matches_regex
+            reason: 'slug must match /^[\w-]+$/ regular expression'
+    ApiSpecContentBadRequestExample:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: content
+            rule: min_length
+            minimum: 1
+            reason: content must be longer than or equal to 1 characters
+    ApiImplementationBadRequestExample:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: service.id
+            rule: missing_reference
+            reason: Service not found
+    ApiUnauthorizedExample:
+      value:
+        status: 401
+        title: ApiUnauthorized
+        instance: 'kong:trace:8347343766220159418'
+        detail: ApiUnauthorized
+    ApiNotFoundExample:
+      value:
+        status: 404
+        title: Not Found
+        instance: 'kong:trace:6816496025408232265'
+        detail: Not Found
+    ApiForbiddenExample:
+      value:
+        status: 403
+        title: ApiForbidden
+        instance: 'kong:trace:2723154947768991354'
+        detail: You do not have permission to perform this action
+    ApiSlugConflictExample:
+      value:
+        status: 409
+        title: Conflict
+        instance: 'kong:trace:3169213858331814220'
+    ApiSpecConflictExample:
+      value:
+        status: 409
+        title: Conflict
+        instance: 'kong:trace:3169213858331814220'
+        detail: >-
+          Specification for API '9f5061ce-78f6-4452-9108-ad7c02821fd5' already
+          exists
+    ApiSpecHiddenConflictExample:
+      value:
+        status: 409
+        title: Conflict
+        instance: 'kong:trace:9039922446017540182'
+        detail: >-
+          Key (api_id, path)=(23380be0-c15e-4ca8-bcf7-43aadddc91b1, hidden.yaml)
+          already exists.
+    ApiImplementationServiceConflictExample:
+      value:
+        status: 409
+        title: Conflict
+        instance: 'kong:trace:3169213858331814220'
+        detail: This gateway service is already linked to another API
+    ApiImplementationCountConflictExample:
+      value:
+        status: 409
+        title: Conflict
+        instance: 'kong:trace:3169213858331814220'
+        detail: An implementation already exists for this API
+    InvalidApiSortQueryBadRequestExample:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:4725061142075238974'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: sort
+            rule: enum
+            choices:
+              - name
+            reason: '"sort" field must contain any of: [name]'
+    InvalidApiSortQueryNameBadRequestExample:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:4725061142075238974'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: sort
+            rule: enum
+            choices:
+              - name
+            reason: '"sort" field must contain any of: [name]'
+    UnsupportedMediaTypeExample:
+      value:
+        status: 415
+        title: Unsupported Media Type
+        instance: 'kong:trace:8347343766220159418'
+        detail: 'This API only supports requests with `Content-Type: application/json`'

--- a/api-specs/Konnect/v3/yaml/portal-management.yaml
+++ b/api-specs/Konnect/v3/yaml/portal-management.yaml
@@ -1,0 +1,7561 @@
+openapi: 3.0.3
+info:
+  title: Portal Management
+  version: 3.0.8
+  description: The management API for Portals
+  contact:
+    name: Kong
+    url: 'https://konghq.com'
+servers:
+  - url: 'https://us.api.konghq.com/v3'
+    description: United-States Production region
+  - url: 'https://eu.api.konghq.com/v3'
+    description: Europe Production region
+  - url: 'https://au.api.konghq.com/v3'
+    description: Australia Production region
+  - url: 'https://me.api.konghq.com/v3'
+    description: Middle-East Production region
+  - url: 'https://in.api.konghq.com/v3'
+    description: India Production region
+paths:
+  /portals:
+    get:
+      operationId: list-portals
+      summary: List Portals
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists developer portals defined in this region for this organization.
+        Each developer portal is available at a unique address and has isolated
+        configuration, customization, developers, and applications.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/SortPortals'
+        - name: filter
+          in: query
+          description: Filter portals returned in the response.
+          required: false
+          schema:
+            $ref: '#/components/schemas/PortalFilterParameters'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListPortalsResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ListPortalsBadRequestExample1:
+                  $ref: '#/components/examples/ListPortalsBadRequestExample1'
+                ListPortalsBadRequestExample2:
+                  $ref: '#/components/examples/ListPortalsBadRequestExample2'
+                ListPortalsBadRequestExample3:
+                  $ref: '#/components/examples/ListPortalsBadRequestExample3'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portals
+    post:
+      operationId: create-portal
+      summary: Create Portal
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Creates a new developer portal scoped in this region for this
+        organization.
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePortal'
+      responses:
+        '201':
+          $ref: '#/components/responses/PortalResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                UpdatePortalBadRequestExample1:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample1'
+                UpdatePortalBadRequestExample2:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample2'
+                UpdatePortalBadRequestExample3:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample3'
+                UpdatePortalBadRequestExample4:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample4'
+                UpdatePortalBadRequestExample5:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample5'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portals
+  '/portals/{portalId}':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: get-portal
+      summary: Fetch Portal
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the configuration for a single developer portal, including  the
+        current visibility, access, and domain settings.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portals
+    patch:
+      operationId: update-portal
+      summary: Update Portal
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Updates the configuration for a single portal including the visibility,
+        access, and custom domain settings.
+      requestBody:
+        $ref: '#/components/requestBodies/UpdatePortal'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                UpdatePortalBadRequestExample1:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample1'
+                UpdatePortalBadRequestExample2:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample2'
+                UpdatePortalBadRequestExample3:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample3'
+                UpdatePortalBadRequestExample4:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample4'
+                UpdatePortalBadRequestExample5:
+                  $ref: '#/components/examples/UpdatePortalBadRequestExample5'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Portals
+    delete:
+      operationId: delete-portal
+      summary: Delete Portal
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Deletes a single portal, along with all related entities.
+      parameters:
+        - name: force
+          in: query
+          description: >-
+            If true, the portal will be deleted, automatically deleting all API
+            publications. If the force param is not set, the deletion will only
+            succeed if there are no APIs currently published.
+          schema:
+            type: string
+            default: 'false'
+            enum:
+              - 'true'
+              - 'false'
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portals
+  '/portals/{portalId}/custom-domain':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: get-portal-custom-domain
+      summary: Get Custom Domain
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Get the custom domain associated to the portal.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalCustomDomain'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Custom Domains
+    post:
+      operationId: create-portal-custom-domain
+      summary: Create Custom Domain
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Creates the custom domain associated with the portal. Only one custom
+        domain can be associated with a portal at a time.
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePortalCustomDomain'
+      responses:
+        '201':
+          $ref: '#/components/responses/PortalCustomDomain'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Custom Domains
+    patch:
+      operationId: update-portal-custom-domain
+      summary: Enable or Disable Domain
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Updates the portal domain associated with the portal.
+      requestBody:
+        $ref: '#/components/requestBodies/UpdatePortalCustomDomain'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalCustomDomain'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portal Custom Domains
+    delete:
+      operationId: delete-portal-custom-domain
+      summary: Remove Domain
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Deletes the custom domain associated with the portal.
+      responses:
+        '204':
+          description: No Content
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Custom Domains
+  '/portals/{portalId}/assets/logo':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: get-portal-asset-logo
+      summary: Get Logo
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns the logo of the portal.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalAssetResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Assets
+    put:
+      operationId: replace-portal-asset-logo
+      summary: Replace Logo
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Replaces the logo of the portal.
+      requestBody:
+        $ref: '#/components/requestBodies/ReplacePortalImageAsset'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalAssetResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ReplacePortalImageAssetBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/ReplacePortalImageAssetBadRequestExample1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Assets
+  '/portals/{portalId}/assets/favicon':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: get-portal-asset-favicon
+      summary: Get Favicon
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns the favicon of the portal.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalAssetResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Assets
+    put:
+      operationId: replace-portal-asset-favicon
+      summary: Replace Favicon
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Replaces the favicon of the portal. The favicon is used in the browser
+        tab of the portal.
+      requestBody:
+        $ref: '#/components/requestBodies/ReplacePortalImageAsset'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalAssetResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ReplacePortalImageAssetBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/ReplacePortalImageAssetBadRequestExample1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Assets
+  '/portals/{portalId}/customization':
+    get:
+      operationId: get-portal-customization
+      summary: Get Customization
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns the portal customization options.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalCustomizationResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Customization
+    put:
+      operationId: replace-portal-customization
+      summary: Replace Customization
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Replace the portal customization options.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+      requestBody:
+        $ref: '#/components/requestBodies/ReplacePortalCustomization'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalCustomizationResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ReplacePortalImageAssetBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/ReplacePortalCustomizationBadRequestExample1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Customization
+    patch:
+      operationId: update-portal-customization
+      summary: Update Customization
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Update the portal customization options, merging properties.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+      requestBody:
+        $ref: '#/components/requestBodies/ReplacePortalCustomization'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalCustomizationResponse'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ReplacePortalImageAssetBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/UpdatePortalCustomizationBadRequestExample1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Customization
+  '/portals/{portalId}/pages':
+    get:
+      operationId: list-portal-pages
+      summary: List Pages
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the paginated list of custom pages that have been created for
+        this portal.
+      parameters:
+        - $ref: '#/components/parameters/SortPortalPages'
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - name: filter
+          in: query
+          description: Filter pages returned in the response.
+          required: false
+          schema:
+            $ref: '#/components/schemas/PortalPagesFilterParameters'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListPortalPages'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ListPortalPagesBadRequestExample1:
+                  $ref: '#/components/examples/ListPortalPagesBadRequestExample1'
+                ListPortalPagesBadRequestExample2:
+                  $ref: '#/components/examples/ListPortalPagesBadRequestExample2'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Pages
+    post:
+      operationId: create-portal-page
+      summary: Create Page
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Creates a new custom page for this portal. Custom pages can be used to
+        display static content, documentation, or other information to
+        developers.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePortalPage'
+      responses:
+        '201':
+          $ref: '#/components/responses/PortalPage'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                UpdatePortalPageBadRequestExample1:
+                  $ref: '#/components/examples/UpdatePortalPageBadRequestExample1'
+                'UpdatePortalPageBadRequestExample2:':
+                  $ref: '#/components/examples/UpdatePortalPageBadRequestExample2'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Pages
+  '/portals/{portalId}/pages/{pageId}':
+    get:
+      operationId: get-portal-page
+      summary: Fetch Page
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the configuration of a single custom page for this portal.
+        Custom pages can be used to display static content, documentation, or
+        other information to developers.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/PageId'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalPage'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Pages
+    patch:
+      operationId: update-portal-page
+      summary: Update Page
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Updates the configuration of a single custom page for this portal.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/PageId'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdatePortalPage'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalPage'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                'UpdatePortalPageBadRequestExample1:':
+                  $ref: '#/components/examples/UpdatePortalPageBadRequestExample1'
+                'UpdatePortalPageBadRequestExample2:':
+                  $ref: '#/components/examples/UpdatePortalPageBadRequestExample2'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Pages
+    delete:
+      operationId: delete-portal-page
+      summary: Delete Page
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Deletes a single custom page for this portal.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/PageId'
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Pages
+  '/portals/{portalId}/pages/{pageId}/move':
+    put:
+      operationId: move-portal-pages
+      summary: Move Page
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        This api allows the user to move a page within the page tree using the
+        parameters parent_page_id and index. If parent_page_id is not provided,
+        the page will be placed at the top level of the page tree. index
+        represents a zero-indexed page order relative to its siblings under the
+        same parent. For example, if we want to put the page at top level in
+        first position we would send parent_page_id: null and index: 0. This api
+        also supports using a negative index to count backwards from the end of
+        the page list, which means you can put the page in last position by
+        using index: -1.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/PageId'
+      requestBody:
+        $ref: '#/components/requestBodies/MovePage'
+      responses:
+        '200':
+          description: The document has been moved
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Pages
+  '/portals/{portalId}/snippets':
+    get:
+      operationId: list-portal-snippets
+      summary: List Snippets
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the paginated list of custom snippets that have been created for
+        this portal.
+      parameters:
+        - $ref: '#/components/parameters/SortPortalSnippets'
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - name: filter
+          in: query
+          description: Filter snippets returned in the response.
+          required: false
+          schema:
+            $ref: '#/components/schemas/PortalSnippetsFilterParameters'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListPortalSnippets'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ListPortalSnippetsBadRequestExample1:
+                  $ref: '#/components/examples/ListPortalSnippetsBadRequestExample1'
+                ListPortalSnippetsBadRequestExample2:
+                  $ref: '#/components/examples/ListPortalSnippetsBadRequestExample2'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Snippets
+    post:
+      operationId: create-portal-snippet
+      summary: Create Snippet
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Creates a new custom snippet for this portal. Custom snippets can be
+        used to display static content, documentation, or other information to
+        developers.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePortalSnippet'
+      responses:
+        '201':
+          $ref: '#/components/responses/PortalSnippet'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                UpdatePortalPageBadRequestExample1:
+                  $ref: '#/components/examples/UpdatePortalSnippetBadRequestExample1'
+                UpdatePortalSnippetBadRequestExample2:
+                  $ref: '#/components/examples/UpdatePortalSnippetBadRequestExample2'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Snippets
+  '/portals/{portalId}/snippets/{snippetId}':
+    get:
+      operationId: get-portal-snippet
+      summary: Fetch Snippet
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the configuration of a single custom snippet for this portal.
+        Custom snippets can be used to display static content, documentation, or
+        other information to developers.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/SnippetId'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalSnippet'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Snippets
+    patch:
+      operationId: update-portal-snippet
+      summary: Update Snippet
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Updates the configuration of a single custom snippet for this portal.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/SnippetId'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdatePortalSnippet'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalSnippet'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                'UpdatePortalPageBadRequestExample1:':
+                  $ref: '#/components/examples/UpdatePortalPageBadRequestExample1'
+                'UpdatePortalPageBadRequestExample2:':
+                  $ref: '#/components/examples/UpdatePortalPageBadRequestExample2'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Snippets
+    delete:
+      operationId: delete-portal-snippet
+      summary: Delete Snippet
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Deletes a single custom snippet for this portal.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/SnippetId'
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Snippets
+  '/portals/{portalId}/default-content':
+    post:
+      operationId: create-default-content
+      summary: Creates Default Pages
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Creates the default pages for a portal if they do not already exists.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+      responses:
+        '201':
+          $ref: '#/components/responses/DefaultContentResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Pages
+  '/portals/{portalId}/applications':
+    get:
+      operationId: list-applications
+      summary: List Applications
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists applications in this portal. Each application can be registered
+        for various APIs, issuing credentials for API access. If using DCR, an
+        application will be linked to an Identity Provider's application by its
+        `client_id`.
+      parameters:
+        - $ref: '#/components/parameters/PortalId'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/SortApplications'
+        - name: filter
+          in: query
+          description: Filter applications returned in the response.
+          required: false
+          schema:
+            type: object
+            properties:
+              developer_id:
+                $ref: '#/components/schemas/UuidFieldFilter'
+              name:
+                $ref: '#/components/schemas/StringFieldFilter'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApplications'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ListApplicationsBadRequestExample1:
+                  $ref: '#/components/examples/ListApplicationsBadRequestExample1'
+                ListApplicationsBadRequestExample2:
+                  $ref: '#/components/examples/ListApplicationsBadRequestExample2'
+                ListApplicationsBadRequestExample3:
+                  $ref: '#/components/examples/ListApplicationsBadRequestExample3'
+                ListApplicationsBadRequestExample4:
+                  $ref: '#/components/examples/ListApplicationsBadRequestExample4'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Applications
+  '/portals/{portalId}/applications/{applicationId}':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/ApplicationId'
+    get:
+      operationId: get-application
+      summary: Fetch Application by Portal
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the configuration of a single application in this portal. If an
+        application is linked to a DCR Provider, the `dcr_provider.id` and
+        `client_id` can be used to correlate it. An application manages a set of
+        credentials and registrations for specific APIs.
+      responses:
+        '200':
+          $ref: '#/components/responses/GetApplication'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Applications
+    delete:
+      operationId: delete-application
+      summary: Delete Application by Portal
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Delete a single application in this portal, along with its registrations
+        and credentials.
+      responses:
+        '204':
+          description: The application has been deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Applications
+  '/applications/{applicationId}':
+    parameters:
+      - $ref: '#/components/parameters/ApplicationId'
+    get:
+      operationId: get-application-unscoped
+      summary: Fetch Application
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the configuration of a single application in any portal. If an
+        application is linked to a DCR Provider, the `dcr_provider.id` and
+        `client_id` can be used to correlate it. An application manages a set of
+        credentials and registrations for specific APIs.
+      responses:
+        '200':
+          $ref: '#/components/responses/GetApplication'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Applications
+  '/portals/{portalId}/application-registrations':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: list-registrations
+      summary: List Registrations by Portal
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists all of the application registrations and their current status
+        (e.g., approved or pending) for this portal. Each registration is
+        associated with a single API. Access is provided through the credentials
+        issued to the application that contains each registration.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/SortListAllApplicationRegistrations'
+        - name: filter
+          in: query
+          description: Filter application registrations returned in the response.
+          required: false
+          schema:
+            type: object
+            properties:
+              developer_id:
+                $ref: '#/components/schemas/UuidFieldFilter'
+              application_name:
+                $ref: '#/components/schemas/StringFieldFilter'
+              status:
+                $ref: '#/components/schemas/StringFieldFilter'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApplicationRegistrations'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ListApplicationRegistrationsByPortalBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/ListApplicationRegistrationsByPortalBadRequestExample1
+                ListApplicationRegistrationsByPortalBadRequestExample2:
+                  $ref: >-
+                    #/components/examples/ListApplicationRegistrationsByPortalBadRequestExample2
+                ListApplicationRegistrationsByPortalBadRequestExample3:
+                  $ref: >-
+                    #/components/examples/ListApplicationRegistrationsByPortalBadRequestExample3
+                ListApplicationRegistrationsByPortalBadRequestExample4:
+                  $ref: >-
+                    #/components/examples/ListApplicationRegistrationsByPortalBadRequestExample4
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Application Registrations
+  '/portals/{portalId}/applications/{applicationId}/registrations':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/ApplicationId'
+    get:
+      operationId: list-registrations-by-application
+      summary: List Registrations by Application
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists each API that this application is registered for and their current
+        status (e.g., pending, approved, rejected, revoked).
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/SortApplicationRegistrations'
+        - name: filter
+          in: query
+          description: Filter application registrations returned in the response.
+          required: false
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: '#/components/schemas/StringFieldFilter'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApplicationRegistrations'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ListRegistrationsByApplicationBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/ListRegistrationsByApplicationBadRequestExample1
+                ListRegistrationsByApplicationBadRequestExample2:
+                  $ref: >-
+                    #/components/examples/ListRegistrationsByApplicationBadRequestExample2
+                ListRegistrationsByApplicationBadRequestExample3:
+                  $ref: >-
+                    #/components/examples/ListRegistrationsByApplicationBadRequestExample3
+                ListRegistrationsByApplicationBadRequestExample4:
+                  $ref: >-
+                    #/components/examples/ListRegistrationsByApplicationBadRequestExample4
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Application Registrations
+  '/portals/{portalId}/applications/{applicationId}/registrations/{registrationId}':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/ApplicationId'
+      - $ref: '#/components/parameters/RegistrationId'
+    get:
+      operationId: get-application-registration
+      summary: Fetch Registration
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns information about an application's registration status for a
+        particular API.
+      responses:
+        '200':
+          $ref: '#/components/responses/GetApplicationRegistration'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Application Registrations
+    patch:
+      operationId: update-application-registration
+      summary: Update Registration
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Updates the status of a particular application registration to an API.
+        Approved application registrations will allow API traffic to the
+        corresponding API. Revoked, rejected, or pending will not allow API
+        traffic.
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateApplicationRegistration'
+      responses:
+        '200':
+          $ref: '#/components/responses/UpdateApplicationRegistration'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                UpdateApplicationRegistrationBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/UpdateApplicationRegistrationBadRequestExample1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Application Registrations
+    delete:
+      operationId: delete-application-registration
+      summary: Delete Registration
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Deletes an application registration, which if currently approved will
+        immediately block API traffic to the API.
+
+        Note: Developers can request a new application registration for the
+        given API as long as they have RBAC access to consume.
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Application Registrations
+  '/portals/{portalId}/authentication-settings':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: get-portal-authentication-settings
+      summary: Get Auth Settings
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the developer authentication configuration for a portal, which
+        determines how developers can log in and how they are assigned to teams.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalAuthenticationSettings'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      tags:
+        - Portal Auth Settings
+    patch:
+      operationId: update-portal-authentication-settings
+      summary: Update Auth Settings
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Updates the developer authentication configuration for a portal.
+        Developers can be allowed to login using basic auth (email & password)
+        or use Single-Sign-On (SSO) through an OIDC Identity Provider (IdP).
+        Developers can be automatically assigned to teams by mapping claims from
+        thier IdP account.
+      requestBody:
+        $ref: '#/components/requestBodies/UpdatePortalAuthenticationSettings'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalAuthenticationSettings'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                UpdateAuthSettingsBadRequestExample1:
+                  $ref: '#/components/examples/UpdateAuthSettingsBadRequestExample1'
+                UpdateAuthSettingsBadRequestExample2:
+                  $ref: '#/components/examples/UpdateAuthSettingsBadRequestExample2'
+                UpdateAuthSettingsBadRequestExample3:
+                  $ref: '#/components/examples/UpdateAuthSettingsBadRequestExample3'
+                UpdateAuthSettingsBadRequestExample4:
+                  $ref: '#/components/examples/UpdateAuthSettingsBadRequestExample4'
+                UpdateAuthSettingsBadRequestExample5:
+                  $ref: '#/components/examples/UpdateAuthSettingsBadRequestExample5'
+                UpdateAuthSettingsBadRequestExample6:
+                  $ref: '#/components/examples/UpdateAuthSettingsBadRequestExample6'
+                UpdateAuthSettingsBadRequestExample7:
+                  $ref: '#/components/examples/UpdateAuthSettingsBadRequestExample7'
+                UpdateAuthSettingsBadRequestExample8:
+                  $ref: '#/components/examples/UpdateAuthSettingsBadRequestExample8'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portal Auth Settings
+  '/portals/{portalId}/identity-provider/team-group-mappings':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: list-portal-team-group-mappings
+      summary: List Team Group Mappings
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists mappings between Konnect portal teams and Identity Provider (IdP)
+        groups. Returns a 400 error if an IdP has not yet been configured.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalTeamGroupMappingCollection'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ListTeamGroupMappingsBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/ListTeamGroupMappingsBadRequestExample1
+                ListTeamGroupMappingsBadRequestExample2:
+                  $ref: >-
+                    #/components/examples/ListTeamGroupMappingsBadRequestExample2
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portal Auth Settings
+    patch:
+      operationId: update-portal-team-group-mappings
+      summary: Update Team Group Mappings
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Allows partial updates to the mappings between Konnect portal teams and
+        Identity Provider (IdP) groups. The request body must be keyed on team
+        ID. For a given team ID, the given group list is a complete replacement.
+        To remove all mappings for a given team, provide an empty group list.
+
+        Returns a 400 error if an IdP has not yet been configured, or if a team
+        ID in the request body is not found or is not a UUID.
+      requestBody:
+        $ref: '#/components/requestBodies/UpdatePortalTeamGroupMappings'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalTeamGroupMappingCollection'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                UpdateTeamGroupMappingsBadRequestExample1:
+                  $ref: >-
+                    #/components/examples/UpdateTeamGroupMappingsBadRequestExample1
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portal Auth Settings
+  '/portals/{portalId}/teams':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: list-portal-teams
+      summary: List Teams
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists the developer teams in a portal. Each team can contain any
+        developer and developers can be part of multiple teams.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - name: filter
+          in: query
+          description: Filter teams returned in the response.
+          required: false
+          schema:
+            type: object
+            properties:
+              name:
+                $ref: '#/components/schemas/StringFieldFilter'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListPortalTeams'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Teams
+    post:
+      operationId: create-portal-team
+      summary: Create Team
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Creates a developer team in a portal. Developers can be added to teams
+        to provide RBAC access to API products. Teams can be assigned roles that
+        grant permissions to perform an action on a resource.
+      requestBody:
+        $ref: '#/components/requestBodies/PortalCreateTeam'
+      responses:
+        '201':
+          $ref: '#/components/responses/PortalTeam'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                CreateTeamBadRequestExample1:
+                  $ref: '#/components/examples/CreateTeamBadRequestExample1'
+                CreateTeamBadRequestExample2:
+                  $ref: '#/components/examples/CreateTeamBadRequestExample2'
+                CreateTeamBadRequestExample3:
+                  $ref: '#/components/examples/CreateTeamBadRequestExample3'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Teams
+  '/portals/{portalId}/teams/{teamId}':
+    parameters:
+      - $ref: '#/components/parameters/TeamId'
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: get-portal-team
+      summary: Get Team
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Get an individual team.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalTeam'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Teams
+    patch:
+      operationId: update-portal-team
+      summary: Update Team
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Updates an individual developer team for a portal.
+      requestBody:
+        $ref: '#/components/requestBodies/PortalUpdateTeam'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalTeam'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Teams
+    delete:
+      operationId: delete-portal-team
+      summary: Delete Team
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Deletes a developer team from a portal. Deleting a team also deletes its
+        assigned roles. Members of the team are not deleted, but they will lose
+        any access provided through the team.
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Teams
+  '/portals/{portalId}/teams/{teamId}/developers':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/TeamId'
+    get:
+      operationId: list-portal-team-developers
+      summary: List Team Developers
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        List a team's developers.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - name: filter
+          in: query
+          description: Filter developers returned in the response.
+          required: false
+          schema:
+            type: object
+            properties:
+              email:
+                $ref: '#/components/schemas/StringFieldFilter'
+              full_name:
+                $ref: '#/components/schemas/StringFieldFilter'
+              attributes:
+                $ref: '#/components/schemas/StringFieldFilter'
+              active:
+                $ref: '#/components/schemas/BooleanFieldFilter'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListBasicDevelopers'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Team Membership
+    post:
+      operationId: add-developer-to-portal-team
+      summary: Add Developer to Team
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Adds a developer to a team. This associates them with all of the roles
+        that have been assigned to the team, providing specific permissions to
+        perform actions on resources.
+      requestBody:
+        $ref: '#/components/requestBodies/AddDeveloperToTeam'
+      responses:
+        '201':
+          description: Created
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                AddDeveloperToTeamBadRequestExample1:
+                  $ref: '#/components/examples/AddDeveloperToTeamBadRequestExample1'
+                AddDeveloperToTeamBadRequestExample2:
+                  $ref: '#/components/examples/AddDeveloperToTeamBadRequestExample2'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Portal Team Membership
+  '/portals/{portalId}/teams/{teamId}/developers/{developerId}':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/DeveloperId'
+      - $ref: '#/components/parameters/TeamId'
+    delete:
+      operationId: remove-developer-from-portal-team
+      summary: Remove Developer from Team
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Removes a developer from a team. This removes the association of the
+        team's roles from the developer.
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Team Membership
+  '/portals/{portalId}/teams/{teamId}/assigned-roles':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/TeamId'
+      - $ref: '#/components/parameters/PageSize'
+      - $ref: '#/components/parameters/PageNumber'
+    get:
+      operationId: list-portal-team-roles
+      summary: List Team Roles
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists the roles belonging to a developer team. Each role provides
+        permissions to perform actions on a specified resource or collection.
+      responses:
+        '200':
+          $ref: '#/components/responses/AssignedPortalRoleCollection'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Team Roles
+    post:
+      operationId: assign-role-to-portal-teams
+      summary: Assign Role
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Assign a role to a developer team. This associates the set of
+        permissions in a role with the team, so that they will be applied to any
+        developer who is a member of the team.
+      requestBody:
+        $ref: '#/components/requestBodies/PortalAssignRole'
+      responses:
+        '201':
+          $ref: '#/components/responses/PortalAssignedRole'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                AssignRoleBadRequestExample1:
+                  $ref: '#/components/examples/AssignRoleBadRequestExample1'
+                AssignRoleBadRequestExample2:
+                  $ref: '#/components/examples/AssignRoleBadRequestExample2'
+                AssignRoleBadRequestExample3:
+                  $ref: '#/components/examples/AssignRoleBadRequestExample3'
+                AssignRoleBadRequestExample4:
+                  $ref: '#/components/examples/AssignRoleBadRequestExample4'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Portal Team Roles
+  '/portals/{portalId}/teams/{teamId}/assigned-roles/{roleId}':
+    parameters:
+      - $ref: '#/components/parameters/RoleId'
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/TeamId'
+    delete:
+      operationId: remove-role-from-portal-team
+      summary: Remove Role
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Removes an assigned role from a developer team. This deletes the
+        association of the role with team and each of its members.
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Team Roles
+  '/portals/{portalId}/developers':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: list-portal-developers
+      summary: List Developers
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists the developers that have registered for this portal. Each
+        developer can be registered to one portal and must be approved to login
+        unless using the developer auto-approve setting.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/SortDevelopers'
+        - name: filter
+          in: query
+          description: Filter developers returned in the response.
+          required: false
+          schema:
+            type: object
+            properties:
+              name:
+                $ref: '#/components/schemas/StringFieldFilter'
+              status:
+                $ref: '#/components/schemas/StringFieldFilter'
+              email:
+                $ref: '#/components/schemas/StringFieldFilter'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/ListDevelopers'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                ListDevelopersBadRequestExample1:
+                  $ref: '#/components/examples/ListDevelopersBadRequestExample1'
+                ListDevelopersBadRequestExample2:
+                  $ref: '#/components/examples/ListDevelopersBadRequestExample2'
+                ListDevelopersBadRequestExample3:
+                  $ref: '#/components/examples/ListDevelopersBadRequestExample3'
+                ListDevelopersBadRequestExample4:
+                  $ref: '#/components/examples/ListDevelopersBadRequestExample4'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Developers
+  '/portals/{portalId}/developers/{developerId}':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/DeveloperId'
+    get:
+      operationId: get-developer
+      summary: Fetch Developer
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns information about a single developer in this portal. Each
+        developer manages a set applications, providing them credentials to
+        access registered APIs. Developer registration access can be limited to
+        specific APIs using RBAC.
+      responses:
+        '200':
+          $ref: '#/components/responses/GetDeveloper'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Developers
+    patch:
+      operationId: update-developer
+      summary: Update Developer
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Updates the status of a particular developer. Approved developers have
+        access to login to the portal. Revoked, rejected, or pending are not
+        allowed to login. Even if a developer's status is no longer approved,
+        they will still be able to using any existing credentials generated
+        while they were approved, until each application registration is revoked
+        or deleted.
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateDeveloper'
+      responses:
+        '200':
+          $ref: '#/components/responses/UpdateDeveloper'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestError'
+              examples:
+                UpdateDeveloperBadRequestExample1:
+                  $ref: '#/components/examples/UpdateDeveloperBadRequestExample1'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Developers
+    delete:
+      operationId: delete-developer
+      summary: Delete Developer
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Deletes a developer, which will discontinue their ability to login, view
+        any non-public resources, and delete all applications owned by them. All
+        credentials issued to the developer will no longer provide access to any
+        APIs. A deleted developer's unique email must be re-registered and
+        approved to gain access again.
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Developers
+  '/portals/{portalId}/developers/{developerId}/teams':
+    parameters:
+      - $ref: '#/components/parameters/DeveloperId'
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: list-portal-developer-teams
+      summary: List Developer Teams
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists the teams to which a developer belongs. Each team a developer is a
+        member of grants them various roles that provide permissions to perform
+        actions on certain resources.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListPortalTeams'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Team Membership
+  /portal-roles:
+    get:
+      operationId: list-portal-roles
+      summary: List Portal Roles
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        List roles that can be assigned to teams in a portal. Each role provides
+        a set of permissions to perform an action on a resource.
+      responses:
+        '200':
+          $ref: '#/components/responses/ListRoles'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portal Team Roles
+  '/portals/{portalId}/identity-providers':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+    get:
+      operationId: get-portal-identity-providers
+      summary: Retrieve Identity Providers
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Retrieves the identity providers available within the portal. This
+        operation provides information about
+
+        various identity providers for SAML or OIDC authentication integrations.
+      parameters:
+        - name: filter
+          in: query
+          description: Filter identity providers returned in the response.
+          required: false
+          schema:
+            type: object
+            properties:
+              type:
+                $ref: '#/components/schemas/schemas-StringFieldEqualsFilter'
+          style: deepObject
+      responses:
+        '200':
+          $ref: '#/components/responses/IdentityProviders'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portal Auth Settings
+    post:
+      operationId: create-portal-identity-provider
+      summary: Create Identity Provider
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Creates a new identity provider. This operation allows the creation of a
+        new identity provider for
+
+        authentication purposes.
+      requestBody:
+        $ref: '#/components/requestBodies/CreateIdentityProviderRequest'
+      responses:
+        '201':
+          $ref: '#/components/responses/IdentityProvider'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Portal Auth Settings
+  '/portals/{portalId}/identity-providers/{id}':
+    parameters:
+      - $ref: '#/components/parameters/PortalId'
+      - $ref: '#/components/parameters/IdentityProviderId'
+    get:
+      operationId: get-portal-identity-provider
+      summary: Get Identity Provider
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Retrieves the configuration of a single identity provider. This
+        operation returns information about a
+
+        specific identity provider's settings and authentication integration
+        details.
+      responses:
+        '200':
+          $ref: '#/components/responses/IdentityProvider'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Auth Settings
+    patch:
+      operationId: update-portal-identity-provider
+      summary: Update Identity Provider
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Updates the configuration of an existing identity provider. This
+        operation allows modifications to be made
+
+        to an existing identity provider's configuration.
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateIdentityProviderRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/IdentityProvider'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Auth Settings
+    delete:
+      operationId: delete-portal-identity-provider
+      summary: Delete Identity Provider
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Deletes an existing identity provider configuration. This operation
+        removes a specific identity provider
+
+        from the portal.
+      responses:
+        '204':
+          description: No Content
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Portal Auth Settings
+components:
+  parameters:
+    ApplicationId:
+      name: applicationId
+      in: path
+      required: true
+      description: ID of the application.
+      schema:
+        type: string
+        format: uuid
+    DeveloperId:
+      schema:
+        type: string
+        format: uuid
+        example: d32d905a-ed33-46a3-a093-d8f536af9a8a
+      name: developerId
+      in: path
+      required: true
+      description: ID of the developer.
+    IdentityProviderId:
+      schema:
+        type: string
+        format: uuid
+        example: d32d905a-ed33-46a3-a093-d8f536af9a8a
+      name: id
+      in: path
+      required: true
+      description: ID of the identity provider.
+    PageId:
+      schema:
+        type: string
+        format: uuid
+        example: ebbac5b0-ac89-45c3-9d2e-c4542c657e79
+      name: pageId
+      in: path
+      required: true
+      description: ID of the page.
+    PageNumber:
+      name: 'page[number]'
+      description: Determines which page of the entities to retrieve.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: integer
+        example: 1
+    PageSize:
+      name: 'page[size]'
+      description: >-
+        The maximum number of items to include per page. The last page of a
+        collection may include fewer items.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: integer
+        example: 10
+    PortalId:
+      schema:
+        type: string
+        format: uuid
+      name: portalId
+      in: path
+      required: true
+      description: ID of the portal.
+    RegistrationId:
+      name: registrationId
+      in: path
+      required: true
+      description: ID of the application registration.
+      schema:
+        type: string
+        format: uuid
+    RoleId:
+      schema:
+        type: string
+        format: uuid
+        example: 8350205f-a305-4e39-abe9-bc082a80091a
+      name: roleId
+      in: path
+      required: true
+    SnippetId:
+      schema:
+        type: string
+        format: uuid
+        example: ebbac5b0-ac89-45c3-9d2e-c4542c657e79
+      name: snippetId
+      in: path
+      required: true
+      description: ID of the snippet.
+    SortApplicationRegistrations:
+      name: sort
+      description: >
+        Sorts a set of registrations for an application. Supported sort
+        attributes are:
+          - created_at
+          - updated_at
+          - status
+      in: query
+      required: false
+      schema:
+        type: string
+    SortApplications:
+      name: sort
+      description: |
+        Sorts a collection of applications. Supported sort attributes are:
+          - created_at
+          - developer_id
+          - name
+      in: query
+      required: false
+      schema:
+        type: string
+    SortDevelopers:
+      name: sort
+      description: |
+        Sorts a collection of developers. Supported sort attributes are:
+          - created_at
+          - updated_at
+          - email
+          - name
+          - status
+      in: query
+      required: false
+      schema:
+        type: string
+    SortListAllApplicationRegistrations:
+      name: sort
+      description: >
+        Sorts a collection of application registrations. Supported sort
+        attributes are:
+          - created_at
+          - updated_at
+          - developer_id
+          - status
+      in: query
+      required: false
+      schema:
+        type: string
+    SortPortalPages:
+      name: sort
+      description: |
+        Sorts a collection of portal pages. Supported sort attributes are:
+          - created_at
+          - updated_at
+          - slug
+          - title
+          - visibility
+      in: query
+      required: false
+      schema:
+        type: string
+    SortPortalSnippets:
+      name: sort
+      description: |
+        Sorts a collection of portal snippets. Supported sort attributes are:
+          - created_at
+          - updated_at
+          - name
+          - title
+          - visibility
+      in: query
+      required: false
+      schema:
+        type: string
+    SortPortals:
+      name: sort
+      description: |
+        Sorts a collection of portals. Supported sort attributes are:
+          - name
+          - description
+          - authentication_enabled
+          - rbac_enabled
+          - auto_approve_applications
+          - auto_approve_developers
+          - default_domain
+          - canonical_domain
+          - created_at
+          - updated_at
+      in: query
+      required: false
+      schema:
+        type: string
+    TeamId:
+      schema:
+        type: string
+        format: uuid
+        example: d32d905a-ed33-46a3-a093-d8f536af9a8a
+      name: teamId
+      in: path
+      required: true
+      description: ID of the team.
+  schemas:
+    PortalImageAsset:
+      type: string
+      format: binary
+      example: 'data:image/png;base64,bmljZV9sb29raW5nX3BpY3R1cmU='
+      title: PortalImageAsset
+    ReplacePortalImageAsset:
+      description: >-
+        The image data to upload, along with an optional filename. Images must
+        be a data URL with binary image data in base 64 format. See
+        https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs.
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ImageDataUri'
+        filename:
+          type: string
+          maxLength: 512
+      example:
+        data: 'data:image/jpeg;base64,bmljZV9sb29raW5nX3BpY3R1cmU='
+      additionalProperties: false
+      nullable: true
+      required:
+        - data
+      title: ReplacePortalImageAsset
+    UpdateDeveloperRequest:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/DeveloperStatus'
+      example:
+        status: approved
+      additionalProperties: false
+      title: UpdateDeveloperRequest
+    PortalDeveloper:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        email:
+          type: string
+          format: email
+          maxLength: 255
+        full_name:
+          type: string
+          maxLength: 255
+        status:
+          $ref: '#/components/schemas/DeveloperStatus'
+        application_count:
+          type: number
+          example: 4
+          readOnly: true
+      example:
+        id: 7cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+        email: developer@example.com
+        full_name: Jane Dev
+        status: approved
+        application_count: 3
+        created_at: '2022-11-15T20:37:41.457Z'
+        updated_at: '2022-11-15T20:37:47.456Z'
+      additionalProperties: false
+      required:
+        - id
+        - created_at
+        - updated_at
+        - email
+        - full_name
+        - status
+        - application_count
+      title: PortalDeveloper
+    BasicDeveloper:
+      description: Basic information about a developer.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+          readOnly: true
+        email:
+          type: string
+          format: email
+          example: developer@email.com
+          maxLength: 250
+        full_name:
+          type: string
+          example: API Developer
+          maxLength: 250
+          pattern: '^[\w \W]+$'
+        active:
+          type: boolean
+          example: true
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          example: '2022-02-07T17:46:57.52Z'
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          example: '2022-10-08T17:00:00.52Z'
+          readOnly: true
+      example:
+        id: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+        email: user@email.com
+        full_name: API Developer
+        active: true
+        created_at: '2022-02-07T17:46:57.52Z'
+        updated_at: '2022-10-08T17:00:00.52Z'
+      title: BasicDeveloper
+    ListDevelopersResponse:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalDeveloper'
+      example:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 4
+        data:
+          - id: 8cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+            email: jane.developer@example.com
+            full_name: Jane Dev
+            status: approved
+            application_count: 8
+            created_at: '2022-11-15T20:37:41.457Z'
+            updated_at: '2022-11-15T20:37:47.456Z'
+          - id: 4cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+            email: john.developer@example.com
+            full_name: John Dev
+            status: revoked
+            application_count: 27
+            created_at: '2022-11-15T20:37:41.457Z'
+            updated_at: '2022-11-15T20:37:47.456Z'
+          - id: 6cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+            email: john.developer@example.com
+            full_name: Jim Dev
+            status: pending
+            application_count: 0
+            created_at: '2022-11-15T20:37:41.457Z'
+            updated_at: '2022-11-15T20:37:47.456Z'
+          - id: 7cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+            email: john.developer@example.com
+            full_name: Jan Dev
+            status: rejected
+            application_count: 1
+            created_at: '2022-11-15T20:37:41.457Z'
+            updated_at: '2022-11-15T20:37:47.456Z'
+      additionalProperties: false
+      required:
+        - data
+        - meta
+    DeveloperStatus:
+      description: >-
+        The status of a developer in a portal. Approved developers can log in,
+        create applications, and view and register for products they have access
+        to. Pending, revoked, and rejected developers cannot login or view any
+        non-public portal information, or create or modify applications or
+        registrations.
+      type: string
+      example: approved
+      enum:
+        - approved
+        - pending
+        - revoked
+        - rejected
+      title: DeveloperStatus
+    MovePageRequestPayload:
+      description: move page request payload
+      type: object
+      properties:
+        parent_page_id:
+          description: parent page id
+          type: string
+          format: uuid
+          example: dd4e1b98-3629-4dd3-acc0-759a726ffee2
+        index:
+          description: index of the document in the parent document's children
+          type: integer
+          example: 1
+      title: MovePage
+    PageSlug:
+      description: >-
+        The slug of a page in a portal. Is used to compute the full path
+        /slug1/slug2/slug3.
+      type: string
+      example: /my-page
+      maxLength: 512
+      title: PageSlug
+    ParentPageId:
+      description: >
+        Pages may be rendered as a tree of files.
+
+
+        Specify the `id` of another page as the `parent_page_id` to add some
+        hierarchy to your pages.
+      type: string
+      format: uuid
+      example: null
+      nullable: true
+    PageTitle:
+      description: The title of a page in a portal.
+      type: string
+      example: My Page
+      maxLength: 512
+      title: PageTitle
+    PageContent:
+      description: The renderable markdown content of a page in a portal.
+      type: string
+      example: '# Welcome to My Page'
+      maxLength: 1000000
+      title: PageContent
+    SnippetName:
+      description: The unique name of a snippet in a portal.
+      type: string
+      example: my-snippet
+      maxLength: 512
+      title: SnippetName
+    SnippetTitle:
+      description: The display title of a snippet in a portal.
+      type: string
+      example: My Snippet
+      maxLength: 512
+      title: SnippetTitle
+    SnippetContent:
+      description: The renderable markdown content of a page in a portal.
+      type: string
+      example: '# Welcome to My Snippet'
+      maxLength: 1000000
+      title: SnippetContent
+    VisibilityStatus:
+      description: >-
+        Whether the resource is publicly accessible to non-authenticated users.
+        Defaults to private.
+      type: string
+      example: public
+      enum:
+        - public
+        - private
+      title: VisibilityStatus
+    PublishedStatus:
+      description: Whether the resource is visible on a given portal. Defaults to false.
+      type: string
+      example: published
+      enum:
+        - published
+        - unpublished
+      title: PublishedStatus
+    Description:
+      type: string
+      example: A custom page about developer portals
+      maxLength: 160
+      title: ResourceDescription
+    PageVisibilityStatusWithDefault:
+      description: Whether a page is publicly accessible to non-authenticated users.
+      type: string
+      example: public
+      default: private
+      title: PageVisibilityStatusWithDefault
+    SnippetVisibilityStatusWithDefault:
+      description: Whether a page is publicly accessible to non-authenticated users.
+      type: string
+      example: public
+      default: private
+      title: PageVisibilityStatusWithDefault
+    UpdatePortalPageRequest:
+      description: Update a page in a portal.
+      type: object
+      properties:
+        slug:
+          $ref: '#/components/schemas/PageSlug'
+        title:
+          $ref: '#/components/schemas/PageTitle'
+        content:
+          $ref: '#/components/schemas/PageContent'
+        visibility:
+          $ref: '#/components/schemas/VisibilityStatus'
+        status:
+          $ref: '#/components/schemas/PublishedStatus'
+        description:
+          $ref: '#/components/schemas/Description'
+        parent_page_id:
+          $ref: '#/components/schemas/ParentPageId'
+      additionalProperties: false
+      title: UpdatePortalPageRequest
+    CreatePortalPageRequest:
+      description: Create a page in a portal.
+      type: object
+      properties:
+        slug:
+          $ref: '#/components/schemas/PageSlug'
+        title:
+          $ref: '#/components/schemas/PageTitle'
+        content:
+          $ref: '#/components/schemas/PageContent'
+        visibility:
+          $ref: '#/components/schemas/PageVisibilityStatusWithDefault'
+        status:
+          $ref: '#/components/schemas/PublishedStatus'
+        description:
+          $ref: '#/components/schemas/Description'
+        parent_page_id:
+          $ref: '#/components/schemas/ParentPageId'
+      additionalProperties: false
+      required:
+        - slug
+        - title
+        - content
+      title: CreatePortalPageRequest
+    PortalPageInfo:
+      description: Information about a page in a portal.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        slug:
+          $ref: '#/components/schemas/PageSlug'
+        title:
+          $ref: '#/components/schemas/PageTitle'
+        visibility:
+          $ref: '#/components/schemas/VisibilityStatus'
+        status:
+          $ref: '#/components/schemas/PublishedStatus'
+        description:
+          $ref: '#/components/schemas/Description'
+        parent_page_id:
+          $ref: '#/components/schemas/ParentPageId'
+        children:
+          description: children of the page
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalPageInfo'
+          example:
+            - id: d32d905a-ed33-46a3-a093-d8f536af9a8a
+              slug: hello-world
+              title: Hello world
+              visibility: public
+              created_at: '2023-01-11T02:30:42.227Z'
+              updated_at: '2023-01-11T02:30:42.227Z'
+              status: unpublished
+              parent_page_id: null
+              children: []
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - title
+        - visibility
+        - created_at
+        - updated_at
+        - status
+        - parent_page_id
+        - children
+      title: PortalPageInfo
+    PortalSnippetInfo:
+      description: Information about a snippet in a portal.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        name:
+          $ref: '#/components/schemas/SnippetName'
+        title:
+          $ref: '#/components/schemas/SnippetTitle'
+        visibility:
+          $ref: '#/components/schemas/VisibilityStatus'
+        status:
+          $ref: '#/components/schemas/PublishedStatus'
+        description:
+          $ref: '#/components/schemas/Description'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - title
+        - visibility
+        - status
+        - created_at
+        - updated_at
+      title: PortalSnippetInfo
+    DefaultContent:
+      description: Summary of created default content
+      type: object
+      properties:
+        pages:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      required:
+        - pages
+      title: DefaultContent
+    PortalPageResponse:
+      description: Details about a page in a portal.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        slug:
+          $ref: '#/components/schemas/PageSlug'
+        title:
+          $ref: '#/components/schemas/PageTitle'
+        content:
+          $ref: '#/components/schemas/PageContent'
+        visibility:
+          $ref: '#/components/schemas/VisibilityStatus'
+        status:
+          $ref: '#/components/schemas/PublishedStatus'
+        description:
+          $ref: '#/components/schemas/Description'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        parent_page_id:
+          $ref: '#/components/schemas/ParentPageId'
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - title
+        - content
+        - visibility
+        - status
+        - created_at
+        - updated_at
+        - parent_page_id
+      title: PortalPageResponse
+    ListPortalPagesResponse:
+      description: A paginated list of custom pages in a portal.
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalPageInfo'
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+      example:
+        data:
+          - id: 437c7192-fea0-4f35-8478-c8d57783f8c1
+            slug: /my-page
+            title: My Page
+            visibilit: public
+            status: unpublished
+            description: A custom page
+            created_at: '2021-01-01T00:00:00Z'
+            updated_at: '2021-01-01T00:00:00Z'
+            parent_page_id: null
+            children: []
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 1
+      additionalProperties: false
+      required:
+        - data
+        - meta
+      title: ListPortalPagesResponse
+    PortalSnippetResponse:
+      description: Details about a page in a portal.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        name:
+          $ref: '#/components/schemas/SnippetName'
+        title:
+          $ref: '#/components/schemas/SnippetTitle'
+        content:
+          $ref: '#/components/schemas/SnippetContent'
+        visibility:
+          $ref: '#/components/schemas/VisibilityStatus'
+        status:
+          $ref: '#/components/schemas/PublishedStatus'
+        description:
+          $ref: '#/components/schemas/Description'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - content
+        - visibility
+        - status
+        - created_at
+        - updated_at
+      title: PortalSnippetResponse
+    ListPortalSnippetsResponse:
+      description: A paginated list of custom pages in a portal.
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalSnippetInfo'
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+      example:
+        data:
+          - id: 437c7192-fea0-4f35-8478-c8d57783f8c1
+            name: my-snippet
+            title: My Snippet
+            visibility: public
+            status: published
+            description: A custom snippet
+            created_at: '2021-01-01T00:00:00Z'
+            updated_at: '2021-01-01T00:00:00Z'
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 1
+      additionalProperties: false
+      required:
+        - data
+        - meta
+      title: ListPortalPagesResponse
+    UpdatePortalSnippetRequest:
+      description: Update a snippet in a portal.
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/SnippetName'
+        title:
+          $ref: '#/components/schemas/SnippetTitle'
+        content:
+          $ref: '#/components/schemas/SnippetContent'
+        visibility:
+          $ref: '#/components/schemas/VisibilityStatus'
+        status:
+          $ref: '#/components/schemas/PublishedStatus'
+        description:
+          $ref: '#/components/schemas/Description'
+      additionalProperties: false
+      title: UpdatePortalSnippetRequest
+    CreatePortalSnippetRequest:
+      description: Create a snippet in a portal.
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/SnippetName'
+        title:
+          $ref: '#/components/schemas/SnippetTitle'
+        content:
+          $ref: '#/components/schemas/SnippetContent'
+        visibility:
+          $ref: '#/components/schemas/SnippetVisibilityStatusWithDefault'
+        status:
+          $ref: '#/components/schemas/PublishedStatus'
+        description:
+          $ref: '#/components/schemas/Description'
+      additionalProperties: false
+      required:
+        - name
+        - title
+        - content
+      title: CreatePortalSnippetRequest
+    ListApplicationsResponse:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Application'
+      example:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 2
+        data:
+          - id: b15e2460-ba40-431d-9df0-4957fcffacda
+            labels:
+              env: test
+            name: App 1
+            description: An easy to manage app in a Konnect developer portal
+            registration_count: 2
+            portal:
+              id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+            auth_strategy:
+              id: 85606071-49c7-4c2e-ae49-8a86d72a8110
+              name: API Key
+              credential_type: key_auth
+              key_names:
+                - apikey
+            developers:
+              - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+            created_at: '2022-12-22T19:09:30.712Z'
+            updated_at: '2022-12-22T19:09:30.712Z'
+          - id: b15e2460-ba40-431d-9df0-4957fcffacda
+            labels:
+              env: test
+            name: App 1
+            description: >-
+              A Konnect application that is linked to an Identity Provider
+              application using Dynamic Client Registration (DCR)
+            client_id: yr1k0d9kj3l0cl01hp4o0
+            registration_count: 3
+            portal:
+              id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+            auth_strategy:
+              id: 65606071-49c7-4c2e-ae49-8a86d72a8110
+              name: Client Credentials
+              credential_type: client_credentials
+              auth_methods:
+                - client_credentials
+                - bearer
+                - session
+            dcr_provider:
+              id: 7ea06071-49c7-4c2e-ae49-8a86d72a8110
+            granted_scopes: null
+            developers:
+              - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+            created_at: '2022-12-22T19:07:30.712Z'
+            updated_at: '2022-12-22T19:07:30.712Z'
+      additionalProperties: false
+      required:
+        - data
+        - meta
+    GetApplicationResponse:
+      $ref: '#/components/schemas/Application'
+    ListApplicationRegistrationsResponse:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationRegistration'
+      example:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 2
+        data:
+          - id: c200cc33-2d33-4754-b086-a98e0fcd36fb
+            status: approved
+            application:
+              id: e15e2460-ba40-431d-9df0-4957fcff7cda
+              name: App 1
+            api:
+              id: 56f637b7-cd95-478b-9b02-d770618f641c
+              name: Great Stuff
+              version: v1
+            created_at: '2022-12-22T20:13:07.305Z'
+            updated_at: '2022-12-22T20:13:36.710Z'
+          - id: d200cc33-2d33-4754-b086-a98e0fcd36fb
+            status: rejected
+            application:
+              id: e15e2460-ba40-431d-9df0-4957fcff7cda
+              name: App 2
+            api:
+              id: 56f637b7-cd95-478b-9b02-d770618f641c
+              name: Great Stuff
+              version: v2
+            created_at: '2022-12-22T20:13:07.305Z'
+            updated_at: '2022-12-22T20:13:36.710Z'
+          - id: d300cc33-2d33-4754-b086-a98e0fcd36fb
+            status: pending
+            application:
+              id: e15e2460-ba40-431d-9df0-4957fcff7cda
+              name: App 3
+            api:
+              id: 56f637b7-cd95-478b-9b02-d770618f641c
+              name: Good Stuff
+              version: v2
+            created_at: '2022-12-22T20:13:07.305Z'
+            updated_at: '2022-12-22T20:13:36.710Z'
+          - id: d300cc33-2d33-4754-b086-a98e0fcd36fb
+            status: revoked
+            application:
+              id: e15e2460-ba40-431d-9df0-4957fcff7cda
+              name: App 3
+            api:
+              id: 56f637b7-cd95-478b-9b02-d770618f641c
+              name: Good Stuff
+              version: v1
+            created_at: '2022-12-22T20:13:07.305Z'
+            updated_at: '2022-12-22T20:13:36.710Z'
+      additionalProperties: false
+      required:
+        - data
+        - meta
+      title: ListApplicationRegistrationsResponse
+    GetApplicationRegistrationResponse:
+      $ref: '#/components/schemas/ApplicationRegistration'
+    UpdateApplicationRegistrationResponse:
+      $ref: '#/components/schemas/ApplicationRegistration'
+    ApplicationDevelopers:
+      description: List of developers that have access to this application.
+      type: array
+      items:
+        type: object
+        required:
+          - id
+        properties:
+          id:
+            type: string
+            format: uuid
+      title: ApplicationDevelopers
+    Application:
+      example:
+        id: b15e2460-ba40-431d-9df0-4957fcffacda
+        labels:
+          env: test
+        name: App 1
+        description: An easy to manage app in a Konnect developer portal
+        registration_count: 4
+        portal:
+          id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+        auth_strategy:
+          id: 45606071-49c7-4c2e-ae49-8a86d72a8110
+          name: API Key
+          credential_type: key_auth
+          key_names:
+            - apikey
+        developers:
+          - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+        created_at: '2022-12-22T19:09:30.712Z'
+        updated_at: '2022-12-22T19:09:30.712Z'
+      oneOf:
+        - title: Client Credentials Application
+          additionalProperties: false
+          type: object
+          required:
+            - id
+            - created_at
+            - updated_at
+            - name
+            - description
+            - registration_count
+            - client_id
+            - auth_strategy
+            - dcr_provider
+            - portal
+            - labels
+            - granted_scopes
+            - developers
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            created_at:
+              $ref: '#/components/schemas/CreatedAt'
+            updated_at:
+              $ref: '#/components/schemas/UpdatedAt'
+            name:
+              description: The name of the application.
+              type: string
+            description:
+              description: A description of the application.
+              type: string
+              nullable: true
+            labels:
+              $ref: '#/components/schemas/LabelsUpdate'
+            client_id:
+              description: >-
+                The ID used to linked the portal application to an Identity
+                Provider application.
+              type: string
+              readOnly: true
+            registration_count:
+              description: >-
+                The number of API registrations that are associated with the
+                application. Registrations of any status are included in the
+                count.
+              type: number
+              readOnly: true
+            dcr_provider:
+              description: >-
+                Information about the DCR provider this application uses, if
+                using DCR.
+              type: object
+              additionalProperties: false
+              nullable: true
+              properties:
+                id:
+                  $ref: '#/components/schemas/UUID'
+              required:
+                - id
+            portal:
+              description: Information about the portal the application is in.
+              type: object
+              additionalProperties: false
+              properties:
+                id:
+                  $ref: '#/components/schemas/UUID'
+              required:
+                - id
+            auth_strategy:
+              $ref: '#/components/schemas/AuthStrategyClientCredentials'
+            granted_scopes:
+              description: >-
+                List of granted scopes for the application. Null if application
+                type does not support returning granted scopes.
+              type: array
+              items:
+                type: string
+              nullable: true
+            developers:
+              $ref: '#/components/schemas/ApplicationDevelopers'
+        - title: Key Auth Application
+          example:
+            id: b15e2460-ba40-431d-9df0-4957fcffacda
+            labels:
+              env: test
+            name: App 1
+            description: An easy to manage app in a Konnect developer portal
+            registration_count: 4
+            portal:
+              id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+            auth_strategy:
+              id: 45606071-49c7-4c2e-ae49-8a86d72a8110
+              name: API Key
+              credential_type: key_auth
+              key_names:
+                - apikey
+            developers:
+              - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+            created_at: '2022-12-22T19:09:30.712Z'
+            updated_at: '2022-12-22T19:09:30.712Z'
+          additionalProperties: false
+          type: object
+          required:
+            - id
+            - created_at
+            - updated_at
+            - name
+            - description
+            - auth_strategy
+            - portal
+            - registration_count
+            - labels
+            - developers
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            created_at:
+              $ref: '#/components/schemas/CreatedAt'
+            updated_at:
+              $ref: '#/components/schemas/UpdatedAt'
+            name:
+              description: The name of the application.
+              type: string
+            description:
+              description: A description of the application.
+              type: string
+              nullable: true
+            auth_strategy:
+              $ref: '#/components/schemas/AuthStrategyKeyAuth'
+            portal:
+              description: Information about the portal the application is in.
+              type: object
+              additionalProperties: false
+              properties:
+                id:
+                  $ref: '#/components/schemas/UUID'
+              required:
+                - id
+            labels:
+              $ref: '#/components/schemas/LabelsUpdate'
+            registration_count:
+              description: >-
+                The number of API registrations that are associated with the
+                application. Registrations of any status are included in the
+                count.
+              type: number
+              readOnly: true
+            developers:
+              $ref: '#/components/schemas/ApplicationDevelopers'
+      title: Application
+    ApplicationRegistration:
+      description: A application's registration for a specific version of an API.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        status:
+          $ref: '#/components/schemas/ApplicationRegistrationStatus'
+        api:
+          description: Details about the API the application is registered to.
+          type: object
+          additionalProperties: false
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            name:
+              description: The name of the API the application is registered to.
+              type: string
+            version:
+              description: The version of the API the application is registered to.
+              type: string
+              nullable: true
+          required:
+            - id
+            - name
+            - version
+        application:
+          description: Details about the application the registration is part of.
+          type: object
+          additionalProperties: false
+          properties:
+            id:
+              $ref: '#/components/schemas/UUID'
+            name:
+              description: The name of the application the registration is part of.
+              type: string
+          required:
+            - id
+            - name
+      example:
+        id: c300cc33-2d33-4754-b086-a98e0fcd36fb
+        status: approved
+        application:
+          id: c15e2460-ba40-431d-9df0-4957fcff7cda
+          name: App 1
+        api:
+          id: 86f637b7-cd95-478b-9b02-d770618f641c
+          name: Great Stuff
+          version: v1
+        created_at: '2022-12-22T20:13:07.305Z'
+        updated_at: '2022-12-22T20:13:36.710Z'
+      additionalProperties: false
+      required:
+        - id
+        - created_at
+        - updated_at
+        - status
+        - api
+        - application
+      title: ApplicationRegistration
+    ApplicationRegistrationStatus:
+      description: >-
+        The status of an application registration request. Each registration is
+        linked to a single API, and application credentials will not grant
+        access to the API until the registration is approved.
+
+        Pending, revoked, and rejected registrations will not provide access to
+        the API.
+      type: string
+      example: approved
+      enum:
+        - approved
+        - pending
+        - revoked
+        - rejected
+      title: ApplicationRegistrationStatus
+    UpdateApplicationRegistrationRequest:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/ApplicationRegistrationStatus'
+      example:
+        status: rejected
+      additionalProperties: false
+      title: UpdateApplicationRegistrationRequest
+    PortalFilterParameters:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        name:
+          $ref: '#/components/schemas/StringFieldFilter'
+        description:
+          $ref: '#/components/schemas/StringFieldFilter'
+        authentication_enabled:
+          $ref: '#/components/schemas/BooleanFieldFilter'
+        rbac_enabled:
+          $ref: '#/components/schemas/BooleanFieldFilter'
+        default_api_visibility:
+          $ref: '#/components/schemas/StringFieldFilter'
+        default_page_visibility:
+          $ref: '#/components/schemas/StringFieldFilter'
+        default_application_auth_strategy_id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        auto_approve_developers:
+          $ref: '#/components/schemas/BooleanFieldFilter'
+        auto_approve_applications:
+          $ref: '#/components/schemas/BooleanFieldFilter'
+        default_domain:
+          $ref: '#/components/schemas/StringFieldFilter'
+        canonical_domain:
+          $ref: '#/components/schemas/StringFieldFilter'
+      title: PortalFilterParameters
+    PortalPagesFilterParameters:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        slug:
+          $ref: '#/components/schemas/StringFieldFilter'
+        title:
+          $ref: '#/components/schemas/StringFieldFilter'
+        visibility:
+          $ref: '#/components/schemas/StringFieldFilter'
+        created_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+        updated_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+      additionalProperties: false
+      title: PortalPagesFilterParameters
+    PortalSnippetsFilterParameters:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        name:
+          $ref: '#/components/schemas/StringFieldFilter'
+        title:
+          $ref: '#/components/schemas/StringFieldFilter'
+        visibility:
+          $ref: '#/components/schemas/StringFieldFilter'
+        created_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+        updated_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+      additionalProperties: false
+      title: PortalSnippetsFilterParameters
+    PortalCustomDomain:
+      type: object
+      properties:
+        hostname:
+          type: string
+        enabled:
+          type: boolean
+        ssl:
+          $ref: '#/components/schemas/PortalCustomDomainSSL'
+        cname_status:
+          $ref: '#/components/schemas/PortalCustomDomainCnameStatus'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - hostname
+        - enabled
+        - ssl
+        - cname_status
+        - created_at
+        - updated_at
+      title: PortalCustomDomain
+    PortalCustomDomainSSL:
+      type: object
+      properties:
+        domain_verification_method:
+          $ref: '#/components/schemas/PortalCustomDomainVerificationMethod'
+        verification_status:
+          $ref: '#/components/schemas/PortalCustomDomainVerificationStatus'
+        validation_errors:
+          $ref: '#/components/schemas/PortalCustomDomainValidationErrors'
+      additionalProperties: false
+      required:
+        - domain_verification_method
+        - ownership_verification
+        - verification_status
+      title: PortalCustomDomainSSL
+    CreatePortalCustomDomainSSL:
+      type: object
+      properties:
+        domain_verification_method:
+          $ref: '#/components/schemas/PortalCustomDomainVerificationMethod'
+      additionalProperties: false
+      required:
+        - domain_verification_method
+      title: CreatePortalCustomDomainSSL
+    PortalCustomDomainVerificationMethod:
+      type: string
+      enum:
+        - http
+      title: PortalCustomDomainVerificationMethod
+    PortalCustomDomainVerificationStatus:
+      type: string
+      enum:
+        - verified
+        - pending
+        - error
+      readOnly: true
+      title: PortalCustomDomainVerificationStatus
+    PortalCustomDomainCnameStatus:
+      type: string
+      enum:
+        - verified
+        - pending
+      readOnly: true
+      title: PortalCustomDomainCnameStatus
+    PortalCustomDomainValidationErrors:
+      type: array
+      items:
+        type: string
+      readOnly: true
+      title: PortalCustomDomainValidationErrors
+    CreatePortalCustomDomainRequest:
+      type: object
+      properties:
+        hostname:
+          type: string
+        enabled:
+          type: boolean
+        ssl:
+          $ref: '#/components/schemas/CreatePortalCustomDomainSSL'
+      additionalProperties: false
+      required:
+        - hostname
+        - enabled
+        - ssl
+      title: CreatePortalCustomDomainRequest
+    UpdatePortalCustomDomainRequest:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+      additionalProperties: false
+      title: UpdatePortalCustomDomainRequest
+    PortalClaimMappings:
+      description: Mappings from a portal developer atribute to an Identity Provider claim.
+      type: object
+      properties:
+        name:
+          type: string
+          example: name
+          default: name
+        email:
+          type: string
+          example: email
+          default: email
+        groups:
+          type: string
+          example: custom-group-claim
+          default: groups
+      example:
+        name: name
+        email: email
+        groups: custom-group-claim
+      maxProperties: 3
+      minProperties: 0
+      title: PortalClaimMappings
+    PortalOIDCConfig:
+      description: Configuration properties for an OpenID Connect Identity Provider.
+      type: object
+      properties:
+        issuer:
+          type: string
+          example: 'https://identity.example.com/v2'
+        client_id:
+          type: string
+          example: x7id0o42lklas0blidl2
+        scopes:
+          type: array
+          items:
+            type: string
+            default: openid
+          example:
+            - email
+            - openid
+            - profile
+          default:
+            - email
+            - openid
+            - profile
+        claim_mappings:
+          $ref: '#/components/schemas/PortalClaimMappings'
+      example:
+        issuer: 'https://identity.example.com/v2'
+        client_id: x7id0o42lklas0blidl2
+        scopes:
+          - email
+          - openid
+          - profile
+        claim_mappings:
+          name: name
+          email: email
+          groups: custom-group-claim
+      required:
+        - issuer
+        - client_id
+      title: PortalOIDCConfig
+    PortalAuthenticationSettingsResponse:
+      description: The developer authentication settings for a portal.
+      type: object
+      properties:
+        basic_auth_enabled:
+          description: The portal has basic auth enabled or disabled.
+          type: boolean
+          example: true
+        oidc_auth_enabled:
+          description: The portal has OIDC enabled or disabled.
+          type: boolean
+          example: false
+        saml_auth_enabled:
+          description: The portal has SAML enabled or disabled.
+          type: boolean
+          example: false
+        oidc_team_mapping_enabled:
+          description: IdP groups determine the Portal Teams a developer has.
+          type: boolean
+          example: true
+        idp_mapping_enabled:
+          description: >-
+            IdP groups determine the Portal Teams a developer has. This will
+            soon replace oidc_team_mapping_enabled.
+          type: boolean
+          example: true
+        konnect_mapping_enabled:
+          description: A Konnect Identity Admin assigns teams to a developer.
+          type: boolean
+          example: false
+        oidc_config:
+          $ref: '#/components/schemas/PortalOIDCConfig'
+      example:
+        basic_auth_enabled: true
+        oidc_auth_enabled: true
+        oidc_team_mapping_enabled: true
+        konnect_mapping_enabled: false
+        oidc_config:
+          issuer: 'https://identity.example.com/v2'
+          client_id: x7id0o42lklas0blidl2
+          scopes:
+            - email
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: custom-group-claim
+      required:
+        - basic_auth_enabled
+        - konnect_mapping_enabled
+        - oidc_auth_enabled
+        - oidc_team_mapping_enabled
+      title: PortalAuthenticationSettingsResponse
+    AssignedPortalRoleCollectionResponse:
+      description: A paginated list of roles assigned to a team.
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalAssignedRoleResponse'
+      example:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 3
+        data:
+          - id: b02e23c5-8ee4-4e5a-99f4-43329923adce
+            role_name: API Viewer
+            entity_id: 437c7192-fea0-4f35-8478-c8d57783f8c1
+            entity_type_name: Services
+            entity_region: us
+          - id: b02e23c5-8ee4-4e5a-99f4-43329923adce
+            role_name: API Consumer
+            entity_id: 437c7192-fea0-4f35-8478-c8d57783f8c1
+            entity_type: Services
+            entity_region: us
+          - id: 869d9402-f117-4f9a-840f-69acaf70a81a
+            role_name: API Viewer
+            entity_id: 18ee2573-dec0-4b83-be99-fa7700bcdc61
+            entity_type_name: Services
+            entity_region: us
+      required:
+        - meta
+        - data
+      title: AssignedPortalRoleCollectionResponse
+    ListPortalTeamsResponse:
+      description: A paginated list of teams in a portal.
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalTeamResponse'
+      example:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 3
+        data:
+          - id: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            name: Partner
+            description: Team with access to Partner APIs
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-09-25T13:00:00.00Z'
+          - id: af9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            name: Internal
+            description: Team with access to Internal APIs
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-09-25T13:00:00.00Z'
+          - id: 4f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            name: Root
+            description: Team with access to Internal Systems
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-09-25T13:00:00.00Z'
+      required:
+        - data
+        - meta
+      title: ListPortalTeamsResponse
+    ListRolesResponse:
+      description: >-
+        The set of roles available to associate with resources and assign to
+        teams.
+      type: object
+      properties:
+        services:
+          type: object
+          properties:
+            name:
+              type: string
+              enum:
+                - Services
+            roles:
+              type: object
+              properties:
+                apiviewer:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      enum:
+                        - API Viewer
+                    description:
+                      type: string
+                      enum:
+                        - >-
+                          API Viewers have read-only access to the documentation
+                          of a service in a portal
+                  required:
+                    - name
+                    - description
+                apiconsumer:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      enum:
+                        - API Consumer
+                    description:
+                      type: string
+                      enum:
+                        - API Consumers can make calls to the given service
+                  required:
+                    - name
+                    - description
+              required:
+                - apiviewer
+                - apiconsumer
+          required:
+            - name
+            - roles
+      example:
+        services:
+          name: Services
+          roles:
+            apiviewer:
+              name: API Viewer
+              description: >-
+                API Viewers have read-only access to the documentation of a
+                service in a portal
+            apiconsumer:
+              name: API Consumer
+              description: API Consumers can make calls to the given service
+      required:
+        - services
+      title: ListRolesResponse
+    ListBasicDevelopersResponse:
+      description: A paginated list of basic information about a set of developers.
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/BasicDeveloper'
+      example:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 2
+        data:
+          - id: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            email: james.woods@email.com
+            full_name: James Woods
+            active: true
+            created_at: '2022-08-17T17:46:57.52Z'
+            updated_at: '2022-10-03T17:00:00.00Z'
+          - id: 4f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            email: jill.stone@email.com
+            full_name: Jill Stone
+            active: false
+            created_at: '2022-07-17T17:46:57.52Z'
+            updated_at: '2022-10-03T17:00:00.00Z'
+      title: ListBasicDevelopersResponse
+    AddDeveloperToTeamRequest:
+      description: Add a developer to a team by specifying the developer ID.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: df120cb4-f60b-47bc-a2f8-6a28e6a3c63b
+          writeOnly: true
+      example:
+        id: df120cb4-f60b-47bc-a2f8-6a28e6a3c63b
+      required:
+        - id
+      title: AddDeveloperToTeamRequest
+    PortalAssignRoleRequest:
+      description: An assigned role associates a service and an action to a team.
+      type: object
+      properties:
+        role_name:
+          type: string
+          example: API Viewer
+        entity_id:
+          type: string
+          format: uuid
+          example: e67490ce-44dc-4cbd-b65e-b52c746fc26a
+        entity_type_name:
+          type: string
+          example: Services
+        entity_region:
+          description: Region of the entity.
+          type: string
+          example: eu
+          enum:
+            - us
+            - eu
+            - au
+            - me
+            - in
+            - '*'
+      example:
+        role_name: API Viewer
+        entity_id: 18ee2573-dec0-4b83-be99-fa7700bcdc61
+        entity_type_name: Services
+        entity_region: us
+      title: PortalAssignRoleRequest
+    PortalAuthenticationSettingsUpdateRequest:
+      description: Properties to update a portal's developer auth settings.
+      type: object
+      properties:
+        basic_auth_enabled:
+          description: The organization has basic auth enabled.
+          type: boolean
+          example: true
+        oidc_auth_enabled:
+          description: The organization has OIDC disabled.
+          type: boolean
+          example: false
+        saml_auth_enabled:
+          description: The portal has SAML enabled or disabled.
+          type: boolean
+          example: false
+        oidc_team_mapping_enabled:
+          description: >-
+            Whether IdP groups determine the Konnect Portal teams a developer
+            has.
+          type: boolean
+          example: true
+        konnect_mapping_enabled:
+          description: Whether a Konnect Identity Admin assigns teams to a developer.
+          type: boolean
+          example: false
+        idp_mapping_enabled:
+          description: >-
+            Whether IdP groups determine the Konnect Portal teams a developer
+            has. This will soon replace oidc_team_mapping_enabled.
+          type: boolean
+          example: true
+        oidc_issuer:
+          type: string
+        oidc_client_id:
+          type: string
+        oidc_client_secret:
+          type: string
+        oidc_scopes:
+          type: array
+          items:
+            type: string
+            default: openid
+          default:
+            - email
+            - openid
+            - profile
+        oidc_claim_mappings:
+          $ref: '#/components/schemas/PortalClaimMappings'
+      example:
+        basic_auth_enabled: true
+        oidc_auth_enabled: true
+        oidc_team_mapping_enabled: true
+        konnect_mapping_enabled: false
+        oidc_issuer: 'https://identity.example.com/v2'
+        oidc_client_id: x7id0o42lklas0blidl2
+        oidc_scopes:
+          - email
+          - openid
+          - profile
+        oidc_claim_mappings:
+          name: name
+          email: email
+          groups: custom-group-claim
+      title: PortalAuthenticationSettingsUpdateRequest
+    PortalTeamGroupMappingsUpdateRequest:
+      description: A set of mappings to update from a team to their groups.
+      type: object
+      properties:
+        data:
+          description: The IdP groups to map to the given team.
+          type: array
+          items:
+            type: object
+            properties:
+              team_id:
+                type: string
+                format: uuid
+              groups:
+                type: array
+                items:
+                  type: string
+      example:
+        data:
+          - team_id: af91db4c-6e51-403e-a2bf-33d27ae50c0a
+            groups:
+              - Service Developer
+      title: PortalTeamGroupMappingsUpdateRequest
+    PortalUpdateTeamRequest:
+      description: Properties to update on a team.
+      type: object
+      properties:
+        name:
+          type: string
+          example: IDM - Developers
+          pattern: '^[\w \W]+$'
+          writeOnly: true
+        description:
+          type: string
+          example: The Identity Management (IDM) API team.
+          maxLength: 250
+          writeOnly: true
+      example:
+        name: IDM - Developers
+        description: The Identity Management (IDM) API team.
+      title: PortalUpdateTeamRequest
+    PortalCreateTeamRequest:
+      description: Details about a team to create.
+      type: object
+      properties:
+        name:
+          type: string
+          example: IDM - Developers
+          pattern: '^[\w \W]+$'
+          writeOnly: true
+        description:
+          type: string
+          example: The Identity Management (IDM) team.
+          maxLength: 250
+          writeOnly: true
+      example:
+        name: IDM - Developers
+        description: The Identity Management (IDM) team.
+      required:
+        - name
+      title: PortalCreateTeamRequest
+    PortalTeamResponse:
+      description: Details about a developer team.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+          readOnly: true
+        name:
+          type: string
+          example: IDM - Developers
+          maxLength: 250
+          pattern: '^[\w \W]+$'
+        description:
+          type: string
+          example: The developers for the IDM API.
+          maxLength: 250
+        created_at:
+          type: string
+          format: date-time
+          example: '1992-02-07T17:46:57.52Z'
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          example: '2022-02-07T17:00:00.52Z'
+          readOnly: true
+      example:
+        id: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+        name: IDM - Developers
+        description: The developers for the IDM API.
+        created_at: '1992-02-07T17:46:57.52Z'
+        updated_at: '2022-08-31T17:00:00.52Z'
+      title: PortalTeamResponse
+    PortalTeamGroupMappingResponse:
+      description: A paginated list of portal team group mappings.
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalTeamGroupMapping'
+      example:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 2
+        data:
+          - team_id: 6801e673-cc10-498a-94cd-4271de07a0d3
+            groups:
+              - Tech Leads
+              - API Engineers
+          - team_id: 7301e673-cc10-498a-94cd-4271de07a0d3
+            groups:
+              - Managers
+              - Directors
+      title: PortalTeamGroupMappingResponse
+    PortalTeamGroupMapping:
+      description: A map of portal teams to Identity Provider groups.
+      type: object
+      properties:
+        team_id:
+          description: The Konnect team ID.
+          type: string
+          format: uuid
+          example: 6801e673-cc10-498a-94cd-4271de07a0d3
+        groups:
+          description: The IdP groups that are mapped to the specified team.
+          type: array
+          items:
+            type: string
+            example: API Engineers
+          uniqueItems: true
+      example:
+        team_id: 6801e673-cc10-498a-94cd-4271de07a0d3
+        groups:
+          - Tech Leads
+          - API Engineers
+      title: PortalTeamGroupMapping
+    PortalAssignedRoleResponse:
+      description: An assigned role associates a service and an action to a team.
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: eaf7adf1-32c8-4bbf-b960-d1f8456afe67
+        role_name:
+          type: string
+          example: API Viewer
+        entity_id:
+          type: string
+          format: uuid
+          example: 817d0422-45c9-4d88-8d64-45aef05c1ae7
+        entity_type_name:
+          type: string
+          example: Services
+        entity_region:
+          description: Region of the entity.
+          type: string
+          example: eu
+          enum:
+            - us
+            - eu
+            - au
+            - me
+            - in
+            - '*'
+      example:
+        id: 1a3c2169-27f8-4594-926b-41df3432d5dc
+        role_name: API Viewer
+        entity_id: 18ee2573-dec0-4b83-be99-fa7700bcdc61
+        entity_type_name: Services
+        entity_region: us
+      title: PortalAssignedRoleResponse
+    StringFieldEqualsFilter:
+      description: Filters on the given string field value by exact match.
+      oneOf:
+        - type: string
+        - type: object
+          title: StringFieldEqualsComparison
+          additionalProperties: false
+          properties:
+            eq:
+              type: string
+          required:
+            - eq
+      title: StringFieldEqualsFilter
+      x-examples:
+        example-1: equals-some-value
+        example-2:
+          eq: some-value
+    StringFieldOEQFilter:
+      description: >-
+        Returns entities that exact match any of the comma-delimited phrases in
+        the filter string.
+      type: object
+      properties:
+        oeq:
+          type: string
+      additionalProperties: false
+      required:
+        - oeq
+      title: StringFieldOEQFilter
+      x-examples:
+        example-1:
+          oeq: 'some-value,some-other-value'
+    StringFieldNEQFilter:
+      description: Filters on the given string field value by exact match inequality.
+      type: object
+      properties:
+        neq:
+          type: string
+      additionalProperties: false
+      required:
+        - neq
+      title: StringFieldNEQFilter
+      x-examples:
+        example-1:
+          neq: not-this-value
+    UuidFieldFilter:
+      description: Filters on the given UUID field value by exact match.
+      oneOf:
+        - $ref: '#/components/schemas/StringFieldEqualsFilter'
+        - $ref: '#/components/schemas/StringFieldOEQFilter'
+        - $ref: '#/components/schemas/StringFieldNEQFilter'
+      title: UuidFieldFilter
+      x-examples:
+        example-1: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-2:
+          eq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-3:
+          oeq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-4:
+          neq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+    StringFieldContainsFilter:
+      description: Filters on the given string field value by fuzzy match.
+      type: object
+      properties:
+        contains:
+          type: string
+      additionalProperties: false
+      required:
+        - contains
+      title: StringFieldContainsFilter
+      x-examples:
+        example-1:
+          contains: some-value
+    StringFieldOContainsFilter:
+      description: >-
+        Returns entities that fuzzy-match any of the comma-delimited phrases in
+        the filter string.
+      type: object
+      properties:
+        ocontains:
+          type: string
+      additionalProperties: false
+      required:
+        - ocontains
+      title: StringFieldOContainsFilter
+      x-examples:
+        example-1:
+          ocontains: 'this-value,or-that-value'
+    StringFieldFilter:
+      description: Filters on the given string field value by either exact or fuzzy match.
+      oneOf:
+        - $ref: '#/components/schemas/StringFieldEqualsFilter'
+        - $ref: '#/components/schemas/StringFieldContainsFilter'
+        - $ref: '#/components/schemas/StringFieldOContainsFilter'
+        - $ref: '#/components/schemas/StringFieldOEQFilter'
+        - $ref: '#/components/schemas/StringFieldNEQFilter'
+      title: StringFieldFilter
+      x-examples:
+        example-1: equals-some-value
+        example-2:
+          eq: some-value
+        example-3:
+          contains: some-value
+        example-4:
+          ocontains: 'some-potential,value'
+        example-5:
+          oeq: 'some-potential,value'
+        example-6:
+          neq: not-this-value
+    BooleanFieldFilter:
+      description: Filter by a boolean value (true/false).
+      type: boolean
+      title: BooleanFieldFilter
+      x-examples:
+        example-1: true
+    UUID:
+      description: Contains a unique identifier used for this resource.
+      type: string
+      format: uuid
+      example: 5f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+      readOnly: true
+    CreatedAt:
+      description: An ISO-8601 timestamp representation of entity creation date.
+      type: string
+      format: date-time
+      example: '2022-11-04T20:10:06.927Z'
+      readOnly: true
+    UpdatedAt:
+      description: An ISO-8601 timestamp representation of entity update date.
+      type: string
+      format: date-time
+      example: '2022-11-04T20:10:06.927Z'
+      readOnly: true
+    Labels:
+      description: >
+        Labels store metadata of an entity that can be used for filtering an
+        entity list or for searching across entity types. 
+
+
+        Keys must be of length 1-63 characters, and cannot start with "kong",
+        "konnect", "mesh", "kic", or "_".
+      type: object
+      example:
+        env: test
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+      maxProperties: 50
+      title: Labels
+    PageMeta:
+      description: >-
+        Contains pagination query parameters and the total number of objects
+        returned.
+      type: object
+      properties:
+        number:
+          type: number
+          example: 1
+        size:
+          type: number
+          example: 10
+        total:
+          type: number
+          example: 100
+      required:
+        - number
+        - size
+        - total
+    PaginatedMeta:
+      description: returns the pagination information
+      type: object
+      properties:
+        page:
+          $ref: '#/components/schemas/PageMeta'
+      required:
+        - page
+      title: PaginatedMeta
+    BaseError:
+      description: standard error
+      type: object
+      properties:
+        status:
+          description: >
+            The HTTP status code of the error. Useful when passing the response
+
+            body to child properties in a frontend UI. Must be returned as an
+            integer.
+          type: integer
+          readOnly: true
+        title:
+          description: |
+            A short, human-readable summary of the problem. It should not
+            change between occurences of a problem, except for localization.
+            Should be provided as "Sentence case" for direct use in the UI.
+          type: string
+          readOnly: true
+        type:
+          description: The error type.
+          type: string
+          readOnly: true
+        instance:
+          description: |
+            Used to return the correlation ID back to the user, in the format
+            kong:trace:<correlation_id>. This helps us find the relevant logs
+            when a customer reports an issue.
+          type: string
+          readOnly: true
+        detail:
+          description: >
+            A human readable explanation specific to this occurence of the
+            problem.
+
+            This field may contain request/entity data to help the user
+            understand
+
+            what went wrong. Enclose variable values in square brackets. Should
+            be
+
+            provided as "Sentence case" for direct use in the UI.
+          type: string
+          readOnly: true
+      required:
+        - status
+        - title
+        - instance
+        - detail
+      title: Error
+    InvalidRules:
+      description: invalid parameters rules
+      type: string
+      enum:
+        - required
+        - is_array
+        - is_base64
+        - is_boolean
+        - is_date_time
+        - is_integer
+        - is_null
+        - is_number
+        - is_object
+        - is_string
+        - is_uuid
+        - is_fqdn
+        - is_arn
+        - unknown_property
+        - missing_reference
+        - is_label
+        - matches_regex
+        - invalid
+        - is_supported_network_availability_zone_list
+        - is_supported_network_cidr_block
+        - is_supported_provider_region
+      nullable: true
+      readOnly: true
+    InvalidParameterStandard:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          $ref: '#/components/schemas/InvalidRules'
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+    InvalidParameterMinimumLength:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - min_length
+            - min_digits
+            - min_lowercase
+            - min_uppercase
+            - min_symbols
+            - min_items
+            - min
+          nullable: false
+          readOnly: true
+        minimum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must have at least 8 characters
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - minimum
+    InvalidParameterMaximumLength:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - max_length
+            - max_items
+            - max
+          nullable: false
+          readOnly: true
+        maximum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must not have more than 8 characters
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - maximum
+    InvalidParameterChoiceItem:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - enum
+          nullable: false
+          readOnly: true
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+        choices:
+          type: array
+          items: {}
+          minItems: 1
+          nullable: false
+          readOnly: true
+          uniqueItems: true
+        source:
+          type: string
+          example: body
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - choices
+    InvalidParameterDependentItem:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - dependent_fields
+          nullable: true
+          readOnly: true
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+        dependents:
+          type: array
+          items: {}
+          nullable: true
+          readOnly: true
+          uniqueItems: true
+        source:
+          type: string
+          example: body
+      additionalProperties: false
+      required:
+        - field
+        - rule
+        - reason
+        - dependents
+    InvalidParameters:
+      description: invalid parameters
+      type: array
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/InvalidParameterStandard'
+          - $ref: '#/components/schemas/InvalidParameterMinimumLength'
+          - $ref: '#/components/schemas/InvalidParameterMaximumLength'
+          - $ref: '#/components/schemas/InvalidParameterChoiceItem'
+          - $ref: '#/components/schemas/InvalidParameterDependentItem'
+      minItems: 1
+      nullable: false
+      uniqueItems: true
+    BadRequestError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - invalid_parameters
+          properties:
+            invalid_parameters:
+              $ref: '#/components/schemas/InvalidParameters'
+    UnauthorizedError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 401
+            title:
+              example: Unauthorized
+            type:
+              example: 'https://httpstatuses.com/401'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Invalid credentials
+    ForbiddenError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 403
+            title:
+              example: Forbidden
+            type:
+              example: 'https://httpstatuses.com/403'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Forbidden
+    LabelsUpdate:
+      description: >
+        Labels store metadata of an entity that can be used for filtering an
+        entity list or for searching across entity types. 
+
+
+        Labels are intended to store **INTERNAL** metadata.
+
+
+        Keys must be of length 1-63 characters, and cannot start with "kong",
+        "konnect", "mesh", "kic", or "_".
+      type: object
+      example:
+        env: test
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+        nullable: true
+      maxProperties: 50
+      nullable: true
+      writeOnly: true
+    NotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 404
+            title:
+              example: Not Found
+            type:
+              example: 'https://httpstatuses.com/404'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Not found
+    ConflictError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 409
+            title:
+              example: Conflict
+            type:
+              example: 'https://httpstatuses.com/409'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Conflict
+    ImageDataUri:
+      description: >-
+        must be a data URL with base64 image data, e.g.,
+        data:image/jpeg;base64,<BASE64_IMAGE_DATA>
+      type: string
+      format: uri
+      example: 'data:image/png,YW5faW1hZ2VfZmlsZQ=='
+      pattern: >-
+        ^data:image/(png|jpeg|x-icon|ico|icon|vnd.microsoft.icon|gif)(;base64)?,(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$
+      title: ImageDataUri
+      x-validation-message: >-
+        must be a data URL with base64 image data, e.g.,
+        data:image/jpeg;base64,<BASE64_IMAGE_DATA>
+    PortalMenuItem:
+      type: object
+      properties:
+        path:
+          description: The absolute path of a page in a portal with a leading slash.
+          type: string
+          example: /about/company
+          maxLength: 512
+        title:
+          description: The link display text
+          type: string
+          example: My Page
+        visibility:
+          description: >-
+            Whether a menu item is public or private. Private menu items are
+            only accessible to authenticated users.
+          type: string
+          example: public
+          enum:
+            - public
+            - private
+        external:
+          description: 'When clicked, open the link in a new window'
+          type: boolean
+      additionalProperties: false
+      required:
+        - path
+        - title
+        - visibility
+        - external
+    PortalFooterMenuSection:
+      type: object
+      properties:
+        title:
+          description: The footer menu section title
+          type: string
+          maxLength: 512
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalMenuItem'
+      additionalProperties: false
+      required:
+        - title
+        - items
+    PortalCustomization:
+      description: The custom settings of this portal
+      type: object
+      properties:
+        theme:
+          type: object
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+              nullable: false
+            mode:
+              type: string
+              enum:
+                - light
+                - dark
+                - system
+            colors:
+              type: object
+              additionalProperties: false
+              properties:
+                primary:
+                  type: string
+                  example: '#000000'
+                  nullable: false
+                  pattern: '^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$'
+                  x-validation-message: must be a valid hex color value
+        layout:
+          type: string
+          nullable: false
+        css:
+          type: string
+          nullable: true
+        js:
+          type: object
+          additionalProperties: false
+          properties:
+            custom:
+              type: string
+              nullable: true
+            scripts:
+              type: array
+              items:
+                type: string
+                pattern: '^https://[^:.]+\..+$'
+              maxItems: 20
+        menu:
+          type: object
+          additionalProperties: false
+          properties:
+            main:
+              type: array
+              items:
+                $ref: '#/components/schemas/PortalMenuItem'
+            footer_sections:
+              type: array
+              items:
+                $ref: '#/components/schemas/PortalFooterMenuSection'
+            footer_bottom:
+              type: array
+              items:
+                $ref: '#/components/schemas/PortalMenuItem'
+        spec_renderer:
+          type: object
+          additionalProperties: false
+          properties:
+            try_it_ui:
+              type: boolean
+              default: true
+            try_it_insomnia:
+              type: boolean
+              default: true
+            infinite_scroll:
+              type: boolean
+              default: true
+            show_schemas:
+              type: boolean
+              default: true
+        robots:
+          type: string
+          nullable: true
+      additionalProperties: false
+      title: PortalCustomization
+    DateTimeFieldFilter:
+      description: Filters on the given datetime (RFC-3339) field value.
+      oneOf:
+        - type: string
+          format: date-time
+          description: Value strictly equals given RFC-3339 formatted timestamp in UTC
+          example: '2022-03-30T07:20:50Z'
+        - type: object
+          title: DateTimeFieldEqualsFilter
+          additionalProperties: false
+          properties:
+            eq:
+              description: Value strictly equals given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - eq
+        - type: object
+          title: DateTimeFieldLTFilter
+          additionalProperties: false
+          properties:
+            lt:
+              description: Value is less than the given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - lt
+        - type: object
+          title: DateTimeFieldLTEFilter
+          additionalProperties: false
+          properties:
+            lte:
+              description: >-
+                Value is less than or equal to the given RFC-3339 formatted
+                timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - lte
+        - type: object
+          title: DateTimeFieldGTFilter
+          additionalProperties: false
+          properties:
+            lt:
+              description: >-
+                Value is greater than the given RFC-3339 formatted timestamp in
+                UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - gt
+        - type: object
+          title: DateTimeFieldGTEFilter
+          additionalProperties: false
+          properties:
+            lte:
+              description: >-
+                Value is greater than or equal to the given RFC-3339 formatted
+                timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - gte
+      title: DateTimeFieldFilter
+      x-examples:
+        datetime_field_1: '2022-03-30T07:20:50Z'
+        datetime_field_2:
+          eq: '2022-03-30T07:20:50Z'
+        datetime_field_3:
+          lt: '2022-03-30T07:20:50Z'
+        datetime_field_4:
+          lte: '2022-03-30T07:20:50Z'
+        datetime_field_5:
+          gt: '2022-03-30T07:20:50Z'
+        datetime_field_6:
+          gte: '2022-03-30T07:20:50Z'
+    AuthMethods:
+      type: array
+      items:
+        description: Auth Methods enabled for this strategy
+        type: string
+      example:
+        - bearer
+    AvailableScopes:
+      description: >-
+        Possible developer selectable scopes for an application. Only present
+        when using DCR Provider that supports it.
+      type: array
+      items:
+        type: string
+      example:
+        - scope1
+        - scope2
+    AuthStrategyClientCredentials:
+      description: Client Credential Auth strategy that the application uses.
+      type: object
+      properties:
+        id:
+          description: The Application Auth Strategy ID.
+          type: string
+          format: uuid
+          example: b9e81174-b5bb-4638-a3c3-8afe61a0abf8
+          readOnly: true
+        name:
+          type: string
+          example: name
+          default: name
+        credential_type:
+          type: string
+          enum:
+            - client_credentials
+            - self_managed_client_credentials
+        auth_methods:
+          $ref: '#/components/schemas/AuthMethods'
+        available_scopes:
+          $ref: '#/components/schemas/AvailableScopes'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - credential_type
+        - auth_methods
+    AuthStrategyKeyAuth:
+      description: KeyAuth Auth strategy that the application uses.
+      type: object
+      properties:
+        id:
+          description: The Application Auth Strategy ID.
+          type: string
+          format: uuid
+          example: b9e81174-b5bb-4638-a3c3-8afe61a0abf8
+          readOnly: true
+        name:
+          type: string
+          example: name
+          default: name
+        credential_type:
+          type: string
+          enum:
+            - key_auth
+        key_names:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - credential_type
+        - key_names
+    schemas-StringFieldEqualsFilter:
+      description: Filter a string value by exact match.
+      type: string
+      title: StringFieldEqualsFilter
+    IdentityProviderType:
+      description: Specifies the type of identity provider.
+      type: string
+      example: oidc
+      enum:
+        - oidc
+        - saml
+    IdentityProviderEnabled:
+      description: >
+        Indicates whether the identity provider is enabled. 
+
+        Only one identity provider can be active at a time, such as SAML or
+        OIDC.
+      type: boolean
+      example: true
+      default: false
+      title: Identity Provider Enabled Property
+    OIDCIdentityProviderIssuer:
+      description: >-
+        The issuer URI of the identity provider. This is the URL where the
+        provider's metadata can be obtained.
+      type: string
+      format: uri
+      example: 'https://konghq.okta.com/oauth2/default'
+      title: OIDC Identity Provider Issuer Property
+    OIDCIdentityProviderClientId:
+      description: The client ID assigned to your application by the identity provider.
+      type: string
+      example: YOUR_CLIENT_ID
+      title: OIDC Identity Provider Login Client Id Property
+    OIDCIdentityProviderScopes:
+      description: >-
+        The scopes requested by your application when authenticating with the
+        identity provider.
+      type: array
+      items:
+        type: string
+      default:
+        - email
+        - openid
+        - profile
+      title: OIDC Identity Provider Scopes Property
+    OIDCIdentityProviderClaimMappings:
+      description: >
+        Defines the mappings between OpenID Connect (OIDC) claims and local
+        claims used by your application for 
+
+        authentication.
+      type: object
+      properties:
+        name:
+          description: The claim mapping for the user's name.
+          type: string
+          example: name
+          default: name
+        email:
+          description: The claim mapping for the user's email address.
+          type: string
+          example: email
+          default: email
+        groups:
+          description: The claim mapping for the user's group membership information.
+          type: string
+          example: groups
+          default: groups
+      title: OIDC Claim Mappings
+    OIDCIdentityProviderConfig:
+      description: >-
+        The identity provider that contains configuration data for the OIDC
+        authentication integration.
+      type: object
+      properties:
+        issuer_url:
+          $ref: '#/components/schemas/OIDCIdentityProviderIssuer'
+        client_id:
+          $ref: '#/components/schemas/OIDCIdentityProviderClientId'
+        scopes:
+          $ref: '#/components/schemas/OIDCIdentityProviderScopes'
+        claim_mappings:
+          $ref: '#/components/schemas/OIDCIdentityProviderClaimMappings'
+      additionalProperties: false
+      required:
+        - issuer_url
+        - client_id
+      title: OIDC Identity Provider Config
+    SAMLIdentityProviderMetadataURL:
+      description: >-
+        The identity provider's metadata URL where the identity provider's
+        metadata can be obtained.
+      type: string
+      format: uri
+      example: 'https://mocksaml.com/api/saml/metadata'
+      title: SAML Identity Provider Metadata URL
+    SAMLIdentityProviderMetadata:
+      description: >
+        The identity provider's SAML metadata. If the identity provider supports
+        a metadata URL, you can use the `idp_metadata_url` field instead.
+      type: string
+      example: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+          <!-- SAML metadata content here -->
+        </EntityDescriptor>
+      title: SAML Identity Provider Metadata
+    SAMLIdentityProviderConfig:
+      description: >-
+        The identity provider that contains configuration data for the SAML
+        authentication integration.
+      type: object
+      properties:
+        idp_metadata_url:
+          $ref: '#/components/schemas/SAMLIdentityProviderMetadataURL'
+        idp_metadata_xml:
+          $ref: '#/components/schemas/SAMLIdentityProviderMetadata'
+        sp_metadata_url:
+          type: string
+          format: path
+          example: /api/v2/developer/authenticate/saml/metadata
+          readOnly: true
+        sp_entity_id:
+          description: The entity ID of the service provider (SP).
+          type: string
+          example: 'https://cloud.konghq.com/sp/00000000-0000-0000-0000-000000000000'
+          readOnly: true
+        callback_url:
+          description: >-
+            The path URL where the SAML identity provider sends authentication
+            responses after successful login attempts.
+          type: string
+          format: path
+          example: /api/v2/developer/authenticate/saml/acs
+          readOnly: true
+      additionalProperties: false
+      title: SAML Identity Provider Config
+    IdentityProvider:
+      description: >-
+        The identity provider that contains configuration data for
+        authentication integration.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        type:
+          $ref: '#/components/schemas/IdentityProviderType'
+        enabled:
+          $ref: '#/components/schemas/IdentityProviderEnabled'
+        config:
+          type: object
+          oneOf:
+            - $ref: '#/components/schemas/OIDCIdentityProviderConfig'
+            - $ref: '#/components/schemas/SAMLIdentityProviderConfig'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      title: Identity Provider
+    OIDCIdentityProviderClientSecret:
+      description: The Client Secret assigned to your application by the identity provider.
+      type: string
+      example: YOUR_CLIENT_SECRET
+      title: OIDC Identity Provider Login Client Secret Property
+    ConfigureOIDCIdentityProviderConfig:
+      description: >-
+        The identity provider that contains configuration data for the OIDC
+        authentication integration.
+      type: object
+      properties:
+        issuer_url:
+          $ref: '#/components/schemas/OIDCIdentityProviderIssuer'
+        client_id:
+          $ref: '#/components/schemas/OIDCIdentityProviderClientId'
+        client_secret:
+          $ref: '#/components/schemas/OIDCIdentityProviderClientSecret'
+        scopes:
+          $ref: '#/components/schemas/OIDCIdentityProviderScopes'
+        claim_mappings:
+          $ref: '#/components/schemas/OIDCIdentityProviderClaimMappings'
+      additionalProperties: false
+      required:
+        - issuer_url
+        - client_id
+      title: OIDC Identity Provider Config
+    CreateIdentityProvider:
+      description: >-
+        The identity provider that contains configuration data for creating an
+        authentication integration.
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/IdentityProviderType'
+        config:
+          type: object
+          oneOf:
+            - $ref: '#/components/schemas/ConfigureOIDCIdentityProviderConfig'
+            - $ref: '#/components/schemas/SAMLIdentityProviderConfig'
+      title: Identity Provider
+    UpdateIdentityProvider:
+      description: >-
+        The identity provider that contains configuration data for updating an
+        authentication integration.
+      type: object
+      properties:
+        enabled:
+          $ref: '#/components/schemas/IdentityProviderEnabled'
+        config:
+          type: object
+          oneOf:
+            - $ref: '#/components/schemas/ConfigureOIDCIdentityProviderConfig'
+            - $ref: '#/components/schemas/SAMLIdentityProviderConfig'
+      title: Identity Provider
+  examples:
+    ListDevelopersExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 4
+        data:
+          - id: 8cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+            email: jane.developer@example.com
+            full_name: Jane Dev
+            status: approved
+            application_count: 8
+            created_at: '2022-11-15T20:37:41.457Z'
+            updated_at: '2022-11-15T20:37:47.456Z'
+          - id: 4cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+            email: john.developer@example.com
+            full_name: John Dev
+            status: revoked
+            application_count: 27
+            created_at: '2022-11-15T20:37:41.457Z'
+            updated_at: '2022-11-15T20:37:47.456Z'
+          - id: 6cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+            email: john.developer@example.com
+            full_name: Jim Dev
+            status: pending
+            application_count: 0
+            created_at: '2022-11-15T20:37:41.457Z'
+            updated_at: '2022-11-15T20:37:47.456Z'
+          - id: 7cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+            email: john.developer@example.com
+            full_name: Jan Dev
+            status: rejected
+            application_count: 1
+            created_at: '2022-11-15T20:37:41.457Z'
+            updated_at: '2022-11-15T20:37:47.456Z'
+    GetDeveloperExample1:
+      value:
+        id: 7cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+        email: developer@example.com
+        full_name: Jane Dev
+        status: approved
+        application_count: 3
+        created_at: '2022-11-15T20:37:41.457Z'
+        updated_at: '2022-11-15T20:37:47.456Z'
+    UpdateTeamExample1:
+      value:
+        name: IDM - Developers
+        description: The Identity Management (IDM) API team.
+    CreateTeamExample1:
+      value:
+        name: IDM - Developers
+        description: The Identity Management (IDM) API team.
+    AddDeveloperToTeamExample1:
+      value:
+        id: df120cb4-f60b-47bc-a2f8-6a28e6a3c63b
+    UpdatePortalTeamGroupMappingsExample1:
+      value:
+        data:
+          - team_id: af91db4c-6e51-403e-a2bf-33d27ae50c0a
+            groups:
+              - Service Developer
+          - team_id: bc11db4c-6e51-403e-a2bf-33d27ae50c0a
+            groups:
+              - Service Owner
+    PortalExample1:
+      value:
+        id: 9f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+        created_at: '2022-02-07T17:46:57.52Z'
+        updated_at: '2022-10-08T17:00:00.52Z'
+        name: Portal A
+        display_name: Developer Portal A
+        description: The Portal A
+        default_domain: 123455678abcd.us.portal.konghq.com
+        authentication_enabled: false
+        rbac_enabled: true
+        default_api_visibility: private
+        default_page_visibility: private
+        default_application_auth_strategy_id: 5f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+        auto_approve_applications: false
+        auto_approve_developers: true
+        canonical_domain: api.example.com
+    UpdatePortalExampleRbacEnabled:
+      value:
+        authentication_enabled: true
+        rbac_enabled: true
+    UpdatePortalExampleAuthenticationDisabled:
+      value:
+        authentication_enabled: false
+    UpdatePortalExampleAutoApprove:
+      value:
+        auto_approve_applications: true
+        auto_approve_developers: true
+    UpdatePortalExample1:
+      value:
+        authentication_enabled: false
+        rbac_enabled: false
+        auto_approve_applications: false
+        auto_approve_developers: false
+    CreatePortalExampleRbacEnabled:
+      value:
+        name: MyDevPortal
+        authentication_enabled: true
+        rbac_enabled: true
+    CreatePortalExampleAuthenticationDisabled:
+      value:
+        name: MyDevPortal
+        authentication_enabled: false
+    CreatePortalExampleAutoApprove:
+      value:
+        name: MyDevPortal
+        auto_approve_applications: true
+        auto_approve_developers: true
+    CreatePortalExample1:
+      value:
+        name: MyDevPortal
+        authentication_enabled: true
+        rbac_enabled: true
+        auto_approve_applications: false
+        auto_approve_developers: false
+    ListPortalsExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 1
+        data:
+          - id: 8f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-10-08T17:00:00.52Z'
+            name: Portal A
+            display_name: Developer Portal A
+            description: The Portal A
+            authentication_enabled: false
+            rbac_enabled: true
+            default_api_visibility: private
+            default_page_visibility: private
+            default_application_auth_strategy_id: 5f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            auto_approve_applications: false
+            auto_approve_developers: true
+            default_domain: 123455678abcd.edge.us.portal.konghq.com
+            canonical_domain: 123455678abcd.edge.us.portal.konghq.com
+    ListPortalsBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[size]'
+            rule: is_number
+            reason: '"page[size]" must be a number'
+            source: query
+    ListPortalsBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[number]'
+            rule: is_number
+            reason: '"page[number]" must be a number'
+            source: query
+    ListPortalsBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: sort
+            rule: enum
+            choices:
+              - created_at
+              - updated_at
+            reason: 'must be one of [created_at, updated_at]'
+            source: query
+    UpdatePortalBadRequestExample1:
+      summary: Unknown property
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_property
+            rule: unknown_property
+            reason: '"my_property" is not allowed'
+            source: body
+    UpdatePortalBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: authentication_enabled
+            rule: is_boolean
+            reason: value of "authentication_enabled" must be true or false
+            source: body
+    UpdatePortalBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: rbac_enabled
+            rule: is_boolean
+            reason: value of "rbac_enabled" must be true or false
+            source: body
+    UpdatePortalBadRequestExample4:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: auto_approve_applications
+            rule: is_boolean
+            reason: value of "auto_approve_applications" must be true or false
+            source: body
+    UpdatePortalBadRequestExample5:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: auto_approve_developers
+            rule: is_boolean
+            reason: value of "auto_approve_developers" must be true or false
+            source: body
+    UpdatePortalCustomizationBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_property
+            rule: unknown_property
+            reason: '"my_property" is not allowed'
+            source: body
+    ReplacePortalCustomizationBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_property
+            rule: unknown_property
+            reason: '"my_property" is not allowed'
+            source: body
+    PortalAssetResponseExamplePNG:
+      value: 'data:image/png;base64,bmljZV9sb29raW5nX3BpY3R1cmU='
+    PortalAssetResponseExampleJPEG:
+      value: 'data:image/jpeg;base64,bmljZV9sb29raW5nX3BpY3R1cmU='
+    ReplacePortalImageAssetExample1:
+      value:
+        data: 'data:image/png;base64,bmljZV9sb29raW5nX3BpY3R1cmU='
+        filename: logo.png
+    ReplacePortalImageAssetBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: data
+            rule: required
+            reason: data is required
+            source: body
+    CreatePortalPageExample1:
+      value:
+        title: Getting Started
+        slug: /getting-started
+        content: >-
+          Welcome to the Getting Started page. This is where you can learn how
+          to use our APIs.
+        visibility: public
+        status: published
+    UpdatePortalPageExample1:
+      value:
+        title: About Us
+        slug: /about-us
+        content: >-
+          Welcome to the About Us page. This is where you can learn about our
+          company.
+    PortalPageExample1:
+      value:
+        id: 8f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+        slug: /
+        title: Home
+        content: >-
+          Welcome to the home page of the portal. This is where you can find
+          information about the portal and its APIs.
+        visibility: public
+        status: published
+        created_at: '2022-02-07T17:46:57.52Z'
+        updated_at: '2022-10-08T17:00:00.52Z'
+        parent_page_id: null
+    DefaultContentExample1:
+      value:
+        pages:
+          - /about
+          - /home
+          - /privacy
+    ListPortalPagesExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 1
+        data:
+          - id: 8f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            slug: /
+            title: Home
+            visibility: public
+            status: published
+            description: A custom page
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-10-08T17:00:00.52Z'
+            parent_page_id: null
+            children: []
+    ListPortalPagesBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[size]'
+            rule: is_number
+            reason: '"page[size]" must be a number'
+            source: query
+    ListPortalPagesBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'filter[my_attribute]'
+            rule: unknown_property
+            reason: '"filter[my_attribute]" is not allowed'
+            source: query
+    UpdatePortalPageBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_property
+            rule: unknown_property
+            reason: '"my_property" is not allowed'
+            source: body
+    UpdatePortalPageBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: title
+            rule: max_length
+            reason: value of "title" must not exceed 512 characters
+            source: body
+            maximum: 512
+    CreatePortalSnippetExample1:
+      value:
+        title: Getting Started
+        name: getting-started
+        content: >-
+          Welcome to the Getting Started page. This is where you can learn how
+          to use our APIs.
+        visibility: public
+        status: published
+    UpdatePortalSnippetExample1:
+      value:
+        title: About Us
+        name: about-us
+        content: >-
+          Welcome to the About Us page. This is where you can learn about our
+          company.
+    PortalSnippetExample1:
+      value:
+        id: 8f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+        name: snip1
+        title: Home
+        content: Welcome to the first snippet of the portal.
+        visibility: public
+        status: published
+        created_at: '2022-02-07T17:46:57.52Z'
+        updated_at: '2022-10-08T17:00:00.52Z'
+    ListPortalSnippetsExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 1
+        data:
+          - id: 8f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            name: snip1
+            title: Home
+            visibility: public
+            status: published
+            description: A custom snippet
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-10-08T17:00:00.52Z'
+    ListPortalSnippetsBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[size]'
+            rule: is_number
+            reason: '"page[size]" must be a number'
+            source: query
+    ListPortalSnippetsBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'filter[my_attribute]'
+            rule: unknown_property
+            reason: '"filter[my_attribute]" is not allowed'
+            source: query
+    UpdatePortalSnippetBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_property
+            rule: unknown_property
+            reason: '"my_property" is not allowed'
+            source: body
+    UpdatePortalSnippetBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: title
+            rule: max_length
+            reason: value of "title" must not exceed 512 characters
+            source: body
+            maximum: 512
+    ListApplicationsExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 2
+        data:
+          - id: b15e2460-ba40-431d-9df0-4957fcffacda
+            labels:
+              env: test
+            name: App 1
+            description: An easy to manage app in a Konnect developer portal
+            registration_count: 2
+            portal:
+              id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+            auth_strategy:
+              id: 85606071-49c7-4c2e-ae49-8a86d72a8110
+              name: API Key
+              credential_type: key_auth
+              key_names:
+                - apikey
+            developers:
+              - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+            created_at: '2022-12-22T19:09:30.712Z'
+            updated_at: '2022-12-22T19:09:30.712Z'
+          - id: b15e2460-ba40-431d-9df0-4957fcffacda
+            labels:
+              env: test
+            name: App 1
+            description: >-
+              A Konnect application that is linked to an Identity Provider
+              application using Dynamic Client Registration (DCR)
+            client_id: yr1k0d9kj3l0cl01hp4o0
+            registration_count: 3
+            portal:
+              id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+            auth_strategy:
+              id: 65606071-49c7-4c2e-ae49-8a86d72a8110
+              name: Client Credentials
+              credential_type: client_credentials
+              auth_methods:
+                - client_credentials
+                - bearer
+                - session
+            dcr_provider:
+              id: 7ea06071-49c7-4c2e-ae49-8a86d72a8110
+            granted_scopes: null
+            developers:
+              - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+            created_at: '2022-12-22T19:07:30.712Z'
+            updated_at: '2022-12-22T19:07:30.712Z'
+    GetApplicationExampleBasic:
+      value:
+        id: b15e2460-ba40-431d-9df0-4957fcffacda
+        labels:
+          env: test
+        name: App 1
+        description: An easy to manage app in a Konnect developer portal
+        registration_count: 4
+        portal:
+          id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+        auth_strategy:
+          id: 45606071-49c7-4c2e-ae49-8a86d72a8110
+          name: API Key
+          credential_type: key_auth
+          key_names:
+            - apikey
+        developers:
+          - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+        created_at: '2022-12-22T19:09:30.712Z'
+        updated_at: '2022-12-22T19:09:30.712Z'
+    GetApplicationExampleDcr:
+      value:
+        id: b15e2460-ba40-431d-9df0-4957fcffacda
+        labels:
+          env: test
+        name: App 1
+        description: >-
+          A Konnect application that is linked to an Identity Provider
+          application, where the relationship is managed by Konnect using
+          Dynamic Client Registration (DCR)
+        client_id: yr1k0d9kj3l0cl01hp4o0
+        registration_count: 1
+        portal:
+          id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+        auth_strategy:
+          id: 45606071-49c7-4c2e-ae49-8a86d72a8110
+          name: Client Credentials
+          credential_type: client_credentials
+          auth_methods:
+            - client_credentials
+        dcr_provider:
+          id: 7ea06071-49c7-4c2e-ae49-8a86d72a8110
+        granted_scopes:
+          - openid
+        developers:
+          - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+        created_at: '2022-12-22T19:07:30.712Z'
+        updated_at: '2022-12-22T19:07:30.712Z'
+    GetApplicationExampleOIDC:
+      value:
+        id: b15e2460-ba40-431d-9df0-4957fcffacda
+        labels:
+          env: test
+        name: App 1
+        description: >-
+          A Konnect application that is linked to an Identity Provider
+          application by client_id, but the relationship is not managed by
+          Konnect through DCR
+        client_id: yr1k0d9kj3l0cl01hp4o0
+        registration_count: 1
+        portal:
+          id: 95606071-49c7-4c2e-ae49-8a86d72a8110
+        auth_strategy:
+          id: 45606071-49c7-4c2e-ae49-8a86d72a8110
+          name: Client Credentials
+          credential_type: self_managed_client_credentials
+          auth_methods:
+            - client_credentials
+        dcr_provider: null
+        granted_scopes: null
+        developers:
+          - id: 75606071-49c7-4c2e-ae49-8a86d72a8110
+        created_at: '2022-12-22T19:07:30.712Z'
+        updated_at: '2022-12-22T19:07:30.712Z'
+    ListApplicationRegistrationsExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 2
+        data:
+          - id: c200cc33-2d33-4754-b086-a98e0fcd36fb
+            status: approved
+            application:
+              id: e15e2460-ba40-431d-9df0-4957fcff7cda
+              name: App 1
+            api:
+              id: 56f637b7-cd95-478b-9b02-d770618f641c
+              name: Great Stuff
+              version: v1
+            created_at: '2022-12-22T20:13:07.305Z'
+            updated_at: '2022-12-22T20:13:36.710Z'
+          - id: d200cc33-2d33-4754-b086-a98e0fcd36fb
+            status: rejected
+            application:
+              id: e15e2460-ba40-431d-9df0-4957fcff7cda
+              name: App 2
+            api:
+              id: 56f637b7-cd95-478b-9b02-d770618f641c
+              name: Great Stuff
+              version: v2
+            created_at: '2022-12-22T20:13:07.305Z'
+            updated_at: '2022-12-22T20:13:36.710Z'
+          - id: d300cc33-2d33-4754-b086-a98e0fcd36fb
+            status: pending
+            application:
+              id: e15e2460-ba40-431d-9df0-4957fcff7cda
+              name: App 3
+            api:
+              id: 56f637b7-cd95-478b-9b02-d770618f641c
+              name: Good Stuff
+              version: v2
+            created_at: '2022-12-22T20:13:07.305Z'
+            updated_at: '2022-12-22T20:13:36.710Z'
+          - id: d300cc33-2d33-4754-b086-a98e0fcd36fb
+            status: revoked
+            application:
+              id: e15e2460-ba40-431d-9df0-4957fcff7cda
+              name: App 3
+            api:
+              id: 56f637b7-cd95-478b-9b02-d770618f641c
+              name: Good Stuff
+              version: v1
+            created_at: '2022-12-22T20:13:07.305Z'
+            updated_at: '2022-12-22T20:13:36.710Z'
+    GetApplicationRegistrationExample1:
+      value:
+        id: c300cc33-2d33-4754-b086-a98e0fcd36fb
+        status: approved
+        application:
+          id: c15e2460-ba40-431d-9df0-4957fcff7cda
+          name: App 1
+        api:
+          id: 86f637b7-cd95-478b-9b02-d770618f641c
+          name: Great Stuff
+          version: v1
+        created_at: '2022-12-22T20:13:07.305Z'
+        updated_at: '2022-12-22T20:13:36.710Z'
+    UpdateApplicationRegistrationResponseExample1:
+      value:
+        id: c300cc33-2d33-4754-b086-a98e0fcd36fb
+        status: approved
+        application:
+          id: c15e2460-ba40-431d-9df0-4957fcff7cda
+          name: App 1
+        api:
+          id: 86f637b7-cd95-478b-9b02-d770618f641c
+          name: Great Stuff
+          version: v1
+        created_at: '2022-12-22T20:13:07.305Z'
+        updated_at: '2022-12-22T20:13:36.710Z'
+    ListApplicationsBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[size]'
+            rule: is_number
+            reason: '"page[size]" must be a number'
+            source: query
+    ListApplicationsBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[number]'
+            rule: is_number
+            reason: '"page[number]" must be a number'
+            source: query
+    ListApplicationsBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: sort
+            rule: enum
+            choices:
+              - created_at
+              - developer_id
+              - name
+            reason: 'must be one of [created_at, developer_id, name]'
+            source: query
+    ListApplicationsBadRequestExample4:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'filter[my_attribute]'
+            rule: unknown_property
+            reason: '"filter[my_attribute]" is not allowed'
+            source: query
+    ListApplicationRegistrationsByPortalBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[size]'
+            rule: is_number
+            reason: '"page[size]" must be a number'
+            source: query
+    ListApplicationRegistrationsByPortalBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[number]'
+            rule: is_number
+            reason: '"page[number]" must be a number'
+            source: query
+    ListApplicationRegistrationsByPortalBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: sort
+            rule: enum
+            choices:
+              - created_at
+              - updated_at
+              - developer_id
+              - status
+            reason: 'must be one of [created_at, updated_at, developer_id, status]'
+            source: query
+    ListApplicationRegistrationsByPortalBadRequestExample4:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'filter[my_attribute]'
+            rule: unknown_property
+            reason: '"filter[my_attribute]" is not allowed'
+            source: query
+    ListRegistrationsByApplicationBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[size]'
+            rule: is_number
+            reason: '"page[size]" must be a number'
+            source: query
+    ListRegistrationsByApplicationBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[number]'
+            rule: is_number
+            reason: '"page[number]" must be a number'
+            source: query
+    ListRegistrationsByApplicationBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: sort
+            rule: enum
+            choices:
+              - created_at
+              - updated_at
+              - status
+            reason: 'must be one of [created_at, updated_at, status]'
+            source: query
+    ListRegistrationsByApplicationBadRequestExample4:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'filter[my_attribute]'
+            rule: unknown_property
+            reason: '"filter[my_attribute]" is not allowed'
+            source: query
+    UpdateApplicationRegistrationBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_property
+            rule: unknown_property
+            reason: '"my_property" is not allowed'
+            source: body
+    UpdateApplicationRegistrationApproved:
+      value:
+        status: approved
+    UpdateApplicationRegistrationPending:
+      value:
+        status: pending
+    UpdateApplicationRegistrationRejected:
+      value:
+        status: rejected
+    UpdateApplicationRegistrationRevoked:
+      value:
+        status: revoked
+    UpdateDeveloperExampleApproved:
+      value:
+        status: approved
+    UpdateDeveloperExamplePending:
+      value:
+        status: pending
+    UpdateDeveloperExampleRejected:
+      value:
+        status: rejected
+    UpdateDeveloperExampleRevoked:
+      value:
+        status: revoked
+    PortalTeamGroupMappingCollectionExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 2
+        data:
+          - team_id: 6801e673-cc10-498a-94cd-4271de07a0d3
+            groups:
+              - Tech Leads
+              - API Engineers
+          - team_id: 7301e673-cc10-498a-94cd-4271de07a0d3
+            groups:
+              - Managers
+              - Directors
+    PortalAuthenticationSettingsExample1:
+      value:
+        basic_auth_enabled: true
+        oidc_auth_enabled: true
+        saml_auth_enabled: true
+        oidc_team_mapping_enabled: true
+        konnect_mapping_enabled: true
+        idp_mapping_enabled: true
+        oidc_config:
+          issuer: 'https://identity.example.com/v2'
+          client_id: x7id0o42lklas0blidl2
+          scopes:
+            - email
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: custom-group-claim
+    PortalAssignedRoleUSExample:
+      value:
+        id: 1a3c2169-27f8-4594-926b-41df3432d5dc
+        role_name: API Viewer
+        entity_id: 18ee2573-dec0-4b83-be99-fa7700bcdc61
+        entity_type_name: Services
+        entity_region: us
+    PortalAssignedRoleAllRegionsExample:
+      value:
+        id: 034cb810-1f2d-40d2-a1ce-31944144668e
+        role_name: API Consumer
+        entity_id: 18ee2573-dec0-4b83-be99-fa7700bcdc61
+        entity_type_name: Services
+        entity_region: '*'
+    PortalTeamExample1:
+      value:
+        id: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+        name: Gold Tier
+        description: Team with access to APIs in the Gold tier
+        created_at: '2022-02-07T17:46:57.52Z'
+        updated_at: '2022-09-25T13:00:00.00Z'
+    AssignedPortalRoleCollectionExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 3
+        data:
+          - id: b02e23c5-8ee4-4e5a-99f4-43329923adce
+            role_name: API Viewer
+            entity_id: 437c7192-fea0-4f35-8478-c8d57783f8c1
+            entity_type_name: Services
+            entity_region: us
+          - id: b02e23c5-8ee4-4e5a-99f4-43329923adce
+            role_name: API Consumer
+            entity_id: 437c7192-fea0-4f35-8478-c8d57783f8c1
+            entity_type: Services
+            entity_region: us
+          - id: 869d9402-f117-4f9a-840f-69acaf70a81a
+            role_name: API Viewer
+            entity_id: 18ee2573-dec0-4b83-be99-fa7700bcdc61
+            entity_type_name: Services
+            entity_region: us
+    ListPortalTeamsExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 3
+        data:
+          - id: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            name: Partner
+            description: Team with access to Partner APIs
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-09-25T13:00:00.00Z'
+          - id: af9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            name: Internal
+            description: Team with access to Internal APIs
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-09-25T13:00:00.00Z'
+          - id: 4f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            name: Root
+            description: Team with access to Internal Systems
+            created_at: '2022-02-07T17:46:57.52Z'
+            updated_at: '2022-09-25T13:00:00.00Z'
+    ListRolesExample1:
+      value:
+        services:
+          name: Services
+          roles:
+            apiviewer:
+              name: API Viewer
+              description: >-
+                API Viewers have read-only access to the documentation of a
+                service in a portal
+            apiconsumer:
+              name: API Consumer
+              description: API Consumers can make calls to the given service
+    ListBasicDevelopersExample1:
+      value:
+        meta:
+          page:
+            number: 1
+            size: 10
+            total: 2
+        data:
+          - id: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            email: james.woods@email.com
+            full_name: James Woods
+            active: true
+            created_at: '2022-08-17T17:46:57.52Z'
+            updated_at: '2022-10-03T17:00:00.00Z'
+          - id: 4f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+            email: jill.stone@email.com
+            full_name: Jill Stone
+            active: false
+            created_at: '2022-07-17T17:46:57.52Z'
+            updated_at: '2022-10-03T17:00:00.00Z'
+    UpdateAuthSettingsBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: basic_auth_enabled
+            rule: is_boolean
+            reason: value of "basic_auth_enabled" must be true or false
+            source: body
+    UpdateAuthSettingsBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: oidc_auth_enabled
+            rule: is_boolean
+            reason: value of "oidc_auth_enabled" must be true or false
+            source: body
+    UpdateAuthSettingsBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: oidc_team_mapping_enabled
+            rule: is_boolean
+            reason: value of "oidc_team_mapping_enabled" must be true or false
+            source: body
+    UpdateAuthSettingsBadRequestExample4:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: konnect_mapping_enabled
+            rule: is_boolean
+            reason: value of "konnect_mapping_enabled" must be true or false
+            source: body
+    UpdateAuthSettingsBadRequestExample5:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: oidc_issuer
+            rule: is_string
+            reason: value of "oidc_issuer" must be a utf-8 string
+            source: body
+    UpdateAuthSettingsBadRequestExample6:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: oidc_client_id
+            rule: is_string
+            reason: value of "oidc_client_id" must be a utf-8 string
+            source: body
+    UpdateAuthSettingsBadRequestExample7:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: oidc_client_secret
+            rule: is_string
+            reason: value of "oidc_client_secret" must be a utf-8 string
+            source: body
+    UpdateAuthSettingsBadRequestExample8:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: oidc_scopes
+            rule: is_array
+            reason: '"oidc_scopes" must be an array'
+            source: body
+    ListTeamGroupMappingsBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[size]'
+            rule: is_number
+            reason: '"page[size]" must be a number'
+            source: query
+    ListTeamGroupMappingsBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[number]'
+            rule: is_number
+            reason: '"page[number]" must be a number'
+            source: query
+    UpdateTeamGroupMappingsBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: data
+            rule: is_array
+            reason: '"data" must be an array'
+            source: body
+    CreateTeamBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_attribute
+            rule: required
+            reason: '"my_attribute" is required'
+            source: body
+    CreateTeamBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: name
+            rule: is_string
+            reason: value of "name" must be a utf-8 string
+            source: body
+    CreateTeamBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: description
+            rule: max_length
+            reason: value of "description" must not exceed 250 characters
+            source: body
+            maximum: 250
+    AddDeveloperToTeamBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_attribute
+            rule: required
+            reason: '"my_attribute" is required'
+            source: body
+    AddDeveloperToTeamBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: id
+            rule: is_uuid
+            reason: value of "id" must be a UUID
+            source: body
+    AssignRoleBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: role_name
+            rule: is_string
+            reason: value of "role_name" must be a utf-8 string
+            source: body
+    AssignRoleBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: entity_id
+            rule: is_uuid
+            reason: value of "entity_id" must be a UUID
+            source: body
+    AssignRoleBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: entity_type_name
+            rule: is_string
+            reason: value of "entity_type_name" must be a utf-8 string
+            source: body
+    AssignRoleBadRequestExample4:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: entity_region
+            rule: enum
+            choices:
+              - us
+              - eu
+              - au
+              - me
+              - in
+              - '*'
+            reason: 'must be one of [us, eu, au, me, in, *]'
+            source: body
+    ListDevelopersBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[size]'
+            rule: is_number
+            reason: '"page[size]" must be a number'
+            source: query
+    ListDevelopersBadRequestExample2:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'page[number]'
+            rule: is_number
+            reason: '"page[number]" must be a number'
+            source: query
+    ListDevelopersBadRequestExample3:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: sort
+            rule: enum
+            choices:
+              - created_at
+              - updated_at
+              - email
+              - name
+              - status
+            reason: 'must be one of [created_at, updated_at, email, name, status]'
+            source: query
+    ListDevelopersBadRequestExample4:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: 'filter[my_attribute]'
+            rule: unknown_property
+            reason: '"filter[my_attribute]" is not allowed'
+            source: query
+    UpdateDeveloperResponseExample1:
+      value:
+        id: 7cd9feff-b4da-4a9f-ba49-cbe83c75ff22
+        email: developer@example.com
+        full_name: Jane Dev
+        status: approved
+        application_count: 3
+        created_at: '2022-11-15T20:37:41.457Z'
+        updated_at: '2022-11-15T20:37:47.456Z'
+    UpdateDeveloperBadRequestExample1:
+      value:
+        status: 400
+        title: Invalid Request
+        instance: 'kong:trace:1433447772874964729'
+        detail: Invalid Parameters
+        invalid_parameters:
+          - field: my_property
+            rule: unknown_property
+            reason: '"my_property" is not allowed'
+            source: body
+    UpdatePortalAuthenticationSettingsExample1:
+      value:
+        basic_auth_enabled: true
+        oidc_auth_enabled: true
+        saml_auth_enabled: true
+        oidc_team_mapping_enabled: true
+        konnect_mapping_enabled: false
+        idp_mapping_enabled: true
+        oidc_issuer: 'https://identity.example.com/v2'
+        oidc_client_id: x7id0o42lklas0blidl2
+        oidc_scopes:
+          - email
+          - openid
+          - profile
+        oidc_claim_mappings:
+          name: name
+          email: email
+          groups: custom-group-claim
+    UpdatePortalAuthenticationSettingsExampleDisableBasicAuth:
+      value:
+        basic_auth_enabled: false
+    UpdatePortalAuthenticationSettingsExampleEnableOIDC:
+      value:
+        oidc_auth_enabled: true
+        oidc_team_mapping_enabled: false
+        konnect_mapping_enabled: true
+        oidc_issuer: 'https://identity.example.com/v2'
+        oidc_client_id: x7id0o42lklas0blidl2
+        oidc_scopes:
+          - email
+          - openid
+          - profile
+        oidc_claim_mappings:
+          name: name
+          email: email
+          groups: custom-group-claim
+    UpdatePortalAuthenticationSettingsExampleEnableOIDCTeamMapping:
+      value:
+        oidc_team_mapping_enabled: true
+        konnect_mapping_enabled: true
+        oidc_claim_mappings:
+          name: name
+          email: email
+          groups: custom-group-claim
+    PortalAssignRoleExampleViewer:
+      value:
+        role_name: API Viewer
+        entity_id: 18ee2573-dec0-4b83-be99-fa7700bcdc61
+        entity_type_name: Services
+        entity_region: us
+    PortalAssignRoleExampleConsumer:
+      value:
+        role_name: API Consumer
+        entity_id: 18ee2573-dec0-4b83-be99-fa7700bcdc61
+        entity_type_name: Services
+        entity_region: us
+    UnauthorizedExample:
+      value:
+        status: 401
+        title: Unauthorized
+        instance: 'kong:trace:8347343766220159418'
+        detail: Unauthorized
+    ForbiddenExample:
+      value:
+        status: 403
+        title: Forbidden
+        instance: 'kong:trace:2723154947768991354'
+        detail: You do not have permission to perform this action
+    NotFoundExample:
+      value:
+        status: 404
+        title: Not Found
+        instance: 'kong:trace:6816496025408232265'
+        detail: Not Found
+    IdentityProviders:
+      value:
+        - id: a2c3156d-ebb1-432b-b2f1-edcc5f133c60
+          type: saml
+          enabled: true
+          config:
+            idp_metadata_url: 'https://mocksaml.com/api/saml/metadata'
+            sp_entity_id: 'https://cloud.konghq.com/sp/00000000-0000-0000-0000-000000000000'
+            sp_metadata_url: /api/v2/developer/authenticate/saml/metadata
+            callback_url: /api/v2/developer/authenticate/saml/acs
+          created_at: '2022-02-07T17:46:57.52Z'
+          updated_at: '2022-02-07T17:46:57.52Z'
+        - id: 66da2d42-469d-48cd-9ff3-0db135dd82d8
+          type: oidc
+          enabled: false
+          config:
+            issuer_url: 'https://konghq.okta.com/oauth2/default'
+            client_id: 0oaqhb43ckTZ02j1F357
+            scopes:
+              - openid
+              - email
+              - profile
+            claim_mappings:
+              email: email
+              name: name
+              groups: groups
+          created_at: '2022-02-07T17:46:57.52Z'
+          updated_at: '2022-02-07T17:46:57.52Z'
+    CreateOIDCIdentityProvider:
+      value:
+        type: oidc
+        config:
+          issuer_url: 'https://konghq.okta.com/oauth2/default'
+          client_id: 0oaqhb43ckTZ02j1F357
+          client_secret: BbqwI8xP9E4evOK
+          scopes:
+            - openid
+            - email
+            - profile
+          claim_mappings:
+            email: email
+            name: name
+            groups: groups
+    CreateSAMLIdentityProviderWithMetadataURL:
+      value:
+        type: saml
+        config:
+          idp_metadata_url: 'https://mocksaml.com/api/saml/metadata'
+    CreateSAMLIdentityProviderWithMetadata:
+      value:
+        type: saml
+        config:
+          idp_metadata_xml: |
+            <?xml version="1.0" encoding="UTF-8"?>
+            <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+            <!-- SAML metadata content here -->
+            </EntityDescriptor>
+    OIDCIdentityProvider:
+      value:
+        id: 66da2d42-469d-48cd-9ff3-0db135dd82d8
+        type: oidc
+        enabled: false
+        config:
+          issuer_url: 'https://konghq.okta.com/oauth2/default'
+          client_id: 0oaqhb43ckTZ02j1F357
+          scopes:
+            - openid
+            - email
+            - profile
+          claim_mappings:
+            email: email
+            name: name
+            groups: groups
+        created_at: '2022-02-07T17:46:57.52Z'
+        updated_at: '2022-02-07T17:46:57.52Z'
+    SAMLIdentityProvider:
+      value:
+        id: a2c3156d-ebb1-432b-b2f1-edcc5f133c60
+        type: saml
+        enabled: true
+        config:
+          idp_metadata_url: 'https://mocksaml.com/api/saml/metadata'
+          sp_entity_id: 'https://cloud.konghq.com/sp/00000000-0000-0000-0000-000000000000'
+          sp_metadata_url: /api/v2/developer/authenticate/saml/metadata
+          callback_url: /api/v2/developer/authenticate/saml/acs
+        created_at: '2022-02-07T17:46:57.52Z'
+        updated_at: '2022-02-07T17:46:57.52Z'
+    SAMLIdentityProviderWithMetadata:
+      value:
+        id: a2c3156d-ebb1-432b-b2f1-edcc5f133c60
+        type: saml
+        enabled: true
+        config:
+          idp_metadata_xml: |
+            <?xml version="1.0" encoding="UTF-8"?>
+            <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+            <!-- SAML metadata content here -->
+            </EntityDescriptor>
+          sp_entity_id: 'https://cloud.konghq.com/sp/00000000-0000-0000-0000-000000000000'
+          sp_metadata_url: /api/v2/developer/authenticate/saml/metadata
+          callback_url: /api/v2/developer/authenticate/saml/acs
+        created_at: '2022-02-07T17:46:57.52Z'
+        updated_at: '2022-02-07T17:46:57.52Z'
+    UpdateOIDCIdentityProvider:
+      value:
+        enabled: true
+        config:
+          issuer_url: 'https://konghq.okta.com/oauth2/default'
+          client_id: 0oaqhb43ckTZ02j1F357
+          client_secret: BbqwI8xP9E4evOK
+          scopes:
+            - openid
+            - email
+            - profile
+          claim_mappings:
+            email: email
+            name: name
+            groups: groups
+    UpdateSAMLIdentityProvider:
+      value:
+        enabled: true
+        config:
+          idp_metadata_url: 'https://mocksaml.com/api/saml/metadata'
+  requestBodies:
+    CreatePortalCustomDomain:
+      description: Create a portal custom domain.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatePortalCustomDomainRequest'
+    UpdatePortalCustomDomain:
+      description: Create a portal custom domain.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdatePortalCustomDomainRequest'
+    CreatePortal:
+      description: Create a portal.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                $ref: '#/components/schemas/UUID'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+              name:
+                description: >-
+                  The name of the portal, used to distinguish it from other
+                  portals. Name must be unique.
+                type: string
+                maxLength: 255
+                minLength: 1
+              display_name:
+                description: >-
+                  The display name of the portal. This value will be the
+                  portal's `name` in Portal API.
+                type: string
+                maxLength: 255
+                minLength: 1
+              description:
+                description: A description of the portal.
+                type: string
+                maxLength: 512
+                nullable: true
+              authentication_enabled:
+                description: >-
+                  Whether the portal supports developer authentication. If
+                  disabled, developers cannot register for accounts or create
+                  applications.
+                type: boolean
+                default: true
+              rbac_enabled:
+                description: >-
+                  Whether the portal resources are protected by Role Based
+                  Access Control (RBAC). If enabled, developers view or register
+                  for APIs until unless assigned to teams with access to view
+                  and consume specific APIs. Authentication must be enabled to
+                  use RBAC.
+                type: boolean
+                default: false
+              default_api_visibility:
+                description: >-
+                  The default visibility of APIs in the portal. If set to
+                  `public`, newly published APIs are visible to unauthenticated
+                  developers. If set to `private`, newly published APIs are
+                  hidden from unauthenticated developers.
+                type: string
+                enum:
+                  - public
+                  - private
+              default_page_visibility:
+                description: >-
+                  The default visibility of pages in the portal. If set to
+                  `public`, newly created pages are visible to unauthenticated
+                  developers. If set to `private`, newly created pages are
+                  hidden from unauthenticated developers.
+                type: string
+                enum:
+                  - public
+                  - private
+              default_application_auth_strategy_id:
+                description: >-
+                  The default authentication strategy for APIs published to the
+                  portal. Newly published APIs will use this authentication
+                  strategy unless overridden during publication. If set to
+                  `null`, API publications will not use an authentication
+                  strategy unless set during publication. DCR support for Auth
+                  Strategies is currently in development.
+                type: string
+                format: uuid
+                nullable: true
+              auto_approve_developers:
+                description: >-
+                  Whether developer account registrations will be automatically
+                  approved, or if they will be set to pending until approved by
+                  an admin.
+                type: boolean
+                default: false
+              auto_approve_applications:
+                description: >-
+                  Whether requests from applications to register for APIs will
+                  be automatically approved, or if they will be set to pending
+                  until approved by an admin.
+                type: boolean
+                default: false
+              default_domain:
+                description: >-
+                  The domain assigned to the portal by Konnect. This is the
+                  default place to access the portal and its API if not using a
+                  `custom_domain``.
+                type: string
+                format: hostname
+                readOnly: true
+              canonical_domain:
+                description: The canonical domain of the developer portal
+                type: string
+                format: hostname
+                nullable: false
+                readOnly: true
+              labels:
+                $ref: '#/components/schemas/LabelsUpdate'
+            additionalProperties: false
+            required:
+              - name
+            title: Portal
+          examples:
+            Example 1:
+              $ref: '#/components/examples/CreatePortalExample1'
+            Authentication Disabled:
+              $ref: '#/components/examples/CreatePortalExampleAuthenticationDisabled'
+            Enable RBAC:
+              $ref: '#/components/examples/CreatePortalExampleRbacEnabled'
+            Auto Approve Settings:
+              $ref: '#/components/examples/CreatePortalExampleAutoApprove'
+    UpdatePortal:
+      description: Update a portal's settings.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                $ref: '#/components/schemas/UUID'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+              name:
+                description: >-
+                  The name of the portal, used to distinguish it from other
+                  portals. Name must be unique.
+                type: string
+                maxLength: 255
+                minLength: 1
+              display_name:
+                description: >-
+                  The display name of the portal. This value will be the
+                  portal's `name` in Portal API.
+                type: string
+                maxLength: 255
+                minLength: 1
+              description:
+                description: A description of the portal.
+                type: string
+                maxLength: 512
+                nullable: true
+              authentication_enabled:
+                description: >-
+                  Whether the portal supports developer authentication. If
+                  disabled, developers cannot register for accounts or create
+                  applications.
+                type: boolean
+                default: true
+              rbac_enabled:
+                description: >-
+                  Whether the portal resources are protected by Role Based
+                  Access Control (RBAC). If enabled, developers view or register
+                  for APIs until unless assigned to teams with access to view
+                  and consume specific APIs. Authentication must be enabled to
+                  use RBAC.
+                type: boolean
+                default: false
+              default_api_visibility:
+                description: >-
+                  The default visibility of APIs in the portal. If set to
+                  `public`, newly published APIs are visible to unauthenticated
+                  developers. If set to `private`, newly published APIs are
+                  hidden from unauthenticated developers.
+                type: string
+                enum:
+                  - public
+                  - private
+              default_page_visibility:
+                description: >-
+                  The default visibility of pages in the portal. If set to
+                  `public`, newly created pages are visible to unauthenticated
+                  developers. If set to `private`, newly created pages are
+                  hidden from unauthenticated developers.
+                type: string
+                enum:
+                  - public
+                  - private
+              default_application_auth_strategy_id:
+                description: >-
+                  The default authentication strategy for APIs published to the
+                  portal. Newly published APIs will use this authentication
+                  strategy unless overridden during publication. If set to
+                  `null`, API publications will not use an authentication
+                  strategy unless set during publication. DCR support for Auth
+                  Strategies is currently in development.
+                type: string
+                format: uuid
+                nullable: true
+              auto_approve_developers:
+                description: >-
+                  Whether developer account registrations will be automatically
+                  approved, or if they will be set to pending until approved by
+                  an admin.
+                type: boolean
+                default: false
+              auto_approve_applications:
+                description: >-
+                  Whether requests from applications to register for APIs will
+                  be automatically approved, or if they will be set to pending
+                  until approved by an admin.
+                type: boolean
+                default: false
+              default_domain:
+                description: >-
+                  The domain assigned to the portal by Konnect. This is the
+                  default place to access the portal and its API if not using a
+                  `custom_domain``.
+                type: string
+                format: hostname
+                readOnly: true
+              canonical_domain:
+                description: The canonical domain of the developer portal
+                type: string
+                format: hostname
+                nullable: false
+                readOnly: true
+              labels:
+                $ref: '#/components/schemas/LabelsUpdate'
+            additionalProperties: false
+            title: Portal
+          examples:
+            Example 1:
+              $ref: '#/components/examples/UpdatePortalExample1'
+            Authentication Disabled:
+              $ref: '#/components/examples/UpdatePortalExampleAuthenticationDisabled'
+            Enable RBAC:
+              $ref: '#/components/examples/UpdatePortalExampleRbacEnabled'
+            Auto Approve Settings:
+              $ref: '#/components/examples/UpdatePortalExampleAutoApprove'
+    UpdateDeveloper:
+      description: Update a developer.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateDeveloperRequest'
+          examples:
+            Approved:
+              $ref: '#/components/examples/UpdateDeveloperExampleApproved'
+            Pending:
+              $ref: '#/components/examples/UpdateDeveloperExamplePending'
+            Rejected:
+              $ref: '#/components/examples/UpdateDeveloperExampleRejected'
+            Revoked:
+              $ref: '#/components/examples/UpdateDeveloperExampleRevoked'
+    ReplacePortalImageAsset:
+      description: Update an image asset for the portal.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ReplacePortalImageAsset'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ReplacePortalImageAssetExample1'
+    ReplacePortalCustomization:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalCustomization'
+    CreatePortalPage:
+      description: Create a page in a portal.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatePortalPageRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/CreatePortalPageExample1'
+    UpdatePortalPage:
+      description: Update a page in a portal.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdatePortalPageRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/UpdatePortalPageExample1'
+    MovePage:
+      description: move page
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/MovePageRequestPayload'
+    CreatePortalSnippet:
+      description: Create a snippet in a portal.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreatePortalSnippetRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/CreatePortalSnippetExample1'
+    UpdatePortalSnippet:
+      description: Update a snippet in a portal.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdatePortalSnippetRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/UpdatePortalSnippetExample1'
+    UpdateApplicationRegistration:
+      description: Update an application registration.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateApplicationRegistrationRequest'
+          examples:
+            Approved:
+              $ref: '#/components/examples/UpdateApplicationRegistrationApproved'
+            Pending:
+              $ref: '#/components/examples/UpdateApplicationRegistrationPending'
+            Rejected:
+              $ref: '#/components/examples/UpdateApplicationRegistrationRejected'
+            Revoked:
+              $ref: '#/components/examples/UpdateApplicationRegistrationRevoked'
+    PortalUpdateTeam:
+      description: Update a team in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalUpdateTeamRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/UpdateTeamExample1'
+    PortalCreateTeam:
+      description: Create a team in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalCreateTeamRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/CreateTeamExample1'
+    UpdatePortalTeamGroupMappings:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalTeamGroupMappingsUpdateRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/UpdatePortalTeamGroupMappingsExample1'
+    UpdatePortalAuthenticationSettings:
+      description: Update a portal's developer authentication settings.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalAuthenticationSettingsUpdateRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/UpdatePortalAuthenticationSettingsExample1'
+            Disable Basic Developer Auth:
+              $ref: >-
+                #/components/examples/UpdatePortalAuthenticationSettingsExampleDisableBasicAuth
+            Enable OIDC Developer Auth:
+              $ref: >-
+                #/components/examples/UpdatePortalAuthenticationSettingsExampleEnableOIDC
+            Enable OIDC Team Mapping:
+              $ref: >-
+                #/components/examples/UpdatePortalAuthenticationSettingsExampleEnableOIDCTeamMapping
+    PortalAssignRole:
+      description: Assign a role to a team.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalAssignRoleRequest'
+          examples:
+            API Viewer:
+              $ref: '#/components/examples/PortalAssignRoleExampleViewer'
+            API Consumer:
+              $ref: '#/components/examples/PortalAssignRoleExampleConsumer'
+    AddDeveloperToTeam:
+      description: Add a developer to a team.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AddDeveloperToTeamRequest'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/AddDeveloperToTeamExample1'
+    CreateIdentityProviderRequest:
+      description: >
+        An object representing the configuration for creating a new identity
+        provider. This configuration may pertain  to either an OIDC or a SAML
+        identity provider.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateIdentityProvider'
+          examples:
+            OIDC Identity Provider Request:
+              $ref: '#/components/examples/CreateOIDCIdentityProvider'
+            SAML Identity Provider Request With MetadataURL:
+              $ref: '#/components/examples/CreateSAMLIdentityProviderWithMetadataURL'
+            SAML Identity Provider Request With Metadata:
+              $ref: '#/components/examples/CreateSAMLIdentityProviderWithMetadata'
+    UpdateIdentityProviderRequest:
+      description: >
+        An object representing the configuration for updating an identity
+        provider. This configuration may pertain  to either an OIDC or a SAML
+        identity provider.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateIdentityProvider'
+          examples:
+            Update OIDC Identity Provider:
+              $ref: '#/components/examples/UpdateOIDCIdentityProvider'
+            Update SAML Identity Provider:
+              $ref: '#/components/examples/UpdateSAMLIdentityProvider'
+  responses:
+    PortalTeamGroupMappingCollection:
+      description: A paginated collection of mappings grouped by team ID.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalTeamGroupMappingResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/PortalTeamGroupMappingCollectionExample1'
+    PortalAuthenticationSettings:
+      description: Details about a portal's authentication settings.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalAuthenticationSettingsResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/PortalAuthenticationSettingsExample1'
+    PortalAssignedRole:
+      description: Details about the role assignment.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalAssignedRoleResponse'
+          examples:
+            US Example:
+              $ref: '#/components/examples/PortalAssignedRoleUSExample'
+            All Regions Example:
+              $ref: '#/components/examples/PortalAssignedRoleAllRegionsExample'
+    PortalTeam:
+      description: Details about a team of developers in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalTeamResponse'
+          examples:
+            PortalTeamExample1:
+              $ref: '#/components/examples/PortalTeamExample1'
+    AssignedPortalRoleCollection:
+      description: A paginated collection of assigned roles.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AssignedPortalRoleCollectionResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/AssignedPortalRoleCollectionExample1'
+    GetDeveloper:
+      description: Details about a developer in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalDeveloper'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/GetDeveloperExample1'
+    UpdateDeveloper:
+      description: Details about the developer being updated.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalDeveloper'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/UpdateDeveloperResponseExample1'
+    ListDevelopers:
+      description: A paginated list of developers in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListDevelopersResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListDevelopersExample1'
+    ListPortalTeams:
+      description: A paginated list of teams in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListPortalTeamsResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListPortalTeamsExample1'
+    ListRoles:
+      description: A set of roles available in portals.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListRolesResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListRolesExample1'
+    ListBasicDevelopers:
+      description: A paginated list of basic developer information.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListBasicDevelopersResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListBasicDevelopersExample1'
+    PortalCustomDomain:
+      description: Portal custom domain
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalCustomDomain'
+    ListPortalsResponse:
+      description: A paginated list of portals in the current region of an organization.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  title: Portal
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    id:
+                      $ref: '#/components/schemas/UUID'
+                    created_at:
+                      $ref: '#/components/schemas/CreatedAt'
+                    updated_at:
+                      $ref: '#/components/schemas/UpdatedAt'
+                    name:
+                      description: >-
+                        The name of the portal, used to distinguish it from
+                        other portals. Name must be unique.
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                    display_name:
+                      description: >-
+                        The display name of the portal. This value will be the
+                        portal's `name` in Portal API.
+                      type: string
+                      maxLength: 255
+                      minLength: 1
+                    description:
+                      description: A description of the portal.
+                      type: string
+                      maxLength: 512
+                      nullable: true
+                    authentication_enabled:
+                      description: >-
+                        Whether the portal supports developer authentication. If
+                        disabled, developers cannot register for accounts or
+                        create applications.
+                      type: boolean
+                      default: true
+                    rbac_enabled:
+                      description: >-
+                        Whether the portal resources are protected by Role Based
+                        Access Control (RBAC). If enabled, developers view or
+                        register for APIs until unless assigned to teams with
+                        access to view and consume specific APIs. Authentication
+                        must be enabled to use RBAC.
+                      type: boolean
+                      default: false
+                    default_api_visibility:
+                      description: >-
+                        The default visibility of APIs in the portal. If set to
+                        `public`, newly published APIs are visible to
+                        unauthenticated developers. If set to `private`, newly
+                        published APIs are hidden from unauthenticated
+                        developers.
+                      type: string
+                      enum:
+                        - public
+                        - private
+                    default_page_visibility:
+                      description: >-
+                        The default visibility of pages in the portal. If set to
+                        `public`, newly created pages are visible to
+                        unauthenticated developers. If set to `private`, newly
+                        created pages are hidden from unauthenticated
+                        developers.
+                      type: string
+                      enum:
+                        - public
+                        - private
+                    default_application_auth_strategy_id:
+                      description: >-
+                        The default authentication strategy for APIs published
+                        to the portal. Newly published APIs will use this
+                        authentication strategy unless overridden during
+                        publication. If set to `null`, API publications will not
+                        use an authentication strategy unless set during
+                        publication. DCR support for Auth Strategies is
+                        currently in development.
+                      type: string
+                      format: uuid
+                      nullable: true
+                    auto_approve_developers:
+                      description: >-
+                        Whether developer account registrations will be
+                        automatically approved, or if they will be set to
+                        pending until approved by an admin.
+                      type: boolean
+                      default: false
+                    auto_approve_applications:
+                      description: >-
+                        Whether requests from applications to register for APIs
+                        will be automatically approved, or if they will be set
+                        to pending until approved by an admin.
+                      type: boolean
+                      default: false
+                    default_domain:
+                      description: >-
+                        The domain assigned to the portal by Konnect. This is
+                        the default place to access the portal and its API if
+                        not using a `custom_domain``.
+                      type: string
+                      format: hostname
+                      readOnly: true
+                    canonical_domain:
+                      description: The canonical domain of the developer portal
+                      type: string
+                      format: hostname
+                      nullable: false
+                      readOnly: true
+                    labels:
+                      $ref: '#/components/schemas/Labels'
+                  required:
+                    - id
+                    - name
+                    - display_name
+                    - description
+                    - authentication_enabled
+                    - rbac_enabled
+                    - default_api_visibility
+                    - default_page_visibility
+                    - default_application_auth_strategy_id
+                    - auto_approve_applications
+                    - auto_approve_developers
+                    - default_domain
+                    - canonical_domain
+                    - created_at
+                    - updated_at
+              meta:
+                $ref: '#/components/schemas/PaginatedMeta'
+            additionalProperties: false
+            required:
+              - data
+              - meta
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListPortalsExample1'
+    PortalResponse:
+      description: Details about a portal.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                $ref: '#/components/schemas/UUID'
+              created_at:
+                $ref: '#/components/schemas/CreatedAt'
+              updated_at:
+                $ref: '#/components/schemas/UpdatedAt'
+              name:
+                description: >-
+                  The name of the portal, used to distinguish it from other
+                  portals. Name must be unique.
+                type: string
+                maxLength: 255
+                minLength: 1
+              display_name:
+                description: >-
+                  The display name of the portal. This value will be the
+                  portal's `name` in Portal API.
+                type: string
+                maxLength: 255
+                minLength: 1
+              description:
+                description: A description of the portal.
+                type: string
+                maxLength: 512
+                nullable: true
+              authentication_enabled:
+                description: >-
+                  Whether the portal supports developer authentication. If
+                  disabled, developers cannot register for accounts or create
+                  applications.
+                type: boolean
+                default: true
+              rbac_enabled:
+                description: >-
+                  Whether the portal resources are protected by Role Based
+                  Access Control (RBAC). If enabled, developers view or register
+                  for APIs until unless assigned to teams with access to view
+                  and consume specific APIs. Authentication must be enabled to
+                  use RBAC.
+                type: boolean
+                default: false
+              default_api_visibility:
+                description: >-
+                  The default visibility of APIs in the portal. If set to
+                  `public`, newly published APIs are visible to unauthenticated
+                  developers. If set to `private`, newly published APIs are
+                  hidden from unauthenticated developers.
+                type: string
+                enum:
+                  - public
+                  - private
+              default_page_visibility:
+                description: >-
+                  The default visibility of pages in the portal. If set to
+                  `public`, newly created pages are visible to unauthenticated
+                  developers. If set to `private`, newly created pages are
+                  hidden from unauthenticated developers.
+                type: string
+                enum:
+                  - public
+                  - private
+              default_application_auth_strategy_id:
+                description: >-
+                  The default authentication strategy for APIs published to the
+                  portal. Newly published APIs will use this authentication
+                  strategy unless overridden during publication. If set to
+                  `null`, API publications will not use an authentication
+                  strategy unless set during publication. DCR support for Auth
+                  Strategies is currently in development.
+                type: string
+                format: uuid
+                nullable: true
+              auto_approve_developers:
+                description: >-
+                  Whether developer account registrations will be automatically
+                  approved, or if they will be set to pending until approved by
+                  an admin.
+                type: boolean
+                default: false
+              auto_approve_applications:
+                description: >-
+                  Whether requests from applications to register for APIs will
+                  be automatically approved, or if they will be set to pending
+                  until approved by an admin.
+                type: boolean
+                default: false
+              default_domain:
+                description: >-
+                  The domain assigned to the portal by Konnect. This is the
+                  default place to access the portal and its API if not using a
+                  `custom_domain``.
+                type: string
+                format: hostname
+                readOnly: true
+              canonical_domain:
+                description: The canonical domain of the developer portal
+                type: string
+                format: hostname
+                nullable: false
+                readOnly: true
+              labels:
+                $ref: '#/components/schemas/Labels'
+            additionalProperties: false
+            required:
+              - id
+              - name
+              - display_name
+              - description
+              - authentication_enabled
+              - rbac_enabled
+              - default_api_visibility
+              - default_page_visibility
+              - default_application_auth_strategy_id
+              - auto_approve_applications
+              - auto_approve_developers
+              - default_domain
+              - canonical_domain
+              - updated_at
+              - created_at
+            title: Portal
+          examples:
+            Example 1:
+              $ref: '#/components/examples/PortalExample1'
+    PortalAssetResponse:
+      description: Logo of the portal. Can be either png or jpeg
+      content:
+        image/jpeg:
+          schema:
+            $ref: '#/components/schemas/PortalImageAsset'
+          examples:
+            JPEG Example:
+              $ref: '#/components/examples/PortalAssetResponseExampleJPEG'
+        image/png:
+          schema:
+            $ref: '#/components/schemas/PortalImageAsset'
+          examples:
+            PNG Example:
+              $ref: '#/components/examples/PortalAssetResponseExamplePNG'
+    PortalCustomizationResponse:
+      description: The current customization options for a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalCustomization'
+    DefaultContentResponse:
+      description: Summary of created default content
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/DefaultContent'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/DefaultContentExample1'
+    PortalPage:
+      description: Details about a page in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalPageResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/PortalPageExample1'
+    ListPortalPages:
+      description: A paginated list of custom pages in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListPortalPagesResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListPortalPagesExample1'
+    PortalSnippet:
+      description: Details about a snippet in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalSnippetResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/PortalSnippetExample1'
+    ListPortalSnippets:
+      description: A paginated list of custom snippets in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListPortalSnippetsResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListPortalSnippetsExample1'
+    ListApplications:
+      description: A paginated list of applications in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListApplicationsResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListApplicationsExample1'
+    GetApplication:
+      description: Details about an application in a portal.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GetApplicationResponse'
+          examples:
+            Key Auth Application:
+              $ref: '#/components/examples/GetApplicationExampleBasic'
+            Client Credentials Application with DCR:
+              $ref: '#/components/examples/GetApplicationExampleDcr'
+            Client Credentials Application without DCR:
+              $ref: '#/components/examples/GetApplicationExampleOIDC'
+    ListApplicationRegistrations:
+      description: A paginated list of application registrations.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListApplicationRegistrationsResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/ListApplicationRegistrationsExample1'
+    GetApplicationRegistration:
+      description: Details about an application registration.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GetApplicationRegistrationResponse'
+          examples:
+            Example 1:
+              $ref: '#/components/examples/GetApplicationRegistrationExample1'
+    UpdateApplicationRegistration:
+      description: Details about the application registration being updated.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateApplicationRegistrationResponse'
+          examples:
+            Example 1:
+              $ref: >-
+                #/components/examples/UpdateApplicationRegistrationResponseExample1
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/UnauthorizedExample'
+    Forbidden:
+      description: Forbidden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ForbiddenError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/ForbiddenExample'
+    NotFound:
+      description: Not Found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/NotFoundError'
+          examples:
+            NotFoundExample:
+              $ref: '#/components/examples/NotFoundExample'
+    Conflict:
+      description: Conflict
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictError'
+    BadRequest:
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BadRequestError'
+    IdentityProviders:
+      description: >
+        A collection of identity providers. This response contains a collection
+        of identity providers, which may  include both OIDC and SAML identity
+        providers.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/IdentityProvider'
+            title: Identity Provider Collection Response
+          examples:
+            Identity Provider Collection:
+              $ref: '#/components/examples/IdentityProviders'
+    IdentityProvider:
+      description: >
+        An identity provider configuration. This response represents the
+        configuration of a specific identity provider, which can be either OIDC
+        or SAML.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/IdentityProvider'
+          examples:
+            OIDC Identity Provider:
+              $ref: '#/components/examples/OIDCIdentityProvider'
+            SAML Identity Provider With Meta Data URL:
+              $ref: '#/components/examples/SAMLIdentityProvider'
+            SAML Identity Provider With Meta Data:
+              $ref: '#/components/examples/SAMLIdentityProviderWithMetadata'
+  securitySchemes:
+    personalAccessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Token
+      description: >
+        The personal access token is meant to be used as an alternative to
+        basic-auth when accessing Konnect via APIs.
+
+        You can generate a Personal Access Token (PAT) from the [personal access
+        token page](https://cloud.konghq.com/global/tokens/) in the Konnect
+        dashboard.
+
+        The PAT token must be passed in the header of a request, for example:
+
+        `curl -X GET 'https://global.api.konghq.com/v2/users/' --header
+        'Authorization: Bearer kpat_xgfT...'`
+    systemAccountAccessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Token
+      description: >
+        The system account access token is meant for automations and
+        integrations that are not directly associated with a human identity.
+
+        You can generate a system account Access Token by creating a system
+        account and then obtaining a system account access token for that
+        account.
+
+        The access token must be passed in the header of a request, for example:
+
+        `curl -X GET 'https://global.api.konghq.com/v2/users/' --header
+        'Authorization: Bearer spat_i2Ej...'`
+tags:
+  - name: Portals
+    description: APIs related to configuration of Konnect Developer Portals.
+  - name: Portal Custom Domains
+    description: APIs related to configuration of Konnect Developer Portals custom domains.
+  - name: Portal Customization
+    description: APIs related to customization of Konnect Developer Portals.
+  - name: Portal Auth Settings
+    description: APIs related to configuration of Konnect Developer Portal auth settings.
+  - name: Portal Developers
+    description: APIs related to Konnect Developer Portal developers.
+  - name: Portal Teams
+    description: APIs related to configuration of Konnect Developer Portal developer teams.
+  - name: Portal Team Membership
+    description: APIs related to Konnect Developer Portal developer team membership.
+  - name: Portal Team Roles
+    description: APIs related to Konnect Developer Portal developer team roles.
+  - name: Assets
+    description: APIs for managing static assets for Konnect Developer Portals.
+  - name: Pages
+    description: APIs related to Konnect Developer Portal Custom Pages.
+  - name: Snippets
+    description: APIs related to Konnect Developer Portal Custom Snippets.
+  - name: Applications
+    description: APIs related to Konnect Developer Portal Applications.
+  - name: Application Registrations
+    description: APIs related to Konnect Developer Portal Application Registrations.
+security:
+  - personalAccessToken: []
+  - systemAccountAccessToken: []

--- a/api-specs/Konnect/v3/yaml/portal.yaml
+++ b/api-specs/Konnect/v3/yaml/portal.yaml
@@ -1,0 +1,4208 @@
+openapi: 3.0.3
+info:
+  title: Portal API
+  version: 3.0.0
+  description: Portal API
+  contact:
+    name: Kong
+    url: 'https://cloud.konghq.com'
+servers:
+  - url: 'https://custom.example.com'
+    description: Production
+paths:
+  /api/v3/apis:
+    get:
+      operationId: list-apis
+      summary: List APIs
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns a paginated list of published APIs.
+      parameters:
+        - $ref: '#/components/parameters/ApiFilters'
+        - $ref: '#/components/parameters/ApiSort'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - APIs
+  '/api/v3/apis/{apiIdOrSlug}':
+    get:
+      operationId: fetch-api
+      summary: Fetch API
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Gets the details for an existing published API.
+      parameters:
+        - $ref: '#/components/parameters/ApiIdOrSlug'
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiGet'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - APIs
+  '/api/v3/apis/{apiIdOrSlug}/actions':
+    parameters:
+      - $ref: '#/components/parameters/ApiIdOrSlug'
+    get:
+      operationId: get-api-actions
+      summary: Fetch API Actions
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Get a set of actions that the current developer is allowed to perform on
+        an API.
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiActions'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/NotAvailable'
+      tags:
+        - APIs
+  '/api/v3/apis/{apiIdOrSlug}/applications':
+    parameters:
+      - $ref: '#/components/parameters/ApiIdOrSlug'
+      - $ref: '#/components/parameters/QueryUnregisteredApplications'
+      - $ref: '#/components/parameters/ApplicationFilters'
+      - $ref: '#/components/parameters/PageSize'
+      - $ref: '#/components/parameters/PageNumber'
+    get:
+      operationId: get-api-applications
+      summary: List API Applications
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Get applications that have a registration for a given API.  
+
+        Any registration will count, regardless of status (i.e. even if it is
+        pending, rejected, or revoked).  
+
+        Use the unregistered query param to return the inverse, only including
+        applicatons that do not have a registration (regardless of status).
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiListApplications'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - APIs
+  '/api/v3/apis/{apiIdOrSlug}/documents':
+    get:
+      operationId: list-api-documents
+      summary: List API Docs
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns a list of documents that are associated with an API. The list is
+        paginated, and is in either a list or tree format (based on the Accept
+        header).
+      parameters:
+        - $ref: '#/components/parameters/ApiIdOrSlug'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiDocumentList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - API Docs
+  '/api/v3/apis/{apiIdOrSlug}/documents/{documentIdOrSlug}':
+    get:
+      operationId: fetch-api-document
+      summary: Fetch API Doc
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns the specified document from the API's document tree.
+      parameters:
+        - name: Accept
+          in: header
+          schema:
+            $ref: '#/components/schemas/DocumentFormatContentTypeEnum'
+        - $ref: '#/components/parameters/ApiIdOrSlug'
+        - $ref: '#/components/parameters/DocumentIdOrSlug'
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiDocumentGet'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - API Docs
+  '/api/v3/apis/{apiIdOrSlug}/specifications':
+    get:
+      operationId: list-api-specs
+      summary: List API Specs
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns the API specification documents attached to the API. Currently
+        only OpenAPI is supported.
+      parameters:
+        - $ref: '#/components/parameters/ApiIdOrSlug'
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiSpecList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - API Docs
+  '/api/v3/apis/{apiIdOrSlug}/specifications/{specId}':
+    get:
+      operationId: fetch-api-spec
+      summary: Fetch API Spec
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns an API specification document for an API. Currently only OpenAPI
+        is supported.
+      parameters:
+        - $ref: '#/components/parameters/ApiIdOrSlug'
+        - $ref: '#/components/parameters/SpecId'
+      responses:
+        '200':
+          $ref: '#/components/responses/ApiSpecGet'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - API Docs
+  /api/v3/application-auth-strategies:
+    get:
+      operationId: list-application-auth-strategies
+      summary: Available Auth Strategies
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Retrieve the auth strategies on this portal.
+
+        An auth strategy represents the way your application provides
+        credentials to authenticate with an API.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/FilterByNameEquality'
+        - $ref: '#/components/parameters/FilterByNameEqualityShort'
+        - $ref: '#/components/parameters/FilterByNameContains'
+        - $ref: '#/components/parameters/FilterByCredentialTypeEquality'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListAuthStrategies'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Applications
+  /api/v3/applications:
+    get:
+      operationId: list-applications
+      summary: List Applications
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        List applications the currently logged in developer can access.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/FilterByNameEquality'
+        - $ref: '#/components/parameters/FilterByNameEqualityShort'
+        - $ref: '#/components/parameters/FilterByNameContains'
+        - $ref: '#/components/parameters/FilterByAuthStrategyEquality'
+        - $ref: '#/components/parameters/FilterByAuthStrategyEqualityShort'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApplications'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Applications
+    post:
+      operationId: create-application
+      summary: Create Application
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Creates a new Application.
+      requestBody:
+        $ref: '#/components/requestBodies/CreateApplication'
+      responses:
+        '201':
+          $ref: '#/components/responses/ApplicationCreation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Applications
+  '/api/v3/applications/{applicationId}':
+    get:
+      operationId: get-application
+      summary: Fetch Application
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Gets the details for an existing application. You need only supply the
+        unique application identifier that was returned upon application
+        creation or by the list-applications endpoint.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+      responses:
+        '200':
+          $ref: '#/components/responses/GetApplication'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Applications
+    delete:
+      operationId: delete-application
+      summary: Delete Application
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Deletes an application and all of its associated entities
+        (registrations).
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+      responses:
+        '204':
+          description: Application was deleted successfully.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Applications
+    patch:
+      operationId: update-application
+      summary: Update Application
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Updates an application, replacing specified properties with any new
+        values supplied in the request body.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateApplication'
+      responses:
+        '200':
+          $ref: '#/components/responses/ApplicationUpdate'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Applications
+  '/api/v3/applications/{applicationId}/credentials':
+    get:
+      operationId: list-credentials
+      summary: List Credentials
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Lists the credentials for an application.
+
+        Basic information about the credential is returned, but not the
+        credential secret itself.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListCredentials'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Credentials
+    post:
+      operationId: create-credential
+      summary: Create Credential
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Allows a developer to create a credential for an application they own.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateCredential'
+      responses:
+        '201':
+          $ref: '#/components/responses/CredentialCreation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/PostCredentials403Response'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Credentials
+  '/api/v3/applications/{applicationId}/credentials/{credentialId}':
+    put:
+      operationId: update-credential
+      summary: Update Credential
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Updates a credential for an application owned by the current logged in
+        developer.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+        - $ref: '#/components/parameters/CredentialId'
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateCredential'
+      responses:
+        '200':
+          description: Credential successfully updated.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Credentials
+    delete:
+      operationId: delete-credential
+      summary: Delete Credential
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Deletes a credential for an application they own.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+        - $ref: '#/components/parameters/CredentialId'
+      responses:
+        '204':
+          description: Credential successfully deleted.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Credentials
+  '/api/v3/applications/{applicationId}/registrations':
+    get:
+      operationId: list-application-registrations
+      summary: List Registrations for App
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Lists API registrations for an application.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/ApplicationId'
+        - $ref: '#/components/parameters/FilterByIdEquality'
+        - $ref: '#/components/parameters/FilterByIdEqualityShort'
+        - $ref: '#/components/parameters/FilterByStatusEquality'
+        - $ref: '#/components/parameters/FilterByStatusEqualityShort'
+        - $ref: '#/components/parameters/FilterByAPINameEquality'
+        - $ref: '#/components/parameters/FilterByAPINameEqualityShort'
+        - $ref: '#/components/parameters/FilterByAPINameContains'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListApiRegistrations'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Registrations
+    post:
+      operationId: create-application-registration
+      summary: Register App for API
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Registers an application for an API.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+      requestBody:
+        $ref: '#/components/requestBodies/CreateAPIRegistration'
+      responses:
+        '201':
+          $ref: '#/components/responses/CreateAPIRegistration'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Registrations
+  '/api/v3/applications/{applicationId}/registrations/{registrationId}':
+    get:
+      operationId: get-application-registration
+      summary: Fetch App Registration
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Retrieves the specified API registration for an application.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+        - $ref: '#/components/parameters/RegistrationId'
+      responses:
+        '200':
+          $ref: '#/components/responses/GetAPIRegistration'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Registrations
+    delete:
+      operationId: delete-application-registration
+      summary: Delete App Registration
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Unregister an application for an API.
+      parameters:
+        - $ref: '#/components/parameters/ApplicationId'
+        - $ref: '#/components/parameters/RegistrationId'
+      responses:
+        '204':
+          description: The registration has been deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Registrations
+  /api/v3/assets/favicon:
+    get:
+      operationId: get-portal-favicon
+      summary: Favicon Asset
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Gets favicon of the developer portal.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalImageAssetResponse'
+      security:
+        - {}
+      tags:
+        - Content
+  /api/v3/assets/logo:
+    get:
+      operationId: get-portal-logo
+      summary: Logo Asset
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Gets logo of the developer portal.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalImageAssetResponse'
+      security:
+        - {}
+      tags:
+        - Content
+  /api/v3/customization:
+    get:
+      operationId: get-portal-customization
+      summary: Settings
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns the portal's custom settings.
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalCustomizationResponse'
+      security:
+        - {}
+      tags:
+        - Content
+  /api/v3/developer:
+    post:
+      operationId: register
+      summary: Register
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Register to the developer portal.
+      requestBody:
+        description: Developer registration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterPayload'
+            examples:
+              RegisterDeveloperRequestExample1:
+                $ref: '#/components/examples/RegisterDeveloperRequestExample1'
+      responses:
+        '201':
+          description: the developer has been properly registered.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      security:
+        - {}
+      tags:
+        - Developer
+  /api/v3/developer/authenticate:
+    post:
+      operationId: authenticate
+      summary: Login
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        This endpoint allows a developer to authenticate to their portal using a
+        username and password.
+      requestBody:
+        $ref: '#/components/requestBodies/AuthenticateRequest'
+      responses:
+        '204':
+          description: No Content
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+                example: >
+                  portalaccesstoken=access12345; Path=/;
+                  Domain=example.us.portal.konghq.com; Expires=Thu, 20 Jul 2023
+                  12:00:00 GMT; HttpOnly; Secure; SameSite=None
+
+                  portalrefreshtoken=refresh12345; Path=/v2/refresh;
+                  Domain=example.us.portal.konghq.com; Expires=Thu, 20 Jul 2023
+                  12:00:00 GMT; HttpOnly; Secure; SameSite=None
+              description: The access and refresh tokens.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Developer
+  /api/v3/developer/authenticate/sso:
+    get:
+      operationId: authenticate-sso
+      summary: SSO Login
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        This endpoint allows a developer to authenticate to their portal using
+        an external IdP.
+      responses:
+        '302':
+          description: Found
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      tags:
+        - Developer
+  /api/v3/developer/forgot-password:
+    post:
+      operationId: forgot-password
+      summary: Forgot Password
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Starts the password reset flow for the desired account. An email
+        will be sent to the email address to initiate the password reset flow.
+      requestBody:
+        description: Developer registration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetPasswordPayload'
+      responses:
+        '200':
+          description: the password reset flow has been initiated.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      security:
+        - {}
+      tags:
+        - Developer
+  /api/v3/developer/logout:
+    post:
+      operationId: logout
+      summary: Logout
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        This endpoint allows a developer to logout of the portal. This operation
+        revokes all active tokens and clears the portal cookies.
+      responses:
+        '204':
+          description: No Content
+      tags:
+        - Developer
+  /api/v3/developer/me:
+    get:
+      operationId: get-developer-me
+      summary: Retrieve My Account
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns info about the current developer.
+      responses:
+        '200':
+          $ref: '#/components/responses/MeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - portalAccessToken: []
+      tags:
+        - Developer
+  /api/v3/developer/refresh:
+    post:
+      operationId: refresh
+      summary: Refresh Access Token
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        This endpoint allows a developer to refresh their existing access token.
+      responses:
+        '204':
+          description: No Content
+          headers:
+            Set-Cookie:
+              schema:
+                type: string
+                example: >
+                  portalaccesstoken=access12345; Path=/;
+                  Domain=example.us.portal.konghq.com; Expires=Thu, 20 Jul 2023
+                  12:00:00 GMT; HttpOnly; Secure; SameSite=None
+
+                  portalrefreshtoken=refresh12345; Path=/v2/refresh;
+                  Domain=example.us.portal.konghq.com; Expires=Thu, 20 Jul 2023
+                  12:00:00 GMT; HttpOnly; Secure; SameSite=None
+        '401':
+          $ref: '#/components/responses/responses-Unauthorized'
+      tags:
+        - Developer
+  /api/v3/developer/reset-password:
+    post:
+      operationId: reset-password
+      summary: Reset Password
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        This endpoint allows a developer to reset their password, using a reset
+        token.
+      requestBody:
+        $ref: '#/components/requestBodies/ResetPasswordRequest'
+      responses:
+        '204':
+          description: No Content
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/responses-Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '410':
+          $ref: '#/components/responses/Gone'
+      tags:
+        - Developer
+    parameters: []
+  /api/v3/developer/verify-email:
+    post:
+      operationId: verify-email
+      summary: Verify Email
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        This endpoint allows a new developer to verify their email.
+      requestBody:
+        $ref: '#/components/requestBodies/VerifyEmailRequest'
+      responses:
+        '202':
+          $ref: '#/components/responses/VerifyEmailResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '410':
+          $ref: '#/components/responses/Gone'
+      tags:
+        - Developer
+    parameters: []
+  /api/v3/pages:
+    get:
+      operationId: list-portal-pages
+      summary: List Pages
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns a paginated list of pages for the portal. Each page has a slug,
+        title, and content. Public pages will be returned for non-authenticated
+        users, while both private and public pages will be returned for
+        authenticated users.
+      parameters:
+        - $ref: '#/components/parameters/SortPortalPages'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/FilterByTitleEquality'
+        - $ref: '#/components/parameters/FilterByTitleEqualityShort'
+        - $ref: '#/components/parameters/FilterByTitleContains'
+        - $ref: '#/components/parameters/FilterBySlugEquality'
+        - $ref: '#/components/parameters/FilterBySlugEqualityShort'
+        - $ref: '#/components/parameters/FilterBySlugContains'
+        - $ref: '#/components/parameters/FilterByVisibilityEquality'
+        - $ref: '#/components/parameters/FilterByVisibilityEqualityShort'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListPortalPagesResponse'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - Content
+  '/api/v3/pages/{pagePath}':
+    get:
+      operationId: get-portal-page-by-name
+      summary: Fetch Page
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns a single page for the portal. Each page has a slug, title, and
+        content. Public pages will be returned for non-authenticated users,
+        while both private and public pages will be returned for authenticated
+        users.
+      parameters:
+        - $ref: '#/components/parameters/pagePath'
+      responses:
+        '200':
+          $ref: '#/components/responses/GetPortalPageResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - Content
+  /api/v3/portal:
+    get:
+      operationId: get-portal-context
+      summary: Get Portal Context
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Returns information about the portal.
+      responses:
+        '200':
+          $ref: '#/components/responses/GetPortalContextResponse'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - Portal
+  /api/v3/search:
+    get:
+      operationId: search-portal
+      summary: Search Portal
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns paginated search results for all entities with the given search
+        parameters.
+      parameters:
+        - $ref: '#/components/parameters/PortalSearchQuery'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageAfter'
+      responses:
+        '200':
+          $ref: '#/components/responses/PortalSearchResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - Search
+  /api/v3/snippets:
+    get:
+      operationId: list-portal-snippets
+      summary: List Snippets
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns a paginated list of snippets for the portal. Each snippet has a
+        name, title, and content. Public snippets will be returned for
+        non-authenticated users, while both private and public snippets will be
+        returned for authenticated users.
+      parameters:
+        - $ref: '#/components/parameters/SortPortalSnippets'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - $ref: '#/components/parameters/FilterByTitleEquality'
+        - $ref: '#/components/parameters/FilterByTitleEqualityShort'
+        - $ref: '#/components/parameters/FilterByTitleContains'
+        - $ref: '#/components/parameters/FilterByNameEquality'
+        - $ref: '#/components/parameters/FilterByNameEqualityShort'
+        - $ref: '#/components/parameters/FilterByVisibilityEquality'
+        - $ref: '#/components/parameters/FilterByVisibilityEqualityShort'
+      responses:
+        '200':
+          $ref: '#/components/responses/ListPortalSnippetsResponse'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - Content
+  '/api/v3/snippets/{snippetName}':
+    get:
+      operationId: get-portal-snippet-by-name
+      summary: Fetch Snippet
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        Returns a single snippet for the portal. Each snippet has a name, title,
+        and content. Public snippets will be returned for non-authenticated
+        users, while both private and public snippets will be returned for
+        authenticated users.
+      parameters:
+        - $ref: '#/components/parameters/snippetName'
+      responses:
+        '200':
+          $ref: '#/components/responses/GetPortalSnippetResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      security:
+        - portalAccessToken: []
+        - {}
+      tags:
+        - Content
+components:
+  parameters:
+    ApiFilters:
+      name: filter
+      description: Filters APIs in the response.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/ApiFilterParameters'
+      style: deepObject
+    ApiIdOrSlug:
+      name: apiIdOrSlug
+      schema:
+        oneOf:
+          - $ref: '#/components/schemas/ApiId'
+          - $ref: '#/components/schemas/ApiSlug'
+      in: path
+      required: true
+      description: 'The API identifier, either ApiId or Api Slug'
+    ApiSort:
+      name: sort
+      description: |
+        Sorts a collection of APIs. Supported sort attributes are:
+          - name
+          - version
+          - created_at
+          - updated_at
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/SortQuery'
+    ApplicationFilters:
+      name: applicationfilter
+      description: Filters Applications to retrieve.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/ApplicationFilterParameter'
+      style: deepObject
+    ApplicationId:
+      name: applicationId
+      in: path
+      required: true
+      description: Id of the targeted application
+      schema:
+        type: string
+        format: uuid
+    CredentialId:
+      name: credentialId
+      in: path
+      required: true
+      description: Id of the targeted credential
+      schema:
+        type: string
+        format: uuid
+    DocumentIdOrSlug:
+      name: documentIdOrSlug
+      schema:
+        oneOf:
+          - $ref: '#/components/schemas/DocumentId'
+          - $ref: '#/components/schemas/DocumentSlug'
+      in: path
+      required: true
+      description: 'The document identifier, either DocumentId or Document Slug'
+    FilterByAPINameContains:
+      name: 'filter[api_name][contains]'
+      description: >-
+        Filter by contains comparison of the api_name property with a supplied
+        substring
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good service
+    FilterByAPINameEquality:
+      name: 'filter[api_name][eq]'
+      description: >-
+        Filter by direct equality comparison of the api_name property with a
+        supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good service
+    FilterByAPINameEqualityShort:
+      name: 'filter[api_name]'
+      description: >-
+        Filter by direct equality comparison (short-hand) of the api_name
+        property with a supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good service
+    FilterByAuthStrategyEquality:
+      name: 'filter[auth_strategy_id][eq]'
+      description: Filter by the id of the auth strategy supported by the application.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: 5be86298-147b-45ab-bfaf-a1bff97dce39
+    FilterByAuthStrategyEqualityShort:
+      name: 'filter[auth_strategy_id]'
+      description: >-
+        Filter by the id of the auth strategy supported by the application
+        (short-hand).
+      in: query
+      required: false
+      schema:
+        type: string
+        example: 5be86298-147b-45ab-bfaf-a1bff97dce39
+    FilterByCredentialTypeEquality:
+      name: 'filter[credential_type][eq]'
+      description: >-
+        Filter by direct equality comparison of the credential_type with a
+        supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: key_auth
+        enum:
+          - client_credentials
+          - self_managed_client_credentials
+          - key_auth
+    FilterByIdEquality:
+      name: 'filter[id][eq]'
+      description: >-
+        Filter by direct equality comparison of the id property with a supplied
+        value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: 5be86298-147b-45ab-bfaf-a1bff97dce39
+    FilterByIdEqualityShort:
+      name: 'filter[id]'
+      description: >-
+        Filter by direct equality comparison (short-hand) of the id property
+        with a supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: 5be86298-147b-45ab-bfaf-a1bff97dce39
+    FilterByNameContains:
+      name: 'filter[name][contains]'
+      description: >-
+        Filter by contains comparison of the name property with a supplied
+        substring
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good service
+    FilterByNameEquality:
+      name: 'filter[name][eq]'
+      description: >-
+        Filter by direct equality comparison of the name property with a
+        supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good service
+    FilterByNameEqualityShort:
+      name: 'filter[name]'
+      description: >-
+        Filter by direct equality comparison (short-hand) of the name property
+        with a supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good service
+    FilterBySlugContains:
+      name: 'filter[slug][contains]'
+      description: >-
+        Filter by contains comparison of the slug property with a supplied
+        substring
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good
+    FilterBySlugEquality:
+      name: 'filter[slug][eq]'
+      description: >-
+        Filter by direct equality comparison of the slug property with a
+        supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good-page
+    FilterBySlugEqualityShort:
+      name: 'filter[slug]'
+      description: >-
+        Filter by direct equality comparison (short-hand) of the slug property
+        with a supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: good-page
+    FilterByStatusEquality:
+      name: 'filter[status][eq]'
+      description: >-
+        Filter by direct equality comparison of the status property with a
+        supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: approved
+        enum:
+          - approved
+          - pending
+          - rejected
+          - revoked
+    FilterByStatusEqualityShort:
+      name: 'filter[status]'
+      description: >-
+        Filter by direct equality comparison (short-hand) of the status property
+        with a supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: approved
+        enum:
+          - approved
+          - pending
+          - rejected
+          - revoked
+    FilterByTitleContains:
+      name: 'filter[title][contains]'
+      description: >-
+        Filter by contains comparison of the title property with a supplied
+        substring
+      in: query
+      required: false
+      schema:
+        type: string
+        example: Good
+    FilterByTitleEquality:
+      name: 'filter[title][eq]'
+      description: >-
+        Filter by direct equality comparison of the title property with a
+        supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: Good Page
+    FilterByTitleEqualityShort:
+      name: 'filter[title]'
+      description: >-
+        Filter by direct equality comparison (short-hand) of the title property
+        with a supplied value.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: Good Page
+    FilterByVisibilityEquality:
+      name: 'filter[visibility][eq]'
+      description: >-
+        Filter by whether the pages returned are public or private. Private
+        pages are only accessible to authenticated users. For authenticated
+        users, results will include both public and private pages if not
+        specified.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: public
+        enum:
+          - public
+          - private
+    FilterByVisibilityEqualityShort:
+      name: 'filter[visibility]'
+      description: >-
+        Filter (short-hand) by whether the pages returned are public or private.
+        Private pages are only accessible to authenticated users. For
+        authenticated users, results will include both public and private pages
+        if not specified.
+      in: query
+      required: false
+      schema:
+        type: string
+        example: private
+        enum:
+          - public
+          - private
+    PageAfter:
+      name: 'page[after]'
+      description: >-
+        Request the next page of data, starting with the item after this
+        parameter.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: string
+        example: ewogICJpZCI6ICJoZWxsbyB3b3JsZCIKfQ
+    PageNumber:
+      name: 'page[number]'
+      description: Determines which page of the entities to retrieve.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: integer
+        example: 1
+    PageSize:
+      name: 'page[size]'
+      description: >-
+        The maximum number of items to include per page. The last page of a
+        collection may include fewer items.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: integer
+        example: 10
+    PortalSearchQuery:
+      name: q
+      description: Determines how to filter search results
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/PortalSearchQueryParameters'
+    QueryUnregisteredApplications:
+      name: unregistered
+      description: >-
+        Return applications that do **not** have a registration for the API
+        (regardless of registration status).
+      in: query
+      required: false
+      schema:
+        type: boolean
+      allowEmptyValue: true
+    RegistrationId:
+      name: registrationId
+      in: path
+      required: true
+      description: Contains a unique identifier used by the Portal API for this resource.
+      schema:
+        type: string
+        format: uuid
+    SortPortalPages:
+      name: sort
+      description: |
+        Sorts a collection of portal pages. Supported sort attributes are:
+          - created_at
+          - updated_at
+          - slug
+          - title
+          - visibility
+      in: query
+      required: false
+      schema:
+        type: string
+    SortPortalSnippets:
+      name: sort
+      description: |
+        Sorts a collection of portal snippets. Supported sort attributes are:
+          - created_at
+          - updated_at
+          - name
+          - title
+          - visibility
+      in: query
+      required: false
+      schema:
+        type: string
+    SpecId:
+      name: specId
+      in: path
+      required: true
+      description: Contains a unique identifier for this resource.
+      schema:
+        type: string
+        format: uuid
+    pagePath:
+      name: pagePath
+      in: path
+      required: true
+      description: 'Targeted page, url-encoded.'
+      example: '%2Fmypage'
+      schema:
+        type: string
+    snippetName:
+      name: snippetName
+      in: path
+      required: true
+      description: 'Targeted snippet, url-encoded. Must not start with /.'
+      example: mysnippet
+      schema:
+        type: string
+  schemas:
+    ApiSlug:
+      description: >
+        The Api `slug` is used in generated URLs to provide human readable
+        paths.
+
+
+        Defaults to `slugify(name + version)`
+      type: string
+      example: my-api-v1
+      pattern: '^[\w-]+$'
+    ApiId:
+      description: The API identifier.
+      type: string
+      format: uuid
+      example: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+      readOnly: true
+    ApiActionsResponse:
+      type: object
+      properties:
+        actions:
+          description: List of actions that can be performed on the API
+          type: object
+          additionalProperties: false
+          properties:
+            view:
+              type: boolean
+            register:
+              type: boolean
+            view_documentation:
+              type: boolean
+          required:
+            - view
+            - register
+            - view_documentation
+      example:
+        actions:
+          view: true
+          register: false
+          view_documentation: true
+      additionalProperties: false
+      required:
+        - actions
+      title: API Actions Response
+    Api:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        name:
+          description: Name of API.
+          type: string
+          example: Billing
+        version:
+          description: Version of API.
+          type: string
+          example: v1
+          nullable: true
+        description:
+          type: string
+          example: V1 API for billing functions
+          nullable: true
+        deprecated:
+          description: 'If true, the API is deprecated.'
+          type: boolean
+        visibility:
+          description: >
+            Visibility of the API listing.
+
+            Public APIs are visible to anyone and do not require authentication
+            to view and retrieve information about them.
+
+            Private APIs are only visible to authenticated developers who have
+            been granted access.
+          type: string
+          enum:
+            - public
+            - private
+        slug:
+          description: >
+            The API `slug` is used in generated URLs to provide human readable
+            paths.
+
+
+            Defaults to `slugify(name + version)`
+          type: string
+          example: my-api-v1
+          nullable: false
+          pattern: '^[\w-]+$'
+        public_labels:
+          $ref: '#/components/schemas/Labels'
+        auth_strategies:
+          description: >-
+            Configurations for how the API is able to be registered for by
+            applications.
+          type: array
+          items:
+            $ref: '#/components/schemas/AuthStrategy'
+        specifications:
+          description: |
+            Returns a list of specifications for an API.
+            **Note:** You can only have one specification for an API.
+          type: array
+          items:
+            type: object
+            required:
+              - id
+              - type
+            properties:
+              id:
+                description: The API specification identifier.
+                type: string
+                format: uuid
+                example: 7710d5c4-d902-410b-992f-18b814155b53
+                readOnly: true
+              type:
+                $ref: '#/components/schemas/ApiSpecType'
+      additionalProperties: false
+      required:
+        - id
+        - created_at
+        - updated_at
+        - name
+        - version
+        - description
+        - deprecated
+        - visibility
+        - public_labels
+        - slug
+        - specifications
+      title: Api
+    ApiListPage:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Api'
+      required:
+        - meta
+        - data
+      title: ApiListPage
+    ApiListApplicationsPage:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiApplication'
+      additionalProperties: false
+      required:
+        - meta
+        - data
+      title: ApiListApplicationsPage
+    ApiApplication:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        name:
+          description: The name of the application
+          type: string
+        registration_id:
+          $ref: '#/components/schemas/NullableUUID'
+        registration_status:
+          type: string
+          enum:
+            - approved
+            - pending
+            - rejected
+            - revoked
+          nullable: true
+        auth_strategy:
+          $ref: '#/components/schemas/AuthStrategy'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - created_at
+        - updated_at
+        - registration_status
+        - registration_id
+      title: ApiApplication
+    ApiSpecDocumentSummary:
+      description: Info about an API specification document.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        api_type:
+          $ref: '#/components/schemas/ApiTypeEnum'
+      required:
+        - id
+        - api_type
+      title: ApiSpecDocumentSummary
+    ApiSpecDocument:
+      description: API specification document.
+      type: object
+      properties:
+        api_type:
+          $ref: '#/components/schemas/ApiTypeEnum'
+        content:
+          type: string
+      required:
+        - api_type
+        - content
+      title: ApiSpecDocument
+    ApiTypeEnum:
+      type: string
+      enum:
+        - oas3
+    ApiDocument:
+      description: >-
+        A document for an API. This is a document that is not a part of the API
+        specification.
+      type: object
+      properties:
+        id:
+          description: Unique identifier of the document.
+          type: string
+          format: uuid
+          example: 5f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+          readOnly: true
+        parent_document_id:
+          description: Unique identifier of the parent document.
+          type: string
+          format: uuid
+          example: dd4e1b98-3629-4dd3-acc0-759a726ffee2
+          nullable: true
+        slug:
+          description: >-
+            Slug of the document. This is used in the URL to identify the
+            document.
+          type: string
+          example: getting-started
+        content:
+          description: Markdown document
+          example: |
+            # My Kong api
+
+            This api is powered by Konnect
+          type: string
+        title:
+          description: Title of the document.
+          type: string
+          example: Hello World
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - title
+        - content
+      title: ApiDocument
+    ApiDocumentTree:
+      description: a document tree
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d32d905a-ed33-46a3-a093-d8f536af9a8a
+        parent_document_id:
+          type: string
+          format: uuid
+          example: dd4e1b98-3629-4dd3-acc0-759a726ffee2
+          nullable: true
+        title:
+          description: the title of the document
+          type: string
+          example: Getting Started
+        slug:
+          description: the slug of the document
+          type: string
+          example: getting-started
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiDocumentTree'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - slug
+        - children
+        - updated_at
+        - created_at
+      title: ApiDocumentTree
+    ApiFilterParameters:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        name:
+          $ref: '#/components/schemas/StringFieldFilter'
+        version:
+          $ref: '#/components/schemas/StringFieldFilter'
+        description:
+          $ref: '#/components/schemas/StringFieldFilter'
+        public_labels:
+          $ref: '#/components/schemas/LabelsFieldFilter'
+        deprecated:
+          $ref: '#/components/schemas/BooleanFieldFilter'
+        created_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+        updated_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+      title: ApiFilterParameters
+    DocumentId:
+      type: string
+      format: uuid
+      example: d32d905a-ed33-46a3-a093-d8f536af9a8a
+    DocumentSlug:
+      description: Slug of the document. This is used in the URL to identify the document.
+      type: string
+      example: getting-started
+      pattern: '^[\w-]+$'
+    ApplicationFilterParameter:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/StringFieldFilter'
+      title: ApplicationFilterParameter
+    UUID:
+      description: Contains a unique identifier used by the API for this resource.
+      type: string
+      format: uuid
+      example: 5f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+      readOnly: true
+    CreatedAt:
+      description: An ISO-8601 timestamp representation of entity creation date.
+      type: string
+      format: date-time
+      example: '2022-11-04T20:10:06.927Z'
+      readOnly: true
+    UpdatedAt:
+      description: An ISO-8601 timestamp representation of entity update date.
+      type: string
+      format: date-time
+      example: '2022-11-04T20:10:06.927Z'
+      readOnly: true
+    Labels:
+      description: >
+        Labels store metadata of an entity that can be used for filtering an
+        entity list or for searching across entity types. 
+
+
+        Keys must be of length 1-63 characters, and cannot start with "kong",
+        "konnect", "mesh", "kic", or "_".
+      type: object
+      example:
+        env: test
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+      maxProperties: 50
+      title: Labels
+    AuthStrategyKeyAuth:
+      description: KeyAuth Auth strategy that the application uses.
+      type: object
+      properties:
+        id:
+          description: The Application Auth Strategy ID.
+          type: string
+          format: uuid
+          example: b9e81174-b5bb-4638-a3c3-8afe61a0abf8
+          readOnly: true
+        name:
+          type: string
+          example: name
+          default: name
+        credential_type:
+          type: string
+          enum:
+            - key_auth
+        key_names:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - credential_type
+        - key_names
+    AuthMethods:
+      type: array
+      items:
+        description: Auth Methods enabled for this strategy
+        type: string
+      example:
+        - bearer
+    AvailableScopes:
+      description: >-
+        Possible developer selectable scopes for an application. Only present
+        when using DCR Provider that supports it.
+      type: array
+      items:
+        type: string
+      example:
+        - scope1
+        - scope2
+    AuthStrategyClientCredentials:
+      description: Client Credential Auth strategy that the application uses.
+      type: object
+      properties:
+        id:
+          description: The Application Auth Strategy ID.
+          type: string
+          format: uuid
+          example: b9e81174-b5bb-4638-a3c3-8afe61a0abf8
+          readOnly: true
+        name:
+          type: string
+          example: name
+          default: name
+        credential_type:
+          type: string
+          enum:
+            - client_credentials
+            - self_managed_client_credentials
+        auth_methods:
+          $ref: '#/components/schemas/AuthMethods'
+        available_scopes:
+          $ref: '#/components/schemas/AvailableScopes'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - credential_type
+        - auth_methods
+    AuthStrategy:
+      type: object
+      discriminator:
+        propertyName: credential_type
+      oneOf:
+        - $ref: '#/components/schemas/AuthStrategyKeyAuth'
+        - $ref: '#/components/schemas/AuthStrategyClientCredentials'
+    ApiSpecType:
+      description: >
+        The type of specification being stored. This allows us to render the
+        specification correctly.
+
+
+        If this field is not set, it will be autodetected from `content`
+      type: string
+      example: oas3
+      enum:
+        - oas3
+        - asyncapi
+      title: API Spec Type
+    BaseError:
+      description: standard error
+      type: object
+      properties:
+        status:
+          description: >
+            The HTTP status code of the error. Useful when passing the response
+
+            body to child properties in a frontend UI. Must be returned as an
+            integer.
+          type: integer
+          readOnly: true
+        title:
+          description: |
+            A short, human-readable summary of the problem. It should not
+            change between occurences of a problem, except for localization.
+            Should be provided as "Sentence case" for direct use in the UI.
+          type: string
+          readOnly: true
+        type:
+          description: The error type.
+          type: string
+          readOnly: true
+        instance:
+          description: |
+            Used to return the correlation ID back to the user, in the format
+            kong:trace:<correlation_id>. This helps us find the relevant logs
+            when a customer reports an issue.
+          type: string
+          readOnly: true
+        detail:
+          description: >
+            A human readable explanation specific to this occurence of the
+            problem.
+
+            This field may contain request/entity data to help the user
+            understand
+
+            what went wrong. Enclose variable values in square brackets. Should
+            be
+
+            provided as "Sentence case" for direct use in the UI.
+          type: string
+          readOnly: true
+      required:
+        - status
+        - title
+        - instance
+        - detail
+      title: Error
+    InvalidRules:
+      description: invalid parameters rules
+      type: string
+      enum:
+        - required
+        - is_array
+        - is_base64
+        - is_boolean
+        - is_date_time
+        - is_integer
+        - is_null
+        - is_number
+        - is_object
+        - is_string
+        - is_uuid
+        - is_fqdn
+        - is_arn
+        - unknown_property
+        - missing_reference
+        - is_label
+        - matches_regex
+        - invalid
+        - is_supported_network_availability_zone_list
+        - is_supported_network_cidr_block
+        - is_supported_provider_region
+      nullable: true
+      readOnly: true
+    InvalidParameterStandard:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          $ref: '#/components/schemas/InvalidRules'
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+    InvalidParameterMinimumLength:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - min_length
+            - min_digits
+            - min_lowercase
+            - min_uppercase
+            - min_symbols
+            - min_items
+            - min
+          nullable: false
+          readOnly: true
+        minimum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must have at least 8 characters
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - minimum
+    InvalidParameterMaximumLength:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - max_length
+            - max_items
+            - max
+          nullable: false
+          readOnly: true
+        maximum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must not have more than 8 characters
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - maximum
+    InvalidParameterChoiceItem:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - enum
+          nullable: false
+          readOnly: true
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+        choices:
+          type: array
+          items: {}
+          minItems: 1
+          nullable: false
+          readOnly: true
+          uniqueItems: true
+        source:
+          type: string
+          example: body
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - choices
+    InvalidParameterDependentItem:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - dependent_fields
+          nullable: true
+          readOnly: true
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+        dependents:
+          type: array
+          items: {}
+          nullable: true
+          readOnly: true
+          uniqueItems: true
+        source:
+          type: string
+          example: body
+      additionalProperties: false
+      required:
+        - field
+        - rule
+        - reason
+        - dependents
+    InvalidParameters:
+      description: invalid parameters
+      type: array
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/InvalidParameterStandard'
+          - $ref: '#/components/schemas/InvalidParameterMinimumLength'
+          - $ref: '#/components/schemas/InvalidParameterMaximumLength'
+          - $ref: '#/components/schemas/InvalidParameterChoiceItem'
+          - $ref: '#/components/schemas/InvalidParameterDependentItem'
+      minItems: 1
+      nullable: false
+      uniqueItems: true
+    BadRequestError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - invalid_parameters
+          properties:
+            invalid_parameters:
+              $ref: '#/components/schemas/InvalidParameters'
+    UnauthorizedError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 401
+            title:
+              example: Unauthorized
+            type:
+              example: 'https://httpstatuses.com/401'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Invalid credentials
+    NotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 404
+            title:
+              example: Not Found
+            type:
+              example: 'https://httpstatuses.com/404'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Not found
+    StringFieldEqualsFilter:
+      description: Filters on the given string field value by exact match.
+      oneOf:
+        - type: string
+        - type: object
+          title: StringFieldEqualsComparison
+          additionalProperties: false
+          properties:
+            eq:
+              type: string
+          required:
+            - eq
+      title: StringFieldEqualsFilter
+      x-examples:
+        example-1: equals-some-value
+        example-2:
+          eq: some-value
+    StringFieldOEQFilter:
+      description: >-
+        Returns entities that exact match any of the comma-delimited phrases in
+        the filter string.
+      type: object
+      properties:
+        oeq:
+          type: string
+      additionalProperties: false
+      required:
+        - oeq
+      title: StringFieldOEQFilter
+      x-examples:
+        example-1:
+          oeq: 'some-value,some-other-value'
+    StringFieldNEQFilter:
+      description: Filters on the given string field value by exact match inequality.
+      type: object
+      properties:
+        neq:
+          type: string
+      additionalProperties: false
+      required:
+        - neq
+      title: StringFieldNEQFilter
+      x-examples:
+        example-1:
+          neq: not-this-value
+    UuidFieldFilter:
+      description: Filters on the given UUID field value by exact match.
+      oneOf:
+        - $ref: '#/components/schemas/StringFieldEqualsFilter'
+        - $ref: '#/components/schemas/StringFieldOEQFilter'
+        - $ref: '#/components/schemas/StringFieldNEQFilter'
+      title: UuidFieldFilter
+      x-examples:
+        example-1: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-2:
+          eq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-3:
+          oeq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+        example-4:
+          neq: 3bbfd3a-e9ab-48a9-9881-ed589e4615d1
+    StringFieldContainsFilter:
+      description: Filters on the given string field value by fuzzy match.
+      type: object
+      properties:
+        contains:
+          type: string
+      additionalProperties: false
+      required:
+        - contains
+      title: StringFieldContainsFilter
+      x-examples:
+        example-1:
+          contains: some-value
+    StringFieldOContainsFilter:
+      description: >-
+        Returns entities that fuzzy-match any of the comma-delimited phrases in
+        the filter string.
+      type: object
+      properties:
+        ocontains:
+          type: string
+      additionalProperties: false
+      required:
+        - ocontains
+      title: StringFieldOContainsFilter
+      x-examples:
+        example-1:
+          ocontains: 'this-value,or-that-value'
+    StringFieldFilter:
+      description: Filters on the given string field value by either exact or fuzzy match.
+      oneOf:
+        - $ref: '#/components/schemas/StringFieldEqualsFilter'
+        - $ref: '#/components/schemas/StringFieldContainsFilter'
+        - $ref: '#/components/schemas/StringFieldOContainsFilter'
+        - $ref: '#/components/schemas/StringFieldOEQFilter'
+        - $ref: '#/components/schemas/StringFieldNEQFilter'
+      title: StringFieldFilter
+      x-examples:
+        example-1: equals-some-value
+        example-2:
+          eq: some-value
+        example-3:
+          contains: some-value
+        example-4:
+          ocontains: 'some-potential,value'
+        example-5:
+          oeq: 'some-potential,value'
+        example-6:
+          neq: not-this-value
+    LabelsFieldFilter:
+      allOf:
+        - title: LabelsFieldFilter
+          description: >
+            Filters on the resource's `labels` field. Filters must use
+            dot-notation to identify
+
+            the label key that will be used to filter the results. For example:
+              - `filter[labels.owner]`
+              - `filter[labels.owner][neq]=kong`
+              - `filter[labels.env]=dev`
+              - `filter[labels.env][ocontains]=dev,test`
+        - $ref: '#/components/schemas/StringFieldFilter'
+    BooleanFieldFilter:
+      description: Filter by a boolean value (true/false).
+      type: boolean
+      title: BooleanFieldFilter
+      x-examples:
+        example-1: true
+    DateTimeFieldFilter:
+      description: Filters on the given datetime (RFC-3339) field value.
+      oneOf:
+        - type: string
+          format: date-time
+          description: Value strictly equals given RFC-3339 formatted timestamp in UTC
+          example: '2022-03-30T07:20:50Z'
+        - type: object
+          title: DateTimeFieldEqualsFilter
+          additionalProperties: false
+          properties:
+            eq:
+              description: Value strictly equals given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - eq
+        - type: object
+          title: DateTimeFieldLTFilter
+          additionalProperties: false
+          properties:
+            lt:
+              description: Value is less than the given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - lt
+        - type: object
+          title: DateTimeFieldLTEFilter
+          additionalProperties: false
+          properties:
+            lte:
+              description: >-
+                Value is less than or equal to the given RFC-3339 formatted
+                timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - lte
+        - type: object
+          title: DateTimeFieldGTFilter
+          additionalProperties: false
+          properties:
+            lt:
+              description: >-
+                Value is greater than the given RFC-3339 formatted timestamp in
+                UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - gt
+        - type: object
+          title: DateTimeFieldGTEFilter
+          additionalProperties: false
+          properties:
+            lte:
+              description: >-
+                Value is greater than or equal to the given RFC-3339 formatted
+                timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - gte
+      title: DateTimeFieldFilter
+      x-examples:
+        datetime_field_1: '2022-03-30T07:20:50Z'
+        datetime_field_2:
+          eq: '2022-03-30T07:20:50Z'
+        datetime_field_3:
+          lt: '2022-03-30T07:20:50Z'
+        datetime_field_4:
+          lte: '2022-03-30T07:20:50Z'
+        datetime_field_5:
+          gt: '2022-03-30T07:20:50Z'
+        datetime_field_6:
+          gte: '2022-03-30T07:20:50Z'
+    SortQuery:
+      description: >
+        The `asc` suffix is optional as the default sort order is ascending.
+
+        The `desc` suffix is used to specify a descending order.
+
+        Multiple sort attributes may be provided via a comma separated list.
+
+        JSONPath notation may be used to specify a sub-attribute (eg: 'foo.bar
+        desc').
+      type: string
+      example: 'name,created_at desc'
+      title: SortQuery
+    PageMeta:
+      description: >-
+        Contains pagination query parameters and the total number of objects
+        returned.
+      type: object
+      properties:
+        number:
+          type: number
+          example: 1
+        size:
+          type: number
+          example: 10
+        total:
+          type: number
+          example: 100
+      required:
+        - number
+        - size
+        - total
+    PaginatedMeta:
+      description: returns the pagination information
+      type: object
+      properties:
+        page:
+          $ref: '#/components/schemas/PageMeta'
+      required:
+        - page
+      title: PaginatedMeta
+    DocumentFormatContentTypeEnum:
+      type: string
+      default: application/json
+      enum:
+        - text/markdown
+        - application/json
+        - application/vnd.konnect.document-nodes+json
+    NullableUUID:
+      description: Contains a unique identifier for a resource.
+      type: string
+      format: uuid
+      example: 5f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+      nullable: true
+    ListApplicationsResponse:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/GetApplicationResponse'
+      additionalProperties: false
+      required:
+        - data
+        - meta
+    ApplicationClientId:
+      description: |
+        An identifier to correlate the application with an external system.
+        Cannot be set when using Dynamic Client Registration.
+      type: string
+      maxLength: 255
+    GetApplicationResponse:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        name:
+          type: string
+        client_id:
+          $ref: '#/components/schemas/ApplicationClientId'
+        description:
+          type: string
+          nullable: true
+        redirect_uri:
+          type: string
+          nullable: true
+        auth_strategy:
+          $ref: '#/components/schemas/PortalAuthStrategy'
+        scopes:
+          $ref: '#/components/schemas/Scopes'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - updated_at
+        - created_at
+    CreateApplicationPayload:
+      description: Application creation payload
+      type: object
+      properties:
+        name:
+          description: The name of the application
+          type: string
+          maxLength: 255
+        client_id:
+          $ref: '#/components/schemas/ApplicationClientId'
+        redirect_uri:
+          description: URL to redirect to after completing an OIDC auth flow
+          type: string
+          format: uri
+        description:
+          description: A brief description of the application
+          type: string
+          maxLength: 255
+        auth_strategy_id:
+          $ref: '#/components/schemas/AuthStrategyId'
+        scopes:
+          $ref: '#/components/schemas/Scopes'
+      additionalProperties: false
+      required:
+        - name
+      title: CreateApplicationPayload
+    ApplicationCreationResponse:
+      description: Application creation response payload
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        redirect_uri:
+          type: string
+          nullable: true
+        client_id:
+          $ref: '#/components/schemas/ApplicationClientId'
+        auth_strategy:
+          $ref: '#/components/schemas/PortalAuthStrategy'
+        scopes:
+          $ref: '#/components/schemas/Scopes'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - created_at
+        - updated_at
+        - auth_strategy
+      title: ApplicationCreationResponse
+    UpdateApplicationPayload:
+      description: Payload required to update an application
+      type: object
+      properties:
+        name:
+          description: The name of the application
+          type: string
+          maxLength: 255
+        client_id:
+          $ref: '#/components/schemas/ApplicationClientId'
+        redirect_uri:
+          description: URL to redirect to after completing an OIDC auth flow
+          type: string
+          format: uri
+        description:
+          description: A brief description of the application
+          type: string
+          maxLength: 255
+        scopes:
+          $ref: '#/components/schemas/Scopes'
+      additionalProperties: false
+      title: UpdateApplicationPayload
+    ApplicationUpdateResponse:
+      description: Application update response payload
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        name:
+          type: string
+        client_id:
+          $ref: '#/components/schemas/ApplicationClientId'
+        description:
+          type: string
+          example: A brief description of the application
+          nullable: true
+        redirect_uri:
+          type: string
+          example: 'https://example.com/callback'
+          nullable: true
+        auth_strategy:
+          $ref: '#/components/schemas/PortalAuthStrategy'
+        scopes:
+          $ref: '#/components/schemas/Scopes'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - updated_at
+        - created_at
+      title: ApplicationUpdateResponse
+    PortalAuthStrategyKeyAuth:
+      description: KeyAuth Auth strategy that the application uses.
+      type: object
+      properties:
+        id:
+          description: The Application Auth Strategy ID.
+          type: string
+          format: uuid
+          example: b9e81174-b5bb-4638-a3c3-8afe61a0abf8
+          readOnly: true
+        name:
+          type: string
+          example: name
+          default: name
+        credential_type:
+          type: string
+          enum:
+            - key_auth
+        key_names:
+          type: array
+          items:
+            type: string
+          example:
+            - apikey
+      required:
+        - id
+        - name
+        - credential_type
+        - key_names
+    PortalAuthStrategyClientCredentials:
+      description: Client Credential Auth strategy that the application uses.
+      type: object
+      properties:
+        id:
+          description: The Application Auth Strategy ID.
+          type: string
+          format: uuid
+          example: b9e81174-b5bb-4638-a3c3-8afe61a0abf8
+          readOnly: true
+        available_scopes:
+          $ref: '#/components/schemas/AvailableScopes'
+        name:
+          type: string
+          example: name
+          default: name
+        credential_type:
+          type: string
+          enum:
+            - client_credentials
+            - self_managed_client_credentials
+        auth_methods:
+          $ref: '#/components/schemas/AuthMethods'
+      required:
+        - id
+        - name
+        - credential_type
+        - auth_methods
+    PortalAuthStrategy:
+      type: object
+      discriminator:
+        propertyName: credential_type
+      oneOf:
+        - $ref: '#/components/schemas/PortalAuthStrategyKeyAuth'
+        - $ref: '#/components/schemas/PortalAuthStrategyClientCredentials'
+    Scopes:
+      description: >-
+        **Pre-release Endpoint**
+
+        This endpoint is currently in beta and is subject to change.
+
+
+        The granted scopes for the application. Will only be included if
+        supported by the application's auth strategy.
+      type: array
+      items:
+        type: string
+    AuthStrategyId:
+      description: >-
+        ID of the auth strategy to use for the application. If null or not
+        included, the default application auth strategy will be used.
+      type: string
+      format: uuid
+      nullable: true
+    ForbiddenError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 403
+            title:
+              example: Forbidden
+            type:
+              example: 'https://httpstatuses.com/403'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Forbidden
+    ConflictError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 409
+            title:
+              example: Conflict
+            type:
+              example: 'https://httpstatuses.com/409'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Conflict
+    TooManyRequestsError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 429
+            title:
+              example: Too Many Requests
+            type:
+              example: 'https://httpstatuses.com/429'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Too Many Requests
+    ListCredentialsResponse:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              id:
+                $ref: '#/components/schemas/UUID'
+              display_name:
+                type: string
+            required:
+              - id
+              - display_name
+      additionalProperties: false
+      required:
+        - data
+        - meta
+    CreateCredentialRequest:
+      type: object
+      properties:
+        display_name:
+          type: string
+          maxLength: 255
+      additionalProperties: false
+    CredentialCreationResponse:
+      type: object
+      properties:
+        credential:
+          type: string
+        id:
+          $ref: '#/components/schemas/UUID'
+        display_name:
+          type: string
+      additionalProperties: false
+      required:
+        - credential
+        - id
+        - display_name
+    UpdateCredentialRequest:
+      type: object
+      properties:
+        display_name:
+          type: string
+          maxLength: 255
+      additionalProperties: false
+      required:
+        - display_name
+    ListAuthStrategiesResponse:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalAuthStrategy'
+      additionalProperties: false
+      required:
+        - data
+        - meta
+    AuthenticateRequest:
+      description: The request schema for the authenticate endpoint.
+      type: object
+      properties:
+        username:
+          type: string
+          format: email
+          example: developer@example.com
+          writeOnly: true
+        password:
+          type: string
+          format: password
+          example: <!N0taP@$$w0rd!>
+          writeOnly: true
+      example:
+        username: developer@example.com
+        password: <!N0taP@$$w0rd!>
+      additionalProperties: false
+      required:
+        - username
+        - password
+      title: AuthenticateRequest
+    ResetPasswordRequest:
+      description: The request schema for the reset password endpoint.
+      type: object
+      properties:
+        password:
+          type: string
+          format: password
+          example: <!N0taP@$$w0rd!>
+          writeOnly: true
+        token:
+          type: string
+          format: uuid
+          example: c8efd006-d8e1-4743-b91b-f163b9eae06a
+          writeOnly: true
+      example:
+        password: <!D3finitelyN0taP@$$w0rd!>
+        token: c8efd006-d8e1-4743-b91b-f163b9eae06a
+      additionalProperties: false
+      required:
+        - password
+        - token
+      title: ResetPasswordRequest
+    VerifyEmailRequest:
+      description: The request schema for the verify email endpoint.
+      type: object
+      properties:
+        token:
+          type: string
+          format: uuid
+          example: c8efd006-d8e1-4743-b91b-f163b9eae06a
+          writeOnly: true
+      example:
+        token: c8efd006-d8e1-4743-b91b-f163b9eae06a
+      additionalProperties: false
+      required:
+        - token
+      title: VerifyEmailRequest
+    VerifyEmailResponse:
+      description: The response schema for the verify email endpoint.
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          example: developer@example.com
+          readOnly: true
+        token:
+          type: string
+          format: uuid
+          example: c8efd006-d8e1-4743-b91b-f163b9eae06a
+          readOnly: true
+      example:
+        email: developer@example.com
+        token: c8efd006-d8e1-4743-b91b-f163b9eae06a
+      additionalProperties: false
+      title: VerifyEmailResponse
+    GoneError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 410
+            title:
+              example: Gone
+            type:
+              example: 'https://httpstatuses.com/410'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Gone
+    Developer:
+      description: A user who can use a developer portal
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        email:
+          type: string
+          format: email
+          example: developer@email.com
+          maxLength: 250
+        full_name:
+          type: string
+          example: API Developer
+          maxLength: 250
+          pattern: '^[\w \W]+$'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - full_name
+        - email
+      title: Developer
+    RegisterPayload:
+      description: |
+        Payload required to be sent to register a developer to the
+        portal.
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          example: developer@konghq.com
+        full_name:
+          type: string
+          example: Jane Doe
+          maxLength: 256
+          minLength: 1
+      additionalProperties: true
+      required:
+        - full_name
+        - email
+      title: RegisterPayload
+    ResetPasswordPayload:
+      description: |
+        Payload required to start the reset password flow
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          example: developer@konghq.com
+      additionalProperties: false
+      required:
+        - email
+      title: ResetPasswordPayload
+    PortalContext:
+      description: Describes the portal execution context
+      type: object
+      properties:
+        portal_id:
+          description: ID of the portal
+          type: string
+          format: uuid
+        org_id:
+          description: ID of the organization
+          type: string
+          format: uuid
+        basic_auth_enabled:
+          description: Whether the portal can be accessed via email and password
+          type: boolean
+        oidc_auth_enabled:
+          description: >-
+            Whether the portal can be accessed via authentication with Single
+            Sign On (SSO) through OpenID Connect (OIDC) from a third-party
+            Identity Provider
+          type: boolean
+        saml_auth_enabled:
+          description: Whether the portal can be accessed via SAML authentication
+          type: boolean
+        authentication_enabled:
+          description: Whether authentication is enabled for the portal
+          type: boolean
+        rbac_enabled:
+          description: Whether Role-Based Access Control is enabled for the portal
+          type: boolean
+        name:
+          description: Name of the developer portal
+          type: string
+        canonical_domain:
+          description: The canonical domain of the developer portal
+          type: string
+      additionalProperties: false
+      required:
+        - portal_id
+        - org_id
+        - basic_auth_enabled
+        - oidc_auth_enabled
+        - saml_auth_enabled
+        - authentication_enabled
+        - rbac_enabled
+        - name
+        - canonical_domain
+      title: PortalContext
+    PortalCustomization:
+      description: The custom settings of this portal
+      type: object
+      properties:
+        theme:
+          type: object
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+              nullable: false
+            mode:
+              type: string
+              enum:
+                - light
+                - dark
+                - system
+            colors:
+              type: object
+              additionalProperties: false
+              properties:
+                primary:
+                  type: string
+                  example: '#000000'
+                  nullable: false
+                  pattern: '^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$'
+                  x-validation-message: must be a valid hex color value
+        layout:
+          type: string
+          nullable: false
+        css:
+          type: string
+          nullable: true
+        js:
+          type: object
+          additionalProperties: false
+          properties:
+            custom:
+              type: string
+              nullable: true
+            scripts:
+              type: array
+              items:
+                type: string
+                pattern: '^https://[^:.]+\..+$'
+              maxItems: 20
+        menu:
+          type: object
+          additionalProperties: false
+          properties:
+            main:
+              type: array
+              items:
+                $ref: '#/components/schemas/PortalMenuItem'
+            footer_sections:
+              type: array
+              items:
+                $ref: '#/components/schemas/PortalFooterMenuSection'
+            footer_bottom:
+              type: array
+              items:
+                $ref: '#/components/schemas/PortalMenuItem'
+        spec_renderer:
+          type: object
+          additionalProperties: false
+          properties:
+            try_it_ui:
+              type: boolean
+              default: true
+            try_it_insomnia:
+              type: boolean
+              default: true
+            infinite_scroll:
+              type: boolean
+              default: true
+            show_schemas:
+              type: boolean
+              default: true
+        robots:
+          type: string
+          nullable: true
+      additionalProperties: false
+      title: PortalCustomization
+    PageId:
+      description: The unique identifier of the page
+      type: string
+      format: uuid
+      example: 582b9327-3eba-4bfe-9438-6066840dbbca
+      title: PageId
+    PageSlug:
+      description: The slug of the page.
+      type: string
+      example: /my-page
+      title: PageSlug
+    PageTitle:
+      description: The title of the page
+      type: string
+      example: My Page
+      title: PageTitle
+    PageContent:
+      description: The renderable markdown content of the page
+      type: string
+      example: '# Welcome to the Developer Portal'
+      title: PageContent
+    Visibility:
+      description: >-
+        Whether the page or snippet is public or private. Private pages and
+        snippets are only accessible to authenticated users.
+      type: string
+      example: public
+      enum:
+        - public
+        - private
+      title: Resource Public Visibility
+    Description:
+      type: string
+      example: A custom page about developer portals
+      title: ResourceDescription
+    SnippetId:
+      description: The unique identifier of the snippet
+      type: string
+      format: uuid
+      example: 582b9327-3eba-4bfe-9438-6066840dbbcb
+      title: SnippetId
+    SnippetTitle:
+      description: The title of the snippet
+      type: string
+      example: My Snippet
+      title: SnippetTitle
+    SnippetContent:
+      description: The renderable markdown content of the snippet
+      type: string
+      example: '# Welcome to the Developer Portal'
+      title: SnippetContent
+    SnippetName:
+      description: The name of the snippet (no leading slash)
+      type: string
+      example: my-snippet
+      title: SnippetName
+    ListPortalPages:
+      description: A paginated list of pages for the portal
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalPageInfo'
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+      additionalProperties: false
+      title: ListPortalPages
+    ListPortalSnippets:
+      description: A paginated list of snippets for the portal
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalSnippetInfo'
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+      additionalProperties: false
+      title: ListPortalSnippets
+    PortalPageInfo:
+      description: A single page for the portal
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/PageId'
+        slug:
+          $ref: '#/components/schemas/PageSlug'
+        title:
+          $ref: '#/components/schemas/PageTitle'
+        visibility:
+          $ref: '#/components/schemas/Visibility'
+        description:
+          $ref: '#/components/schemas/Description'
+        parent_page_id:
+          $ref: '#/components/schemas/ParentPageId'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        children:
+          description: children of the page
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalPageInfo'
+          example:
+            - id: d32d905a-ed33-46a3-a093-d8f536af9a8a
+              slug: hello-world
+              title: Hello world
+              visibility: public
+              parent_page_id: null
+              children: []
+      additionalProperties: false
+      required:
+        - id
+        - slug
+        - title
+        - public
+        - created_at
+        - updated_at
+        - children
+        - parent_page_id
+      title: PortalPageInfo
+    PortalSnippetInfo:
+      description: A single snippet for the portal
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/SnippetId'
+        name:
+          $ref: '#/components/schemas/SnippetName'
+        title:
+          $ref: '#/components/schemas/SnippetTitle'
+        visibility:
+          $ref: '#/components/schemas/Visibility'
+        description:
+          $ref: '#/components/schemas/Description'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - title
+        - visibility
+        - created_at
+        - updated_at
+      title: PortalSnippetInfo
+    PortalPage:
+      description: A single page for the portal
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/PageId'
+        title:
+          $ref: '#/components/schemas/PageTitle'
+        slug:
+          $ref: '#/components/schemas/PageSlug'
+        content:
+          $ref: '#/components/schemas/PageContent'
+        visibility:
+          $ref: '#/components/schemas/Visibility'
+        description:
+          $ref: '#/components/schemas/Description'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        parent_page_id:
+          $ref: '#/components/schemas/ParentPageId'
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - slug
+        - content
+        - visibility
+        - created_at
+        - updated_at
+        - parent_page_id
+      title: PortalPage
+    ParentPageId:
+      description: |
+        Pages may be rendered as a tree of files.
+      type: string
+      format: uuid
+      nullable: true
+    PortalSnippet:
+      description: A single snippet for the portal
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/PageId'
+        title:
+          $ref: '#/components/schemas/SnippetTitle'
+        name:
+          $ref: '#/components/schemas/SnippetName'
+        content:
+          $ref: '#/components/schemas/SnippetContent'
+        visibility:
+          $ref: '#/components/schemas/Visibility'
+        description:
+          $ref: '#/components/schemas/Description'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - name
+        - content
+        - visibility
+        - created_at
+        - updated_at
+      title: PortalSnippet
+    PortalMenuItem:
+      type: object
+      properties:
+        path:
+          description: The absolute path of a page in a portal with a leading slash.
+          type: string
+          example: /about/company
+          maxLength: 512
+        title:
+          description: The link display text
+          type: string
+          example: My Page
+        visibility:
+          description: >-
+            Whether a menu item is public or private. Private menu items are
+            only accessible to authenticated users.
+          type: string
+          example: public
+          enum:
+            - public
+            - private
+        external:
+          description: 'When clicked, open the link in a new window'
+          type: boolean
+      additionalProperties: false
+      required:
+        - path
+        - title
+        - visibility
+        - external
+    PortalFooterMenuSection:
+      type: object
+      properties:
+        title:
+          description: The footer menu section title
+          type: string
+          maxLength: 512
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalMenuItem'
+      additionalProperties: false
+      required:
+        - title
+        - items
+    CreateApiRegistrationPayload:
+      description: The payload to create a registration.
+      type: object
+      properties:
+        api_id:
+          description: The API id required for registration.
+          type: string
+          format: uuid
+      additionalProperties: false
+      required:
+        - api_id
+      title: CreateRegistrationPayload
+    ListApiRegistrationsResponse:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/GetApiRegistrationResponse'
+      additionalProperties: false
+      required:
+        - data
+        - meta
+    GetApiRegistrationResponse:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UUID'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+        status:
+          description: The approval status of the registration.
+          type: string
+          enum:
+            - approved
+            - pending
+            - rejected
+            - revoked
+        api_name:
+          description: >-
+            The name of the API. This is the name that is displayed in the
+            developer portal.
+          type: string
+        api_id:
+          description: >-
+            Contains a unique identifier used by the Portal API for this
+            resource.
+          type: string
+          format: uuid
+        application_id:
+          description: >-
+            Contains a unique identifier used by the Portal API for this
+            resource.
+          type: string
+          format: uuid
+      additionalProperties: false
+      required:
+        - id
+        - status
+        - application_id
+        - api_name
+        - api_id
+        - created_at
+        - updated_at
+    PortalSearchResults:
+      type: object
+      properties:
+        meta:
+          $ref: '#/components/schemas/CursorMeta'
+        data:
+          description: The paginated results that matched the search query
+          type: array
+          items:
+            $ref: '#/components/schemas/PortalSearchResultItem'
+      additionalProperties: false
+      required:
+        - data
+        - meta
+      title: SearchResults
+    PortalSearchResultItem:
+      type: object
+      properties:
+        id:
+          description: Unique identifier for the record.
+          type: string
+        type:
+          description: Portal entity type.
+          type: string
+        name:
+          description: Name of the entity.
+          type: string
+        description:
+          description: Description of the entity.
+          type: string
+        attributes:
+          description: Attributes for the entity.
+          type: object
+          additionalProperties: false
+          properties:
+            created_at:
+              $ref: '#/components/schemas/CreatedAt'
+            updated_at:
+              $ref: '#/components/schemas/UpdatedAt'
+            operation_id:
+              description: The operation ID of the operation.
+              type: string
+            operation_key:
+              description: The operation key of the operation.
+              type: string
+            path:
+              description: The path of the operation.
+              type: string
+            method:
+              description: The method of the operation.
+              type: string
+            summary:
+              description: The summary of the operation.
+              type: string
+          required:
+            - created_at
+            - updated_at
+            - operation_id
+            - operation_key
+            - path
+            - method
+        relations:
+          description: Relations for the entity.
+          type: object
+          additionalProperties: false
+          properties:
+            api_id:
+              description: The ID of the API.
+              type: string
+            spec_id:
+              description: The ID of the API specification.
+              type: string
+            portal_id:
+              description: The ID of the portal.
+              type: string
+            org_id:
+              description: The ID of the organization.
+              type: string
+            api_name:
+              description: The name of the API.
+              type: string
+            api_slug:
+              description: The slug of the API.
+              type: string
+            api_version:
+              description: The version of the API.
+              type: string
+            api_description:
+              description: The description of the API.
+              type: string
+          required:
+            - api_id
+            - spec_id
+            - portal_id
+            - org_id
+            - api_name
+            - api_slug
+            - api_version
+            - api_description
+        labels:
+          description: Labels for the entity.
+          type: object
+          additionalProperties: false
+          properties:
+            status:
+              description: The status of the entity.
+              type: string
+            version:
+              description: The version of the entity.
+              type: string
+          required:
+            - status
+      additionalProperties: false
+      required:
+        - id
+        - type
+        - name
+        - description
+        - attributes
+        - relations
+        - labels
+      title: SearchResultItem
+    PortalSearchQueryParameters:
+      type: string
+      title: SearchQueryParameters
+    CursorMetaPage:
+      type: object
+      properties:
+        first:
+          description: URI to the first page
+          type: string
+          format: path
+        last:
+          description: URI to the last page
+          type: string
+          format: path
+        next:
+          description: URI to the next page
+          type: string
+          format: path
+          nullable: true
+        previous:
+          description: URI to the previous page
+          type: string
+          format: path
+          nullable: true
+        size:
+          description: Requested page size
+          type: number
+          example: 10
+      required:
+        - size
+        - next
+        - previous
+    CursorMeta:
+      description: Pagination metadata.
+      type: object
+      properties:
+        page:
+          $ref: '#/components/schemas/CursorMetaPage'
+      required:
+        - page
+  examples:
+    ApiActionsExample:
+      value:
+        actions:
+          register: false
+          view: true
+          view_documentation: true
+    UnauthorizedExample:
+      value:
+        status: 401
+        title: Unauthorized
+        instance: 'kong:trace:8347343766220159418'
+        detail: Unauthorized
+    NotFoundExample:
+      value:
+        status: 404
+        title: Not Found
+        instance: 'kong:trace:6816496025408232265'
+        detail: Not Found
+    ForbiddenExample:
+      value:
+        status: 403
+        title: Forbidden
+        instance: 'kong:trace:2723154947768991354'
+        detail: You do not have permission to perform this action
+    PostCredentials403Example:
+      value:
+        status: 403
+        title: Forbidden
+        detail: 'Maximum number of Credentials exceeded. Max Allowed: 20'
+        instance: 'kong:trace:2724154947768991355'
+    Authenticate-Request:
+      value:
+        username: developer@example.com
+        password: <!N0taP@$$w0rd!>
+    Reset-Password-Request:
+      value:
+        password: <!D3finitelyN0taP@$$w0rd!>
+        token: c8efd006-d8e1-4743-b91b-f163b9eae06a
+    Verify-Email-Request:
+      value:
+        token: c8efd006-d8e1-4743-b91b-f163b9eae06a
+    Verify-Email-Response:
+      value:
+        email: developer@example.com
+        token: c8efd006-d8e1-4743-b91b-f163b9eae06a
+    400-Invalid-Token:
+      value:
+        status: 400
+        title: Bad Request
+        instance: 'konnect:trace:8988732526256293040'
+        detail: The provided token is invalid
+        invalid_parameters:
+          - field: token
+            reason: invalid ID format
+    400-Login-Failed:
+      value:
+        status: 400
+        title: Bad Request
+        instance: 'konnect:trace:8988732526256293040'
+        detail: Required fields are missing
+        invalid_parameters:
+          - field: password
+            reason: is required
+    401-Unauthorized:
+      value:
+        status: 401
+        title: Invalid Credentials
+        instance: 'konnect:trace:7283332526256293094'
+        detail: You have entered an invalid email or password.
+    401-Account-Not-Approved:
+      value:
+        status: 401
+        title: Approval Required
+        instance: 'konnect:trace:7283332526256293094'
+        detail: Your account is pending approval for access.
+    404-Token-Not-Found:
+      value:
+        status: 400
+        title: Not Found
+        instance: 'konnect:trace:8988732526256293040'
+        detail: The provided token was not found
+    410-Expired-Token:
+      value:
+        status: 410
+        title: Gone
+        instance: 'konnect:trace:8988732526256293040'
+        detail: The token has expired
+    RegisterDeveloperRequestExample1:
+      value:
+        email: dev@company.com
+        full_name: Dev Smith
+    PortalSearchResponseExample:
+      value:
+        data:
+          - id: 9f5061ce-78f6-4452-9108-ad7c02821fd5
+            type: operation
+            name: Get Users
+            description: Returns a list of users.
+            attributes:
+              created_at: '2023-01-19T17:41:55.896Z'
+              updated_at: '2023-01-19T17:41:55.896Z'
+              operation_id: listUsersV1
+              operation_key: GET /users
+              path: /users
+              method: GET
+              summary: Returns a list of users.
+            relations:
+              api_id: 7f9fd312-a987-4628-b4c5-bb4f4fddd5f7
+              spec_id: 7710d5c4-d902-410b-992f-18b814155b53
+              portal_id: de5c9818-be5c-42e6-b514-e3d4bc30ddeb
+              org_id: ebbac5b0-ac89-45c3-9d2e-c4542c657e79
+              api_name: Users API
+              api_slug: users-api-v1
+              api_version: 1.0.0
+              api_description: API used to manage users.
+            labels:
+              status: published
+              version: 1.0.0
+        meta:
+          page:
+            previous: null
+            next: '/api/v3/search?page[after]=ewogICJpZCI6ICJoZWxsbyB3b3JsZCIKfQ'
+            size: 1
+  requestBodies:
+    CreateApplication:
+      description: Create an application
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateApplicationPayload'
+    UpdateApplication:
+      description: Update an application
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateApplicationPayload'
+    CreateCredential:
+      description: Create a credential
+      required: false
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateCredentialRequest'
+    UpdateCredential:
+      description: Update a credential
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateCredentialRequest'
+    AuthenticateRequest:
+      description: The request schema for the authenticate endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/AuthenticateRequest'
+          examples:
+            Authenticate-Request:
+              $ref: '#/components/examples/Authenticate-Request'
+    ResetPasswordRequest:
+      description: The request schema for the reset password endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ResetPasswordRequest'
+          examples:
+            ResetPasswordRequest:
+              $ref: '#/components/examples/Reset-Password-Request'
+    VerifyEmailRequest:
+      description: The request schema for the verify email endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/VerifyEmailRequest'
+          examples:
+            VerifyEmailRequest:
+              $ref: '#/components/examples/Verify-Email-Request'
+    CreateAPIRegistration:
+      description: Create an application registration.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateApiRegistrationPayload'
+  responses:
+    ApiActions:
+      description: API actions
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiActionsResponse'
+          examples:
+            Retrieve API Actions Response:
+              $ref: '#/components/examples/ApiActionsExample'
+    ApiGet:
+      description: Response for a single api's details.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Api'
+    ApiList:
+      description: Response for a list of apis.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiListPage'
+    ApiListApplications:
+      description: >-
+        Paginated list of applications either registered or not registered for
+        an API
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiListApplicationsPage'
+    ApiSpecList:
+      description: List of API specification documents.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiSpecDocumentSummary'
+              meta:
+                $ref: '#/components/schemas/PaginatedMeta'
+            required:
+              - data
+              - meta
+    ApiSpecGet:
+      description: API specification document.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiSpecDocument'
+    ApiDocumentList:
+      description: Lists documents for an API.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiDocumentTree'
+              meta:
+                $ref: '#/components/schemas/PaginatedMeta'
+            required:
+              - data
+              - meta
+    ApiDocumentGet:
+      description: Details for a single document for an API.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiDocument'
+    BadRequest:
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BadRequestError'
+          examples:
+            400-Invalid-Token:
+              $ref: '#/components/examples/400-Invalid-Token'
+            400-Login-Failed:
+              $ref: '#/components/examples/400-Login-Failed'
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/UnauthorizedExample'
+            401-Unauthorized:
+              $ref: '#/components/examples/401-Unauthorized'
+            401-Account-Not-Approved:
+              $ref: '#/components/examples/401-Account-Not-Approved'
+    NotFound:
+      description: Not Found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/NotFoundError'
+          examples:
+            NotFoundExample:
+              $ref: '#/components/examples/NotFoundExample'
+            404-Token-Not-Found:
+              $ref: '#/components/examples/404-Token-Not-Found'
+    NotAvailable:
+      description: Service not available
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BaseError'
+    ListApplications:
+      description: Get applications response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListApplicationsResponse'
+    GetApplication:
+      description: Get application response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GetApplicationResponse'
+    ApplicationCreation:
+      description: Application Creation success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApplicationCreationResponse'
+    ApplicationUpdate:
+      description: Application Update success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApplicationUpdateResponse'
+    Forbidden:
+      description: Forbidden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ForbiddenError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/ForbiddenExample'
+    Conflict:
+      description: Conflict
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictError'
+    TooManyRequests:
+      description: Too Many Requests
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/TooManyRequestsError'
+    ListCredentials:
+      description: List credentials response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListCredentialsResponse'
+    CredentialCreation:
+      description: Credential Creation success
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CredentialCreationResponse'
+    PostCredentials403Response:
+      description: Error returned when the number of credentials exceed the quota.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ForbiddenError'
+          examples:
+            PostCredentials403Example:
+              $ref: '#/components/examples/PostCredentials403Example'
+    ListAuthStrategies:
+      description: List auth strategies response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListAuthStrategiesResponse'
+    Gone:
+      description: Gone
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/GoneError'
+          examples:
+            410-Expired-Token:
+              $ref: '#/components/examples/410-Expired-Token'
+    VerifyEmailResponse:
+      description: The response schema for the verify email endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/VerifyEmailResponse'
+          examples:
+            VerifyEmailResponse:
+              $ref: '#/components/examples/Verify-Email-Response'
+    responses-Unauthorized:
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/UnauthorizedExample'
+    MeResponse:
+      description: Response from me endpoint
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Developer'
+    ListPortalPagesResponse:
+      description: Paginated list of portal pages
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListPortalPages'
+          examples:
+            ListPortalPageResponseExample1:
+              value:
+                data:
+                  - id: 582b9327-3eba-4bfe-9438-6066840dbbca
+                    title: Home
+                    slug: /
+                    visibility: public
+                    description: Welcome page
+                    parent_page_id: null
+                    children: []
+                    created_at: '2022-11-04T20:10:06.927Z'
+                    updated_at: '2022-11-04T20:10:06.927Z'
+                meta:
+                  page:
+                    size: 10
+                    total: 1
+                    number: 1
+    ListPortalSnippetsResponse:
+      description: Paginated list of portal snippets
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListPortalSnippets'
+          examples:
+            ListPortalSnippetResponseExample1:
+              value:
+                data:
+                  - id: 582b9327-3eba-4bfe-9438-6066840dbbca
+                    title: Home
+                    name: snip1
+                    visibility: public
+                    description: Welcome snippet
+                    created_at: '2021-09-01T00:00:00Z'
+                    updated_at: '2021-09-01T00:00:00Z'
+                meta:
+                  page:
+                    size: 10
+                    total: 1
+                    number: 1
+    GetPortalPageResponse:
+      description: A single portal page
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalPage'
+          examples:
+            PortalPageResponseExample1:
+              value:
+                id: 582b9327-3eba-4bfe-9438-6066840dbbca
+                title: Home
+                slug: /
+                content: '# Welcome to the Developer Portal'
+                visibility: public
+                parent_page_id: null
+                created_at: '2021-09-01T00:00:00Z'
+                updated_at: '2021-09-01T00:00:00Z'
+    GetPortalSnippetResponse:
+      description: A single portal snippet
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalSnippet'
+          examples:
+            PortalPageResponseExample1:
+              value:
+                id: 582b9327-3eba-4bfe-9438-6066840dbbca
+                title: Home
+                name: snip1
+                content: '# Welcome to the Developer Portal'
+                visibility: public
+                created_at: '2021-09-01T00:00:00Z'
+                updated_at: '2021-09-01T00:00:00Z'
+    GetPortalContextResponse:
+      description: The portal context object
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalContext'
+          examples:
+            GetPortalContextResponseExample1:
+              value:
+                portal_id: 18a9b697-7e68-411b-8e1d-102b261ab18e
+                org_id: a40f5d1f-d889-42e9-94ea-b9b33585fc6b
+                basic_auth_enabled: true
+                oidc_auth_enabled: true
+                saml_auth_enabled: true
+                authentication_enabled: true
+                rbac_enabled: true
+                name: my portal
+                canonical_domain: portal.example.com
+    PortalImageAssetResponse:
+      description: An image asset
+      content:
+        image/jpg:
+          schema:
+            type: string
+            format: binary
+        image/png:
+          schema:
+            type: string
+            format: binary
+    PortalCustomizationResponse:
+      description: Response for custom portal settings
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalCustomization'
+    CreateAPIRegistration:
+      description: Registration creation response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GetApiRegistrationResponse'
+    GetAPIRegistration:
+      description: Get registration response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GetApiRegistrationResponse'
+    ListApiRegistrations:
+      description: Get registrations response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ListApiRegistrationsResponse'
+    PortalSearchResponse:
+      description: Search Results
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PortalSearchResults'
+          examples:
+            Search Response Example:
+              $ref: '#/components/examples/PortalSearchResponseExample'
+  securitySchemes:
+    portalAccessToken:
+      type: apiKey
+      in: cookie
+      name: portalaccesstoken
+      description: >
+        The Developer portal cookie is meant to be used by the Developer API to
+        authenticate with.
+tags:
+  - name: APIs
+    description: Endpoints for viewing APIs published to the portal.
+  - name: API Docs
+    description: Endpoints for viewing API documentation published to the portal.
+  - name: Applications
+    description: >-
+      The API for Konnect Portal developer applications within a private portal
+      (i.e. requires registration/authentication). When a portal is in `public`
+      mode, all of the described endpoints will return a 404 error. A public
+      portal means that applications and registrations are not available/needed.
+      In this API's context, "you" and "your" refers to the developer consuming
+      the API.
+  - name: Credentials
+    description: >-
+      The API for Konnect Portal developer credentials within a private portal
+      (i.e. requires registration/authentication).
+  - name: Developer
+    description: API for managing a Konnect Portal Developer.
+  - name: Portal
+    description: The API for retrieving details about a single Konnect Portal.
+  - name: Content
+    description: The API for retrieving content for a Konnect Portal.
+  - name: Registrations
+    description: >
+      The API for Konnect Portal application registrations. If the portal is
+      public
+
+      all of the described endpoints will return a 404 error
+  - name: Search
+    description: The API for Konnect Portal Search.
+x-errors:
+  granted-scopes-unavailable:
+    description: |
+      The IDP used does not support granted scopes.
+    resolution: |
+      Switch to an IDP that allows you to grant specific scopes.

--- a/app/_api/konnect/api-builder/_index.md
+++ b/app/_api/konnect/api-builder/_index.md
@@ -1,4 +1,4 @@
 ---
 konnect_product_id: 830b5dd0-6914-44fc-ae5d-cc8efcf77c04
-insomnia_link: https://insomnia.rest/run/?label=Konnect%20API%20Builder&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FKonnect%2Fv2%2Fyaml%2Fapi-builder.yaml
+insomnia_link: https://insomnia.rest/run/?label=Konnect%20API%20Builder&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FKonnect%2Fv3%2Fyaml%2Fapi-builder.yaml
 ---

--- a/app/_api/konnect/api-builder/_index.md
+++ b/app/_api/konnect/api-builder/_index.md
@@ -1,0 +1,4 @@
+---
+konnect_product_id: 830b5dd0-6914-44fc-ae5d-cc8efcf77c04
+insomnia_link: https://insomnia.rest/run/?label=Konnect%20API%20Builder&uri=https%3A%2F%2Fraw.githubusercontent.com%2FKong%2Fdocs.konghq.com%2Fmain%2Fapi-specs%2FKonnect%2Fv2%2Fyaml%2Fapi-builder.yaml
+---

--- a/app/dev-portal/portals/index.md
+++ b/app/dev-portal/portals/index.md
@@ -14,7 +14,7 @@ The Konnect Dev Portal is a customizable website for developers to locate, acces
 
 Your Dev Portal use case might dictate different security settings tailored to your audience. While this is not comprehensive of all possibilities, these are typical scenarios. Keep in mind it's quite common to have multiple Dev Portals with APIs shared across them.
 
-![Visibility and Access Control combinations](visibility-access-combinations)
+![Visibility and Access Control combinations](/assets/images/products/konnect/dev-portal-v3/visibility-access-combinations.png)
 > _**Figure 1:** Common visibility and access control combinations_
 
 #### Internal Dev Portal


### PR DESCRIPTION
### Description

Added required files for docs portal to list new API Builder v3, and added YAML versions of specs to potentially fix Insomnia links.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

