### PR TITLE
feat: [demo-feature-banners]: Add demo feature availability banners

### DIFF
--- a/app/_assets/stylesheets/featureflags.less
+++ b/app/_assets/stylesheets/featureflags.less
@@ -1,0 +1,76 @@
+@enterprise-color: #e03c31;
+@cloud-color: #2c7a7b;
+@oss-color: #4a5568;
+
+@enterprise-bg: #fef2f2;
+@cloud-bg: #e6fffa;
+@oss-bg: #f7fafc;
+
+@badge-radius: 10px;
+
+.feature-flag {
+  position: relative;
+  border-left: 6px solid #2684ff;
+  background-color: #f0f8ff;
+  padding: 1.5em 2em;
+  margin: 2.5em 0;
+  border-radius: @badge-radius;
+  font-size: 1.8rem;
+  line-height: 1.9;
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+  transition: background-color 0.3s ease, color 0.3s ease;
+
+//   &::before {
+//     content: '🚩';
+//     margin-right: 0.8em;
+//     font-size: 1.8em;
+//     display: inline-block;
+//     vertical-align: middle;
+//   }
+
+  &.inline {
+    display: inline-block;
+    padding: 0.4em 1em;
+    border: 2px solid #2684ff;
+    border-radius: @badge-radius;
+    font-size: 1.8rem;
+    background-color: #f0f8ff;
+    line-height: 1.6;
+    box-shadow: none;
+  }
+
+//     &::before {
+//       content: '⚠️';
+//       font-size: 1.8em;
+//     }
+//   }
+
+  &.availability-enterprise {
+    border-color: @enterprise-color;
+    background-color: @enterprise-bg;
+    color: darken(@enterprise-color, 8%);
+  }
+
+  &.availability-cloud {
+    border-color: @cloud-color;
+    background-color: @cloud-bg;
+    color: darken(@cloud-color, 8%);
+  }
+
+  &.availability-oss {
+    border-color: @oss-color;
+    background-color: @oss-bg;
+    color: darken(@oss-color, 5%);
+  }
+
+  .version {
+    font-weight: normal;
+    margin-left: 0.75em;
+    font-size: 1.8rem;
+    color: #4a5568;
+  }
+
+  &.inline:hover {
+    background-color: darken(@cloud-bg, 5%);
+  }
+}

--- a/app/_assets/stylesheets/index.less
+++ b/app/_assets/stylesheets/index.less
@@ -33,3 +33,4 @@
 @import "roboto-fonts";
 @import "collapsible-sections";
 @import "tables/install";
+@import "featureflags";

--- a/app/_plugins/blocks/featureflag.rb
+++ b/app/_plugins/blocks/featureflag.rb
@@ -1,0 +1,41 @@
+module Jekyll
+  module Tags
+    class FeatureFlagBlock < Liquid::Block
+      SYNTAX = /availability="(?<availability>[\w-]+)"(?:\s+version="(?<version>[^"]+)")?/i
+
+      ICONS = {
+        'enterprise' => '🏢',
+        'cloud' => '☁️',
+        'oss' => '🌱',
+        'default' => '🚩'
+      }
+
+      def initialize(tag_name, markup, tokens)
+        super
+        if markup =~ SYNTAX
+          @availability = Regexp.last_match[:availability]
+          @version = Regexp.last_match[:version]
+        else
+          raise SyntaxError.new("Invalid syntax for featureflag. Usage: {% featureflag availability=\"enterprise\" version=\"3.5\" %}")
+        end
+      end
+
+      def render(context)
+        content = super.strip
+
+        # Clean version for human-readable usage
+        clean_version = @version&.gsub(/\+|\.x/, '')
+        content.gsub!("{version}", clean_version.to_s) if clean_version
+
+        classes = ["feature-flag", "availability-#{@availability}"]
+        version_info = @version ? "<span class=\"version\">(#{@version})</span>" : ""
+        availability_label = @availability.capitalize.gsub('-', ' ')
+        icon = ICONS.fetch(@availability, ICONS['default'])
+
+        "<div class=\"#{classes.join(' ')}\"><span class=\"icon\">#{icon}</span> <strong>#{availability_label}</strong>#{version_info}: #{content}</div>"
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('featureflag', Jekyll::Tags::FeatureFlagBlock)

--- a/app/_src/gateway/index.md
+++ b/app/_src/gateway/index.md
@@ -6,6 +6,21 @@ description: Kong Gateway is a lightweight, fast, and flexible cloud-native API 
 konnect_cta_card: true
 ---
 
+## Feature availability:
+{% featureflag availability="enterprise" version="3.5+" %}
+Only available in Kong Gateway Enterprise {version} and later.
+{% endfeatureflag %}
+
+{% featureflag availability="cloud" version="1.0+" %}
+Only available in Kong Konnect Cloud {version} and later.
+{% endfeatureflag %}
+
+{% featureflag availability="oss" version="3.3+" %}
+This feature was added to the OSS distribution in version {version}.
+{% endfeatureflag %}
+
+---
+
 <blockquote class="note">
   <p><strong>Set up your Gateway in under 5 minutes with {{ site.konnect_product_name }}:</strong></p>
   <p>


### PR DESCRIPTION
### Description
This PR introduces a reusable featureflag Liquid block plugin that allows documentation writers to clearly indicate feature availability (Enterprise, Cloud, or OSS) and associate version constraints. This improves consistency, reduces duplication, and centralizes formatting for feature-level callouts across the docs.

Authors can now use the following syntax:
```
{% featureflag availability="enterprise" version="3.5+" %}
Only available in Kong Gateway Enterprise {version} and later.
{% endfeatureflag %}
```

- The {version} token is automatically replaced with a clean version string (e.g. 3.5, stripping .x or +).
- An appropriate icon (🏢, ☁️, 🌱) and label are rendered in a styled block to increase visibility and maintain a consistent tone.
- Inline badge support was intentionally excluded to keep implementation and visual standards simple.

Why? This provides a scalable, low-maintenance way to mark feature gating across versions or product editions and supports future refactoring or automation efforts.
⸻

### Testing instructions
To test:
1. Add the block to any Markdown file under app/_src/ using the syntax shown above.
2. Verify that the rendered output includes:
- Correct icon and label.
- Version display in parentheses.
- {version} properly replaced in content.
- No rendering issues or extra icons.

