### PR TITLE
Added a note in changelog for ai-rate-limiting-advanced plugin

### DIFF
--- a/app/_hub/kong-inc/ai-rate-limiting-advanced/_changelog.md
+++ b/app/_hub/kong-inc/ai-rate-limiting-advanced/_changelog.md
@@ -5,7 +5,7 @@
 
 ### {{site.base_gateway}} 3.9.0.0
 * Added support for the Hugging Face provider to the AI Rate Limiting Advanced plugin.
-  To import the deck configuration files that are exported from earlier versions, please use the following script to transform it so that the configuration file can be compatible with the latest version:
+  To import the decK configuration files that are exported from earlier versions, use the following script to transform it so that the configuration file can be compatible with the latest version:
 
   ```
   yq -i '(

--- a/app/_hub/kong-inc/ai-rate-limiting-advanced/_changelog.md
+++ b/app/_hub/kong-inc/ai-rate-limiting-advanced/_changelog.md
@@ -5,6 +5,21 @@
 
 ### {{site.base_gateway}} 3.9.0.0
 * Added support for the Hugging Face provider to the AI Rate Limiting Advanced plugin.
+  To import the deck configuration files that are exported from earlier versions, please use the following script to transform it so that the configuration file can be compatible with the latest version:
+
+  ```
+  yq -i '(
+  .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+  ) |= "requestPrompt" |
+  (
+  .consumers[] | .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+  ) |= "requestPrompt" |
+  (
+  .consumer_groups[] | .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+  ) |= "requestPrompt"
+  ' config.yaml
+  ```
+
 * Updated the error message for exceeding the rate limit to include AI-related information.
 * Fixed an issue where the plugin yielded an error when incrementing the rate limit counters in non-yieldable phases.
 * Fixed an issue where the plugin could fail to authenticate to Redis correctly with vault-referenced Redis configuration.

--- a/app/_src/gateway/breaking-changes/39x.md
+++ b/app/_src/gateway/breaking-changes/39x.md
@@ -1,5 +1,5 @@
 ---
-title: Kong Gateway 3.9.x breaking changes
+title: "{{site.base_gateway}} 3.9.x breaking changes"
 content_type: reference
 book: breaking-changes
 chapter: 11
@@ -26,15 +26,15 @@ This release adds support for the Hugging Face provider.
 
 To import the decK configuration files that are exported from earlier versions, use the following script to transform it so that the configuration file can be compatible with the latest version:
 
-  ```
-  yq -i '(
-  .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
-  ) |= "requestPrompt" |
-  (
-  .consumers[] | .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
-  ) |= "requestPrompt" |
-  (
-  .consumer_groups[] | .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
-  ) |= "requestPrompt"
-  ' config.yaml
-  ```
+```
+yq -i '(
+.plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+) |= "requestPrompt" |
+(
+.consumers[] | .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+) |= "requestPrompt" |
+(
+.consumer_groups[] | .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+) |= "requestPrompt"
+' config.yaml
+```

--- a/app/_src/gateway/breaking-changes/39x.md
+++ b/app/_src/gateway/breaking-changes/39x.md
@@ -19,3 +19,22 @@ Review the [changelog](/gateway/changelog/#3900) for all the changes in this rel
 
 Manually specifying a `node_id` via Kong configuration (`kong.conf`) is deprecated. 
 The `node_id` parameter is planned to be removed in 4.x.
+
+### AI Rate Limiting advanced plugin
+
+This release adds support for the Hugging Face provider.
+
+To import the decK configuration files that are exported from earlier versions, use the following script to transform it so that the configuration file can be compatible with the latest version:
+
+  ```
+  yq -i '(
+  .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+  ) |= "requestPrompt" |
+  (
+  .consumers[] | .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+  ) |= "requestPrompt" |
+  (
+  .consumer_groups[] | .plugins[] | select(.name == "ai-rate-limiting-advanced") | .config.llm_providers[] | select(.name == "huggingface") | .name
+  ) |= "requestPrompt"
+  ' config.yaml
+  ```


### PR DESCRIPTION
### Description

A note is added to describe how to transform a deck yaml config that is exported from a previous version to the latest version where huggingface is supported as the llm_providers in ai-rate-limiting-advanced plugin

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

