### PR TITLE
fix(actions): use kong changed files

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm ci
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf # 4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: Kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
         with:
           sha: ${{  github.event.pull_request.head.sha }}
           files: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -44,7 +44,7 @@ jobs:
       - run: npm ci
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf # 4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: Kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
         with:
           sha: ${{ github.sha }}
           files: |
@@ -96,7 +96,7 @@ jobs:
           fetch-depth: 2
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf # 4edd678ac3f81e2dc578756871e4d00c19191daf
+        uses: Kong/changed-files@4edd678ac3f81e2dc578756871e4d00c19191daf
         with:
           sha: ${{ github.sha }}
           files: |


### PR DESCRIPTION
Use kong changed-files github actions as the original upstream has been compromised and shut down. See #incident-456.