### PR TITLE
Add a netlify function that fetches the latest mesh version from the dev

### DIFF
--- a/app/_headers
+++ b/app/_headers
@@ -1,0 +1,5 @@
+/mesh/latest_version
+    Access-Control-Allow-Origin: *
+    Access-Control-Allow-Method: GET
+    Access-Control-Allow-Headers: Content-Type
+    Content-Type: text/plain

--- a/app/_redirects
+++ b/app/_redirects
@@ -4,6 +4,9 @@
 
 ######################################################################
 
+
+/mesh/latest_version/    /.netlify/functions/mesh_latest_version  200
+
 # XXX: until we have the final url
 /gateway/2.8.x/*    https://legacy-gateway-2-8--kongdocs.netlify.app/gateway/2.8.x/:splat 301
 
@@ -1705,7 +1708,6 @@
 /gateway/2.8.x/install-and-run/kubernetes/  https://developer.konghq.com/gateway/install/kubernetes/ 301
 /konnect/reference/labels/  https://developer.konghq.com/gateway-manager/konnect-labels/ 301
 /konnect/analytics/use-cases/latency/  https://developer.konghq.com/advanced-analytics/ 301
-/mesh/latest_version/  https://developer.konghq.com/mesh/latest_version/ 301
 /gateway/latest/kong-manager/auth/ldap/configure/  https://developer.konghq.com/gateway/kong-manager/ 301
 /deck/file/lint/  https://developer.konghq.com/deck/file/lint/ 301
 /gateway/latest/get-started/load-balancing/  https://developer.konghq.com/gateway/get-started/ 301

--- a/netlify/functions/mesh_latest_version.js
+++ b/netlify/functions/mesh_latest_version.js
@@ -1,0 +1,34 @@
+const fetch = require("node-fetch");
+
+exports.handler = async (event) => {
+  try {
+    // Netlify function to pul the latest version from the developer site
+    // The allow-control headers weren't set in the 301 reponse
+    // Adding the headers back and including the response here from the dev site here
+    // fixes the CORS issue
+    const targetUrl = "https://developer.konghq.com/mesh/latest_version/";
+
+    const response = await fetch(targetUrl);
+    const data = await response.text();
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Content-Type": "text/plain",
+      },
+      body: data,
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 500,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+      body: "Error fetching latest version",
+    };
+  }
+};


### PR DESCRIPTION

### Description

Add a netlify function that fetches the latest mesh version from the dev site and returns it
The redirect was causing a CORS issue because the allow-control-origin weren't passed in the 301 response
With this change there's no longer a redirect, and the site should return a 200 response with the right headers + body.


<img width="1553" alt="Screenshot 2025-06-20 at 14 53 47" src="https://github.com/user-attachments/assets/5ccd4ea9-414c-4acd-8b40-b4dfaab35e53" />

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

