### PR TITLE
chore(kgo): fix latest Kong CE version variable

### DIFF
--- a/app/_src/gateway-operator/get-started/kic/create-gateway-konnect-crds.md
+++ b/app/_src/gateway-operator/get-started/kic/create-gateway-konnect-crds.md
@@ -70,7 +70,7 @@ spec:
         spec:
           containers:
           - name: proxy
-            image: kong:{{ site.data.kong_latest_gateway.ce-version }}
+            image: kong:{{site.latest_gateway_oss_version}}
   controlPlaneOptions:
     deployment:
       podTemplateSpec:


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

CE version used in https://docs.konghq.com/gateway-operator/latest/get-started/kic/create-gateway/#gatewayconfiguration renders to an empty string.

Most likely due to usage of `{{ site.data.kong_latest_gateway.ce-version }}`.

This PR fixes it by using `{{site.latest_gateway_oss_version}}` instead.

### Testing instructions

Preview link: https://deploy-preview-8755--kongdocs.netlify.app/gateway-operator/latest/get-started/kic/create-gateway/#gatewayconfiguration (On Prem tab)

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

