### PR TITLE
Fix: Missing Auth Headers & Request Body in Token Creation API Call

### DIFF
--- a/app/konnect/org-management/system-accounts.md
+++ b/app/konnect/org-management/system-accounts.md
@@ -63,18 +63,21 @@ Create a system account token by sending a `POST` request containing the `accoun
 
 ```sh
 curl --request POST \
-  --url https://global.api.konghq.com/v3/system-accounts/:497f6eca-6276-4993-bfeb-53cbbbba6f08/access-tokens
+  --header 'Authorization: Bearer pat_12345678901234567890123456789012345678901234567890' \
+  --header 'content-type: application/json' \
+  --url 'https://global.api.konghq.com/v3/system-accounts/497f6eca-6276-4993-bfeb-53cbbbba6f08/access-tokens'
+  --data '{"name":"Sample Access Token","expires_at":"2025-05-07T14:44:48.645Z"}'
 ```
 You will receive a `201` response code, and a response body containing the access token for the system account:
 
 ```json
 {
-  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
+  "id": "80f0685e-c103-488b-a4de-4515e2a0d3e0",
   "name": "Sample Access Token",
-  "created_at": "2023-01-12:15:54Z",
-  "expires_at": "2023-11-15T00:00:00Z",
-  "updated_at": "2023-01-13T21:04:22Z",
-  "last_used_at": "2023-01-18T06:45:40Z",
+  "created_at": "2025-01-12:15:54Z",
+  "expires_at": "2025-05-07T14:44:48.645Z",
+  "updated_at": "2025-01-13T21:04:22Z",
+  "last_used_at": "2025-01-18T06:45:40Z",
   "token": "spat_12345678901234567890123456789012345678901234567890"
 }
 ```

--- a/app/konnect/org-management/system-accounts.md
+++ b/app/konnect/org-management/system-accounts.md
@@ -63,9 +63,9 @@ Create a system account token by sending a `POST` request containing the `accoun
 
 ```sh
 curl --request POST \
-  --header 'Authorization: Bearer pat_12345678901234567890123456789012345678901234567890' \
+  --url 'https://global.api.konghq.com/v3/system-accounts/<account-id>/access-tokens'
+  --header 'Authorization: Bearer <personal-access-token> \
   --header 'content-type: application/json' \
-  --url 'https://global.api.konghq.com/v3/system-accounts/497f6eca-6276-4993-bfeb-53cbbbba6f08/access-tokens'
   --data '{"name":"Sample Access Token","expires_at":"2025-05-07T14:44:48.645Z"}'
 ```
 You will receive a `201` response code, and a response body containing the access token for the system account:


### PR DESCRIPTION
### Description

Fix system account token creation process

- Add required authentication header with bearer token
- Include proper request body in the API call
- Set correct content-type header

ref: https://docs.konghq.com/konnect/api/identity-management/latest/#/operations/post-system-accounts-id-access-tokens

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

