### PR TITLE
fix(docs): Add missing bracket in URL link

### DIFF
--- a/app/_hub/kong-inc/request-callout/overview/_index.md
+++ b/app/_hub/kong-inc/request-callout/overview/_index.md
@@ -68,7 +68,7 @@ codes considered errors and the number of retries to make. `error_response_code`
 and `error_response_msg` determine the status code and message to response with 
 in case of failures, both if the error policy is `retry` or `fail`. 
 `error_response_msg` supports Lua expressions, with the same syntax and 
-semantics as Request Transformer Advanced plugin templates](/hub/kong-inc/request-transformer-advanced/templates).
+semantics as Request Transformer Advanced plugin [templates](/hub/kong-inc/request-transformer-advanced/templates).
 
 
 The [schema reference](/hub/kong-inc/request-callout/configuration/) contains the full 


### PR DESCRIPTION
### Description

- Fixed broken markdown link from `templates](/hub/...)` to `[templates](/hub/...)`

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

