### PR TITLE
Warn log interleaving

### DIFF
--- a/app/_hub/kong-inc/file-log/overview/_index.md
+++ b/app/_hub/kong-inc/file-log/overview/_index.md
@@ -9,6 +9,12 @@ when running Kong in Kubernetes.
 This plugin uses blocking I/O, which could affect performance when writing
 to physical files on slow (spinning) disks.
 
+{:.important}
+> Log interleaving can occur when logging to stdout. This happens because data
+> written through a pipe must fit within the pipe buffer, which is typically 4k
+> as defined by the Linux kernel. If the data exceeds this size, the kernel cannot
+> guarantee the atomicity of the write() system call, leading to interleaved logs. 
+
 ## Log format
 
 {% include /md/plugins-hub/log-format.md %}


### PR DESCRIPTION
Warn users that log interleaving may occur.


### Description

Add warn message in file log plugin stating that log interleaving may occur.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added
