### PR TITLE
Feat: Custom plugin streaming

### DIFF
--- a/app/_data/docs_nav_konnect.yml
+++ b/app/_data/docs_nav_konnect.yml
@@ -58,6 +58,8 @@
         url: /gateway-manager/dedicated-cloud-gateways/azure-peering
       - text: Custom Domains
         url: /gateway-manager/dedicated-cloud-gateways/custom-dns/
+      - text: Custom Plugins
+        url: /gateway-manager/dedicated-cloud-gateways/custom-plugins/
       - text: Data plane logs
         url: /gateway-manager/dedicated-cloud-gateways/data-plane-logs
     - text: Serverless Gateways

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
@@ -1,7 +1,6 @@
 ---
 title: Custom plugins in Dedicated Cloud Gateways
 content_type: reference
-beta: true
 ---
 
 With Dedicated Cloud Gateways, {{site.konnect_short_name}} can stream custom plugins from the control plane to the data plane.

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
@@ -25,10 +25,10 @@ Compared to the manual process required in a regular hybrid {{site.konnect_short
 ## Adding a custom plugin to a Dedicated Cloud Gateway deployment
 
 Upload custom plugin schema and handler files to create a configurable entity in {{site.konnect_short_name}}.
+If you prefer using the {{konnect_short_name}} UI, you can also upload these files through the Plugins menu in [Gateway Manager](https://cloud.konghq.com/gateway-manager/).
 
 {:.important}
 > The name you give the plugin must be identical to the name of the plugin in the schema file.
-
 
 Using the following command, make a `POST` request to the [`/custom-plugins`](/konnect/api/control-plane-configuration/latest/#/operations/list-custom-plugin) endpoint of the {{site.konnect_short_name}} Control Plane Config API:
 
@@ -44,7 +44,6 @@ curl -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id
 ```
 
 This request returns an `HTTP 200` response with the schema and handler for your plugin as a JSON object.
-
 
 Once a custom plugin is uploaded to a Dedicated Cloud Gateway control plane, it can be managed like any other plugin, using any of the following tools:
 * [decK](/konnect/gateway-manager/declarative-config/)

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
@@ -19,11 +19,7 @@ In comparison with the manual process required in a regular hybrid {{site.konnec
   * Each custom plugin must have a unique name.
   * Each custom plugin can have a maximum of 1 `handler.lua` file and 1 `schema.lua` file.
   * The plugin can't execute in the `init_worker` phase and can't set any timers.
-  * The schema file must be in Lua, even if the custom plugin is written in another supported language.
-
-      If you have a custom plugin written in a language other than Lua, convert the schema 
-  into a `schema.lua` file before uploading it to {{site.konnect_short_name}}.
-
+  * The plugin must be written in Lua. No other languages are supported.
 * You have a [personal access token or system access token](/konnect/org-management/access-tokens) for the {{site.konnect_short_name}} API
 
 ## Adding a custom plugin to a Dedicated Cloud Gateway deployment

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
@@ -23,7 +23,7 @@ In comparison with the manual process required in a regular hybrid {{site.konnec
       If you have a custom plugin written in a language other than Lua, convert the schema 
   into a `schema.lua` file before uploading it to {{site.konnect_short_name}}.
 
-* You have a [personal acccess token or system access token](/konnect/org-management/access-tokens) for the {{site.konnect_short_name}} API
+* You have a [personal access token or system access token](/konnect/org-management/access-tokens) for the {{site.konnect_short_name}} API
 
 ## Adding a custom plugin to a Dedicated Cloud Gateway deployment
 
@@ -66,7 +66,7 @@ This request returns an `HTTP 200` response with the schema and handler for your
 
 Once a custom plugin is uploaded to a Dedicated Cloud Gateway control plane, it can be managed like any other plugin, using any of the following tools:
 * [decK](/konnect/gateway-manager/declarative-config/)
-* [{{site.konnect_short_name}} Control Plane Config API](https://docs.konghq.com/konnect/api/control-plane-configuration/latest/#/operations/list-custom-plugin)
+* [{{site.konnect_short_name}} Control Plane Config API](/konnect/api/control-plane-configuration/latest/#/operations/list-custom-plugin)
 * [{{site.konnect_short_name}} UI](https://cloud.konghq.com/)
 
 ## More information

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
@@ -8,14 +8,14 @@ With Dedicated Cloud Gateways, {{site.konnect_short_name}} can stream custom plu
 
 This means that the control plane becomes a single source of truth for plugin versions. You only need to upload a plugin once, to the control plane, and {{site.konnect_short_name}} handles distributing the plugin code to all data planes in that control plane.
 
-In comparison with the manual process required in a regular hybrid {{site.konnect_short_name}} deployment, custom plugin streaming in Dedicated Cloud Gateways provides the following benefits:
+Compared to the manual process required in a regular hybrid {{site.konnect_short_name}} deployment, custom plugin streaming in Dedicated Cloud Gateways provides the following benefits:
 * Faster custom plugin distribution
 * Minimal manual maintenance
 * The control plane is the single source of truth
 
 ## Prerequisites
 
-* Your custom plugin meets the following requirements:
+* Your [custom plugin](/gateway/latest/plugin-development/) meets the following requirements:
   * Each custom plugin must have a unique name.
   * Each custom plugin can have a maximum of 1 `handler.lua` file and 1 `schema.lua` file.
   * The plugin can't execute in the `init_worker` phase and can't set any timers.
@@ -29,21 +29,8 @@ Upload custom plugin schema and handler files to create a configurable entity in
 {:.important}
 > The name you give the plugin must be identical to the name of the plugin in the schema file.
 
-{% navtabs %}
-{% navtab Konnect UI %}
 
-You can add a custom plugin using the {{site.konnect_short_name}} UI:
-
-1. Open **Gateway Manager** > Choose a control plane -> Open **Plugins** -> switch to the **Custom Plugins** tab.
-1. Click **Create** on the Custom Plugin tile.
-1. Give the plugin a name.
-   The name must be identical to the name of the plugin in the schema file.
-1. Upload the `schema.lua` and `handler.lua` files, then save.
-
-{% endnavtab %}
-{% navtab Konnect API %}
-
-Using the following command, make a `POST` request to the `/custom-plugins` endpoints of the {{site.konnect_short_name}} Control Plane Config API:
+Using the following command, make a `POST` request to the [`/custom-plugins`](/konnect/api/control-plane-configuration/latest/#/operations/list-custom-plugin) endpoint of the {{site.konnect_short_name}} Control Plane Config API:
 
 ```sh
 curl -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/core-entities/custom-plugins \
@@ -58,8 +45,6 @@ curl -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id
 
 This request returns an `HTTP 200` response with the schema and handler for your plugin as a JSON object.
 
-{% endnavtab %}
-{% endnavtabs %}
 
 Once a custom plugin is uploaded to a Dedicated Cloud Gateway control plane, it can be managed like any other plugin, using any of the following tools:
 * [decK](/konnect/gateway-manager/declarative-config/)

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
@@ -1,6 +1,7 @@
 ---
 title: Custom plugins in Dedicated Cloud Gateways
 content_type: reference
+beta: true
 ---
 
 With Dedicated Cloud Gateways, {{site.konnect_short_name}} can stream custom plugins from the control plane to the data plane.

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
@@ -25,7 +25,7 @@ Compared to the manual process required in a regular hybrid {{site.konnect_short
 ## Adding a custom plugin to a Dedicated Cloud Gateway deployment
 
 Upload custom plugin schema and handler files to create a configurable entity in {{site.konnect_short_name}}.
-If you prefer using the {{konnect_short_name}} UI, you can also upload these files through the Plugins menu in [Gateway Manager](https://cloud.konghq.com/gateway-manager/).
+If you prefer using the {{site.konnect_short_name}} UI, you can also upload these files through the Plugins menu in [Gateway Manager](https://cloud.konghq.com/gateway-manager/).
 
 {:.important}
 > The name you give the plugin must be identical to the name of the plugin in the schema file.

--- a/app/konnect/gateway-manager/dedicated-cloud-gateways/index.md
+++ b/app/konnect/gateway-manager/dedicated-cloud-gateways/index.md
@@ -60,5 +60,6 @@ This includes [Data Plane Resilience](/gateway/latest/kong-enterprise/cp-outage-
 * [Data Plane logs](/konnect/gateway-manager/dedicated-cloud-gateways/)
 * [Transit Gateways](/konnect/gateway-manager/dedicated-cloud-gateways/transit-gateways/)
 * [How to upgrade data planes](/konnect/gateway-manager/data-plane-nodes/upgrade/)
-* [Custom Domains](/konnect/gateway-manager/dedicated-cloud-gateways/custom-dns/)
+* [Custom domains](/konnect/gateway-manager/dedicated-cloud-gateways/custom-dns/)
+* [Custom plugins](/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins/)
 * [Cloud Gateways API](/konnect/api/cloud-gateways/latest/)

--- a/app/konnect/gateway-manager/plugins/add-custom-plugin.md
+++ b/app/konnect/gateway-manager/plugins/add-custom-plugin.md
@@ -17,7 +17,8 @@ See [Editing or deleting a custom plugin's schema](/konnect/gateway-manager/plug
 for more information.
 
 {:.note}
-> **Note**: Custom plugins are not supported in Dedicated Cloud Gateways.
+> **Note**: For adding custom plugins to a Dedicated Cloud Gateway, see 
+[Custom plugins in Dedicated Cloud Gateways](/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins/).
 
 ## Prerequisites
 
@@ -186,6 +187,7 @@ or {{site.base_gateway}} deployments.
 ## More information
 
 * [Edit or delete custom plugins in {{site.konnect_short_name}}](/konnect/gateway-manager/plugins/update-custom-plugin/)
+* [Custom plugins in Dedicated Cloud Gateways](/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins/)
 * [Custom plugin schema endpoints (Control Plane Config API)](/konnect/api/control-plane-configuration/latest/#/Custom%20Plugin%20Schemas)
 * [Custom plugin template](https://github.com/Kong/kong-plugin)
 * [Plugin development guide](/gateway/latest/plugin-development/)

--- a/app/konnect/gateway-manager/plugins/index.md
+++ b/app/konnect/gateway-manager/plugins/index.md
@@ -40,7 +40,8 @@ can access via the Konnect UI or the custom plugins API. This means that {{site.
 only sees a custom plugin's configuration options, and does not see any other data.
 
 {:.note}
-> **Note**: Custom plugins are not supported in Dedicated Cloud Gateways.
+> **Note**: For adding custom plugins to a Dedicated Cloud Gateway, see 
+[Custom plugins in Dedicated Cloud Gateways](/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins/).
 
 To run in {{site.konnect_short_name}}, every custom plugin must meet the following requirements:
 
@@ -88,6 +89,7 @@ for the full list, as well as a breakdown of the pricing tiers that each plugin 
 ### Custom plugins
 * [Add a custom plugin in {{site.konnect_short_name}}](/konnect/gateway-manager/plugins/add-custom-plugin/)
 * [Edit or delete custom plugins in {{site.konnect_short_name}}](/konnect/gateway-manager/plugins/update-custom-plugin/)
+* [Custom plugins in Dedicated Cloud Gateways](/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins/)
 * [Custom plugin schema endpoints (Control Plane Config API)](/konnect/api/control-plane-configuration/latest/#/Custom%20Plugin%20Schemas)
 * [Custom plugin template](https://github.com/Kong/kong-plugin)
 * [Plugin development guide](/gateway/latest/plugin-development/)


### PR DESCRIPTION
### Description

Docs for custom plugin streaming on DCGWs.

### Testing instructions

Preview link: https://deploy-preview-8556--kongdocs.netlify.app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

