### PR TITLE
Fix: add missing Kong Manager changelog entries

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -206,6 +206,8 @@ You can use this setting to [strengthen security in Kong Manager](/gateway/3.10.
 
 * Fixed an issue where the lists in the UI would flicker under some circumstances.
 * Fixed an issue where the license expiration date was calculated incorrectly.
+* Fixed an issue where creating a `jwt-credential` with the `PS256`, `PS384`, `PS512`, or `EdDSA` algorithms wouldn't populate the `rsa_public_key` in Kong Manager.
+* Fixed an issue where editing an upstream would not remove the values of some fields (`client certificate`, `tags`, `timeouts`, `host_header`, and others) in Kong Manager.
 
 #### PDK
 


### PR DESCRIPTION
### Description

Issue raised on Slack. We're missing these changelog entries in 3.10.0.0: https://github.com/Kong/kong-ee/pull/11844/files

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

