### PR TITLE
update MeshOPA targetRef support matrix and fix outdated examples

### DIFF
--- a/app/_src/mesh/features/meshopa.md
+++ b/app/_src/mesh/features/meshopa.md
@@ -20,7 +20,25 @@ When the `MeshOPA` policy is applied, the control plane configures the following
 
 ## TargetRef support matrix
 
+{% if_version gte:2.11.x %}
+{% tabs %}
+{% tab Sidecar %}
+| `targetRef`           | Allowed kinds                                            |
+| --------------------- | -------------------------------------------------------- |
+| `targetRef.kind`      | `Mesh`, `Dataplane`, `MeshSubset(deprecated)` |
+{% endtab %}
+
+{% tab Builtin Gateway %}
+| `targetRef`             | Allowed kinds                                             |
+| ----------------------- | --------------------------------------------------------- |
+| `targetRef.kind`        | `Mesh`, `MeshGateway`                                     |
+{% endtab %}
+{% endtabs %}
+{% endif_version %}
+
+
 {% if_version gte:2.6.x %}
+{% if_version lte:2.10.x %}
 {% tabs %}
 {% tab Sidecar %}
 | `targetRef`           | Allowed kinds                                            |
@@ -36,6 +54,8 @@ When the `MeshOPA` policy is applied, the control plane configures the following
 {% endtabs %}
 
 {% endif_version %}
+{% endif_version %}
+
 {% if_version lte:2.5.x %}
 
 | TargetRef type    | top level | to  | from |
@@ -351,7 +371,7 @@ spec:
   default:
     authConfig: # optional
       statusOnError: 413 # optional: defaults to 403.
-      onAgentFailure: allow # optional: one of 'allow' or 'deny', defaults to 'deny' defines the behavior when communication with the agent fails or the policy execution fails.
+      onAgentFailure: Allow # optional: one of 'Allow' or 'Deny', defaults to 'Deny' defines the behavior when communication with the agent fails or the policy execution fails.
       requestBody: # optional
           maxSize: 1024 # the max number of bytes to send to the agent, if we exceed this, the request to the agent will have: `x-envoy-auth-partial-body: true`.
           sendRawBody: true # use when the body is not plaintext. The agent request will have `raw_body` instead of `body`
@@ -371,7 +391,7 @@ spec:
   default:
     authConfig: # optional
       statusOnError: 413 # optional: defaults to 403. http statusCode to use when the connection to the agent failed.
-      onAgentFailure: allow # optional: one of 'allow' or 'deny', defaults to 'deny'. defines the behavior when communication with the agent fails or the policy execution fails.
+      onAgentFailure: Allow # optional: one of 'Allow' or 'Deny', defaults to 'deny'. defines the behavior when communication with the agent fails or the policy execution fails.
       requestBody: # optional
         maxSize: 1024 # the maximum number of bytes to send to the agent, if we exceed this, the request to the agent will have: `x-envoy-auth-partial-body: true`.
         sendRawBody: true # use when the body is not plaintext. The agent request will have `raw_body` instead of `body`


### PR DESCRIPTION
### Description

We have updated MeshOPA policy in Kong Mesh in 2.11.x this aligns docs with current functionality 

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

