### PR TITLE
Update kong-vault.md

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/security/kong-vault.md
+++ b/app/_src/kubernetes-ingress-controller/guides/security/kong-vault.md
@@ -67,7 +67,7 @@ To learn more about the available vaults, see the [{{ site.base_gateway }} docum
       hour: 10000
       policy: redis
       redis_host: <redis_host>
-      redis_password: "vault://env/secret-redis-password"
+      redis_password: '{vault://env/secret-redis-password}'
     ```
 
 ### HashiCorp Vault
@@ -233,6 +233,6 @@ config:
   hour: 10000
   policy: redis
   redis_host: <redis_host>
-  redis_password: "vault://aws-us-east/secret-redis-password"
+  redis_password: '{vault://aws-us-east/secret-redis-password}'
 ```
 {% endif_version %}


### PR DESCRIPTION
### Description

The docs show incorrect usage of vault references

This (current) will result in a literal string being used
redis_password: "vault://aws-us-east/secret-redis-password"

This was updated to
redis_password: '{vault://aws-us-east/secret-redis-password}'

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [X] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

