### PR TITLE
fix: Incorrect links in azure content safety docs

### DIFF
--- a/app/_hub/kong-inc/ai-azure-content-safety/overview/_index.md
+++ b/app/_hub/kong-inc/ai-azure-content-safety/overview/_index.md
@@ -2,16 +2,16 @@
 nav_title: Overview
 ---
 
-The Azure Content Safety plugin allows administrators to enforce 
-introspection with the [Azure Content Safety](https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety) service 
+The Azure Content Safety plugin allows administrators to enforce
+introspection with the [Azure Content Safety](https://azure.microsoft.com/en-us/products/ai-services/ai-content-safety) service
 for all requests handled by the AI Proxy plugin.
-The plugin enables configurable thresholds for the different moderation categories 
+The plugin enables configurable thresholds for the different moderation categories
 and you can specify an array set of pre-configured blocklist IDs from your Azure Content Safety instance.
 
 Audit failures can be observed and reported on using the {{Site.base_gateway}} logging plugins.
 
 {:.note}
-> This plugin extends the functionality of the [AI Proxy plugin](/hub/kong-inc/ai-proxy/), and requires AI Proxy to be configured first. 
+> This plugin extends the functionality of the [AI Proxy plugin](/hub/kong-inc/ai-proxy/), and requires AI Proxy to be configured first.
 Check out the [AI Gateway quickstart](/gateway/latest/get-started/ai-gateway/) to get an AI proxy up and running within minutes!
 
 ## Format
@@ -23,8 +23,8 @@ compose an Azure Content Safety text check by compiling all chat history, or jus
 
 * [AI Gateway quickstart: Set up AI Proxy](/gateway/latest/get-started/ai-gateway/)
 * [Configuration reference](/hub/kong-inc/ai-azure-content-safety/configuration/)
-* [Basic configuration example](/hub/kong-inc/ai-prompt-decorator/how-to/basic-example/)
-* [Learn how to use the plugin](/hub/kong-inc/ai-prompt-decorator/how-to/)
+* [Basic configuration example](/hub/kong-inc/ai-azure-content-safety/how-to/basic-example/)
+* [Learn how to use the plugin](/hub/kong-inc/ai-azure-content-safety/how-to/)
 
 ### All AI Gateway plugins
 


### PR DESCRIPTION

### Description

This PR fixes two incorrect links pointing to AI prompt decorator in the Azure content safety main doc.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

