### PR TITLE
fix bedrock docs to cover supported authentication sources

### DIFF
--- a/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_bedrock.md
+++ b/app/_hub/kong-inc/ai-proxy-advanced/how-to/llm-provider-integration-guides/_bedrock.md
@@ -5,12 +5,19 @@ title: Set up AI Proxy Advanced with Bedrock
 
 This guide walks you through setting up the AI Proxy Advanced plugin with [Amazon Bedrock](https://aws.amazon.com/bedrock/).
 
-## Prerequisites
-* [{{site.base_gateway}} is installed and running](/gateway/latest/get-started/)
-* An AWS account
-* An [AWS access key ID and AWS secret access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) 
+{{site.base_gateway}} can automatically fetch IAM role credentials based on your AWS environment, observing the following precedence order:
+- Fetch from credentials defined in environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+- Fetch from profile and credential file, defined by `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`.
+- Fetch from an ECS [container credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html).
+- Fetch from an EKS [IAM roles for service account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+- Fetch from EC2 IMDS metadata. Both v1 and v2 are supported
 
-## Configure the AI Proxy plugin
+
+## Configure the AI Proxy Advanced plugin
+
+
+The following steps demonstrate how to set up the AI Proxy Advanced plugin using
+Access Key ID and Secret Access Key credentials.
 
 1. Create a service in {{site.base_gateway}} that will represent the Bedrock API:
 ```sh

--- a/app/_hub/kong-inc/ai-proxy/how-to/llm-provider-integration-guides/_bedrock.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/llm-provider-integration-guides/_bedrock.md
@@ -5,12 +5,19 @@ title: Set up AI Proxy with Bedrock
 
 This guide walks you through setting up the AI Proxy plugin with [Amazon Bedrock](https://aws.amazon.com/bedrock/).
 
-## Prerequisites
-* [{{site.base_gateway}} is installed and running](/gateway/latest/get-started/)
-* An AWS account
-* An [AWS access key ID and AWS secret access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) 
+{{site.base_gateway}} can automatically fetch IAM role credentials based on your AWS environment, observing the following precedence order:
+- Fetch from credentials defined in environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+- Fetch from profile and credential file, defined by `AWS_PROFILE` and `AWS_SHARED_CREDENTIALS_FILE`.
+- Fetch from an ECS [container credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html).
+- Fetch from an EKS [IAM roles for service account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+- Fetch from EC2 IMDS metadata. Both v1 and v2 are supported
+
 
 ## Configure the AI Proxy plugin
+
+
+The following steps demonstrate how to set up the AI Proxy plugin using
+Access Key ID and Secret Access Key credentials.
 
 1. Create a service in {{site.base_gateway}} that will represent the Bedrock API:
 ```sh


### PR DESCRIPTION
### Description

Update bedrock document to the full list of supported credential sources (same to https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/backends/aws-sm/#main).

This is not a new feature but what we support from beginning so no need to add `if version` blocks.

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

