### PR TITLE
Chore: Gateway 3.7 moves into sunset support

### DIFF
--- a/app/_src/gateway/support/index.md
+++ b/app/_src/gateway/support/index.md
@@ -85,19 +85,14 @@ After the product hits the end of the support period, Kong will provide limited 
 Kong supports the following versions of {{site.ee_product_name}}: 
 
 {% navtabs %}
-  {% if_version gte: 3.10.x %}
   {% navtab 3.10 LTS %}
     {% include_cached gateway-support.html version="3.10" data=site.data.tables.support.gateway.versions.310 eol="March 2028" %}
   {% endnavtab %}
-  {% endif_version %}
   {% navtab 3.9 %}
     {% include_cached gateway-support.html version="3.9" data=site.data.tables.support.gateway.versions.39 eol="Dec 2025" %}
   {% endnavtab %}
   {% navtab 3.8 %}
     {% include_cached gateway-support.html version="3.8" data=site.data.tables.support.gateway.versions.38 eol="Sept 2025" %}
-  {% endnavtab %}
-  {% navtab 3.7 %}
-    {% include_cached gateway-support.html version="3.7" data=site.data.tables.support.gateway.versions.37 eol="May 2025" %}
   {% endnavtab %}
   {% navtab 3.4 LTS %}
     {% include_cached gateway-support.html version="3.4" data=site.data.tables.support.gateway.versions.34 eol="August 2026" %}
@@ -135,6 +130,7 @@ These versions have reached the end of full support.
 
 | Version  | Released Date | End of Full Support | End of Sunset Support |
 |:--------:|:-------------:|:-------------------:|:---------------------:|
+|  3.7.x.x |  2024-05-28   |     2025-05-28      |      2026-05-28       |
 |  3.6.x.x |  2024-02-12   |     2025-02-12      |      2026-02-12       |
 |  3.5.x.x |  2023-11-08   |     2024-11-08      |      2025-11-08       |
 |  3.3.x.x |  2023-05-19   |     2024-05-19      |      2025-05-19       |

--- a/app/_src/gateway/support/third-party.md
+++ b/app/_src/gateway/support/third-party.md
@@ -11,26 +11,15 @@ Unless otherwise noted, Kong supports the last 2 versions any third party tool, 
 > Some third party tools below do not have a version number. These tools are managed services and Kong provides compatibility with the currently released version
 
 {% navtabs %}
-  {% if_version gte: 3.10.x %}
   {% navtab 3.10 LTS %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.310 %}
   {% endnavtab %}
-  {% endif_version %}
-  {% if_version gte: 3.9.x %}
   {% navtab 3.9 %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.39 %}
   {% endnavtab %}
-  {% endif_version %}
-  {% if_version gte: 3.8.x %}
   {% navtab 3.8 %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.38 %}
   {% endnavtab %}
-  {% endif_version %}
-  {% if_version gte: 3.7.x %}
-  {% navtab 3.7 %}
-    {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.37 %}
-  {% endnavtab %}
-  {% endif_version %}
   {% navtab 3.4 LTS %}
     {% include_cached gateway-support-third-party.html data=site.data.tables.support.gateway.versions.34 %}
   {% endnavtab %}


### PR DESCRIPTION
Gateway 3.7 entered sunset support on May 28, 2025. Updating support pages to reflect this.

https://deploy-preview-8828--kongdocs.netlify.app/gateway/latest/support-policy/
