### PR TITLE
Fix: cluster key in hybrid mode setup page

### DIFF
--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/setup.md
@@ -443,8 +443,8 @@ docker run -d --name kong-dp --network=kong-net \
 -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
 -e "KONG_CLUSTER_MTLS=pki" \
 -e "KONG_CLUSTER_SERVER_NAME=control-plane.kong.yourcorp.tld" \
--e "KONG_CLUSTER_CERT=data-plane.crt" \
--e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.crt" \
+-e "KONG_CLUSTER_CERT=/<path-to-file>/data-plane.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.key" \
 -e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
 -e "KONG_CLUSTER_DP_LABELS=deployment:cloud1,region:us-east-1" \
 --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
@@ -462,8 +462,8 @@ docker run -d --name kong-dp --network=kong-net \
 -e "KONG_CLUSTER_TELEMETRY_ENDPOINT=control-plane.<admin-hostname>.com:8006" \
 -e "KONG_CLUSTER_MTLS=pki" \
 -e "KONG_CLUSTER_SERVER_NAME=control-plane.kong.yourcorp.tld" \
--e "KONG_CLUSTER_CERT=data-plane.crt" \
--e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.crt" \
+-e "KONG_CLUSTER_CERT=/<path-to-file>/data-plane.crt" \
+-e "KONG_CLUSTER_CERT_KEY=/<path-to-file>/data-plane.key" \
 -e "KONG_CLUSTER_CA_CERT=/<path-to-file>/ca-cert.pem" \
 -e "KONG_CLUSTER_DP_LABELS=deployment:cloud1,region:us-east-1" \
 --mount type=bind,source="$(pwd)"/cluster,target=<path-to-keys-and-certs>,readonly \
@@ -550,7 +550,7 @@ and follow the instructions in Steps 1 and 2 **only** to download
     cluster_mtls = pki
     cluster_server_name = control-plane.kong.yourcorp.tld
     cluster_cert = /<path-to-file>/data-plane.crt
-    cluster_cert_key = /<path-to-file>/data-plane.crt
+    cluster_cert_key = /<path-to-file>/data-plane.key
     cluster_ca_cert = /<path-to-file>/ca-cert.pem
     cluster_dp_labels = deployment:cloud1,region:us-east-1
     ```


### PR DESCRIPTION
### Description

`KONG_CLUSTER_CERT_KEY` was showing `cluster.crt` as the file name. It should be `cluster.key`.

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1741304592807449

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

