### PR TITLE
fix: Add 3.10 to Konnect compatibility table

### DIFF
--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -13,6 +13,7 @@ title: Compatibility
 
 |                                | {{site.konnect_saas}} | Beginning with version | End of support |
 |--------------------------------|:---------------------:|-------------------------------|----------------|
+| {{site.ee_product_name}} 3.10.x | <i class="fa fa-check"></i>    | 3.10.0.0 | March 2026
 | {{site.ee_product_name}} 3.9.x | <i class="fa fa-check"></i>    | 3.9.0.0 | Dec 2025
 | {{site.ee_product_name}} 3.8.x | <i class="fa fa-check"></i>    | 3.8.0.0 | Oct 2025
 | {{site.ee_product_name}} 3.7.x | <i class="fa fa-check"></i>    | 3.7.0.0 | Jun 2025

--- a/app/konnect/compatibility.md
+++ b/app/konnect/compatibility.md
@@ -13,7 +13,7 @@ title: Compatibility
 
 |                                | {{site.konnect_saas}} | Beginning with version | End of support |
 |--------------------------------|:---------------------:|-------------------------------|----------------|
-| {{site.ee_product_name}} 3.10.x | <i class="fa fa-check"></i>    | 3.10.0.0 | March 2026
+| {{site.ee_product_name}} 3.10.x (LTS) | <i class="fa fa-check"></i>    | 3.10.0.0 | March 2028
 | {{site.ee_product_name}} 3.9.x | <i class="fa fa-check"></i>    | 3.9.0.0 | Dec 2025
 | {{site.ee_product_name}} 3.8.x | <i class="fa fa-check"></i>    | 3.8.0.0 | Oct 2025
 | {{site.ee_product_name}} 3.7.x | <i class="fa fa-check"></i>    | 3.7.0.0 | Jun 2025


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Added 3.10 to Konnect compatibility table
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
https://kongstrong.slack.com/archives/CDSTDSG9J/p1744771182817609
### Testing instructions

Preview link: https://deploy-preview-8715--kongdocs.netlify.app/konnect/compatibility/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

