### PR TITLE
Fix: remove url for non-existent page

### DIFF
--- a/app/_data/docs_nav_dev-portal.yml
+++ b/app/_data/docs_nav_dev-portal.yml
@@ -55,7 +55,6 @@
     - text: Overview
       url: /app-reg/
     - text: Auth Strategies
-      url: /app-reg/auth-strategies/
       items:
         - text: Key Auth
           url: /app-reg/auth-strategies/key-auth/


### PR DESCRIPTION
### Description
This page doesn't exist, and it's triggering the broken link checker: https://github.com/Kong/docs.konghq.com/actions/runs/13723604625/job/38384691884?pr=8527

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

