### PR TITLE
Variable for latest gateway OSS version

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -108,7 +108,7 @@
   endOfLifeDate: 2025-09-30
 - release: "3.9.x"
   ee-version: "3.9.1.1"
-  ce-version: "3.9.0"
+  ce-version: "3.9.0" # make sure to update latest OSS gateway version in jekyll.yml
   edition: "gateway"
   luarocks_version: "3.0.0-0"
   dependencies:

--- a/app/_includes/md/kic/prerequisites.md
+++ b/app/_includes/md/kic/prerequisites.md
@@ -122,7 +122,7 @@ helm install kong kong/ingress -n kong --create-namespace
 {% endnavtab %}
 {% navtab Kong Gateway (OSS) %}
 ```bash
-helm install kong kong/ingress -n kong --create-namespace --set gateway.image.repository=kong --set gateway.image.tag="{{ site.data.kong_latest_gateway.ce-version }}"
+helm install kong kong/ingress -n kong --create-namespace --set gateway.image.repository=kong --set gateway.image.tag="{{site.latest_gateway_oss_version}}"
 ```
 {% endnavtab %}
 {% endnavtabs_ee %}

--- a/app/_src/gateway-operator/get-started/kic/create-gateway.md
+++ b/app/_src/gateway-operator/get-started/kic/create-gateway.md
@@ -153,7 +153,7 @@ spec:
         spec:
           containers:
           - name: proxy
-            image: kong:{{ site.data.kong_latest_gateway.ce-version }}
+            image: kong:{{site.latest_gateway_oss_version}}
   controlPlaneOptions:
     deployment:
       podTemplateSpec:

--- a/app/_src/gateway-operator/guides/upgrade/data-plane/blue-green.md
+++ b/app/_src/gateway-operator/guides/upgrade/data-plane/blue-green.md
@@ -171,10 +171,10 @@ Blue/Green upgrades can be accomplished when working with the `DataPlane` resour
     Connection: keep-alive
     Content-Length: 52
     X-Kong-Response-Latency: 0
-    Server: kong/{{ site.data.kong_latest_gateway.ce-version }}
+    Server: kong/{{site.latest_gateway_oss_version}}
     ```
 
-    As you can see the live `Service` is still serving traffic using `{{ site.data.kong_latest_gateway.ce-version }}`
+    As you can see, the live `Service` is still serving traffic using `{{site.latest_gateway_oss_version}}`.
 
 1. Now you can perform additional validation steps by inspecting the deployed resources.
 

--- a/app/_src/kubernetes-ingress-controller/get-started/key-authentication.md
+++ b/app/_src/kubernetes-ingress-controller/get-started/key-authentication.md
@@ -64,7 +64,7 @@ For more information, see [What is API Gateway Authentication?](https://konghq.c
     WWW-Authenticate: Key realm="kong"
     Content-Length: 45
     X-Kong-Response-Latency: 1
-    Server: kong/{{ site.data.kong_latest_gateway.ce-version }}
+    Server: kong/{{site.latest_gateway_oss_version}}
 
     {
       "message":"No API key found in request"

--- a/app/_src/kubernetes-ingress-controller/upgrade/gateway.md
+++ b/app/_src/kubernetes-ingress-controller/upgrade/gateway.md
@@ -53,7 +53,7 @@ To see the available {{ site.base_gateway }} images, refer to Docker Hub:
     ```yaml
     gateway:
       image:
-        tag: {{ site.data.kong_latest_gateway.ce-version }}
+        tag: {{site.latest_gateway_oss_version}}
     ```
 
 1. Run `helm upgrade` with the `--values` flag.
@@ -85,7 +85,7 @@ To see the available {{ site.base_gateway }} images, refer to Docker Hub:
     You should see the new version of {{ site.base_gateway }}:
 
     ```bash
-    kong:{{ site.data.kong_latest_gateway.ce-version }}
+    kong:{{site.latest_gateway_oss_version}}
     ```
 
 [Deployment methods]: /kubernetes-ingress-controller/{{ page.release}}/production/deployment-topologies/

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -194,3 +194,6 @@ jekyll-generator-single-source:
   docs_nav_folder: '_data'
 
 locale: en-US
+
+# Gateway OSS
+latest_gateway_oss_version: 3.9.0

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -185,3 +185,6 @@ locale: en-US
 gtm_id: 'GTM-NL48VKT'
 vwo_account_id: '125292'
 segment_key: 'X7EZTdbdUKQ8M6x42SHHPWiEhjsfs1EQ'
+
+# Gateway OSS
+latest_gateway_oss_version: 3.9.0


### PR DESCRIPTION
### Description

Since we don't have a CE 3.10 version, the "latest" version is no longer defined accurately. This is going to remain mostly static, other than patch releases, so adding it as a site variable.

### Testing instructions

Preview link:
https://deploy-preview-8630--kongdocs.netlify.app/kubernetes-ingress-controller/latest/upgrade/gateway/#upgrade-kong-gateway-using-helm
https://deploy-preview-8630--kongdocs.netlify.app/gateway-operator/latest/guides/upgrade/data-plane/blue-green/ (step 6)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

