### PR TITLE
Fix: Expressions route limitation on mTLS and TLS Handshake Modifier

### DIFF
--- a/app/_hub/kong-inc/mtls-auth/overview/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/overview/_index.md
@@ -47,7 +47,7 @@ SNIs must be set for all routes that mutual TLS authentication uses.
 
 {:.important}
 > When using the plugin with [expressions routes](/gateway/latest/reference/expressions-language/), 
-the client certificate will always be requested, even if the routes are configured with an SNI. 
+the client certificate will always be requested, even if the routes are configured with SNIs. 
 
 {% if_version gte:3.1.x %}
 ### Sending the CA DNs during TLS handshake

--- a/app/_hub/kong-inc/mtls-auth/overview/_index.md
+++ b/app/_hub/kong-inc/mtls-auth/overview/_index.md
@@ -45,6 +45,10 @@ the client certificate during every TLS handshake:
 
 SNIs must be set for all routes that mutual TLS authentication uses.
 
+{:.important}
+> When using the plugin with [expressions routes](/gateway/latest/reference/expressions-language/), 
+the client certificate will always be requested, even if the routes are configured with an SNI. 
+
 {% if_version gte:3.1.x %}
 ### Sending the CA DNs during TLS handshake
 
@@ -79,6 +83,7 @@ the SNI is found in the in-memory map of SNIs, then the corresponding CA DN list
 
 If the client doesn't send SNIs in the ClientHello message or the SNI sent is
 unknown to {{site.base_gateway}}, then the CA DN list associated with `\*` is sent only when the client certificate is requested.
+
 {% endif_version %}
 
 

--- a/app/_hub/kong-inc/tls-handshake-modifier/overview/_index.md
+++ b/app/_hub/kong-inc/tls-handshake-modifier/overview/_index.md
@@ -34,3 +34,7 @@ the client certificate during every TLS handshake:
 
 The result is all routes must have SNIs if you want to restrict the handshake request
 for client certificates to specific requests.
+
+{:.important}
+> When using the plugin with [expressions routes](/gateway/latest/reference/expressions-language/), 
+the client certificate will always be requested, even if the routes are configured with an SNI. 

--- a/app/_hub/kong-inc/tls-handshake-modifier/overview/_index.md
+++ b/app/_hub/kong-inc/tls-handshake-modifier/overview/_index.md
@@ -37,4 +37,4 @@ for client certificates to specific requests.
 
 {:.important}
 > When using the plugin with [expressions routes](/gateway/latest/reference/expressions-language/), 
-the client certificate will always be requested, even if the routes are configured with an SNI. 
+the client certificate will always be requested, even if the routes are configured with SNIs. 


### PR DESCRIPTION
### Description

Add note about limitation on expressions routes to the mTLS and TLS handshake modifier plugins.

https://konghq.atlassian.net/browse/FTI-6227

### Testing instructions

Preview link: 
https://deploy-preview-8611--kongdocs.netlify.app/hub/kong-inc/mtls-auth/
https://deploy-preview-8611--kongdocs.netlify.app/hub/kong-inc/tls-handshake-modifier/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

