### PR TITLE
docs(ai-semantic-cache): add note on cache control behaviour

### DIFF
--- a/app/_hub/kong-inc/ai-semantic-cache/overview/_index.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/overview/_index.md
@@ -108,6 +108,12 @@ The plugin respects cache control headers to determine if requests and responses
 * `private`: Ensures the response is not cached by shared caches
 * `max-age` and `s-maxage`: Sets the maximum age of the cached response. This causes the vector database to drop and delete the cached response message after expiration, so it’s never seen again. 
 
+{:.note}
+
+As most AI services always send `no-cache` in the response headers, setting `cache_control` to true will
+always result in a cache bypass. Thus only consider setting `no-cache` if you are using self-hosted services
+and have control of the response Cache Control headers.
+
 ## Get started with the AI Semantic Caching plugin
 
 * [Configuration reference](/hub/kong-inc/ai-semantic-cache/configuration/)

--- a/app/_hub/kong-inc/ai-semantic-cache/overview/_index.md
+++ b/app/_hub/kong-inc/ai-semantic-cache/overview/_index.md
@@ -109,10 +109,9 @@ The plugin respects cache control headers to determine if requests and responses
 * `max-age` and `s-maxage`: Sets the maximum age of the cached response. This causes the vector database to drop and delete the cached response message after expiration, so it’s never seen again. 
 
 {:.note}
-
-As most AI services always send `no-cache` in the response headers, setting `cache_control` to true will
-always result in a cache bypass. Thus only consider setting `no-cache` if you are using self-hosted services
-and have control of the response Cache Control headers.
+> As most AI services always send `no-cache` in the response headers, setting `cache_control` to `true` will
+always result in a cache bypass. Only consider setting `no-cache` if you are using self-hosted services
+and have control over the response Cache Control headers.
 
 ## Get started with the AI Semantic Caching plugin
 


### PR DESCRIPTION
### Description

Add clarification of the cache_control config and explain the behaviour if being set with common AI services.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [na] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

AG-228
