### PR TITLE
feat(kgo): add watchNamespaces docs for KGO 1.6

### DIFF
--- a/.github/styles/kong/dictionary.txt
+++ b/.github/styles/kong/dictionary.txt
@@ -412,6 +412,7 @@ misconfigured
 Moesif
 MongoDB
 multimodal
+multitenant
 mutex
 nameserver
 nameservers
@@ -663,6 +664,7 @@ vnet
 Vue
 Wallarm
 Wasm
+watchNamespaces
 WebAssembly
 webpages
 websocket

--- a/app/_data/docs_nav_kgo_1.6.x.yml
+++ b/app/_data/docs_nav_kgo_1.6.x.yml
@@ -1,0 +1,184 @@
+product: gateway-operator
+release: 1.6.x
+generate: true
+assume_generated: true
+items:
+  - title: Introduction
+    icon: /assets/images/icons/documentation/icn-flag.svg
+    items:
+      - text: Overview
+        url: /gateway-operator/1.6.x/
+        absolute_url: true
+      - text: Deployment Topologies
+        items:
+          - text: Hybrid Mode
+            url: /topologies/hybrid/
+          - text: DB-less Mode
+            url: /topologies/dbless/
+      - text: Key Concepts
+        items:
+          - text: Gateway API
+            url: /concepts/gateway-api
+          - text: Gateway Configuration
+            url: /concepts/gateway-configuration
+          - text: Managed Gateways
+            url: /concepts/managed-gateways
+      - text: Changelog
+        url: /gateway-operator/changelog
+        absolute_url: true
+      - text: Version Support Policy
+        url: /support
+      - text: FAQ
+        url: /faq
+  - title: Get Started
+    icon: /assets/images/icons/documentation/icn-learning.svg
+    items:
+      - text: Konnect
+        items:
+          - text: Install Gateway Operator
+            url: /get-started/konnect/install/
+          - text: Create a KonnectExtension
+            url: /get-started/konnect/create-konnectextension/
+          - text: Deploy a Data Plane
+            url: /get-started/konnect/deploy-data-plane-with-konnectextension/
+          - text: Create a Route
+            url: /get-started/konnect/create-route/
+            src: get-started/konnect/create-route-konnect-crds
+      - text: Kong Ingress Controller
+        items:
+          - text: Install Gateway Operator
+            url: /get-started/kic/install/
+          - text: Create a Gateway
+            url: /get-started/kic/create-gateway/
+            src: get-started/kic/create-gateway-konnect-crds
+          - text: Create a Route
+            url: /get-started/kic/create-route/
+  - title: Production Deployment
+    icon: /assets/images/icons/icn-server.svg
+    items:
+      - text: Overview
+        url: /production/
+      - text: Install
+        url: /install/
+      - text: Enterprise License
+        url: /license/
+      - text: Monitoring
+        items:
+          - text: Metrics
+            url: /production/monitoring/metrics/
+          - text: Status fields
+            items:
+              - text: Overview
+                url: /production/monitoring/status/overview/
+              - text: DataPlane
+                url: /production/monitoring/status/dataplane/
+              - text: ControlPlane
+                url: /production/monitoring/status/controlplane/
+              - text: Gateway
+                url: /production/monitoring/status/gateway/
+      - text: Upgrade Gateway Operator
+        url: /production/upgrade/gateway-operator/
+      - text: Certificates
+        items:
+          - text: Using custom CA for signing operator certificates
+            url: /production/certificates/custom_ca
+  - title: Guides
+    icon: /assets/images/icons/documentation/icn-solution-guide.svg
+    items:
+      - text: AI Gateway
+        url: /guides/ai-gateway/
+      - text: Customization
+        items:
+          - text: Set data plane image
+            url: /customization/data-plane-image/
+          - text: Deploying Sidecars
+            url: /customization/sidecars/
+          - text: Customizing PodTemplateSpec
+            url: /customization/pod-template-spec/
+          - text: Defining PodDisruptionBudget for DataPlane
+            url: /customization/pod-disruption-budget/
+      - text: Autoscaling Kong Gateway
+        url: /guides/autoscaling-kong/
+      - text: Autoscaling Workloads
+        items:
+          - text: Overview
+            url: /guides/autoscaling-workloads/overview/
+          - text: Prometheus
+            url: /guides/autoscaling-workloads/prometheus/
+          - text: Datadog
+            url: /guides/autoscaling-workloads/datadog/
+      - text: Hardening
+        items:
+          - text: Limiting namespaces watched by ControlPlane
+            url: /guides/hardening/control-plane-watch-namespaces/
+      - text: Upgrading Data Planes
+        items:
+          - text: Rolling Deployment
+            url: /guides/upgrade/data-plane/rolling/
+          - text: Blue / Green Deployment
+            url: /guides/upgrade/data-plane/blue-green/
+      - text: Kong Custom Plugin Distribution
+        url: guides/plugin-distribution/
+      - text: Managing Konnect entities
+        items:
+          - text: Architecture overview
+            url: /guides/konnect-entities/architecture/
+          - text: Gateway Control Plane
+            url: /guides/konnect-entities/gatewaycontrolplane/
+          - text: Service and Route
+            url: /guides/konnect-entities/service-and-route/
+          - text: Consumer, Credentials and Consumer Groups
+            url: /guides/konnect-entities/consumer-and-consumergroup/
+          - text: Key and Key Set
+            url: /guides/konnect-entities/key-and-keyset/
+          - text: Upstream and Targets
+            url: /guides/konnect-entities/upstream-and-target/
+          - text: Certificate and CA Certificate
+            url: /guides/konnect-entities/certificate-and-cacertificate/
+          - text: Vault
+            url: /guides/konnect-entities/vault/
+          - text: Data Plane Client Certificate
+            url: /guides/konnect-entities/dpcertificate/
+          - text: Tagging and Labeling
+            url: /guides/konnect-entities/tagging-and-labeling/
+          - text: Managing Plugin Bindings by CRD
+            url: /guides/konnect-entities/konnect-plugin-binding/
+          - text: Cloud Gateways - Networks
+            url: /guides/konnect-entities/cloud-gateways-network/
+          - text: Cloud Gateways - Data Plane Group Configuration
+            url: /guides/konnect-entities/cloud-gateways-data-plane-group-configuration/
+          - text: FAQ
+            url: /guides/konnect-entities/faq/
+      - text: Migration
+        items:
+          - text: Migrate Konnect DataPlanes from KGO v1.4.x to v1.5.x
+            url: /guides/migrating/migrate-from-1.4-to-1.5/
+  - title: Reference
+    icon: /assets/images/icons/icn-magnifying-glass.svg
+    items:
+      - text: Custom Resources
+        items:
+          - text: Overview
+            url: /reference/custom-resources/
+            src: reference/custom-resources/1.5.x
+          - text: GatewayConfiguration
+            url: /reference/custom-resources/#gatewayconfiguration
+            generate: false
+          - text: ControlPlane
+            url: /reference/custom-resources/#controlplane
+            generate: false
+          - text: DataPlane
+            url: /reference/custom-resources/#dataplane
+            generate: false
+          - text: KongPluginInstallation
+            url: /reference/custom-resources/#kongplugininstallation
+            generate: false
+      - text: Understanding KonnectExtension
+        url: /reference/konnectextension/
+      - text: Configuration Options
+        url: /reference/cli-arguments/
+        src: reference/cli-arguments/1.5.x
+      - text: License
+        url: /reference/license
+      - text: Version Compatibility
+        url: /reference/version-compatibility

