### PR TITLE
Updated ai-rag-injector docs

### DIFF
--- a/app/_hub/kong-inc/ai-rag-injector/how-to/_index.md
+++ b/app/_hub/kong-inc/ai-rag-injector/how-to/_index.md
@@ -114,83 +114,84 @@ If you are running {{site.base_gateway}} in traditional mode, you can update con
 
 However, this won't work in hybrid mode or {{site.konnect_short_name}} because the control plane can't access the plugin's backend storage.
 
- To update content for ingesting in hybrid mode or {{site.konnect_short_name}}, you can use a script:
+To update content for ingesting in hybrid mode or {{site.konnect_short_name}}, you can use a script:
  
- 1. Retrieve the ID of the AI RAG Injector plugin that you want to update.
- 2. Copy and paste the following script to a local file, for example `ingest_update.lua`:
-```lua
-local embeddings = require("kong.llm.embeddings")
-local uuid = require("kong.tools.utils").uuid
-local vectordb = require("kong.llm.vectordb")
-local cjson = require "cjson"
-local function get_plugin_by_id(id)
-  local row, err = kong.db.plugins:select {
-    id = id,
-  }
-  if err then
-    return
-  end
-  if not row then
-    return
-  end
-  return row
-end
-local function ingest_chunk(conf, content)
-  local err
-  local metadata = {
-    ingest_duration = ngx.now(),
-  }
-  -- vectordb driver init
-  local vectordb_driver
-  do
-    vectordb_driver, err = vectordb.new(conf.vectordb.strategy, conf.vectordb_namespace, conf.vectordb)
-    if err then
-      return nil, "Failed to load the '" .. conf.vectordb.strategy .. "' vector database driver: " .. err
-    end
-  end
-  -- embeddings init
-  local embeddings_driver, err = embeddings.new(conf.embeddings, conf.vectordb.dimensions)
-  if err then
-    return nil, "Failed to instantiate embeddings driver: " .. err
-  end
-  local embeddings_vector, embeddings_tokens_count, err = embeddings_driver:generate(content)
-  if err then
-    return nil, "Failed to generate embeddings: " .. err
-  end
-  metadata.embeddings_tokens_count = embeddings_tokens_count
-  if #embeddings_vector ~= conf.vectordb.dimensions then
-    return nil, "Embedding dimensions do not match the configured vector database. Embeddings were " ..
-      #embeddings_vector .. " dimensions, but the vector database is configured for " ..
-      conf.vectordb.dimensions .. " dimensions.", "Embedding dimensions do not match the configured vector database"
-  end
-  metadata.chunk_id = uuid()
-  -- ingest chunk
-  local _, err = vectordb_driver:insert(embeddings_vector, content, metadata.chunk_id)
-  if err then
-    return nil, "Failed to insert chunk: " .. err
-  end
-  ngx.update_time()
-  metadata.ingest_duration = math.floor((ngx.now() - metadata.ingest_duration) * 1000)
-  return metadata
-end
-assert(#args == 3, "2 arguments expected")
-local plugin_id, content = args[2], args[3]
-local plugin = get_plugin_by_id(plugin_id)
-if not plugin then
-  ngx.log(ngx.ERR, "Plugin not found")
-  return
-end
-local metadata, err = ingest_chunk(plugin.config, content)
-if err then
-  ngx.log(ngx.ERR, "Failed to ingest: " .. err)
-  return
-end
-ngx.log(ngx.INFO, "Update completed")
+1. Retrieve the ID of the AI RAG Injector plugin that you want to update.
+2. Copy and paste the following script to a local file, for example `ingest_update.lua`:
 
-```
+	```lua
+	local embeddings = require("kong.llm.embeddings")
+	local uuid = require("kong.tools.utils").uuid
+	local vectordb = require("kong.llm.vectordb")
+	local cjson = require "cjson"
+	local function get_plugin_by_id(id)
+	local row, err = kong.db.plugins:select {
+		id = id,
+	}
+	if err then
+		return
+	end
+	if not row then
+		return
+	end
+	return row
+	end
+	local function ingest_chunk(conf, content)
+	local err
+	local metadata = {
+		ingest_duration = ngx.now(),
+	}
+	-- vectordb driver init
+	local vectordb_driver
+	do
+		vectordb_driver, err = vectordb.new(conf.vectordb.strategy, conf.vectordb_namespace, conf.vectordb)
+		if err then
+			return nil, "Failed to load the '" .. conf.vectordb.strategy .. "' vector database driver: " .. err
+		end
+	end
+	-- embeddings init
+	local embeddings_driver, err = embeddings.new(conf.embeddings, conf.vectordb.dimensions)
+	if err then
+		return nil, "Failed to instantiate embeddings driver: " .. err
+	end
+	local embeddings_vector, embeddings_tokens_count, err = embeddings_driver:generate(content)
+	if err then
+		return nil, "Failed to generate embeddings: " .. err
+	end
+	metadata.embeddings_tokens_count = embeddings_tokens_count
+	if #embeddings_vector ~= conf.vectordb.dimensions then
+		return nil, "Embedding dimensions do not match the configured vector database. Embeddings were " ..
+			#embeddings_vector .. " dimensions, but the vector database is configured for " ..
+			conf.vectordb.dimensions .. " dimensions.", "Embedding dimensions do not match the configured vector database"
+	end
+	metadata.chunk_id = uuid()
+	-- ingest chunk
+	local _, err = vectordb_driver:insert(embeddings_vector, content, metadata.chunk_id)
+	if err then
+		return nil, "Failed to insert chunk: " .. err
+	end
+	ngx.update_time()
+	metadata.ingest_duration = math.floor((ngx.now() - metadata.ingest_duration) * 1000)
+	return metadata
+	end
+	assert(#args == 3, "2 arguments expected")
+	local plugin_id, content = args[2], args[3]
+	local plugin = get_plugin_by_id(plugin_id)
+	if not plugin then
+	ngx.log(ngx.ERR, "Plugin not found")
+	return
+	end
+	local metadata, err = ingest_chunk(plugin.config, content)
+	if err then
+	ngx.log(ngx.ERR, "Failed to ingest: " .. err)
+	return
+	end
+	ngx.log(ngx.INFO, "Update completed")
+
+	```
 
 3. Run the script from your Kong instance:
