### PR TITLE
Add API for Gateway versions

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -14,6 +14,7 @@
     pcre: "8.45"
   lua_doc: true
   lts: true
+  endOfLifeDate: 2025-03-31
 - release: "3.3.x"
   ee-version: "3.3.1.1"
   ce-version: "3.3.1"
@@ -28,6 +29,7 @@
     libyaml: "0.2.5"
     pcre: 8.45
   lua_doc: true
+  endOfLifeDate: 2024-05-19
 - release: "3.4.x"
   ee-version: "3.4.3.16"
   ce-version: "3.4.2"
@@ -43,6 +45,7 @@
     pcre: 8.45
   lua_doc: true
   lts: true
+  endOfLifeDate: 2026-08-31
 - release: "3.5.x"
   ee-version: "3.5.0.7"
   ce-version: "3.5.0"
@@ -57,6 +60,7 @@
     libyaml: "0.2.5"
     pcre: 8.45
   lua_doc: true
+  endOfLifeDate: 2024-11-08
 - release: "3.6.x"
   ee-version: "3.6.1.8"
   ce-version: "3.6.1"
@@ -71,6 +75,7 @@
     libyaml: "0.2.5"
     pcre: 8.45
   lua_doc: true
+  endOfLifeDate: 2025-02-12
 - release: "3.7.x"
   ee-version: "3.7.1.4"
   ce-version: "3.7.1"
@@ -85,6 +90,7 @@
     libyaml: "0.2.5"
     pcre: 8.45
   lua_doc: true
+  endOfLifeDate: 2025-05-31
 - release: "3.8.x"
   ee-version: "3.8.1.0"
   ce-version: "3.8.1"
@@ -99,6 +105,7 @@
     libyaml: "0.2.5"
     pcre: 8.45
   lua_doc: true
+  endOfLifeDate: 2025-09-30
 - release: "3.9.x"
   ee-version: "3.9.1.0"
   ce-version: "3.9.0"
@@ -114,6 +121,7 @@
     pcre: 8.45
   lua_doc: true
   latest: true
+  endOfLifeDate: 2025-12-30
 - release: "3.10.x"
   ee-version: "3.10.0.0"
   ce-version: "3.10.0"

--- a/app/_plugins/hooks/supported_version_api.rb
+++ b/app/_plugins/hooks/supported_version_api.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SupportedVersionApi
+  def self.process(site) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    versions = site.data['kong_versions'].select { |version| version['edition'] == 'gateway' }
+    versions = versions.map do |version|
+      date = nil
+      sunset_date = nil
+      unless version['endOfLifeDate'].nil?
+        date = version['endOfLifeDate'].to_s
+        sunset_date = version['endOfLifeDate'].next_year.to_s
+      end
+
+      {
+        release: version['release'],
+        tag: version['release'].gsub('.x', ''),
+        endOfLifeDate: date,
+        endOfsunset_date: sunset_date,
+        label: version['label']
+      }
+    end
+
+    FileUtils.mkdir_p("#{site.dest}/_api")
+    File.write("#{site.dest}/_api/gateway-versions.json", versions.to_json)
+  end
+end
+
+Jekyll::Hooks.register :site, :post_write do |site, _|
+  SupportedVersionApi.process(site)
+end


### PR DESCRIPTION
### Description

Adds an API that returns supported Gateway versions for use in CI

### Testing instructions

Preview link: /_api/gateway-versions.json

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
