### PR TITLE
Update cluster_type

### DIFF
--- a/app/konnect/reference/terraform.md
+++ b/app/konnect/reference/terraform.md
@@ -30,7 +30,7 @@ provider "konnect" {
 resource "konnect_gateway_control_plane" "tfdemo" {
   name         = "Terraform Control Plane"
   description  = "This is a sample description"
-  cluster_type = "CLUSTER_TYPE_HYBRID"
+  cluster_type = "CLUSTER_TYPE_CONTROL_PLANE"
   auth_type    = "pinned_client_certs"
 
   proxy_urls = [


### PR DESCRIPTION
### Description

In the Konnect API `CLUSTER_TYPE_HYBRID` was deprecated some time ago and no longer exists (see [Control Plane schema](https://docs.konghq.com/konnect/api/control-planes/latest/#/schemas/ControlPlane)). The Terraform provider only still supports `CLUSTER_TYPE_HYBRID` to prevent state recreation. Moving forward `CLUSTER_TYPE_CONTROL_PLANE` should be used.

See also: https://kongstrong.slack.com/archives/C04RXLGNB6K/p1727707794692459

### Testing instructions

Preview link: https://deploy-preview-8688--kongdocs.netlify.app/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

