### PR TITLE
docs(portal): reserved paths

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -92,6 +92,7 @@ Nginx
 Nginx's
 Node.js
 Noname
+Nuxt
 OAuth
 Okta
 Okta's
@@ -293,6 +294,7 @@ healthchecks
 hostname
 hostnames
 href
+HTML
 http
 httpbin
 HTTPie

--- a/app/dev-portal/portals/customization/custom-pages.md
+++ b/app/dev-portal/portals/customization/custom-pages.md
@@ -47,6 +47,7 @@ The Portal requires a number of reserved paths from the root of the URL in order
 | `/logout` | Log out | `^/logout` |
 | `/apps/*` | Developer applications | `^/apps` |
 | `/api/v*/` | Portal API | `^/api\/v\d+\/.*` |
+| `/_api/*` | Nuxt server endpoints | `^/_api\/.*` |
 | `/api/*` | Nuxt server endpoints | `^/api\/(?!v\d+\/).*` |
 | `/npm/*` | CDN Proxy | `^/npm\/.*` |
 | `/_preview-mode/*` | Konnect previews | `^/_preview-mode\/.*` |

--- a/app/dev-portal/portals/customization/custom-pages.md
+++ b/app/dev-portal/portals/customization/custom-pages.md
@@ -4,7 +4,7 @@ title: Custom Pages
 
 Pages are highly customizable using Markdown Components (MDC), allowing to create nested page structures to organize pages and generate URLs/slugs. Visibility controls and Publishing status allow you to stage new Pages, and/or restrict access to logged-in Developers.
 
-To get started creating Pages, navigate to your Dev Portal and select [**Portal Editor**](/dev-portal/portals/portal-editor) from the left sidebar.
+To get started creating Pages, navigate to your Dev Portal and select [**Portal Editor**](/dev-portal/portals/customization/portal-editor/) from the left sidebar.
 
 {:.note}
 > *Pages are built using Markdown Components (MDC). Additional documentation on syntax, as well as tools for generating components, are available on a [dedicated MDC site](https://portaldocs.konghq.com/).*

--- a/app/dev-portal/portals/customization/custom-pages.md
+++ b/app/dev-portal/portals/customization/custom-pages.md
@@ -87,7 +87,7 @@ description: Start building and innovating with our APIs
 ---
 ```
 
-With the above front matter, the portal will render the following html tags for your page:
+With the above front matter, the portal will render the following HTML tags for your page:
 
 ```
 <title>Home | Developer Portal</title>

--- a/app/dev-portal/portals/customization/custom-pages.md
+++ b/app/dev-portal/portals/customization/custom-pages.md
@@ -36,7 +36,8 @@ Example: `about` has a child page, `contact`. The URL for the `contact` page wou
 
 #### Reserved paths
 
-The Portal requires a number of reserved paths from the root of the URL in order to properly function that may not be overridden with custom pages or other functionality.
+The Portal requires a number of reserved paths from the root of the URL to properly function. 
+You cannot override these paths with custom pages or other functionality.
 
 | Path | Description | RegExp
 |:------|:-------|:-------|

--- a/app/dev-portal/portals/customization/custom-pages.md
+++ b/app/dev-portal/portals/customization/custom-pages.md
@@ -34,9 +34,26 @@ Example: `about` has a child page, `contact`. The URL for the `contact` page wou
 {:.note}
 > *`home` is a special page representing the `/` path. If this page is deleted, you'll need to create it from the Pages API.*
 
+#### Reserved paths
+
+The Portal requires a number of reserved paths from the root of the URL in order to properly function that may not be overridden with custom pages or other functionality.
+
+| Path | Description | RegExp
+|:------|:-------|:-------|
+| `/login/*` | Login | `^/login(?:\/.*)?` |
+| `/register` | Registration | `^/register` |
+| `/forgot-password` | Forgot password | `^/forgot-password` |
+| `/reset-password` | Reset password | `^/reset-password` |
+| `/logout` | Log out | `^/logout` |
+| `/apps/*` | Developer applications | `^/apps` |
+| `/api/v*/` | Portal API | `^/api\/v\d+\/.*` |
+| `/api/*` | Nuxt server endpoints | `^/api\/(?!v\d+\/).*` |
+| `/npm/*` | CDN Proxy | `^/npm\/.*` |
+| `/_preview-mode/*` | Konnect previews | `^/_preview-mode\/.*` |
+
 ### Modify a Page
 
-In the middle panel, you can make changes to your MDC content, and instantly see the live Preview. 
+In the middle panel, you can make changes to your MDC content, and instantly see the live Preview.
 
 Once you have completed your changes, be sure to click **Save**.
 


### PR DESCRIPTION
### Description

Document the new Dev Portal reserved paths.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

