### PR TITLE
kgo: add KGO 1.5 Cloud Gateways Data Plane Group Configuration guide

### DIFF
--- a/app/_data/docs_nav_kgo_1.5.x.yml
+++ b/app/_data/docs_nav_kgo_1.5.x.yml
@@ -141,6 +141,8 @@ items:
             url: /guides/konnect-entities/konnect-plugin-binding/
           - text: Cloud Gateways - Networks
             url: /guides/konnect-entities/cloud-gateways-network/
+          - text: Cloud Gateways - Data Plane Group Configuration
+            url: /guides/konnect-entities/cloud-gateways-data-plane-group-configuration/
           - text: FAQ
             url: /guides/konnect-entities/faq/
       - text: Migration

--- a/app/_includes/md/kgo/konnect-cloud-gateways-provider-account.md
+++ b/app/_includes/md/kgo/konnect-cloud-gateways-provider-account.md
@@ -1,0 +1,40 @@
+{% assign entity = include.entity %}
+
+## Provider Account
+
+In order to mange Cloud Gateway {{ entity }}s you need to have a Cloud Gateway Provider Account associated with your {{site.konnect_product_name}} account.
+
+To create one, please contact your Kong Account Manager.
+
+If you already have one, you can use the [{{site.konnect_short_name }}'s `/cloud-gateways/provider-accounts` API][provider_account_list_api]
+to get its name (`provider` response field) and `id`.
+
+```bash
+curl -s -H 'Content-Type: application/json' -H "Authorization: Bearer ${KONNECT_TOKEN}" -XGET https://global.api.konghq.com/v2/cloud-gateways/provider-accounts | jq
+```
+
+[provider_account_list_api]: /konnect/api/cloud-gateways/latest/#/operations/list-provider-accounts
+
+This should return a list of provider accounts.
+You can use the returned `id` and name (`provider` response field) create and managed a Cloud Gateway {{ entity }}s.
+
+```
+{
+  "data": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "provider": "aws",
+      "provider_account_id": "001111111111",
+      "created_at": "2023-07-06T18:40:12.172Z",
+      "updated_at": "2023-07-06T18:40:12.172Z"
+    }
+  ],
+  "meta": {
+    "page": {
+      "total": 1,
+      "size": 100,
+      "number": 1
+    }
+  }
+}
+```

--- a/app/_includes/md/kgo/konnect-cloud-gateways-provider-account.md
+++ b/app/_includes/md/kgo/konnect-cloud-gateways-provider-account.md
@@ -18,7 +18,7 @@ curl -s -H 'Content-Type: application/json' -H "Authorization: Bearer ${KONNECT_
 This should return a list of provider accounts.
 You can use the returned `id` and name (`provider` response field) create and managed a Cloud Gateway {{ entity }}s.
 
-```
+```json
 {
   "data": [
     {

--- a/app/_includes/md/kgo/konnect-entities-prerequisites.md
+++ b/app/_includes/md/kgo/konnect-entities-prerequisites.md
@@ -110,8 +110,8 @@ metadata:
   namespace: default
 spec:
   name: gateway-control-plane # Name used to identify the Gateway Control Plane in Konnect{% if include.control_plane_type == "dcgw" %}
-  cluster_type: {% if include.is-kic-cp == true %}CLUSTER_TYPE_K8S_INGRESS_CONTROLLER{% else %}CLUSTER_TYPE_CONTROL_PLANE{% endif %}
-  cloud_gateway: true{% endif %}
+  cloud_gateway: true{% endif %}{% if include.is-kic-cp == true %}
+  cluster_type: CLUSTER_TYPE_K8S_INGRESS_CONTROLLER{% endif %}
   konnect:
     authRef:
       name: konnect-api-auth # Reference to the KonnectAPIAuthConfiguration object

--- a/app/_includes/md/kgo/konnect-entities-prerequisites.md
+++ b/app/_includes/md/kgo/konnect-entities-prerequisites.md
@@ -109,8 +109,9 @@ metadata:
   name: gateway-control-plane
   namespace: default
 spec:
-  name: gateway-control-plane # Name used to identify the Gateway Control Plane in Konnect
+  name: gateway-control-plane # Name used to identify the Gateway Control Plane in Konnect{% if include.control_plane_type == "dcgw" %}
   cluster_type: {% if include.is-kic-cp == true %}CLUSTER_TYPE_K8S_INGRESS_CONTROLLER{% else %}CLUSTER_TYPE_CONTROL_PLANE{% endif %}
+  cloud_gateway: true{% endif %}
   konnect:
     authRef:
       name: konnect-api-auth # Reference to the KonnectAPIAuthConfiguration object
@@ -131,6 +132,18 @@ gateway-control-plane   True         <konnect-control-plane-id>             <you
 ```
 
 Having that in place, you will be able to reference the `gateway-control-plane` in your {{site.konnect_product_name}} entities as their parent.
+{% endif %}
+
+{% if include.create_network %}
+### Create a Network
+
+To use this CRD, you will need a `Network`. For detailed instructions, see the [Create Cloud Gateways Network](/gateway-operator/latest/guides/konnect-entities/cloud-gateways-network/) document.
+
+If you have already created a network, fetch its ID with the following command:
+
+```bash
+kubectl get konnectcloudgatewaynetworks.konnect.konghq.com konnect-network-1 -o=jsonpath='{.status.id}'
+```
 {% endif %}
 
 {% unless include.disable_accordian %}

--- a/app/_includes/md/kgo/konnect-entities-prerequisites.md
+++ b/app/_includes/md/kgo/konnect-entities-prerequisites.md
@@ -139,11 +139,7 @@ Having that in place, you will be able to reference the `gateway-control-plane` 
 
 To use this CRD, you will need a `Network`. For detailed instructions, see the [Create Cloud Gateways Network](/gateway-operator/latest/guides/konnect-entities/cloud-gateways-network/) document.
 
-If you have already created a network, fetch its ID with the following command:
-
-```bash
-kubectl get konnectcloudgatewaynetworks.konnect.konghq.com konnect-network-1 -o=jsonpath='{.status.id}'
-```
+If you have already created a network, you can refer to it by name later in this guide.
 {% endif %}
 
 {% unless include.disable_accordian %}

--- a/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-data-plane-group-configuration.md
+++ b/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-data-plane-group-configuration.md
@@ -1,0 +1,126 @@
+---
+title: Cloud Gateways Data Plane Group Configurations
+---
+
+{% assign entity = "Data Plane Group Configuration" %}
+{% assign crd = "KonnectCloudGatewayDataPlaneGroupConfiguration" %}
+
+In this guide you'll learn how to use the `{{ crd }}` custom resource to
+manage {{site.konnect_product_name}} Dedicated Cloud Gateways {{ entity }}s natively from your Kubernetes cluster.
+
+{% include md/kgo/konnect-entities-prerequisites.md disable_accordian=false version=page.version release=page.release
+with-control-plane=true %}
+
+{% include md/kgo/konnect-cloud-gateways-provider-account.md entity='Data Plane Group Configuration' %}
+
+## Create a Cloud Gateway {{ entity }}
+
+Creating the `{{ crd }}` object in your Kubernetes cluster will provision a new {{site.konnect_short_name }} Dedicated Cloud Gateway {{ entity }}.
+
+You can refer to the [`{{ crd }}` CRD API](/gateway-operator/{{ page.release }}/reference/custom-resources/#konnectcloudgatewaynetwork)
+for all the available fields.
+
+To create a `{{ crd }}` object you can use the following YAML manifest:
+
+```bash
+echo '
+apiVersion: konnect.konghq.com/v1alpha1
+kind: {{ crd }}
+metadata:
+  name: konnect-cg-dpconf
+spec:
+  api_access: private+public
+  version: "3.9"
+  dataplane_groups:
+    - provider: aws
+      region: eu-central-1
+      networkRef:
+        type: konnectID
+        konnectID: "111111111111111111111111111111111111"
+      autoscale:
+        type: static
+        static:
+          instance_type: small
+          requested_instances: 2
+      environment:
+        - name: KONG_LOG_LEVEL
+          value: debug
+    - provider: aws
+      region: ap-northeast-1
+      networkRef:
+        type: konnectID
+        konnectID: "111111111111111111111111111111111111"
+      autoscale:
+        type: static
+        static:
+          instance_type: small
+          requested_instances: 2
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+     name: konnect-api-auth
+' | kubectl apply -f -
+```
+
+After creating the `{{ crd }}` you can check the status by running:
+
+```bash
+kubectl get {{ crd | downcase }}s.konnect.konghq.com konnect-cg-dpconf -o=jsonpath='{.status}' | yq -p json
+```
+
+Which should return the status of the network:
+
+```yaml
+conditions:
+  - lastTransitionTime: "2025-03-13T09:16:49Z"
+    message: KonnectAPIAuthConfiguration reference default/konnect-api-auth is resolved
+    observedGeneration: 3
+    reason: ResolvedRef
+    status: "True"
+    type: APIAuthResolvedRef
+  - lastTransitionTime: "2025-03-13T09:16:49Z"
+    message: referenced KonnectAPIAuthConfiguration default/konnect-api-auth is valid
+    observedGeneration: 3
+    reason: Valid
+    status: "True"
+    type: APIAuthValid
+  - lastTransitionTime: "2025-03-13T09:18:05Z"
+    message: ""
+    observedGeneration: 3
+    reason: Programmed
+    status: "True"
+    type: Programmed
+id: 1111111-111111111111-11111111111111111
+organizationID: 222222222-22222222-2222222222222222222
+serverURL: https://global.api.konghq.com
+state: initializing
+```
+
+Since creating a {{entity}} can take some time, you can monitor its status by checking the `dataplane_groups` field:
+
+```bash
+kubectl get konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com eu-central-1 -o=jsonpath='{.status.dataplane_groups}'  | jq
+```
+
+Which should return the status of the provisioned {{ entity}}s:
+
+```json
+[
+  {
+    "cloud_gateway_network_id": "19cb7627-1111-1111-1111-111111111111",
+    "egress_ip_addresses": [
+      "18.111.11.111",
+      "35.111.11.111",
+      "18.111.11.111"
+    ],
+    "id": "a94bb897-1111-1111-1111-111111111111",
+    "provider": "aws",
+    "region": "eu-central-1",
+    "state": "ready"
+  }
+]
+```
+
+> Note: Creating multiple {{ entity }}s will cause overwriting each others configurations.
+> There can only exist one {{ entity }} per one Cloud Gateway which sets the configuration
+> for all the Data Plane Groups.

--- a/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-data-plane-group-configuration.md
+++ b/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-data-plane-group-configuration.md
@@ -28,13 +28,14 @@ metadata:
   name: konnect-cg-dpconf
 spec:
   api_access: private+public
-  version: "3.9"
+  version: "{{ site.data.kong_latest_gateway.ee-version | split: "." | slice: 0,2 | join: "." }}"
   dataplane_groups:
     - provider: aws
       region: eu-west-1
       networkRef:
-        type: konnectID
-        konnectID: "111111111111111111111111111111111111"
+        type: namespacedRef
+        namespacedRef:
+         name: konnect-network-1
       autoscale:
         type: static
         static:

--- a/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-data-plane-group-configuration.md
+++ b/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-data-plane-group-configuration.md
@@ -9,9 +9,7 @@ In this guide you'll learn how to use the `{{ crd }}` custom resource to
 manage {{site.konnect_product_name}} Dedicated Cloud Gateways {{ entity }}s natively from your Kubernetes cluster.
 
 {% include md/kgo/konnect-entities-prerequisites.md disable_accordian=false version=page.version release=page.release
-with-control-plane=true %}
-
-{% include md/kgo/konnect-cloud-gateways-provider-account.md entity='Data Plane Group Configuration' %}
+with-control-plane=true control_plane_type="dcgw" create_network=true %}
 
 ## Create a Cloud Gateway {{ entity }}
 
@@ -33,7 +31,7 @@ spec:
   version: "3.9"
   dataplane_groups:
     - provider: aws
-      region: eu-central-1
+      region: eu-west-1
       networkRef:
         type: konnectID
         konnectID: "111111111111111111111111111111111111"
@@ -45,20 +43,10 @@ spec:
       environment:
         - name: KONG_LOG_LEVEL
           value: debug
-    - provider: aws
-      region: ap-northeast-1
-      networkRef:
-        type: konnectID
-        konnectID: "111111111111111111111111111111111111"
-      autoscale:
-        type: static
-        static:
-          instance_type: small
-          requested_instances: 2
   controlPlaneRef:
     type: konnectNamespacedRef
     konnectNamespacedRef:
-     name: konnect-api-auth
+     name: gateway-control-plane
 ' | kubectl apply -f -
 ```
 
@@ -99,7 +87,7 @@ state: initializing
 Since creating a {{entity}} can take some time, you can monitor its status by checking the `dataplane_groups` field:
 
 ```bash
-kubectl get konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com eu-central-1 -o=jsonpath='{.status.dataplane_groups}'  | jq
+kubectl get konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com eu-west-1 -o=jsonpath='{.status.dataplane_groups}'  | jq
 ```
 
 Which should return the status of the provisioned {{ entity}}s:
@@ -115,7 +103,7 @@ Which should return the status of the provisioned {{ entity}}s:
     ],
     "id": "a94bb897-1111-1111-1111-111111111111",
     "provider": "aws",
-    "region": "eu-central-1",
+    "region": "eu-west-1",
     "state": "ready"
   }
 ]

--- a/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-network.md
+++ b/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-network.md
@@ -2,62 +2,29 @@
 title: Cloud Gateways Networks
 ---
 
-In this guide you'll learn how to use the `KonnectCloudGatewayNetwork` custom resource to
+{% assign entity = "Network" %}
+{% assign crd = "KonnectCloudGatewayNetwork" %}
+
+In this guide you'll learn how to use the `{{ crd }}` custom resource to
 manage {{site.konnect_product_name}} Dedicated Cloud Gateways Networks natively from your Kubernetes cluster.
 
 {% include md/kgo/konnect-entities-prerequisites.md disable_accordian=false version=page.version release=page.release
 with-control-plane=false %}
 
-## Provider Account
+{% include md/kgo/konnect-cloud-gateways-provider-account.md entity='Network' %}
 
-In order to mange Cloud Gateway networks you need to have a Cloud Gateway Provider Account associated with your {{site.konnect_product_name}} account.
+## Create a Cloud Gateway {{ entity }}
 
-To create one, please contact your Kong Account Manager.
+Creating the `{{ crd }}` object in your Kubernetes cluster will provision a new {{site.konnect_short_name }} Dedicated Cloud Gateway {{ entity }}.
 
-If you already have one, you can use the [{{site.konnect_short_name }}'s `/cloud-gateways/provider-accounts` API][provider_account_list_api]
-to get the `id` of the provider account.
-
-```bash
-curl -s -H 'Content-Type: application/json' -H "Authorization: Bearer ${KONNECT_TOKEN}" -XGET https://global.api.konghq.com/v2/cloud-gateways/provider-accounts | jq
-```
-
-[provider_account_list_api]: /konnect/api/cloud-gateways/latest/#/operations/list-provider-accounts
-
-This should return a list of provider accounts, you can use the `id` of the account you want to use to create a Cloud Gateway Network.
-
-```
-{
-  "data": [
-    {
-      "id": "11111111-1111-1111-1111-111111111111",
-      "provider": "aws",
-      "provider_account_id": "001111111111",
-      "created_at": "2023-07-06T18:40:12.172Z",
-      "updated_at": "2023-07-06T18:40:12.172Z"
-    }
-  ],
-  "meta": {
-    "page": {
-      "total": 1,
-      "size": 100,
-      "number": 1
-    }
-  }
-}
-```
-
-## Create a Cloud Gateway Network
-
-Creating the `KonnectCloudGatewayNetwork` object in your Kubernetes cluster will provision a new {{site.konnect_short_name }} Dedicated Cloud Gateway Network.
-
-You can refer to the [`KonnectCloudGatewayNetwork` CRD API](/gateway-operator/{{ page.release }}/reference/custom-resources/#konnectcloudgatewaynetwork)
+You can refer to the [`{{ crd }}` CRD API](/gateway-operator/{{ page.release }}/reference/custom-resources/#konnectcloudgatewaynetwork)
 for all the available fields.
 
-To create a `KonnectCloudGatewayNetwork` object you can use the following YAML manifest:
+To create a `{{ crd }}` object you can use the following YAML manifest:
 
 ```bash
 echo '
-kind: KonnectCloudGatewayNetwork
+kind: {{ crd }}
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
  name: konnect-network-1

--- a/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-network.md
+++ b/app/_src/gateway-operator/guides/konnect-entities/cloud-gateways-network.md
@@ -27,20 +27,20 @@ echo '
 kind: {{ crd }}
 apiVersion: konnect.konghq.com/v1alpha1
 metadata:
- name: konnect-network-1
- namespace: default
+  name: konnect-network-1
+  namespace: default
 spec:
- name: network1
- cloud_gateway_provider_account_id: "001111111111"
- availability_zones:
- - euw1-az1
- - euw1-az2
- - euw1-az3
- cidr_block: "192.168.0.0/16"
- region: eu-west-1
- konnect:
-   authRef:
-     name: konnect-api-auth
+  name: network1
+  cloud_gateway_provider_account_id: "001111111111"
+  availability_zones:
+    - euw1-az1
+    - euw1-az2
+    - euw1-az3
+  cidr_block: "192.168.0.0/16"
+  region: eu-west-1
+  konnect:
+    authRef:
+      name: konnect-api-auth
 ' | kubectl apply -f -
 ```
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

Closes #8466

### Testing instructions

Preview link: https://deploy-preview-8576--kongdocs.netlify.app/gateway-operator/unreleased/guides/konnect-entities/cloud-gateways-data-plane-group-configuration/

1. Install CRDs
    
    ```
    kustomize build github.com/kong/kubernetes-configuration/config/crd/gateway-operator\?ref=v1.2.0 | kubectl apply --server-side -f -
    ```

1. Checkout https://github.com/Kong/charts, at `kgo-1.5-cluster-role-permissions` branch ( if it's missing or already merged, then use `main`)

1. Use the following `values.yaml` ( put it into the checked out `charts` repo)

    ```
    fullnameOverride: gateway-operator
    
    image:
      repository: kong/gateway-operator-oss
      tag: "1.5"
      effectiveSemver: "1.5.0"
    
    livenessProbe:
      initialDelaySeconds: 1
      periodSeconds: 1
    
    customEnv:
      # these help to see the requests/responses in flight
      KONNECT_SDK_HTTP_DUMP_REQUEST: "true"
      KONNECT_SDK_HTTP_DUMP_RESPONSE: "true"
      KONNECT_SDK_HTTP_DUMP_RESPONSE_ERROR: "true"
      # remove this if working with prod
      KONG_CUSTOM_DOMAIN: "konghq.tech"
    ```

1. `cd` into the `charts` dir and install using:

    ```
    helm upgrade --install --create-namespace -n kong-system kgo --values values.yaml ./charts/gateway-operator`
    ```

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

