### PR TITLE
[KGO] chore: remove readiness probe from gateways

### DIFF
--- a/app/_src/gateway-operator/get-started/kic/create-gateway.md
+++ b/app/_src/gateway-operator/get-started/kic/create-gateway.md
@@ -97,9 +97,6 @@ To get the endpoint and the authentication details of the data plane.
               containers:
               - name: proxy
                 image: kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
-                readinessProbe:
-                  initialDelaySeconds: 1
-                  periodSeconds: 1
                 env:
                   - name: KONG_DATABASE
                     value: "off"
@@ -157,9 +154,6 @@ spec:
           containers:
           - name: proxy
             image: kong:{{ site.data.kong_latest_gateway.ce-version }}
-            readinessProbe:
-              initialDelaySeconds: 1
-              periodSeconds: 1
   controlPlaneOptions:
     deployment:
       podTemplateSpec:

--- a/app/_src/gateway-operator/guides/autoscaling-workloads/overview.md
+++ b/app/_src/gateway-operator/guides/autoscaling-workloads/overview.md
@@ -126,18 +126,12 @@ spec:
           containers:
           - name: proxy
             image: kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
-            readinessProbe:
-              initialDelaySeconds: 1
-              periodSeconds: 1
   controlPlaneOptions:
     deployment:
       podTemplateSpec:
         spec:
           containers:
           - name: controller
-            readinessProbe:
-              initialDelaySeconds: 1
-              periodSeconds: 1
     extensions:
     - kind: DataPlaneMetricsExtension
       group: gateway-operator.konghq.com

--- a/app/_src/gateway-operator/guides/plugin-distribution.md
+++ b/app/_src/gateway-operator/guides/plugin-distribution.md
@@ -100,9 +100,6 @@ title: Kong custom plugin distribution with KongPluginInstallation
              containers:
                - name: proxy
                  image: kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
-                 readinessProbe:
-                   initialDelaySeconds: 1
-                   periodSeconds: 1
        pluginsToInstall:
          - name: custom-plugin-myheader
      controlPlaneOptions:
@@ -112,9 +109,6 @@ title: Kong custom plugin distribution with KongPluginInstallation
              containers:
                - name: controller
                  image: kong/kubernetes-ingress-controller:{{ site.data.kong_latest_KIC.version }}
-                 readinessProbe:
-                   initialDelaySeconds: 1
-                   periodSeconds: 1
    ---
    apiVersion: gateway.networking.k8s.io/v1
    kind: GatewayClass

--- a/app/_src/gateway-operator/guides/upgrade/data-plane/blue-green.md
+++ b/app/_src/gateway-operator/guides/upgrade/data-plane/blue-green.md
@@ -28,9 +28,6 @@ Blue/Green upgrades can be accomplished when working with the `DataPlane` resour
               env:
               - name: KONG_LOG_LEVEL
                 value: debug
-              readinessProbe:
-                initialDelaySeconds: 1
-                periodSeconds: 1
     ```
 
     > **NOTE**: Currently only `BreakBeforePromotion` is available as promotion strategy.

--- a/app/_src/gateway-operator/topologies/dbless.md
+++ b/app/_src/gateway-operator/topologies/dbless.md
@@ -34,9 +34,6 @@ spec:
           containers:
           - name: proxy
             image: kong/kong-gateway:{{ site.data.kong_latest_gateway.ee-version }}
-            readinessProbe:
-              initialDelaySeconds: 1
-              periodSeconds: 1
   controlPlaneOptions:
     deployment:
       podTemplateSpec:


### PR DESCRIPTION
### Description

Removing readiness grom Gateways as per https://kongstrong.slack.com/archives/CA42V003B/p1742821156530799?thread_ts=1742569562.245049&cid=CA42V003B

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

