### PR TITLE
fix: Remove note about 1:1 Konnect team mapping

### DIFF
--- a/app/_includes/md/konnect/generic-sso.md
+++ b/app/_includes/md/konnect/generic-sso.md
@@ -59,11 +59,7 @@ The {{site.konnect_short_name}} OIDC integration allows you to configure various
         * To manage user and team memberships in {{site.konnect_short_name}} from the Organization settings, select the **Konnect Mapping Enabled** checkbox.
         * To assign team memberships by the IdP during SSO login via group claims mapped to {{site.konnect_short_name}} teams, select the **IdP Mapping Enabled** checkbox and enter your IdP groups in the relevant fields.
 
-        Each {{site.konnect_short_name}} team can be mapped to **one** IdP group.
-
-        For example, if you have a `service_admin` group in your IdP, you might map it
-        to the `Service Admin` team in {{site.konnect_short_name}}. You can hover
-        over the info (`i`) icon beside each field to learn more about the team, or
+        You can hover over the info (`i`) icon beside each field to learn more about the team, or
         see the [teams reference](/konnect/org-management/teams-and-roles/teams-reference/)
         for more information.
 


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Removed the note about only mapping a team 1:1 since users can and do use one to multiple mapping.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
https://kongstrong.slack.com/archives/CDSTDSG9J/p1745342320616519
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

