### PR TITLE
feat: add docs for CSP header in GW 3.10

### DIFF
--- a/app/_data/docs_nav_gateway_3.10.x.yml
+++ b/app/_data/docs_nav_gateway_3.10.x.yml
@@ -135,7 +135,7 @@ items:
           - text: Enable Kong Manager
             url: /install/post-install/kong-manager/
             generate: false
-  
+
   - title: Kong in Production
     icon: /assets/images/icons/documentation/icn-deployment-color.svg
     items:
@@ -489,6 +489,8 @@ items:
         url: /kong-manager/configuring-to-send-email
       - text: Troubleshoot
         url: /kong-manager/troubleshoot/
+      - text: Strengthen Security
+        url: /kong-manager/strengthen-security
 
   - title: Develop Custom Plugins
     icon: /assets/images/icons/documentation/icn-dev-portal-color.svg

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -10,7 +10,7 @@ Content Security Policy (CSP) is a feature that helps to prevent or minimize the
 
 Kong Manager provides an optional configuration parameter [`admin_gui_csp_header`] that allows you to enable the Content Security Policy header in Kong Manager. The Content Security Policy header is turned off by default.
 
-By default, Kong Manager will enforce a default Content Security Policy composed of the following directives when [`admin_gui_csp_header`] is enabled:
+When `admin_gui_csp_header` is enabled, Kong Manager will enforce a default Content Security Policy composed of the following directives:
 
 ```
 default-src 'self';

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -34,7 +34,7 @@ admin_gui_csp_header_value = default-src 'self'; connect-src 'self' https://my-a
 ```
 
 {:.warning}
-> **Note:** Invalid Content Security Policy may break the functionality of Kong Manager or even expose to security risks. Please make sure to test the Content Security Policy before using it in production.
+> **Note:** An invalid Content Security Policy may break the functionality of Kong Manager or even expose it to security risks. Make sure to test the Content Security Policy before using it in production.
 
 ## See also
 

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -6,7 +6,7 @@ badge: enterprise
 
 ## Content Security Policy
 
-Content Security Policy (CSP) is a feature that helps to prevent or minimize the risk of certain types of security threats. It consists of a series of instructions from a website to a browser, which instruct the browser to place restrictions on the things that the code comprising the site is allowed to do.
+A Content Security Policy (CSP) helps prevent or minimize the risk of certain types of security threats. It consists of a series of instructions from a website to a browser, which instruct the browser to place restrictions on the things that the code comprising the site is allowed to do.
 
 Kong Manager provides the optional configuration parameter [`admin_gui_csp_header`] that allows you to enable the Content Security Policy header. The Content Security Policy header is turned off by default.
 

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -8,7 +8,7 @@ badge: enterprise
 
 Content Security Policy (CSP) is a feature that helps to prevent or minimize the risk of certain types of security threats. It consists of a series of instructions from a website to a browser, which instruct the browser to place restrictions on the things that the code comprising the site is allowed to do.
 
