### PR TITLE
fix(mesh): fix nav reference in 2.12.x mesh docs

### DIFF
--- a/app/_data/docs_nav_mesh_2.12.x.yml
+++ b/app/_data/docs_nav_mesh_2.12.x.yml
@@ -4,7 +4,7 @@ release: 2.12.x
 max_depth: 3
 inherit:
   path: /.repos/kuma/app/_src
-  nav: ../_src/.repos/kuma/app/_data/docs_nav_kuma_2.11.x.yml
+  nav: ../_src/.repos/kuma/app/_data/docs_nav_kuma_2.12.x.yml
   patches:
     - path: [ Introduction ]
       action: modify
@@ -126,7 +126,7 @@ inherit:
     - path: [ Policies ]
       action: insert
       index: -2
-      text: MeshOPA 
+      text: MeshOPA
       url: /features/meshopa
       generate: false
     - path: [ Policies ]


### PR DESCRIPTION
### Description

- Update `inherit.nav` path to point to the correct 2.12.x navigation file
- Remove trailing space from MeshOPA text entry

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

