### PR TITLE
docs(kic): add introduction of migration scripts in custom plugins

### DIFF
--- a/app/_src/kubernetes-ingress-controller/plugins/custom.md
+++ b/app/_src/kubernetes-ingress-controller/plugins/custom.md
@@ -52,6 +52,64 @@ secret/kong-plugin-myheader created
 {% endcapture %}
 {{ the_code | indent }}
 
+### Creating Plugin with Custom Entities and Migration Scripts
+
+If your custom plugin includes definition of your own entities, you need to create a `daos.lua` in your directory, and a `migration` sub-directory containing the scripts to create database tables and migrate data between different versions (if your schema of your entities changed between different versions). In the case, the directory should like this:
+
+```bash
+tree myheader
+```
+
+```bash
+  myheader
+  ├── daos.lua
+  ├── handler.lua
+  ├── migrations
+  │   ├── 000_base_my_header.lua
+  │   ├── 001_100_to_110.lua
+  │   └── init.lua
+  └── schema.lua
+
+  1 directories, 6 files
+```
+
+Since `ConfigMap` or `Secret` volumes does not support nested directories, you need to create another `ConfigMap` or `Secret` for the `migrations` directory:
+
+{% capture the_code %}
+{% navtabs codeblock %}
+{% navtab ConfigMap %}
+```bash
+$ kubectl create configmap kong-plugin-myheader-migrations --from-file=myheader/migrations -n kong
+```
+{% endnavtab %}
+
+{% navtab Secret %}
+```bash
+$ kubectl create secret generic -n kong kong-plugin-myheader-migrations --from-file=myheader/migrations
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
+    The results should look like this:
+{% capture the_code %}
+{% navtabs codeblock %}
+{% navtab ConfigMap %}
+```text
+configmap/kong-plugin-myheader-migrations created
+```
+{% endnavtab %}
+
+{% navtab Secret %}
+```text
+secret/kong-plugin-myheader-migrations created
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
 ## Deploying custom plugins
 
 ### Helm
@@ -84,6 +142,51 @@ gateway:
 {% endnavtabs %}
 {% endcapture %}
 {{ the_code | indent }}
+
+
+If you need to include the migration scripts to the plugin, you need to configure `userDefinedVolumes` and `userDefinedVolumeMounts` in `values.yaml` to mount the migration scripts to the {{site.base_gateway}} pod:
+
+{% capture the_code %}
+{% navtabs codeblock %}
+{% navtab ConfigMap %}
+```yaml
+gateway:
+  plugins:
+    configMaps:
+    - name: kong-plugin-myheader
+      pluginName: myheader
+  deployment:
+    userDefinedVolumes:
+    - name: "kong-plugin-myheader-migrations"
+      configMap:
+        name: "kong-plugin-myheader-migrations"
+    userDefinedVolumeMounts:
+    - name: "kong-plugin-myheader-migrations"
+      mountPath: "/opt/kong/plugins/myheader/migrations" # Should be the path /opt/kong/plugins/<plugin-name>/migrations
+```
+{% endnavtab %}
+
+{% navtab Secret %}
+```yaml
+gateway:
+  plugins:
+    secrets:
+    - name: kong-plugin-myheader
+      pluginName: myheader
+  deployment:
+    userDefinedVolumes:
+    - name: "kong-plugin-myheader-migrations"
+      secret:
+        name: "kong-plugin-myheader-migrations"
+    userDefinedVolumeMounts:
+    - name: "kong-plugin-myheader-migrations"
+      mountPath: "/opt/kong/plugins/myheader/migrations" # Should be the path /opt/kong/plugins/<plugin-name>/migrations
+```
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+{{ the_code | indent }}
+
 
 2. Install {{site.kic_product_name}}.
     ```
@@ -129,10 +232,15 @@ spec:
         volumeMounts:
         - name: kong-plugin-myheader
           mountPath: /opt/kong/plugins/myheader
+        - name: kong-plugin-myheader-migrations # Required when you have migration scripts in your plugin
+          mountPath: /opt/kong/plugins/myheader/migrations
       volumes:
       - name: kong-plugin-myheader
         configMap:
           name: kong-plugin-myheader
+      - name: kong-plugin-myheader-migrations # Required when you have migration scripts in your plugin
+        configMap:
+          name: kong-plugin-myheader-migrations
 ```
 
 ## Using custom plugins


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

Add the introduction of installing migration scripts in custom plugins in KIC.
fixes https://github.com/Kong/docs.konghq.com/issues/8317.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

