### PR TITLE
Fix link name to audit logs api

### DIFF
--- a/app/konnect/dev-portal/audit-logging/index.md
+++ b/app/konnect/dev-portal/audit-logging/index.md
@@ -12,4 +12,4 @@ Dev Portal audit logs are set up and managed separately from org-wide {{site.kon
 * [Set up an portal audit log replay job](/konnect/dev-portal/audit-logging/replay-job/)
 * [Portal Audit log event reference](/konnect/reference/audit-logs/)
 * [Verify audit log signatures](/konnect/reference/verify-signatures/)
-* [Dev Portal Audit Logs API](/konnect/api/audit-logs/latest/)
+* [{{site.konnect_short_name}} Audit Logs API](/konnect/api/audit-logs/latest/)


### PR DESCRIPTION
The dev portal audit logging page says it links to the dev portal audit logs API, but there is no such thing. There is a Konnect audit logs API, which you can use for both Konnect platform and Dev Portal.

reported on slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1747335494900349