### PR TITLE
fix: Add KM basic auth redirect, fix the changelog dates

### DIFF
--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -12,7 +12,7 @@ For Kong Gateway OSS, view the [OSS changelog on GitHub](https://github.com/Kong
 For product versions that have reached the end of sunset support, see the [changelog archives](https://legacy-gateway--kongdocs.netlify.app/enterprise/changelog/).
 
 ## 3.10.0.2
-**Release Date** 2025/06/12
+**Release Date** 2025/05/20
 
 ### Features
 #### Configuration
@@ -3512,7 +3512,7 @@ was called multiple times in a request lifecycle.
   * Bumped `nghttp2` from 1.56.0 to 1.57.0
 
 ## 3.4.3.19
-**Release Date** 2025/06/05
+**Release Date** 2025/06/12
 
 ### Fixes
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -173,7 +173,7 @@
   status: "?"
 - docs_url: "/gateway/latest/kong-manager/auth/basic/"
   source_file: _src/gateway/kong-manager/auth/basic.md
-  dev_site_url: "/gateway/kong-manager/"
+  dev_site_url: "/how-to/enable-basic-auth-on-kong-manager/"
   status: post-ga
 - docs_url: "/deck/install/binary/"
   source_file: deck/install/binary.md


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
Added a redirect for the KM basic auth how to I just migrated, fixed the release dates for 3.10.0.2 and 3.4.3.19 since I mixed those up in #8829 
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: 
- https://deploy-preview-8846--kongdocs.netlify.app/gateway/changelog/ (just the date)
- https://deploy-preview-8846--kongdocs.netlify.app/gateway/changelog/#34319 (just the date)
- https://deploy-preview-8846--kongdocs.netlify.app/gateway/latest/kong-manager/auth/basic/#main (test redirect in banner)

### Checklist 

- [x] Review label added <!-- (see below) -->
- [x] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

