### PR TITLE
Rename title in transit-gateways.md

### DIFF
--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/transit-gateways.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/transit-gateways.md
@@ -1,5 +1,5 @@
 ---
-title: How to configure Transit Gateway
+title: How to configure AWS Transit Gateway
 ---
 
 
@@ -25,8 +25,8 @@ To establish private connectivity between the {{site.konnect_short_name}} networ
 ## Configure AWS Transit Gateway
 
 1. While logged in to AWS, select the same region as your cloud gateways network. 
-1. Select **VPC** > **Transit Gateways**, then click **Create Transit Gateway**.
-1. Name the transit gateway and then click **Create Transit Gateway**. 
+1. Select **VPC** > **Transit Gateways**, then click **Create transit gateway**.
+1. Name the transit gateway and then click **Create transit gateway**. 
 
 This will display a **Transit Gateway ID**, save this. 
 


### PR DESCRIPTION
### Description

Issue reported at [https://github.com/Kong/docs.konghq.com/issues/8296](https://github.com/Kong/docs.konghq.com/issues/8296)

Change title from "How to configure Transit Gateway" to "How to configure AWS Transit Gateway", so it clearly states this is an AWS product.

In the "Configure AWS Transit Gateway" section, replace "Create Transit Gateway" with "Create transit gateway", in lowercase, as this is the term appearing in AWS.


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

