### PR TITLE
Fix: Add note about private Docker image

### DIFF
--- a/app/_hub/kong-inc/ai-sanitizer/how-to/_index.md
+++ b/app/_hub/kong-inc/ai-sanitizer/how-to/_index.md
@@ -7,6 +7,7 @@ title: Using the AI Sanitizer plugin
 
 You have an AI PII service. 
 We'll use Kong's [AI PII Anonymizer service](https://hub.docker.com/r/kong/ai-pii-service) in these examples.
+
 {:.note}
 > This Docker image is private, contact [Kong Support](https://support.konghq.com/support/s/) to get access to it.
 

--- a/app/_hub/kong-inc/ai-sanitizer/how-to/_index.md
+++ b/app/_hub/kong-inc/ai-sanitizer/how-to/_index.md
@@ -7,6 +7,8 @@ title: Using the AI Sanitizer plugin
 
 You have an AI PII service. 
 We'll use Kong's [AI PII Anonymizer service](https://hub.docker.com/r/kong/ai-pii-service) in these examples.
+{:.note}
+> This Docker image is private, contact [Kong Support](https://support.konghq.com/support/s/) to get access to it.
 
 ## Set up the Kong AI PII Anonymizer service
 

--- a/app/_hub/kong-inc/ai-sanitizer/overview/_index.md
+++ b/app/_hub/kong-inc/ai-sanitizer/overview/_index.md
@@ -23,7 +23,9 @@ The AI Sanitizer plugin uses the AI PII Anonymizer Service, which can run in a D
 
 ## AI PII Anonymizer service
 
-Kong provides an [AI PII Anonymizer service](https://hub.docker.com/r/kong/ai-pii-service) Docker image. 
+Kong provides an [AI PII Anonymizer service](https://hub.docker.com/r/kong/ai-pii-service) Docker image.
+{:.note}
+> This Docker image is private, contact [Kong Support](https://support.konghq.com/support/s/) to get access to it.
 
 ### Image configuration options
 

--- a/app/_hub/kong-inc/ai-sanitizer/overview/_index.md
+++ b/app/_hub/kong-inc/ai-sanitizer/overview/_index.md
@@ -24,6 +24,7 @@ The AI Sanitizer plugin uses the AI PII Anonymizer Service, which can run in a D
 ## AI PII Anonymizer service
 
 Kong provides an [AI PII Anonymizer service](https://hub.docker.com/r/kong/ai-pii-service) Docker image.
+
 {:.note}
 > This Docker image is private, contact [Kong Support](https://support.konghq.com/support/s/) to get access to it.
 

--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -96,12 +96,6 @@
                 </li>
                 <li>
                   <a
-                    href="/gateway/latest/kong-enterprise/"
-                    >{% t _includes.footer.links.docs.kong_enterprise %}</a
-                  >
-                </li>
-                <li>
-                  <a
                     href="/mesh/latest/"
                     >{% t _includes.footer.links.docs.mesh %}</a
                   >


### PR DESCRIPTION
### Description

Added note to tell users to reach out to support to get access to the private AI PII Service Docker image

https://kongstrong.slack.com/archives/C06GB3KM155/p1743148798458789

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

