### PR TITLE
Add banner for Portal v3 beta docs

### DIFF
--- a/app/_layouts/docs-v2.html
+++ b/app/_layouts/docs-v2.html
@@ -114,6 +114,14 @@ id: documentation
               </blockquote>
           {% endunless %}
 
+          {% assign devPortalPrefix = page.url | slice: 0, 20 %}
+          {% assign apiProductsPrefix = page.url | slice: 0, 22 %}
+          {% if devPortalPrefix == '/konnect/dev-portal/' or apiProductsPrefix == '/konnect/api-products/' %}
+            <blockquote class="note">
+              Looking for the new Developer Portal beta docs? <a href="/dev-portal/">Try the beta now</a>.
+            </blockquote>
+          {% endif %}
+
           <h1 tabindex="-1" id="main" class="page-content-title"
           >{{page.title | flatify }}
             {% if page.github_star_button %}


### PR DESCRIPTION
### Description

Add a banner to highlight the v3 docs

![CleanShot 2025-03-05 at 13 27 09](https://github.com/user-attachments/assets/f68ab62f-d6ab-4606-8eec-ae8cfc2318c9)


### Testing instructions

Preview link: [/konnect/dev-portal/create-dev-portal/](https://deploy-preview-8508--kongdocs.netlify.app/konnect/dev-portal/create-dev-portal/)

### Checklist 

- [x] Review label added <!-- (see below) -->