### PR TITLE
docs(portal): add reserved path for api proxy

### DIFF
--- a/app/dev-portal/portals/customization/custom-pages.md
+++ b/app/dev-portal/portals/customization/custom-pages.md
@@ -36,7 +36,7 @@ Example: `about` has a child page, `contact`. The URL for the `contact` page wou
 
 #### Reserved paths
 
-The Portal requires a number of reserved paths from the root of the URL to properly function. 
+The Portal requires a number of reserved paths from the root of the URL to properly function.
 You cannot override these paths with custom pages or other functionality.
 
 | Path | Description | RegExp
@@ -48,8 +48,9 @@ You cannot override these paths with custom pages or other functionality.
 | `/logout` | Log out | `^/logout` |
 | `/apps/*` | Developer applications | `^/apps` |
 | `/api/v*/` | Portal API | `^/api\/v\d+\/.*` |
-| `/_api/*` | Nuxt server endpoints | `^/_api\/.*` |
+| `/_proxy/*` | Proxied APIs | `^/_proxy/.*` |
 | `/api/*` | Nuxt server endpoints | `^/api\/(?!v\d+\/).*` |
+| `/_api/*` | Nuxt server endpoints | `^/_api\/.*` |
 | `/npm/*` | CDN Proxy | `^/npm\/.*` |
 | `/_preview-mode/*` | Konnect previews | `^/_preview-mode\/.*` |
 


### PR DESCRIPTION
### Description

List the proxy path as reserved in Portal Custom Pages.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