--- a/app/_src/gateway-operator/guides/hardening/control-plane-watch-namespaces.md
+++ b/app/_src/gateway-operator/guides/hardening/control-plane-watch-namespaces.md
@@ -2,27 +2,23 @@
 title: Limiting namespaces watched by ControlPlane
 ---
 
-{{site.kgo_product_name}}'s `ControlPlane` watches all namespaces by default.
-This is a convenient out of the box experience but might not fit all production environments,
-specifically those with multiple teams sharing the same cluster or in multitenant environments.
+By default, {{ site.kgo_product_name }}'s `ControlPlane` watches all namespaces.
+This provides a convenient out-of-the-box experience but may not suit all production environments, especially those where multiple teams share the same cluster or in multitenant setups.
 
 To limit the namespaces watched by `ControlPlane`, you can set the `watchNamespaces` field in the `ControlPlane`'s `spec`.
 
 ## ControlPlane's watchNamespaces field
 
-The `spec.watchNamespaces.type` accepts 3 values to control this behavior:
+The `spec.watchNamespaces.type` field accepts three values to control this behavior:
 
-- `all`: default, as the name implies, watch resources in all namespaces
-- `own`: makes the `ControlPlane` only watch resources in its own namespace
-- `list`: makes the `ControlPlane` watch resources in its own namespace and the provided list of namespaces
-  Using "list" also adds ControlPlane's own namespace to the list of watched namespaces
-  because that's what KIC does.
-  The reason for this is the publish service (`DataPlane`'s `Service` exposed by {{site.base_gateway}})
-  by default would exist in the same namespace as `ControlPlane`.
+- `all` (default): Watches resources in all namespaces.
+- `own`: Watches resources only in the `ControlPlane`'s own namespace.
+- `list`: Watches resources in the `ControlPlane`'s own namespace and in the specified list of additional namespaces.
+  When using `list`, the `ControlPlane`'s own namespace is automatically added to the list of watched namespaces, because this behavior is required by {{ site.kic_product_name }}.  
+  By default, the publish service (the `Service` for the `DataPlane`, exposed by {{ site.base_gateway }}) is created in the same namespace as the `ControlPlane`.
 
-> Note: Please mark that this setting in `ControlPlane` will set the `CONTROLLER_WATCH_NAMESPACE`
-> environment variable in managed {{ site.kic_product_name }} so setting the watched namespaces in the environment variable via
-> `podTemplateSpec` will override this.
+> **Note:** Setting this field in `ControlPlane` will configure the `CONTROLLER_WATCH_NAMESPACE` environment variable in the managed {{ site.kic_product_name }}.
+> If you manually set the `CONTROLLER_WATCH_NAMESPACE` environment variable through `podTemplateSpec`, it will **override** this configuration.
 
 ## Specify a list of namespaces to watch
 
@@ -31,7 +27,8 @@ or additional resources.
 
 The `list` type requires 2 additional steps:
 
-- you must specify the namespaces to watch in the `spec.watchNamespaces.list` field.
+- You must specify the namespaces to watch in the `spec.watchNamespaces.list` field.
+
 
     ```yaml
     spec:
@@ -42,8 +39,8 @@ The `list` type requires 2 additional steps:
         - namespace-b
     ```
 
-- you must create a `WatchNamespaceGrant` resource in each of the specified namespaces.
-  This resource grants the `ControlPlane` the permission to watch resources in said namespace.
+- You must create a `WatchNamespaceGrant` resource in each of the specified namespaces.
+  This resource grants the `ControlPlane` permission to watch resources in the specified namespace.  
   It can be defined as:
 
     ```yaml
@@ -59,4 +56,4 @@ The `list` type requires 2 additional steps:
         namespace: control-plane-namespace
     ```
 
-For more information on the `WatchNamespaceGrant` CRD please consult the [CRD reference](/gateway-operator/{{ page.release }}/reference/custom-resources#watchnamespacegrant).
+For more information on the `WatchNamespaceGrant` CRD, check [CRD reference](/gateway-operator/{{ page.release }}/reference/custom-resources#watchnamespacegrant).

--- a/app/_src/gateway-operator/guides/hardening/control-plane-watch-namespaces.md
+++ b/app/_src/gateway-operator/guides/hardening/control-plane-watch-namespaces.md
@@ -16,12 +16,12 @@ The `spec.watchNamespaces.type` accepts 3 values to control this behavior:
 - `own`: makes the `ControlPlane` only watch resources in its own namespace
 - `list`: makes the `ControlPlane` watch resources in its own namespace and the provided list of namespaces
   Using "list" also adds ControlPlane's own namespace to the list of watched namespaces
-  because that's that KIC does.
+  because that's what KIC does.
   The reason for this is the publish service (`DataPlane`'s `Service` exposed by {{site.base_gateway}})
   by default would exist in the same namespace as `ControlPlane`.
 
 > Note: Please mark that this setting in `ControlPlane` will set the `CONTROLLER_WATCH_NAMESPACE`
-> environment variable in managed {{ site.kic_product_name }} so setting this via
+> environment variable in managed {{ site.kic_product_name }} so setting the watched namespaces in the environment variable via
 > `podTemplateSpec` will override this.
 
 ## Specify a list of namespaces to watch

--- a/app/_src/gateway-operator/guides/hardening/control-plane-watch-namespaces.md
+++ b/app/_src/gateway-operator/guides/hardening/control-plane-watch-namespaces.md
@@ -1,0 +1,62 @@
+---
+title: Limiting namespaces watched by ControlPlane
+---
+
+{{site.kgo_product_name}}'s `ControlPlane` watches all namespaces by default.
+This is a convenient out of the box experience but might not fit all production environments,
+specifically those with multiple teams sharing the same cluster or in multitenant environments.
+
+To limit the namespaces watched by `ControlPlane`, you can set the `watchNamespaces` field in the `ControlPlane`'s `spec`.
+
+## ControlPlane's watchNamespaces field
+
+The `spec.watchNamespaces.type` accepts 3 values to control this behavior:
+
+- `all`: default, as the name implies, watch resources in all namespaces
+- `own`: makes the `ControlPlane` only watch resources in its own namespace
+- `list`: makes the `ControlPlane` watch resources in its own namespace and the provided list of namespaces
+  Using "list" also adds ControlPlane's own namespace to the list of watched namespaces
+  because that's that KIC does.
+  The reason for this is the publish service (`DataPlane`'s `Service` exposed by {{site.base_gateway}})
+  by default would exist in the same namespace as `ControlPlane`.
+
+> Note: Please mark that this setting in `ControlPlane` will set the `CONTROLLER_WATCH_NAMESPACE`
+> environment variable in managed {{ site.kic_product_name }} so setting this via
+> `podTemplateSpec` will override this.
+
+## Specify a list of namespaces to watch
+
+`all` and `own` types are self-explanatory and do not require any further changes
+or additional resources.
+
+The `list` type requires 2 additional steps:
+
+- you must specify the namespaces to watch in the `spec.watchNamespaces.list` field.
+
+    ```yaml
+    spec:
+      watchNamespaces:
+        type: list
+        list:
+        - namespace-a
+        - namespace-b
+    ```
+
+- you must create a `WatchNamespaceGrant` resource in each of the specified namespaces.
+  This resource grants the `ControlPlane` the permission to watch resources in said namespace.
+  It can be defined as:
+
+    ```yaml
+    apiVersion: gateway-operator.konghq.com/v1alpha1
+    kind: WatchNamespaceGrant
+    metadata:
+      name: watch-namespace-grant
+      namespace: namespace-a
+    spec:
+      from:
+      - group: gateway-operator.konghq.com
+        kind: ControlPlane
+        namespace: control-plane-namespace
+    ```
+
+For more information on the `WatchNamespaceGrant` CRD please consult the [CRD reference](/gateway-operator/{{ page.release }}/reference/custom-resources#watchnamespacegrant).


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

- adds new section under guides: `/guides/hardening/control-plane-watch-namespaces/`
- `reference/cli-arguments/1.5.x` and `reference/custom-resources/1.5.x` in `app/_data/docs_nav_kgo_1.6.x.yml` will be updated separately for the 1.6 release

Closes: https://github.com/Kong/gateway-operator/issues/1501

### Testing instructions

Preview link: https://deploy-preview-8741--kongdocs.netlify.app/gateway-operator/unreleased/guides/hardening/control-plane-watch-namespaces/

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

