### PR TITLE
kic: Fix example command for tls termination

### DIFF
--- a/app/_src/kubernetes-ingress-controller/guides/services/tls.md
+++ b/app/_src/kubernetes-ingress-controller/guides/services/tls.md
@@ -133,7 +133,7 @@ The Ingress API supports TLS termination using the `.spec.tls` field. To termina
 You can verify the configuration by using `curl`:
 
 ```bash
-  curl --cacert ./server.crt -i -k -v -H "Host:demo.example.com" https://${PROXY_IP}/echo
+  curl --cacert ./server.crt -i -k -v --resolve "demo.example.com:443:${PROXY_IP}" https://demo.example.com/echo
 ```
 
 You should get the following response:


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

Fix example command in the KIC guide for using TLS termination to configure SNI correctly.
Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/7376.
### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->
https://deploy-preview-8783--kongdocs.netlify.app/kubernetes-ingress-controller/latest/guides/services/tls/#tls-termination
### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