-Kong Manager provides an optional configuration parameter [`admin_gui_csp_header`] that allows you to enable the Content Security Policy header in Kong Manager. The Content Security Policy header is turned off by default.
+Kong Manager provides the optional configuration parameter [`admin_gui_csp_header`] that allows you to enable the Content Security Policy header. The Content Security Policy header is turned off by default.
 
 When `admin_gui_csp_header` is enabled, Kong Manager will enforce a default Content Security Policy composed of the following directives:
 

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -1,0 +1,48 @@
+---
+title: Strengthen Security in Kong Manager
+badge: enterprise
+---
+
+{% if_version gte:3.10.x %}
+
+## Content Security Policy
+
+Content Security Policy (CSP) is a feature that helps to prevent or minimize the risk of certain types of security threats. It consists of a series of instructions from a website to a browser, which instruct the browser to place restrictions on the things that the code comprising the site is allowed to do.
+
+Kong Manager provides an optional configuration parameter [`admin_gui_csp_header`] that allows you to enable the Content Security Policy header in Kong Manager. The Content Security Policy header is turned off by default.
+
+By default, Kong Manager will enforce a default Content Security Policy composed of the following directives when [`admin_gui_csp_header`] is enabled:
+
+```
+default-src 'self';
+connect-src <...see below...>;
+img-src 'self' data:;
+script-src 'self' 'wasm-unsafe-eval';
+script-src-elem 'self';
+style-src 'self' 'unsafe-inline';
+```
+
+If [`admin_gui_api_url`] is not specified, the `connect-src` directive will depends on the requesting host and port. e.g., If the request URL is `http://localhost:9112`, the `connect-src` directive will be `http://localhost:9112`. If the request URL is `https://localhost:9112`, the `connect-src` directive will be `https://localhost:9112`.
+
+If [`admin_gui_api_url`] is specified, and it is started with `http://` or `https://`, the `connect-src` directive will be the value of [`admin_gui_api_url`]. Otherwise, the `connect-src` directive will be the value of [`admin_gui_api_url`] prefixed with `http://` when being accessed over HTTP, and `https://` when being accessed over HTTPS.
+
+### Customize the Content Security Policy header
+
+Sometimes, the default Content Security Policy may not fit your needs. You can customize the Content Security Policy by setting the [`admin_gui_csp_header_value`] parameter in your Kong configuration. For example:
+
+```
+admin_gui_csp_header_value = default-src 'self'; connect-src 'self' https://my-admin-api.tld;
+```
+
+{:.warning}
+> **Note:** Invalid Content Security Policy may break the functionality of Kong Manager or even expose to security risks. Please make sure to test the Content Security Policy before using it in production.
+
+### See also
+
+* [Content Security Policy (CSP) - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+
+[`admin_gui_api_url`]: /gateway/{{page.release}}/reference/configuration/#admin_gui_api_url
+[`admin_gui_csp_header`]: /gateway/{{page.release}}/reference/configuration/#admin_gui_csp_header
+[`admin_gui_csp_header_value`]: /gateway/{{page.release}}/reference/configuration/#admin_gui_csp_header_value
+
+{% endif_version %}

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -44,4 +44,3 @@ admin_gui_csp_header_value = default-src 'self'; connect-src 'self' https://my-a
 [`admin_gui_csp_header`]: /gateway/{{page.release}}/reference/configuration/#admin_gui_csp_header
 [`admin_gui_csp_header_value`]: /gateway/{{page.release}}/reference/configuration/#admin_gui_csp_header_value
 
-{% endif_version %}

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -23,7 +23,9 @@ style-src 'self' 'unsafe-inline';
 
 If [`admin_gui_api_url`] is not specified, the `connect-src` directive will depends on the requesting host and port. e.g., If the request URL is `http://localhost:9112`, the `connect-src` directive will be `http://localhost:9112`. If the request URL is `https://localhost:9112`, the `connect-src` directive will be `https://localhost:9112`.
 
-If [`admin_gui_api_url`] is specified, and it is started with `http://` or `https://`, the `connect-src` directive will be the value of [`admin_gui_api_url`]. Otherwise, the `connect-src` directive will be the value of [`admin_gui_api_url`] prefixed with `http://` when being accessed over HTTP, and `https://` when being accessed over HTTPS.
+If `admin_gui_api_url` is specified, the `connect_src` directive will depend on the presence of the `http` or `https` prefix:
+* If `admin_gui_api_url` starts with `http://` or `https://`, the `connect-src` directive will be the value of `admin_gui_api_url`. 
+*  If `admin_gui_api_url` doesn't start with `http://` or `https://`, the `connect-src` directive will be the value of `admin_gui_api_url` prefixed with `http://` when being accessed over HTTP, and `https://` when being accessed over HTTPS.
 
 ### Customize the Content Security Policy header
 

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -3,7 +3,6 @@ title: Strengthen Security in Kong Manager
 badge: enterprise
 ---
 
-{% if_version gte:3.10.x %}
 
 ## Content Security Policy
 

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -39,7 +39,7 @@ admin_gui_csp_header_value = default-src 'self'; connect-src 'self' https://my-a
 
 ### See also
 
-* [Content Security Policy (CSP) - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+* [Content Security Policy (CSP) - HTTP \| MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 
 [`admin_gui_api_url`]: /gateway/{{page.release}}/reference/configuration/#admin_gui_api_url
 [`admin_gui_csp_header`]: /gateway/{{page.release}}/reference/configuration/#admin_gui_csp_header

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -21,7 +21,9 @@ script-src-elem 'self';
 style-src 'self' 'unsafe-inline';
 ```
 
-If [`admin_gui_api_url`] is not specified, the `connect-src` directive will depends on the requesting host and port. e.g., If the request URL is `http://localhost:9112`, the `connect-src` directive will be `http://localhost:9112`. If the request URL is `https://localhost:9112`, the `connect-src` directive will be `https://localhost:9112`.
+If `admin_gui_api_url` is not specified, the `connect-src` directive will depend on the requesting host and port. For example:
+  * If the request URL is `http://localhost:9112`, the `connect-src` directive will be `http://localhost:9112
+  * If the request URL is `https://localhost:9112`, the `connect-src` directive will be `https://localhost:9112`.
 
 If `admin_gui_api_url` is specified, the `connect_src` directive will depend on the presence of the `http` or `https` prefix:
 * If `admin_gui_api_url` starts with `http://` or `https://`, the `connect-src` directive will be the value of `admin_gui_api_url`. 

--- a/app/_src/gateway/kong-manager/strengthen-security.md
+++ b/app/_src/gateway/kong-manager/strengthen-security.md
@@ -36,7 +36,7 @@ admin_gui_csp_header_value = default-src 'self'; connect-src 'self' https://my-a
 {:.warning}
 > **Note:** Invalid Content Security Policy may break the functionality of Kong Manager or even expose to security risks. Please make sure to test the Content Security Policy before using it in production.
 
-### See also
+## See also
 
 * [Content Security Policy (CSP) - HTTP \| MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 


### PR DESCRIPTION
### Description

This pull request adds documentation for the usage of new configuration parameters `admin_gui_csp_header` and `admin_gui_csp_header_value` in Gateway 3.10 as a guide _Strengthen Security in Kong Manager_.

KM-1003

### Testing instructions

Preview link: https://deploy-preview-8550--kongdocs.netlify.app/gateway/unreleased/kong-manager/strengthen-security/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

