### PR TITLE
Fix: kong.conf broken table

### DIFF
--- a/app/_src/gateway/reference/configuration/configuration-3.10.x.md
+++ b/app/_src/gateway/reference/configuration/configuration-3.10.x.md
@@ -1715,7 +1715,7 @@ name   | description  | default
 **pg_ro_user** | Same as `pg_user`, but for the read-only connection. | `<pg_user>`
 **pg_ro_password** | Same as `pg_password`, but for the read-only connection. | `<pg_password>`
 **pg_ro_iam_auth** | Same as `pg_iam_auth`, but for the read-only connection. | `<pg_iam_auth>`
-**pg_ro_iam_auth_assume_role_arn** | Same as `pg_iam_auth_assume_role_arn', but for the read-only connection. | none
+**pg_ro_iam_auth_assume_role_arn** | Same as `pg_iam_auth_assume_role_arn`, but for the read-only connection. | none
 **pg_ro_iam_auth_role_session_name** | Same as `pg_iam_auth_role_session_name`, but for the read-only connection. | `KongPostgres`
 **pg_ro_iam_auth_sts_endpoint_url** | Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection. | none
 **pg_ro_database** | Same as `pg_database`, but for the read-only connection. | `<pg_database>`


### PR DESCRIPTION
### Description

Code phrase used a `'` instead of a backtick.

### Testing instructions

Preview link: https://deploy-preview-8642--kongdocs.netlify.app/gateway/latest/reference/configuration/#postgres-settings

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

