### PR TITLE
Release: Kong Gateway OSS 3.9.1

### DIFF
--- a/app/_data/kong_versions.yml
+++ b/app/_data/kong_versions.yml
@@ -108,7 +108,7 @@
   endOfLifeDate: 2025-09-30
 - release: "3.9.x"
   ee-version: "3.9.1.1"
-  ce-version: "3.9.0" # make sure to update latest OSS gateway version in jekyll.yml
+  ce-version: "3.9.1" # make sure to update latest OSS gateway version in jekyll.yml
   edition: "gateway"
   luarocks_version: "3.0.0-0"
   dependencies:

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -197,4 +197,4 @@ jekyll-generator-single-source:
 locale: en-US
 
 # Gateway OSS
-latest_gateway_oss_version: 3.9.0
+latest_gateway_oss_version: 3.9.1

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -188,4 +188,4 @@ vwo_account_id: '125292'
 segment_key: 'X7EZTdbdUKQ8M6x42SHHPWiEhjsfs1EQ'
 
 # Gateway OSS
-latest_gateway_oss_version: 3.9.0
+latest_gateway_oss_version: 3.9.1


### PR DESCRIPTION
Bump gateway version for release that came out today: https://github.com/Kong/kong/releases/tag/3.9.1