### PR TITLE
Add tracing and monitoring dev site redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1809,7 +1809,7 @@
   status: migrated
 - docs_url: "/gateway/latest/production/monitoring/"
   source_file: _src/gateway/production/monitoring/index.md
-  dev_site_url: "/gateway/logs/"
+  dev_site_url: "/gateway/monitoring/"
   status: won't do
 - docs_url: "/gateway/latest/production/monitoring/prometheus/"
   source_file: _src/gateway/production/monitoring/prometheus.md
@@ -1833,15 +1833,15 @@
   status: migrated
 - docs_url: "/gateway/latest/production/tracing/"
   source_file: _src/gateway/production/tracing/index.md
-  dev_site_url: "/gateway/"
+  dev_site_url: "/gateway/tracing/"
   status: "?"
 - docs_url: "/gateway/latest/production/tracing/write-custom-trace-exporter/"
   source_file: _src/gateway/production/tracing/write-custom-trace-exporter.md
-  dev_site_url: "/gateway/"
+  dev_site_url: "/gateway/tracing/"
   status: "?"
 - docs_url: "/gateway/latest/production/tracing/api/"
   source_file: _src/gateway/production/tracing/api.md
-  dev_site_url: "/gateway/"
+  dev_site_url: "/gateway/tracing/"
   status: "?"
 - docs_url: "/gateway/latest/production/blue-green/"
   source_file: _src/gateway/production/blue-green.md


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Adds redirects for the dev site monitoring landing page and the tracing reference page.

Don't merge until https://github.com/Kong/developer.konghq.com/pull/1736 is merged.
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

