### PR TITLE
docs(partials): add info about using a parital with custom plugin

### DIFF
--- a/app/_src/gateway/kong-enterprise/partials.md
+++ b/app/_src/gateway/kong-enterprise/partials.md
@@ -15,8 +15,7 @@ Partials address this issue by allowing you to extract shared configurations int
 - **`redis-ce`**: Stores common Redis configurations for plugins available in {{site.ce_product_name}}.
 - **`redis-ee`**: Stores common Redis configurations for plugins available only in {{site.ee_product_name}}.
 
-{:.note}
-> An easy way to determine the required Redis configuration is by examining the fields in use. Redis CE has a shorter and simpler configuration, whereas Redis EE provides options for configuring Redis Sentinel or Redis Cluster for connection.
+An easy way to determine the required Redis configuration is by examining the fields in use. `redis-ce` has a shorter and simpler configuration, whereas `redis-ee` provides options for configuring Redis Sentinel or Redis Cluster for connection.
 
 ## Creating a Partial
 
@@ -115,14 +114,14 @@ Before deleting a Partial, ensure all linked plugins are unlinked. Then, delete 
 curl -i -X DELETE http://localhost:8001/partials/{PARTIAL-ID}
 ```
 
-## Custom Plugins
+## Custom plugins
 
-Users can leverage the Partials feature in their custom plugins by adjusting the plugin schema.
+You can leverage the Partials feature in your custom plugins by adjusting the plugin schema.
 To make custom plugins compatible with Partials, add the `supported_partials` key to the schema and specify
 the appropriate Partial type. If the Redis configuration in use is of the {{site.ce_product_name}} type,
 use `redis-ce`; otherwise, use `redis-ee`.
 
-Below is an example schema for a custom plugin utilizing a Partial:
+Here is an example schema for a custom plugin using a Partial:
 
 ```lua
 {
@@ -144,13 +143,15 @@ Below is an example schema for a custom plugin utilizing a Partial:
 }
 ```
 
-{:.important} > **Using DAO in custom plugins**
+{:.important} 
+> **Using DAO in custom plugins**
+> <br>
 > Be aware that when using a Partial, the configuration belonging to the Partial is no longer stored alongside
-> the plugin. If your code relies on Kong's dao and expects entities to contain Redis information,
-> this data will not be retrieved when using `kong.db.plugins:select(plugin_id)`.
+> the plugin. If your code relies on {{site.base_gateway}}'s DAO and expects entities to contain Redis information,
+> this data won't be retrieved when using `kong.db.plugins:select(plugin_id)`.
 > Such a call will only fetch data stored in the plugin itself.
 >
-> To include the Partial's data within the plugin configuration, pass a special option parameter,
+> To include the Partial's data within the plugin configuration, you must pass a special option parameter,
 > such as: `kong.db.plugins:select(plugin_id, { expand_partials = true })`.
 
 

--- a/app/_src/gateway/kong-enterprise/partials.md
+++ b/app/_src/gateway/kong-enterprise/partials.md
@@ -15,7 +15,7 @@ Partials address this issue by allowing you to extract shared configurations int
 - **`redis-ce`**: Stores common Redis configurations for plugins available in {{site.ce_product_name}}.
 - **`redis-ee`**: Stores common Redis configurations for plugins available only in {{site.ee_product_name}}.
 
-An easy way to determine the required Redis configuration is by examining the fields in use. `redis-ce` has a shorter and simpler configuration, whereas `redis-ee` provides options for configuring Redis Sentinel or Redis Cluster for connection.
+An easy way to determine the required Redis configuration is by examining the fields in use. `redis-ce` has a shorter and simpler configuration, whereas `redis-ee` provides options for configuring Redis Sentinel or Redis Cluster connections.
 
 ## Creating a Partial
 


### PR DESCRIPTION
### Description

There was a request to add information on how to use Partials with Custom Plugins.

### Testing instructions

Preview link: 
Please take a look at the two sections: The note about the difference between CE Redis and EE Redis (at the top of the page) and the section about Custom Partials.

https://deploy-preview-8608--kongdocs.netlify.app/gateway/unreleased/kong-enterprise/partials/

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

