### PR TITLE
Fix: Update config-store.md for decK tab steps

### DIFF
--- a/app/konnect/gateway-manager/configuration/config-store.md
+++ b/app/konnect/gateway-manager/configuration/config-store.md
@@ -48,7 +48,7 @@ curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane
 {% endnavtab %}
 {% navtab decK %}
 
-Create a config store entity in {{site.konnect_short_name}} and save the `config_store_id` from the response body.
+Create a config store entity in {{site.konnect_short_name}} and save the `config_store_id` from the response body:
 
 ```sh 
 curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/config-stores \
@@ -59,7 +59,7 @@ curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane
 }'
 ```
 
-Using the `config_store_id` create a `POST` request to associate the config store with the vault.
+Using the generated `config_store_id`, send a `POST` request to associate the config store with the vault:
     
 ```sh
 curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/core-entities/vaults/  \
@@ -75,7 +75,7 @@ curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane
 }'
 ```
 
-Link the decK YAML file with the {{site.konnect_short_name}} Config Store.
+Reference the {{site.konnect_short_name}} config store in your decK file:
 
 ```yaml
 _format_version: "3.0"

--- a/app/konnect/gateway-manager/configuration/config-store.md
+++ b/app/konnect/gateway-manager/configuration/config-store.md
@@ -48,7 +48,9 @@ curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane
 {% endnavtab %}
 {% navtab decK %}
 
-Create a config store entity in {{site.konnect_short_name}} and save the `config_store_id` from the response body:
+decK doesn't support creating a {{site.konnect_short_name}} config store, but you can reference secrets stored in a config store with decK.
+
+Using the Control Plane Config API, create a config store entity in {{site.konnect_short_name}} and save the `config_store_id` from the response body:
 
 ```sh 
 curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/config-stores \

--- a/app/konnect/gateway-manager/configuration/config-store.md
+++ b/app/konnect/gateway-manager/configuration/config-store.md
@@ -48,13 +48,40 @@ curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane
 {% endnavtab %}
 {% navtab decK %}
 
+Create a config store entity in {{site.konnect_short_name}} and save the `config_store_id` from the response body.
+
+```sh 
+curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/config-stores \
+  --header 'Authorization: Bearer {kpat_token}' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"name": "my-config-store"
+}'
+```
+
 Using the `config_store_id` create a `POST` request to associate the config store with the vault.
+    
+```sh
+curl -i -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/core-entities/vaults/  \
+  --header 'Authorization: Bearer {kpat_token}' \
+  --header 'Content-Type: application/json' \
+  --data '{
+	"config":{
+		"config_store_id": "{my-config-store-id}"
+	},
+	"description": "Description of your vault",
+	"name": "konnect",
+	"prefix": "mysecretvault"
+}'
+```
+
+Link the decK YAML file with the {{site.konnect_short_name}} Config Store.
 
 ```yaml
 _format_version: "3.0"
 vaults:
 - config:
-    config_store_id: ee62068e-1843-49f8-ac22-40293b0a949d
+    config_store_id: {my-config-store-id}
   description: Storing secrets in Konnect
   name: konnect
   prefix: mysecretvault


### PR DESCRIPTION
### Description

Added missing steps from the decK tab for creating and linking the config store to the vault before referencing it in the decK YAML config file.

This was creating confusion for customers wanting to use decK with the Konnect Config Store.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.
