### PR TITLE
docs(plugin): only one plugin instance is executed for the current request

### DIFF
--- a/app/_includes/md/about-plugins.md
+++ b/app/_includes/md/about-plugins.md
@@ -2,7 +2,7 @@
 ## What are plugins?
 
 {{site.base_gateway}} is a Lua application designed to load and execute modules, which
-we commonly refer to as _plugins_. Plugins provide advanced functionality and extend the 
+we commonly refer to as _plugins_. Plugins provide advanced functionality and extend the
 use of the {{site.base_gateway}}, allowing you to add more features to your implementation.
 
 Kong provides a set of
@@ -20,7 +20,7 @@ Each plugin can run globally, or be scoped to some combination of the following:
 * Consumers
 * Consumer groups
 
-Using scopes, you can customize how Kong handles functions in your environment, 
+Using scopes, you can customize how Kong handles functions in your environment,
 either before a request is sent to your backend services or after it receives a response.
 For example, if you apply a plugin to a single [**route**](/gateway/latest/key-concepts/routes/), that plugin will trigger only on the specific path requests take through your system.
 On the other hand, if you apply the plugin [**globally**](#global-scope), it will run on every request, regardless of any other configuration.
@@ -59,13 +59,15 @@ The complete order of precedence for plugins configured to multiple entities is:
 1. **Consumer**: Applies to all requests from a specific, authenticated consumer across all routes and services.
 1. **Consumer group**: Affects all routes and services for a designated group of authenticated users.
 1. **Route**: Specific to given route.
-1. **Service**: Specific to given service. 
+1. **Service**: Specific to given service.
 1. **Globally configured plugins**: Lowest precedence, applies to all requests across all services and routes regardless of consumer status.
+
+The very first matched instance is selected, and all other instances of the same plugin are ignored for the current request context. For example, if you configure the `rate-limiting-advanced` plugin for both the service *foo* and the route *bar* of that service, the instance associated with the route *bar* is executed due to the order of precedence. To work around this limitation, you can create two routes for the service *foo* and bind a separate `rate-limiting-advanced` plugin to each route. If you need to run the plugin twice, you can point the service *foo* to another route (*baz*) within the same {{site.base_gateway}}.
 
 {:.note}
 > **Note on precedence for consumer groups**:
-When a consumer is a member of two consumer groups, each with a scoped plugin, 
-{{site.base_gateway}} ensures deterministic behavior by executing only one of these plugins. 
+When a consumer is a member of two consumer groups, each with a scoped plugin,
+{{site.base_gateway}} ensures deterministic behavior by executing only one of these plugins.
 However, the specific rules that govern this behavior are not defined and are subject to change in future releases.
 
 ## Plugin compatibility with deployment types
@@ -99,8 +101,8 @@ or see the following references:
 
 ### Third-party plugins
 
-Through partnerships with third parties, Kong lists some [third-party custom plugins](/hub/?support=community%2Cpremium-partner) on the Kong Plugin Hub. 
-These plugins are maintained by Kong partners. 
+Through partnerships with third parties, Kong lists some [third-party custom plugins](/hub/?support=community%2Cpremium-partner) on the Kong Plugin Hub.
+These plugins are maintained by Kong partners.
 If you would like to have your plugin featured on the Kong Plugin Hub, we encourage you to become a [Kong Partner](https://konghq.com/partners/).
 
 ## See also

--- a/app/_includes/md/about-plugins.md
+++ b/app/_includes/md/about-plugins.md
@@ -62,7 +62,9 @@ The complete order of precedence for plugins configured to multiple entities is:
 1. **Service**: Specific to given service.
 1. **Globally configured plugins**: Lowest precedence, applies to all requests across all services and routes regardless of consumer status.
 
-The very first matched instance is selected, and all other instances of the same plugin are ignored for the current request context. For example, if you configure the `rate-limiting-advanced` plugin for both the service *foo* and the route *bar* of that service, the instance associated with the route *bar* is executed due to the order of precedence. To work around this limitation, you can create two routes for the service *foo* and bind a separate `rate-limiting-advanced` plugin to each route. If you need to run the plugin twice, you can point the service *foo* to another route (*baz*) within the same {{site.base_gateway}}.
+Only the first matched instance is selected, and all other instances of the same plugin are ignored for the current request context. For example, if you configure the `rate-limiting-advanced` plugin for both the service *foo* and the route *bar* of that service, the instance associated with the route *bar* is executed due to the order of precedence. 
+
+To work around this limitation, you can create two routes for the service *foo* and bind a separate `rate-limiting-advanced` plugin to each route. If you need to run the plugin twice, you can point the service *foo* to another route (*baz*) within the same {{site.base_gateway}}.
 
 {:.note}
 > **Note on precedence for consumer groups**:


### PR DESCRIPTION


### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

docs(plugin): only one instance of a plugin is executed for the current request

The multiple instances of the same plugin are active for the current request context, the very first instance in the order of precedence is executed, and the rest are abandoned.

https://konghq.atlassian.net/browse/FTI-6582

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

