### PR TITLE
chore: Mention that we don't support kafka 4.0

### DIFF
--- a/app/_hub/kong-inc/confluent-consume/overview/_index.md
+++ b/app/_hub/kong-inc/confluent-consume/overview/_index.md
@@ -9,6 +9,7 @@ For more information, see the [Confluent Cloud documentation](https://docs.confl
 > **Note**: This plugin has the following known limitations:
 > * Message compression is not supported.
 > * The message format is not customizable.
+> * {{site.base_gateway}} does not support Kafka 4.0.
 
 Kong also provides a [plugin for publishing messages to Confluent Cloud](/hub/kong-inc/confluent/).
 

--- a/app/_hub/kong-inc/confluent/overview/_index.md
+++ b/app/_hub/kong-inc/confluent/overview/_index.md
@@ -14,6 +14,7 @@ Kong also provides Kafka Log and Kafka Upstream plugins for publishing logs and 
 > **Note**: This plugin has the following known limitations:
 > * Message compression is not supported.
 > * The message format is not customizable.
+> * {{site.base_gateway}} does not support Kafka 4.0.
 
 ## Quickstart
 

--- a/app/_hub/kong-inc/kafka-consume/overview/_index.md
+++ b/app/_hub/kong-inc/kafka-consume/overview/_index.md
@@ -9,6 +9,7 @@ For more information, see [Kafka topics](https://kafka.apache.org/documentation/
 > **Note**: This plugin has the following known limitations:
 > * Message compression is not supported.
 > * The message format is not customizable.
+> * {{site.base_gateway}} does not support Kafka 4.0.
 
 Kong also provides Kafka plugins for publishing messages:
 * See [Kafka Log](/hub/kong-inc/kafka-log/)

--- a/app/_hub/kong-inc/kafka-log/overview/_index.md
+++ b/app/_hub/kong-inc/kafka-log/overview/_index.md
@@ -12,12 +12,14 @@ Kong also provides a Kafka plugin for request transformations. See [Kafka Upstre
 > **Note**: This plugin has the following limitations:
 * Message compression is not supported.
 * The message format is not customizable.
+* {{site.base_gateway}} does not support Kafka 4.0.
 {% endif_version %}
-
 
 {% if_version gte:3.4.x %}
 {:.note}
-> **Note**: This plugin does not support message compression.
+> **Note**: This plugin has the following limitations:
+> * This plugin does not support message compression.
+> * {{site.base_gateway}} does not support Kafka 4.0.
 {% endif_version %}
 
 ## Quickstart

--- a/app/_hub/kong-inc/kafka-upstream/overview/_index.md
+++ b/app/_hub/kong-inc/kafka-upstream/overview/_index.md
@@ -9,6 +9,21 @@ in an [Apache Kafka](https://kafka.apache.org/) topic. For more information, see
 Kong also provides a Kafka Log plugin for publishing logs to a Kafka topic.
 See [Kafka Log](/hub/kong-inc/kafka-log/).
 
+{% if_version lte:3.8.x %}
+{:.note}
+> **Note**: This plugin has the following limitations:
+* Message compression is not supported.
+* The message format is not customizable.
+* {{site.base_gateway}} does not support Kafka 4.0.
+{% endif_version %}
+
+{% if_version gte:3.9.x %}
+{:.note}
+> **Note**: This plugin has the following limitations:
+> * This plugin does not support message compression.
+> * {{site.base_gateway}} does not support Kafka 4.0.
+{% endif_version %}
+
 ## Enable on a service-less route
 
 ```bash
@@ -94,14 +109,6 @@ This plugin supports the following authentication mechanisms:
 
   [Read more on how to create, renew, and revoke delegation tokens.](https://docs.confluent.io/platform/current/kafka/authentication_sasl/authentication_sasl_delegation.html#authentication-using-delegation-tokens)
 
-## Known issues and limitations
-
-Known limitations:
-
-1. Message compression is not supported.
-{% if_version lte: 3.9.x %}
-2. The message format is not customizable.
-{% endif_version %}
 
 ## Quickstart
 


### PR DESCRIPTION
### Description

Kafka 4.0 was released last month and users are running into problems because we don't explicitly say that we don't support it.

https://konghq.atlassian.net/browse/KAG-6911

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

