### PR TITLE
chore(deps): bump kumahq/kuma-website from 502e3f8f to 06312a73

### DIFF
--- a/app/_assets/javascripts/tabs.js
+++ b/app/_assets/javascripts/tabs.js
@@ -71,9 +71,7 @@ class TabsComponent {
 
   selectTab(event) {
     event.stopPropagation();
-    if (this.options['useUrlFragment'] === 'false') {
-      event.preventDefault();
-    }
+    event.preventDefault();
 
     const slug = event.target.dataset.slug || event.target.querySelector('[data-slug]')?.dataset?.slug;
 

--- a/app/_includes/snippets/install_kumactl.md
+++ b/app/_includes/snippets/install_kumactl.md
@@ -1,7 +1,7 @@
 To run Kuma on Kubernetes, you need to download the Kuma CLI (`kumactl`) on your machine.
 
-{% tabs install_kumactl useUrlFragment=false %}
-{% tab install_kumactl Script %}
+{% tabs %}
+{% tab Script %}
 
 You can run the following script to automatically detect the operating system and download Kuma:
 
@@ -11,7 +11,7 @@ You can run the following script to automatically detect the operating system an
 
 You can omit the `VERSION` variable to install the latest version. 
 {% endtab %}
-{% tab install_kumactl Direct Link %}
+{% tab Direct Link %}
 
 You can also download the distribution manually. Download a distribution for the **client host** from where you will be executing the commands to access Kubernetes:
 

--- a/app/_includes/snippets/install_os.md
+++ b/app/_includes/snippets/install_os.md
@@ -46,22 +46,22 @@ ln -s kuma-{{ $page.latestVersion }}/bin/kumactl /usr/local/bin/kumactl
 
 Kuma (`kuma-cp`) is now running! Now that Kuma has been installed you can access the control-plane via either the GUI, the HTTP API, or the CLI:
 
-{% tabs use-kuma useUrlFragment=false %}
-{% tab use-kuma GUI (Read-Only) %}
+{% tabs %}
+{% tab GUI (Read-Only) %}
 
 Kuma ships with a **read-only** GUI that you can use to retrieve Kuma resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
 
 To access Kuma you can navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
 
 {% endtab %}
-{% tab use-kuma HTTP API (Read & Write) %}
+{% tab HTTP API (Read & Write) %}
 
 Kuma ships with a **read and write** HTTP API that you can use to perform operations on Kuma resources. By default the HTTP API listens on port `5681`.
 
 To access Kuma you can navigate to [`127.0.0.1:5681`](http://127.0.0.1:5681) to see the HTTP API.
 
 {% endtab %}
-{% tab use-kuma kumactl (Read & Write) %}
+{% tab kumactl (Read & Write) %}
 
 You can use the `kumactl` CLI to perform **read and write** operations on Kuma resources. The `kumactl` binary is a client to the Kuma HTTP API. For example:
 

--- a/app/_includes/snippets/use_kuma_k8s.md
+++ b/app/_includes/snippets/use_kuma_k8s.md
@@ -1,7 +1,7 @@
 Kuma (`kuma-cp`) will be installed in the newly created `kuma-system` namespace! Now that Kuma has been installed, you can access the control-plane via either the GUI, `kubectl`, the HTTP API, or the CLI:
 
-{% tabs use-kuma-k8s useUrlFragment=false %}
-{% tab use-kuma-k8s GUI (Read-Only) %}
+{% tabs %}
+{% tab GUI (Read-Only) %}
 
 Kuma ships with a **read-only** GUI that you can use to retrieve Kuma resources. By default the GUI listens on the API port and defaults to `:5681/gui`.
 
@@ -14,7 +14,7 @@ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
 And then navigate to [`127.0.0.1:5681/gui`](http://127.0.0.1:5681/gui) to see the GUI.
 
 {% endtab %}
-{% tab use-kuma-k8s kubectl (Read & Write) %}
+{% tab kubectl (Read & Write) %}
 
 You can use Kuma with `kubectl` to perform **read and write** operations on Kuma resources. For example:
 
@@ -40,7 +40,7 @@ spec:
 ```
 
 {% endtab %}
-{% tab use-kuma-k8s HTTP API (Read-Only) %}
+{% tab HTTP API (Read-Only) %}
 
 Kuma ships with a **read-only** HTTP API that you can use to retrieve Kuma resources.
 
@@ -53,7 +53,7 @@ kubectl port-forward svc/kuma-control-plane -n kuma-system 5681:5681
 And then you can navigate to [`127.0.0.1:5681`](http://127.0.0.1:5681) to see the HTTP API.
 
 {% endtab %}
-{% tab use-kuma-k8s kumactl (Read-Only) %}
+{% tab kumactl (Read-Only) %}
 
 You can use the `kumactl` CLI to perform **read-only** operations on Kuma resources. The `kumactl` binary is a client to the Kuma HTTP API, you will need to first port-forward the API service with:
 

--- a/app/_plugins/kuma-specific/tabs/tabs.rb
+++ b/app/_plugins/kuma-specific/tabs/tabs.rb
@@ -6,57 +6,30 @@ require 'securerandom'
 module Jekyll
   module Tabs
     class TabsBlock < Liquid::Block
-      def initialize(tag_name, config, tokens) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def initialize(tag_name, markup, tokens)
         super
 
-        @name, options = config.split(' ', 2)
-        @options = options.split.each_with_object({}) do |o, h|
-          key, value = o.split('=')
-          h[key] = value || ''
-        end
-
-        # Ensure 'useUrlFragment':
-        # - Defaults to 'true' if not present
-        # - If present without a value, it's 'true'
-        # - If present with a value, it keeps that value
-        @options['useUrlFragment'] =
-          if @options.key?('useUrlFragment')
-            @options['useUrlFragment'].empty? ? 'true' : @options['useUrlFragment']
-          else
-            'true'
-          end
-
-        # Normalize 'additionalClasses' by stripping quotes and ensuring proper spacing
-        additional_classes = @options.fetch('additionalClasses', '').gsub(/^"|"$/, '').strip
-        @options['additionalClasses'] = additional_classes.empty? ? '' : " #{additional_classes}"
+        @class = markup.strip.empty? ? '' : " #{markup.strip}"
       end
 
-      def render(context) # rubocop:disable Metrics/AbcSize
+      def render(context)
+        tabs_id = SecureRandom.uuid
         environment = context.environments.first
-        environment['tabs'] ||= {}
-        file_path = context.registers[:page]['dir']
-        environment['tabs'][file_path] ||= {}
+        environment["tabs-#{tabs_id}"] = {}
+        environment['tabs-stack'] ||= []
 
-        if environment['tabs'][file_path].key? @name
-          raise SyntaxError, "There's already a {% tabs %} block with the name '#{@name}'."
-        end
-
-        environment['tabs'][file_path][@name] ||= {}
-
+        environment['tabs-stack'].push(tabs_id)
         super
+        environment['tabs-stack'].pop
 
         ERB.new(self.class.template).result(binding)
       end
 
       def self.template
         <<~ERB
-          <div
-            class="tabs-component navtabs<%= @options['additionalClasses'] %>"
-            data-tab="<%= SecureRandom.uuid %>"
-            data-use-url-fragment="<%= @options['useUrlFragment'] %>"
-          >
+          <div class="tabs-component navtabs<%= @class %>" >
             <div role="tablist" class="tabs-component-tabs navtab-titles">
-              <% environment['tabs'][file_path][@name].each_with_index do |(hash, value), index| %>
+              <% environment['tabs-' + tabs_id].each_with_index do |(hash, _), index| %>
                 <div class="tabs-component-tab navtab-title<%= index == 0 ? ' active' : '' %>" role="presentation">
                   <a
                     aria-controls="<%= hash.rstrip.gsub(' ', '-') %>"
@@ -73,7 +46,7 @@ module Jekyll
             </div>
 
             <div class="tabs-component-panels navtab-contents">
-              <% environment['tabs'][file_path][@name].each_with_index do |(key, value), index| %>
+              <% environment['tabs-' + tabs_id].each_with_index do |(key, value), index| %>
                 <section
                   aria-hidden="<%= index != 0 %>"
                   class="tabs-component-panel navtab-content<%= index != 0 ? ' hidden' : '' %>"
@@ -95,19 +68,28 @@ module Jekyll
 
       def initialize(tag_name, markup, tokens)
         super
+        raise SyntaxError, "No toggle name given in #{tag_name} tag" if markup == ''
 
-        @name, @tab = markup.split(' ', 2)
+        @title = markup.strip
       end
 
-      def render(context) # rubocop:disable Metrics/AbcSize
+      def render(context) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        # Add support for variable titles
+        path = @title.split('.')
+        # 0 is the page scope, 1 is the local scope
+        [0, 1].each do |k|
+          next unless context.scopes[k]
+
+          ref = context.scopes[k].dig(*path)
+          @title = ref if ref
+        end
+
         site = context.registers[:site]
         converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
-        file_path = context.registers[:page]['dir']
-
         environment = context.environments.first
 
-        environment['tabs'][file_path][@name] ||= {}
-        environment['tabs'][file_path][@name][@tab] = converter.convert(render_block(context))
+        tabs_id = environment['tabs-stack'].last
+        environment["tabs-#{tabs_id}"][@title] = converter.convert(render_block(context))
       end
     end
   end

--- a/app/_src/mesh/features/meshglobalratelimit.md
+++ b/app/_src/mesh/features/meshglobalratelimit.md
@@ -109,15 +109,15 @@ TODO: document how to generate and use zone token on universal.-->
 ## TargetRef support matrix
 
 {% if_version gte:2.7.x %}
-{% tabs targetRef useUrlFragment=false %}
-{% tab targetRef Sidecar %}
+{% tabs %}
+{% tab Sidecar %}
 | `targetRef`             | Allowed kinds                         |
 | ----------------------- | ------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshSubset`, `MeshService`   |
 | `from[].targetRef.kind` | `Mesh`                                |
 {% endtab %}
 
-{% tab targetRef Builtin Gateway %}
+{% tab Builtin Gateway %}
 | `targetRef`             | Allowed kinds                                             |
 | ----------------------- | --------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshGateway`                                     |

--- a/app/_src/mesh/features/meshopa.md
+++ b/app/_src/mesh/features/meshopa.md
@@ -21,14 +21,14 @@ When the `MeshOPA` policy is applied, the control plane configures the following
 ## TargetRef support matrix
 
 {% if_version gte:2.6.x %}
-{% tabs targetRef useUrlFragment=false %}
-{% tab targetRef Sidecar %}
+{% tabs %}
+{% tab Sidecar %}
 | `targetRef`           | Allowed kinds                                            |
 | --------------------- | -------------------------------------------------------- |
 | `targetRef.kind`      | `Mesh`, `MeshSubset`, `MeshService`, `MeshServiceSubset` |
 {% endtab %}
 
-{% tab targetRef Builtin Gateway %}
+{% tab Builtin Gateway %}
 | `targetRef`             | Allowed kinds                                             |
 | ----------------------- | --------------------------------------------------------- |
 | `targetRef.kind`        | `Mesh`, `MeshGateway`                                     |


### PR DESCRIPTION
Auto upgrade PR log:

06312a73ffd05c9d54d9a9227d923cdce13e6fff refactor(plugin/tabs): simplify usage and remove useUrlFragment (kumahq/kuma-website#2216)
9c4f7f9b6a3e53f01dc120b7245d7293f7ac834d chore: fix broken datadog agent links (kumahq/kuma-website#2218)

Triggered by [action](https://github.com/Kong/docs.konghq.com/actions/runs/13715870250).