### PR TITLE
Fix hugging face example

### DIFF
--- a/app/_hub/kong-inc/ai-proxy/how-to/llm-provider-integration-guides/_huggingface.md
+++ b/app/_hub/kong-inc/ai-proxy/how-to/llm-provider-integration-guides/_huggingface.md
@@ -41,8 +41,8 @@ curl -X POST http://localhost:8001/routes/huggingface-chat/plugins \
   --data "config.model.name=<huggingface_model>" \
   --data "config.model.options.max_tokens=512" \
   --data "config.model.options.temperature=1.0" \
-  --data "config.model.options.top_p=256" \
-  --data "config.model.options.top_k=0.5"
+  --data "config.model.options.top_p=0.5" \
+  --data "config.model.options.top_k=256"
 ```
 
 {% endnavtab %}
@@ -69,8 +69,8 @@ plugins:
         options:
           max_tokens: 512
           temperature: 1.0
-          top_p: 256
-          top_k: 0.5
+          top_p: 0.5
+          top_k: 256
 ```
 
 {% endnavtab %}


### PR DESCRIPTION
Issue reported on Slack:
The type of top_k should be integer (it currently shows 0.5), while top_p should be a number between 0 to 1: https://github.com/Kong/kong/blob/36db98046b05cfe48b14d3ae00a3c5601bd105a8/kong/llm/schemas/init.lua#L147-L156

The values in the example are flipped.