### PR TITLE
fix(mesh): adjust outdated fragment about AccessRoleBinding for versions higher than 2.5

### DIFF
--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -545,10 +545,15 @@ The `subjects` in `AccessRoleBinding` are compatible with Kubernetes users and g
 
 {{site.mesh_product_name}} creates an `admin` `AccessRole` that allows every action.
 
+{% if_version lte:2.5.x %}
 In a standalone deployment, the `default` `AccessRoleBinding` assigns this role to every authenticated and unauthenticated user.
 
 In a multi-zone deployment, the `default` `AccessRoleBinding` on the global control plane assigns this role to every authenticated and unauthenticated user.
 However, on the zone control plane, the `default` `AccessRoleBinding` is restricted to the `admin` `AccessRole` only.
+{% endif_version %}
+{% if_version lte:2.6.x %}
+The `default` `AccessRoleBinding` assigns this role to every authenticated and unauthenticated user.
+{% endif_version %}
 
 {% navtabs codeblock %}
 {% navtab Kubernetes %}

--- a/app/_src/mesh/features/rbac.md
+++ b/app/_src/mesh/features/rbac.md
@@ -551,7 +551,7 @@ In a standalone deployment, the `default` `AccessRoleBinding` assigns this role 
 In a multi-zone deployment, the `default` `AccessRoleBinding` on the global control plane assigns this role to every authenticated and unauthenticated user.
 However, on the zone control plane, the `default` `AccessRoleBinding` is restricted to the `admin` `AccessRole` only.
 {% endif_version %}
-{% if_version lte:2.6.x %}
+{% if_version gte:2.6.x %}
 The `default` `AccessRoleBinding` assigns this role to every authenticated and unauthenticated user.
 {% endif_version %}
 


### PR DESCRIPTION
### Description

Since 2.6 the AccessRoleBinding looks the same for Global and Zone because we introduced applying policies on the zone.
 
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [X] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

