### PR TITLE
Update incremental config sync flags

### DIFF
--- a/app/_src/gateway/production/deployment-topologies/hybrid-mode/incremental-config-sync.md
+++ b/app/_src/gateway/production/deployment-topologies/hybrid-mode/incremental-config-sync.md
@@ -65,17 +65,15 @@ You can enable incremental config sync when installing {{site.base_gateway}} in 
 [rate limiting plugins](#using-incremental-config-sync-with-rate-limiting-plugins) when using incremental config sync. 
 Review and adjust your plugin config before enabling this feature.
 
-During setup, set the following values in your `kong.conf` files on both Control Planes and Data Planes:
+During setup, set the following value in your `kong.conf` files on both Control Planes and Data Planes:
 
 ```
-cluster_rpc = on
-cluster_rpc_sync = on
+incremental_sync = on
 ```
 
-Or, if running {{site.base_gateway}} in Docker, set the following environment variables:
+Or, if running {{site.base_gateway}} in Docker, set the following environment variable:
 ```
-export KONG_CLUSTER_RPC_SYNC=on
-export KONG_CLUSTER_RPC=on
+export KONG_INCREMENTAL_SYNC=on
 ```
 
 ## Limitations


### PR DESCRIPTION
### Description

The flag to enabled incremental config sync is now renamed to `incremental_sync`. 
https://github.com/Kong/kong-ee/pull/11836

The other flag is not needed.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

