### PR TITLE
chore: fix Gateway breaking changes changelog for 3.9

### DIFF
--- a/app/_src/gateway/breaking-changes/39x.md
+++ b/app/_src/gateway/breaking-changes/39x.md
@@ -1,5 +1,5 @@
 ---
-title: "{{site.base_gateway}} 3.9.x breaking changes"
+title: "Kong Gateway 3.9.x breaking changes"
 content_type: reference
 book: breaking-changes
 chapter: 11


### PR DESCRIPTION
### Description

Fix Gateway 3.9 breaking changes page. `{{site.base_gateway}}` doesn't render in page front matter.

Related page: https://docs.konghq.com/gateway/latest/breaking-changes/39x/

<img width="691" alt="image" src="https://github.com/user-attachments/assets/97c07932-1f4c-492e-968a-d85eadfa19ca" />

3.10's page shows:

<img width="393" alt="image" src="https://github.com/user-attachments/assets/c2268ccd-66c5-4195-968e-b5f4df19c95c" />

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

