### PR TITLE
Fix: Remove `labels` from konnect search query for teams

### DIFF
--- a/app/konnect/reference/search.md
+++ b/app/konnect/reference/search.md
@@ -120,7 +120,7 @@ The following table describes different example search queries:
 | Simple | `Dana` | This query searches for entities with the a searchable attribute containing the value "Dana". |
 | Simple | `name:Dana` | This query searches for entities with the name "Dana". |
 | Simple | `name:"Dana H"` | This query searches for entities with the name "Dana H". The quotes around "Dana H" indicate an exact match, including spaces. |
-| Logical | `type:team AND label.department:qa AND name:*_qa` | This query finds teams in the QA department. It combines multiple selectors: `type:team` limits the search to the "teams" entity type, `label.department:qa` exactly matches the "department" label, and `name:*_qa` filters for teams that have a `_qa` suffix. |
+| Logical | `type:team AND name:*_qa` | This query finds teams in the QA department. It combines multiple selectors: `type:team` limits the search to the "teams" entity type and `name:*_qa` filters for teams that have a `_qa` suffix. |
 | Logical | `name:*dev* OR name:*qa* OR name:*test` | This query finds any entities that contain `dev` or `qa` or `test` in its name. It combines multiple `name:` selectors to limit the results to entities that match one of these terms. |
 | Exclusion | `type:system_account AND NOT *temp*` | This query finds system accounts that don't contain `temp` in their name and description. The `NOT` logical operator is used to exclude entities. |
 | Exclusion | `type:team AND NOT name:team-blue AND NOT description:*blue*` | This query finds teams that are not named `team-blue` and don't contain "blue" in its description. The `NOT` logical operator is used to exclude entities. |


### PR DESCRIPTION
### Description

Teams don't support labels, so this sample query is invalid. Removing the `labels` portion leaves the example as a valid logical AND example.

Issue reported on slack.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

