### PR TITLE
docs: Fix version inconsistency in autodocs guide

### DIFF
--- a/docs/autodocs.md
+++ b/docs/autodocs.md
@@ -29,9 +29,7 @@ cd /path/to/kong
 scripts/autodoc ../docs.konghq.com 2.4.x
 ```
 
-This example assumes that the `Kong/docs.konghq.com` repo is cloned into the
-same directory as the `Kong/kong` repo, and that you want to generate the docs
-for version `3.7.x`. Adjust the paths and version as needed.
+This example assumes that the `Kong/docs.konghq.com` repo is cloned into the same directory as the `Kong/kong` repo, and that you want to generate the docs for version `2.4.x`. Adjust the paths and version as needed.
 
 After everything is generated, review, open a branch with the changes, send a
 pull request, and review the changes.


### PR DESCRIPTION
### Description

<!-- What did you change and why? -->
 
<!-- Include any supporting resources, e.g. link to a Jira ticket, GH issue, FTI, Slack, Aha, etc. -->

### Testing instructions

Preview link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->

### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] [Conditional version tags](https://docs.konghq.com/contributing/conditional-rendering/#conditionally-render-content-by-version) added, if applicable.

<!-- For example, if this change is for an upcoming 3.6 release, enclose your content in `{% if_version gte:3.6.x %} <content> {% endif_version %}` tags. 

Use any of the following keys:
* `gte:<version>` - greater than or equal to a specific version
* `lte:<version>` - less than or equal to a specific version
* `eq:<version>` - exactly equal to a specific version

You can do the same for older versions. -->

<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

