### PR TITLE
Fix incorrect description of routing conflict rules

### DIFF
--- a/app/_src/gateway/kong-enterprise/workspaces/index.md
+++ b/app/_src/gateway/kong-enterprise/workspaces/index.md
@@ -18,15 +18,15 @@ used by Kong to determine if a conflict occurs.
 * At Service or Route **creation or modification** time, Kong runs its internal
 router:
   - If no Services or Routes are found with matching routing rules, the creation
-  or modification proceeds
+  or modification proceeds.
   - If Services or Routes with matching routing rules are found **within the same
-  workspace**, the action will fail.
+  workspace**, the action proceeds.
   - If Services or Routes are found **in a different workspace**:
     * If the matching Service or Route **does not have an associated
       `host` value**—`409 Conflict`
     * If the matching Service or Route's `host` is a wildcard
       - If they are the same, the action fails with a `409 Conflict`
-      - If they are not equal, proceed
+      - If they are not equal, the action proceeds.
     * If the matching Service or Route's `host` is an absolute value, a
       conflict is reported—`409 Conflict`
 


### PR DESCRIPTION
### Description

There is no limitation on having services or routes with the same routing rules in the same workspace.

See Slack for background: https://kongstrong.slack.com/archives/C03CTMSHP6C/p1744188119373439
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