-   
+ 
    ```sh
    kong runner ingest_api.lua <plugin_id> <content_to_update>
    ```

--- a/app/_hub/kong-inc/ai-rag-injector/how-to/_index.md
+++ b/app/_hub/kong-inc/ai-rag-injector/how-to/_index.md
@@ -108,10 +108,17 @@ curl localhost:8001/ai-rag-injector/3194f12e-60c9-4cb6-9cbc-c8fd7a00cff1/lookup_
 
 To omit the chunk content and only return the chunk ID, set `exclude_contents` to true.
 
-## Update ingest content
+## Update content for ingesting
 
-You can update ingest content by sending request `/ai-rag-injector/:plugin_id/ingest_chunk` endpoint if you are runing Kong in traditional mode. However, this won't work for hybrid mode or Konnect because control plane can not access to the backend storage of the plugin. For this case, you can use the following script:
-```
+If you are running {{site.base_gateway}} in traditional mode, you can update content for ingesting by sending a request to the `/ai-rag-injector/:plugin_id/ingest_chunk` endpoint. 
+
+However, this won't work in hybrid mode or {{site.konnect_short_name}} because the control plane can't access the plugin's backend storage.
+
+ To update content for ingesting in hybrid mode or {{site.konnect_short_name}}, you can use a script:
+ 
+ 1. Retrieve the ID of the AI RAG Injector plugin that you want to update.
+ 2. Copy and paste the following script to a local file, for example `ingest_update.lua`:
+```lua
 local embeddings = require("kong.llm.embeddings")
 local uuid = require("kong.tools.utils").uuid
 local vectordb = require("kong.llm.vectordb")
@@ -182,7 +189,8 @@ ngx.log(ngx.INFO, "Update completed")
 
 ```
 
-Copy paste the whole content of the script to your local file, for example `ingest_update.lua`. You should retrieve the plugin id of the ai-rag-injector Plugin you are going to update before runing the run the script:
-```
-kong runner ingest_api.lua <plugin_id> <content_to_update>
-```
+3. Run the script from your Kong instance:
+   
+   ```sh
+   kong runner ingest_api.lua <plugin_id> <content_to_update>
+   ```


### PR DESCRIPTION
### Description

An approach to update the content of ai-rag-injector plugin for Kong instances in hybrid mode or Konnect mode.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

