### PR TITLE
update: Warn users about very high sync rates in RLA

### DIFF
--- a/app/_hub/kong-inc/rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/overview/_index.md
@@ -181,8 +181,25 @@ Two common use cases are:
 In this scenario, because accuracy is important, the `local` policy is not an option. Consider the support effort you might need
 for Redis, and then choose either `cluster` or `redis`.
 
-You could start with the `cluster` policy, and move to `redis`
-if performance reduces drastically.
+You could start with the `cluster` policy, and move to `redis` if performance reduces drastically.
+
+If using a very high sync rate, use `redis`. Very high sync rates with `cluster` mode are **not scalable and not recommended**.
+You can calculate what is considered a very high sync rate in your environment based on your topology, number of plugins, their sync rates, and tolerance for loose rate limits.
+
+Together, the interaction between sync rate and window size affects how accurately the plugin can determine cluster-wide traffic.
+For example, the following table represents the worst-case scenario where a full sync interval's worth of data hasn't yet propagated across nodes:
+
+| Property | Formula or config location | Value |
+|----------|----------------------------|-------|
+| Window size in seconds | Value set in `config.window_size` | 5 |
+| Limit (in window)| Value set in `config.limit` | 1000 |
+| Sync rate (interval) | Value set in `config.sync_rate` |  0.5 |
+| Number of nodes (>1) | -- | 10 |
+| Estimated load balanced rps to a node | Limit / Window size / Number of nodes | 1000 / 5 / 10 = 20 |
+| Max potential lag in cluster count for a given node/sec | Estimated load balanced rps * Sync rate  | 20 * 0.5 = 10 | 
+| Cluster wide max potential overage/sec | Max potential lag * Number of nodes | 10 * 10 = 100 |
+| Cluster wide max potential overage/sec as a percentage | Cluster wide max potential overage / Limit | 100 / 1000 = 10% |
+| Effective worst case cluster wide requests allowed at window size | Limit * Cluster wide max potential overage | 1000 + 100 = 1100 |
 
 Do remember that you cannot port the existing usage metrics from the data store to Redis.
 This might not be a problem with short-lived metrics (for example, seconds or minutes)

--- a/app/_hub/kong-inc/rate-limiting-advanced/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting-advanced/overview/_index.md
@@ -183,7 +183,9 @@ for Redis, and then choose either `cluster` or `redis`.
 
 You could start with the `cluster` policy, and move to `redis` if performance reduces drastically.
 
-If using a very high sync rate, use `redis`. Very high sync rates with `cluster` mode are **not scalable and not recommended**.
+If using a very high sync frequency, use `redis`. Very high sync frequencies with `cluster` mode are **not scalable and not recommended**. 
+The sync frequency becomes higher when the `sync_rate` setting is a lower number - for example, a `sync_rate` of 0.1 is a much higher sync frequency (10 counter syncs per second) than a `sync_rate` of 1 (1 counter sync per second).
+
 You can calculate what is considered a very high sync rate in your environment based on your topology, number of plugins, their sync rates, and tolerance for loose rate limits.
 
 Together, the interaction between sync rate and window size affects how accurately the plugin can determine cluster-wide traffic.

--- a/app/_hub/kong-inc/rate-limiting/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/overview/_index.md
@@ -98,7 +98,9 @@ In this scenario, because accuracy is important, the `local` policy is not an op
 for Redis, and then choose either `cluster` or `redis`.
 You could start with the `cluster` policy, and move to `redis` if performance reduces drastically.
 
-If using a very high sync rate, use `redis`. Very high sync rates with `cluster` mode are **not scalable and not recommended**.
+If using a very high sync frequency, use `redis`. Very high sync frequencies with `cluster` mode are **not scalable and not recommended**. 
+The sync frequency becomes higher when the `sync_rate` setting is a lower number - for example, a `sync_rate` of 0.1 is a much higher sync frequency (10 counter syncs per second) than a `sync_rate` of 1 (1 counter sync per second).
+
 You can calculate what is considered a very high sync rate in your environment based on your topology, number of plugins, their sync rates, and tolerance for loose rate limits.
 
 Do remember that you cannot port the existing usage metrics from the data store to Redis.

--- a/app/_hub/kong-inc/rate-limiting/overview/_index.md
+++ b/app/_hub/kong-inc/rate-limiting/overview/_index.md
@@ -96,9 +96,10 @@ include [Redis Cluster](https://redis.io/docs/management/scaling/) or [Redis Sen
 
 In this scenario, because accuracy is important, the `local` policy is not an option. Consider the support effort you might need
 for Redis, and then choose either `cluster` or `redis`.
+You could start with the `cluster` policy, and move to `redis` if performance reduces drastically.
 
-You could start with the `cluster` policy, and move to `redis`
-if performance reduces drastically.
+If using a very high sync rate, use `redis`. Very high sync rates with `cluster` mode are **not scalable and not recommended**.
+You can calculate what is considered a very high sync rate in your environment based on your topology, number of plugins, their sync rates, and tolerance for loose rate limits.
 
 Do remember that you cannot port the existing usage metrics from the data store to Redis.
 This might not be a problem with short-lived metrics (for example, seconds or minutes)


### PR DESCRIPTION
### Description

Added a table and info about window size and sync rate interactions in RLA, and what strategy they should use.

### Testing instructions

Preview link: https://deploy-preview-8732--kongdocs.netlify.app/hub/kong-inc/rate-limiting-advanced/#every-transaction-counts

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

