### PR TITLE
Chore: Move Gateway 2.8 into sunset support

### DIFF
--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -90,26 +90,17 @@ Kong supports the following versions of {{site.ee_product_name}}:
     {% include_cached gateway-support.html version="3.10" data=site.data.tables.support.gateway.versions.310 eol="March 2026" %}
   {% endnavtab %}
   {% endif_version %}
-  {% if_version gte: 3.9.x %}
   {% navtab 3.9 %}
     {% include_cached gateway-support.html version="3.9" data=site.data.tables.support.gateway.versions.39 eol="Dec 2025" %}
   {% endnavtab %}
-  {% endif_version %}
-  {% if_version gte: 3.8.x %}
   {% navtab 3.8 %}
     {% include_cached gateway-support.html version="3.8" data=site.data.tables.support.gateway.versions.38 eol="Sept 2025" %}
   {% endnavtab %}
-  {% endif_version %}
-  {% if_version gte: 3.7.x %}
   {% navtab 3.7 %}
     {% include_cached gateway-support.html version="3.7" data=site.data.tables.support.gateway.versions.37 eol="May 2025" %}
   {% endnavtab %}
-  {% endif_version %}
   {% navtab 3.4 LTS %}
     {% include_cached gateway-support.html version="3.4" data=site.data.tables.support.gateway.versions.34 eol="August 2026" %}
-  {% endnavtab %}
-  {% navtab 2.8 LTS %}
-    {% include_cached gateway-support.html version="2.8 LTS" data=site.data.tables.support.gateway.versions.28  eol="March 2025" %}
   {% endnavtab %}
 {% endnavtabs %}
 
@@ -150,6 +141,7 @@ These versions have reached the end of full support.
 |  3.2.x.x |  2023-02-28   |     2024-02-28      |      2025-02-28       |
 |  3.1.x.x |  2022-12-06   |     2023-12-06      |      2024-12-06       |
 |  3.0.x.x |  2022-09-09   |     2023-09-09      |      2024-09-09       |
+|  2.8.x.x |  2022-03-02   |     2025-03-26      |      2026-03-26       |
 |  2.7.x.x |  2021-12-16   |     2023-02-24      |      2024-08-24       |
 |  2.6.x.x |  2021-10-14   |     2023-02-24      |      2024-08-24       |
 |  2.5.x.x |  2021-08-03   |     2022-08-24      |      2023-08-24       |

--- a/app/_src/gateway/support/third-party.md
+++ b/app/_src/gateway/support/third-party.md
@@ -34,7 +34,4 @@ Unless otherwise noted, Kong supports the last 2 versions any third party tool, 
   {% navtab 3.4 LTS %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.34 %}
   {% endnavtab %}
-  {% navtab 2.8 LTS %}
-    {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.28 %}
-  {% endnavtab %}
 {% endnavtabs %}

--- a/app/gateway/2.8.x/support-policy.md
+++ b/app/gateway/2.8.x/support-policy.md
@@ -55,17 +55,22 @@ Customers with platinum or higher subscriptions may request fixes outside of the
 Kong supports the following versions of {{site.ee_product_name}}: 
 
 {% navtabs %}
-  {% navtab 3.2 %}
-    {% include_cached gateway-support.html version="3.2" data=site.data.tables.support.gateway.versions.32 eol="February 2024" %}
+  {% if_version gte: 3.10.x %}
+  {% navtab 3.10 LTS %}
+    {% include_cached gateway-support.html version="3.10" data=site.data.tables.support.gateway.versions.310 eol="March 2026" %}
   {% endnavtab %}
-  {% navtab 3.1 %}
-    {% include_cached gateway-support.html version="3.1" data=site.data.tables.support.gateway.versions.31 eol="December 2023" %}
+  {% endif_version %}
+  {% navtab 3.9 %}
+    {% include_cached gateway-support.html version="3.9" data=site.data.tables.support.gateway.versions.39 eol="Dec 2025" %}
   {% endnavtab %}
-  {% navtab 3.0 %}
-    {% include_cached gateway-support.html version="3.0" data=site.data.tables.support.gateway.versions.30 eol="September 2023" %}
+  {% navtab 3.8 %}
+    {% include_cached gateway-support.html version="3.8" data=site.data.tables.support.gateway.versions.38 eol="Sept 2025" %}
   {% endnavtab %}
-  {% navtab 2.8 LTS %}
-    {% include_cached gateway-support.html version="2.8 LTS" data=site.data.tables.support.gateway.versions.28  eol="March 2025" %}
+  {% navtab 3.7 %}
+    {% include_cached gateway-support.html version="3.7" data=site.data.tables.support.gateway.versions.37 eol="May 2025" %}
+  {% endnavtab %}
+  {% navtab 3.4 LTS %}
+    {% include_cached gateway-support.html version="3.4" data=site.data.tables.support.gateway.versions.34 eol="August 2026" %}
   {% endnavtab %}
 {% endnavtabs %}
 
@@ -75,6 +80,13 @@ These versions have reached the end of full support.
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  3.6.x.x |  2024-02-12   |     2025-02-12      |      2026-02-12       |
+|  3.5.x.x |  2023-11-08   |     2024-11-08      |      2025-11-08       |
+|  3.3.x.x |  2023-05-19   |     2024-05-19      |      2025-05-19       |
+|  3.2.x.x |  2023-02-28   |     2024-02-28      |      2025-02-28       |
+|  3.1.x.x |  2022-12-06   |     2023-12-06      |      2024-12-06       |
+|  3.0.x.x |  2022-09-09   |     2023-09-09      |      2024-09-09       |
+|  2.8.x.x |  2022-03-02   |     2025-03-26      |      2026-03-26       |
 |  2.7.x.x |  2021-12-16   |     2023-02-24      |      2024-08-24       |
 |  2.6.x.x |  2021-10-14   |     2023-02-24      |      2024-08-24       |
 |  2.5.x.x |  2021-08-03   |     2022-08-24      |      2023-08-24       |


### PR DESCRIPTION
### Description

Gateway 2.8 moves into sunset support tomorrow (march 26). Can merge then.

We hadn't updated the 2.8 non-single-sourced support policy for a while (oversight), so making the tables match the latest version.

Also removing all version tags except 3.10, since we don't want 3.10 showing on prod yet.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

