### PR TITLE
FIx: re-add missing datakit docs

### DIFF
--- a/app/_data/docs_nav_gateway_3.10.x.yml
+++ b/app/_data/docs_nav_gateway_3.10.x.yml
@@ -610,6 +610,16 @@ items:
             url: /kong-enterprise/plugin-ordering/get-started
       - text: Redis Partials
         url: /kong-enterprise/partials
+      - text: Datakit
+        items:
+          - text: Overview
+            url: /kong-enterprise/datakit/
+          - text: Get Started with Datakit
+            url: /kong-enterprise/datakit/get-started/
+          - text: Datakit Configuration Reference
+            url: /kong-enterprise/datakit/configuration/
+          - text: Datakit Examples Reference
+            url: /kong-enterprise/datakit/examples/
 
   - title: Admin API
     icon: /assets/images/icons/documentation/icn-admin-api-color.svg


### PR DESCRIPTION
### Description

Accidentally removed datakit when breaking up the enterprise section, re-adding it to 3.10.

### Testing instructions

Preview link: https://deploy-preview-8640--kongdocs.netlify.app/gateway/latest/kong-enterprise/datakit/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

