### PR TITLE
fix: Add key auth step directly in central consumers doc

### DIFF
--- a/app/konnect/centralized-consumer-management.md
+++ b/app/konnect/centralized-consumer-management.md
@@ -82,9 +82,38 @@ You can manage consumers centrally using the {{site.konnect_short_name}} API. On
    * `{realmId}`: The ID of the realm you created previously.
    * `{consumerId}`: The ID of the consumer you created previously.
 
-1. Consumers require authentication. Configure authentication using the [Key Auth plugin](/hub/kong-inc/key-auth/how-to/).
+1. Centralized consumers require a specific [Key Auth plugin](/hub/kong-inc/key-auth/how-to/) authentication configuration that includes the `realm id`:
+   ```bash
+    curl -X POST \
+    https://{region}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities/plugins/ \
+    --header "accept: application/json" \
+    --header "Content-Type: application/json" \
+    --header "Authorization: Bearer KONNECT_TOKEN" \
+    --data '{
+        "name": "key-auth",
+        "config": {
+            "key_names": ["apikey"],
+            "identity_realms": [
+                {
+                "region": "$REGION",
+                "id": "$REALM_ID",
+                "scope": "realm"
+                },
+                {
+                "scope": "cp"
+                }
+            ]
+        }
+    }'
+    ```
+    Be sure to replace the following with your own values:
+    * {region}: Region for your {{site.konnect_short_name}} instance.
+    * {controlPlaneId}: ID of your control plane.
+    * KONNECT_TOKEN: Replace with your {{site.konnect_short_name}} personal access token.
+    * $REALM_ID: The ID of the realm you created previously. 
+    * $REGION: Region for your {{site.konnect_short_name}} instance.
 
-   `identity_realms` are scoped to the control plane by default (`scope: cp`). The order in which you configure the `identity_realms` dictates the priority in which the data plane attempts to authenticate the provided API keys:
+    `identity_realms` are scoped to the control plane by default (`scope: cp`). The order in which you configure the `identity_realms` dictates the priority in which the data plane attempts to authenticate the provided API keys:
 
     * **Realm is listed first:** The data plane will first reach out to the realm. If the API key is not found in the realm, the data plane will look for the API key in the control plane config. 
     * **Control plane scope listed first:** The data plane will initially check the control plane configuration (LMDB) for the API key before looking up the API Key in the realm.


### PR DESCRIPTION
### Description

The central consumers doc had a link to the key auth config portion, but users thought a regular key auth setup would work. I added the key auth step directly in and made it clear that this is a specific setup that central consumers require.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->
https://kongstrong.slack.com/archives/CA42V003B/p1747747053933969
### Testing instructions

Preview link: https://deploy-preview-8806--kongdocs.netlify.app/konnect/centralized-consumer-management/#create-consumers-and-realms

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

