### PR TITLE
docs(mesh): don't display feature that was removed

### DIFF
--- a/app/_src/mesh/features/kds-auth.md
+++ b/app/_src/mesh/features/kds-auth.md
@@ -154,9 +154,13 @@ Verify the zone control plane is connected with authentication by looking at the
 
 By default, a connection from the zone control plane to the global control plane is secured with TLS. You should also configure the zone control plane to [verify the certificate authority (CA) of the global control plane][certs].
 
+{% if_version lte:2.9.x %}
+
 ## Legacy Control Plane Token
 
 You can still authenticate a control plane using the separate [Control Plane Token](/mesh/{{page.release}}/features/kds-auth/), but it is deprecated and will be removed in the future.
+
+{% endif_version %}
 
 <!-- links -->
 [zone-proxy]: /mesh/{{page.release}}/production/cp-deployment/zoneproxy-auth


### PR DESCRIPTION
### Description

This feature was removed in 2.10.x

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

